### PR TITLE
Fix Python 3 tests

### DIFF
--- a/examples/ipnbdoctest.py
+++ b/examples/ipnbdoctest.py
@@ -170,7 +170,7 @@ def run_cell(shell, iopub, cell):
     # print cell.input
     shell.execute(cell.input)
     # wait for finish, maximum 20s
-    shell.get_msg(timeout=20)
+    shell.get_msg(timeout=30)
     outs = []
 
     while True:


### PR DESCRIPTION
Not sure why they started failing, but increasing the cell timeout seemed to do the trick. Also caught a bug in the image dimension mismatch reporting.
