### PR TITLE
ENH: add cumulative to kdeplot

### DIFF
--- a/seaborn/tests/test_distributions.py
+++ b/seaborn/tests/test_distributions.py
@@ -1,3 +1,5 @@
+import os
+
 import numpy as np
 import pandas as pd
 import nose.tools as nt
@@ -213,3 +215,20 @@ class TestKDE(object):
         nt.assert_equal(x.shape, (self.gridsize, self.gridsize))
         nt.assert_equal(y.shape, (self.gridsize, self.gridsize))
         nt.assert_equal(len(z), self.gridsize)
+
+    def test_statsmodels_kde_cumulative(self):
+        grid, y = dist._statsmodels_univariate_kde(self.x, self.kernel,
+                                                   self.bw, self.gridsize,
+                                                   self.cut, self.clip,
+                                                   cumulative=True)
+        nt.assert_equal(len(grid), self.gridsize)
+        nt.assert_equal(len(y), self.gridsize)
+        # make sure y is monotonically increasing
+        npt.assert_((np.diff(y) > 0).all())
+
+    # skip for travis matplotlib backend failures
+    @npt.decorators.skipif("DISPLAY" not in os.environ)
+    def test_kde_cummulative_2d(self):
+        # skip for travis matplotlib backend failures
+        with npt.assert_raises(TypeError):
+            dist.kdeplot(self.x, data2=self.y, cumulative=True)


### PR DESCRIPTION
Closes #91

statsmodels backend only right now. I'll take a look at how much work it would be to copy how they calculate the cdf from the kde.

One aesthetic thing. What do you think of the gap between the right side of the cdf and the right side of the grid?

``` python
In [1]: np.random.seed(0)

In [2]: df = pd.DataFrame(np.random.randn(100, 2))

In [3]: import seaborn as sns

In [4]: sns.kdeplot(df[0], shade=True, cumulative=True)
Out[4]: <matplotlib.axes._subplots.AxesSubplot at 0x10d86b090>
```

![sns_cummulative](https://f.cloud.github.com/assets/1312546/2040884/4a4c74fe-89be-11e3-9cad-7f5592f06387.png)

EDIT: here the statsmodels cdf code: https://github.com/statsmodels/statsmodels/blob/master/statsmodels/nonparametric/kde.py#L161
