### PR TITLE
Adding a kwarg to `set` for custom gridweights

### DIFF
--- a/seaborn/rcmod.py
+++ b/seaborn/rcmod.py
@@ -60,7 +60,7 @@ def set_axes_style(style, context, font="Arial", gridweight=None):
     }
     if gridweight is None:
         if context == "paper":
-            glw = gridweights["extra heavy"]
+            glw = gridweights["light"]
         else:
             glw = gridweights['medium']
     elif isreal(gridweight):


### PR DESCRIPTION
Here's a small PR for allowing the user to specify a custom grid line width. Current values are maintained as a default.

How should we go about the tests? my current setup is pretty noisy when it comes to the notebooks. Here's an nbviewer link (`In[]` cells 7 though 9):
http://nbviewer.ipython.org/gist/phobson/8231880
