### PR TITLE
Add travis CI to seaborn

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
 install:
   - conda create -n testenv --yes pip python=$TRAVIS_PYTHON_VERSION
   - source activate testenv
-  - conda install --yes ipython numpy scipy nose matplotlib pandas statsmodels scikit-learn
+  - conda install --yes ipython pyzmq numpy scipy nose matplotlib pandas statsmodels scikit-learn
   - pip install .
 
 before_install:


### PR DESCRIPTION
This now runs and claims the build is passing, but that's a bit of a lie at the moment. Two reasons:
- ipynbdoctest exits with 0 even when cells do not replicate, so currently things that should count as failures are masked (I'm not sure what happens when cells error)
- one cell per notebook is currently not replicating, with the following message. I cannot reproduce this on my laptop (all cells reproduce). The failure seems to happen near, but not at, the beginning of each notebook. Maybe the first plotting cell?
  
  ```
  mismatch output_type:
  stream
    !=  
  display_data
  ```

Nevertheless, merging now as it's running and at least the `nosetests` suite should trigger failures.
