### PR TITLE
WIP: Use joblib to cache computationally intensive parts of plotting functions

### DIFF
--- a/seaborn/linearmodels.py
+++ b/seaborn/linearmodels.py
@@ -353,7 +353,7 @@ class _RegressionPlotter(_LinearPlotter):
                  units=None, order=1, logistic=False, lowess=False,
                  robust=False, x_partial=None, y_partial=None,
                  truncate=False, dropna=True, x_jitter=None, y_jitter=None,
-                 color=None, label=None):
+                 color=None, label=None, mem=None):
 
         # Set member attributes
         self.x_estimator = x_estimator
@@ -400,6 +400,9 @@ class _RegressionPlotter(_LinearPlotter):
 
         # Save the range of the x variable for the grid later
         self.x_range = self.x.min(), self.x.max()
+
+        if mem is not None:
+            self.fit_fast = mem.cache(self.fit_fast, ignore=["self"])
 
     @property
     def scatter_data(self):
@@ -473,7 +476,7 @@ class _RegressionPlotter(_LinearPlotter):
             from statsmodels.api import RLM
             yhat, yhat_boots = self.fit_statsmodels(grid, RLM)
         else:
-            yhat, yhat_boots = self.fit_fast(grid)
+            yhat, yhat_boots = self.fit_fast(self.x, self.y, grid)
 
         # Compute the confidence interval at each grid point
         if ci is None:
@@ -483,9 +486,9 @@ class _RegressionPlotter(_LinearPlotter):
 
         return grid, yhat, err_bands
 
-    def fit_fast(self, grid):
+    def fit_fast(self, x, y, grid):
         """Low-level regression and prediction using linear algebra."""
-        X, y = np.c_[np.ones(len(self.x)), self.x], self.y
+        X, y = np.c_[np.ones(len(x)), x], y
         grid = np.c_[np.ones(len(grid)), grid]
         reg_func = lambda _x, _y: np.linalg.pinv(_x).dot(_y)
         yhat = grid.dot(reg_func(X, y))
@@ -970,7 +973,7 @@ def regplot(x, y, data=None, x_estimator=None, x_bins=None, x_ci=95,
             truncate=False, dropna=True, x_jitter=None, y_jitter=None,
             xlabel=None, ylabel=None, label=None,
             color=None, scatter_kws=None, line_kws=None,
-            ax=None):
+            mem=None, ax=None):
     """Draw a scatter plot between x and y with a regression line.
 
     Parameters
@@ -1061,7 +1064,7 @@ def regplot(x, y, data=None, x_estimator=None, x_bins=None, x_ci=95,
                                  scatter, fit_reg, ci, n_boot, units,
                                  order, logistic, lowess, robust,
                                  x_partial, y_partial, truncate, dropna,
-                                 x_jitter, y_jitter, color, label)
+                                 x_jitter, y_jitter, color, label, mem)
 
     if ax is None:
         ax = plt.gca()


### PR DESCRIPTION
This is a proof of concept using `regplot`. The basic idea is that a lot of the plotting functions do a significant amount of computation to fit the model used in the plot. But, often, a user is going to want to iterate over the plot to tweak the aesthetics, etc.

To make this easier, plotting functions that are compute-intensive will have an optional argument called `mem` that takes a `joblib.Memory` instance. Internally, the function will cache the compute-intensive methods. Basically, you'd get something like:

``` python
In [1]: mem = Memory(".", verbose=2)
In [2]: sns.regplot(x, y, mem=mem)

    [Memory] Calling seaborn.linearmodels._RegressionPlotter.fit_fast...
    fit_fast(array([-0.042867, ..., -1.340816]), array([ 0.886475, ...,  0.291993]), array([-4., ...,  4.]))
    _________________________________________________________fit_fast - 0.3s, 0.0min

In [3]: sns.regplot(x, y, color="salmon", mem=mem)

    [Memory]   14.1s, 0.2min: Loading seaborn.linearmodels._RegressionPlotter.fit_fast...
```

Currently tests fail as this requires a bit of change to the `regplot` fitting functions (moving the data access from `self` attributes inside the methods to method arguments), and I haven't updated the tests to reflect that.

Ideas on this are very appreciated.