### PR TITLE
Update setup.py for `pip install seaborn==dev`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,8 @@ MAINTAINER = 'Michael Waskom'
 MAINTAINER_EMAIL = 'mwaskom@stanford.edu'
 URL = 'https://github.com/mwaskom/seaborn'
 LICENSE = 'BSD (3-clause)'
-DOWNLOAD_URL = 'https://github.com/mwaskom/seaborn'
+DOWNLOAD_URL = ('https://github.com/mwaskom/seaborn/zipball/master'
+                '#egg=seaborn=dev')
 VERSION = '0.2.dev'
 
 from setuptools import setup


### PR DESCRIPTION
This should make it possibly (after updating at pypi) to use `pip install seaborn==dev` for installing the current master directly from github (instead of taking the detour to grab the master zipball url for github and using that for `pip install`).
