### PR TITLE
MNT: Change minconda URL and env spec

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ install:
   - conda create -n testenv --yes pip python=$TRAVIS_PYTHON_VERSION
   - source activate testenv
   - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then conda install --yes imaging; else pip install pillow; fi
-  - conda install --yes ipython==1.1.0 pyzmq numpy scipy nose matplotlib pandas statsmodels scikit-learn
+  - conda install --yes ipython-notebook numpy scipy nose matplotlib pandas statsmodels scikit-learn
   - pip install --no-deps git+git://github.com/mwaskom/moss.git#egg=moss
   - pip install pep8
   - pip install https://github.com/dcramer/pyflakes/tarball/master  
@@ -18,7 +18,7 @@ install:
 before_install:
   - sudo sh -c "echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | debconf-set-selections"
   - sudo apt-get install msttcorefonts -qq
-  - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then wget http://repo.continuum.io/miniconda/Miniconda-2.2.2-Linux-x86_64.sh -O miniconda.sh; else wget http://repo.continuum.io/miniconda/Miniconda3-2.2.2-Linux-x86_64.sh -O miniconda.sh; fi
+  - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then wget http://repo.continuum.io/miniconda/Miniconda-3.0.5-Linux-x86_64.sh -O miniconda.sh; else wget http://repo.continuum.io/miniconda/Miniconda3-3.0.5-Linux-x86_64.sh -O miniconda.sh; fi
   - chmod +x miniconda.sh
   - ./miniconda.sh -b
   - export PATH=/home/travis/anaconda/bin:$PATH


### PR DESCRIPTION
All of my [travis builds are erroring out](https://travis-ci.org/mwaskom/seaborn/jobs/20024477). I think this might be due to the conda version being a bit stale now. 

This is just me taking a stab fixing that.

Relevant portion of the travis log:

```
Extracting packages ...
 |                                                                        |   0%
[freetype            ] |################                                  |  33%
[imaging             ] |#################################                 |  66%
[jpeg                ] |##################################################| 100%
[      COMPLETE      ] |##################################################| 100%

Linking packages ...
[      COMPLETE      ] |                                                  |   0%
[freetype            ] |################                                  |  33%
[imaging             ] |#################################                 |  66%
[jpeg                ] |##################################################| 100%
[      COMPLETE      ] |##################################################| 100%

travis_fold:end:install.3
travis_fold:start:install.4
$ conda install --yes ipython==1.1.0 pyzmq numpy scipy nose matplotlib pandas statsmodels scikit-learn
Error: Unsatisfiable package specifications
Hint: numpy 1.7* has a conflict with the remaining packages

The command "conda install --yes ipython==1.1.0 pyzmq numpy scipy nose matplotlib pandas statsmodels scikit-learn" failed and exited with 1 during install.

Your build has been stopped.
```
