### PR TITLE
ENH: allow for setting a lists of labels with FacetGrid.set_axis_labels

### DIFF
--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -404,7 +404,13 @@ class FacetGrid(object):
         return self
 
     def set_axis_labels(self, x_var=None, y_var=None):
-        """Set axis labels on the left column and bottom row of the grid."""
+        """Set axis labels on the left column and bottom row of the grid.
+
+        If either argument is a string or not iterable, set each axis label to
+        the given value. Otherwise, set axis labels sequentially to the given
+        values.
+
+        """
         if x_var is not None:
             self._x_var = x_var
             self.set_xlabels(x_var)
@@ -413,19 +419,35 @@ class FacetGrid(object):
             self.set_ylabels(y_var)
         return self
 
-    def set_xlabels(self, label=None, **kwargs):
-        """Label the x axis on the bottom row of the grid."""
-        if label is None:
+    def set_xlabels(self, labels=None, **kwargs):
+        """Label the x axis on the bottom row of the grid.
+
+        If `labels` is a string or not iterable, set each x axis label to the
+        given value. Otherwise, set x axis labels sequentially to the given
+        values.
+
+        """
+        if labels is None:
             label = self._x_var
-        for ax in self.axes[-1, :]:
+        if isinstance(labels, basestring) or not np.iterable(labels):
+            labels = self.axes.shape[1] * [labels]
+        for ax, label in zip(self.axes[-1, :], labels):
             ax.set_xlabel(label, **kwargs)
         return self
 
-    def set_ylabels(self, label=None, **kwargs):
-        """Label the y axis on the left column of the grid."""
-        if label is None:
+    def set_ylabels(self, labels=None, **kwargs):
+        """Label the y axis on the left column of the grid.
+
+        If `labels` is a string or not iterable, set each y axis label to the
+        given value. Otherwise, set y axis labels sequentially to the given
+        values.
+
+        """
+        if labels is None:
             label = self._y_var
-        for ax in self.axes[:, 0]:
+        if isinstance(labels, basestring) or not np.iterable(labels):
+            labels = self.axes.shape[0] * [labels]
+        for ax, label in zip(self.axes[:, 0], labels):
             ax.set_ylabel(label, **kwargs)
         return self
 

--- a/seaborn/tests/test_axisgrid.py
+++ b/seaborn/tests/test_axisgrid.py
@@ -312,6 +312,20 @@ class TestFacetGrid(object):
         got_x = [int(l.get_text()) for l in g.axes[0, 0].get_xticklabels()]
         npt.assert_array_equal(x[::2], got_x)
 
+    def test_set_axis_labels(self):
+
+        g = ag.FacetGrid(self.df, row="a", col="b")
+        g.map(plt.plot, "x", "y")
+
+        xlab = ['x1', 'x2']
+        ylab = 'yy'
+
+        g.set_axis_labels(xlab, ylab)
+        got_x = [ax.get_xlabel() for ax in g.axes[-1, :]]
+        got_y = [ax.get_ylabel() for ax in g.axes[:, 0]]
+        npt.assert_array_equal(got_x, xlab)
+        npt.assert_array_equal(got_y, ylab)
+
     def test_subplot_kws(self):
 
         g = ag.FacetGrid(self.df, row="a", col="b", xlim=(0, 4), ylim=(-2, 3))


### PR DESCRIPTION
This allows for easily setting different x or y axis labels to different
facets, without needing to use the matplotlib interface.

It does not break the API, aside from renaming the single argument
to `set_{x, y}labels` from "label" to "labels".

I also added a unit test for this method since I noticed it didn't have any
direct test coverage.
