### PR TITLE
Add cubehelix_palette function

### DIFF
--- a/doc/releases/v0.4.0.txt
+++ b/doc/releases/v0.4.0.txt
@@ -7,3 +7,8 @@ Plotting functions
 
 - Added a keyword argument ``hist_norm`` to :func:`distplot`. When a :func:`distplot` is now drawn without a KDE or parametric density, the histogram is drawn as counts instead of a density. This can be overridden by by setting ``hist_norm`` to ``True``.
 
+Style and color palettes
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Added the :func:`cubehelix_palette` function for generating sequential palettes from the cubehelix system. See the :ref:`palette docs <cubehelix_palettes>` for more information on how these palettes can be used.
+

--- a/doc/tutorial/color_palettes.ipynb
+++ b/doc/tutorial/color_palettes.ipynb
@@ -1,6 +1,7 @@
 {
  "metadata": {
-  "name": ""
+  "name": "",
+  "signature": "sha256:62b22d1076f1a80e621c0613b2b6d16ecec929d2ce23e9ff30af8aef2bad63d5"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -28,7 +29,7 @@
      "cell_type": "raw",
      "metadata": {},
      "source": [
-      "Color is even more important than other aspects of figure style, because color can reveal patterns in the data if used effectively or hide those patterns if used poorly. There are a number of great resources to learn about good techniques for using color in visualizations, I am partial to this `series of blog posts <http://blog.visual.ly/?s=%22subtleties+of+color%22>`_ from Rob Simmon and this `more technical paper <http://www.sandia.gov/~kmorel/documents/ColorMaps/ColorMapsExpanded.pdf>`_.\n",
+      "Color is even more important than other aspects of figure style, because color can reveal patterns in the data if used effectively or hide those patterns if used poorly. There are a number of great resources to learn about good techniques for using color in visualizations, I am partial to this `series of blog posts <http://earthobservatory.nasa.gov/blogs/elegantfigures/2013/08/05/subtleties-of-color-part-1-of-6/>`_ from Rob Simmon and this `more technical paper <http://www.sandia.gov/~kmorel/documents/ColorMaps/ColorMapsExpanded.pdf>`_.\n",
       "\n",
       "Seaborn makes it easy to select and use color palettes that are suited to the kind of data you are working with and the goals you have in visualizing it."
      ]
@@ -194,6 +195,92 @@
      "prompt_number": null
     },
     {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "sns.palplot(sns.color_palette(\"cubehelix\", 8))"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": null
+    },
+    {
+     "cell_type": "raw",
+     "metadata": {},
+     "source": [
+      "The default palette returned by the seaborn :func:`cubehelix_palette` function does not rotate as far or cover as wide a range of intensities. It also reverses the order so that more important values are darker."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "sns.palplot(sns.cubehelix_palette(8))"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": null
+    },
+    {
+     "cell_type": "raw",
+     "metadata": {},
+     "source": [
+      "The seaborn function lets you directly change the parameters of the palette. The two main things you'll change are the ``start`` and ``rot``, or number of rotations:"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "sns.palplot(sns.cubehelix_palette(8, start=.5, rot=-.75))"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": null
+    },
+    {
+     "cell_type": "raw",
+     "metadata": {},
+     "source": [
+      "You can also control how dark and light the endpoints are and even reverse the ramp:"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "sns.palplot(sns.cubehelix_palette(8, start=2, rot=0, dark=0, light=.95, reverse=True))"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": null
+    },
+    {
+     "cell_type": "raw",
+     "metadata": {},
+     "source": [
+      "By default you just get a list of colors, like any other seaborn palette, but you can also return the palette as a colormap object that can be passed to matplotlib functions using ``as_cmap=True``."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "sample = np.random.multivariate_normal([0, 0], [[1, -.5], [-.5, 1]], size=300)\n",
+      "cmap = sns.cubehelix_palette(light=1, as_cmap=True)\n",
+      "f, ax = plt.subplots(figsize=(6, 6))\n",
+      "plt.hexbin(*sample.T, gridsize=17, cmap=cmap);"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": null
+    },
+    {
      "cell_type": "raw",
      "metadata": {},
      "source": [
@@ -236,14 +323,13 @@
      "cell_type": "raw",
      "metadata": {},
      "source": [
-      "By default you just get a list of colors, like any other seaborn palette, but you can also return the palette as a colormap object that can be passed to matplotlib functions."
+      "This function can also return a colormap object:"
      ]
     },
     {
      "cell_type": "code",
      "collapsed": false,
      "input": [
-      "sample = np.random.multivariate_normal([0, 0], [[1, -.5], [-.5, 1]], size=100)\n",
       "pal = sns.dark_palette(\"palegreen\", as_cmap=True)\n",
       "plt.figure(figsize=(6, 6))\n",
       "sns.kdeplot(sample, cmap=pal);"
@@ -436,6 +522,15 @@
       "with sns.color_palette(\"PuBuGn_d\"):\n",
       "    sinplot()"
      ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": null
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [],
      "language": "python",
      "metadata": {},
      "outputs": [],

--- a/examples/cubehelix_palette.py
+++ b/examples/cubehelix_palette.py
@@ -1,0 +1,16 @@
+"""
+Different cubehelix palettes
+============================
+
+"""
+import numpy as np
+import seaborn as sns
+import matplotlib.pyplot as plt
+
+sns.set(style="dark")
+
+f, axes = plt.subplots(9, figsize=(8, 8))
+for ax, s in zip(axes, np.linspace(0, 3, 10)):
+    pal = sns.cubehelix_palette(10, s)
+    ax.imshow([pal], interpolation="nearest")
+    ax.set(yticks=[], xticklabels=[])

--- a/seaborn/palettes.py
+++ b/seaborn/palettes.py
@@ -278,3 +278,66 @@ def blend_palette(colors, n_colors=6, as_cmap=False):
     if not as_cmap:
         pal = pal(np.linspace(0, 1, n_colors))
     return pal
+
+
+def cubehelix_palette(n_colors=6, start=0, rot=.4, gamma=1.0, hue=0.8,
+                      light=.85, dark=.15, reverse=False, as_cmap=False):
+    """Make a sequential palette from the cubehelix system.
+
+    This produces a colormap with linearly-decreasing (or increasing)
+    brightness. That means that information will be preserved if printed to
+    black and white or viewed by someone who is colorblind.  "cubehelix" is
+    also availible as a matplotlib-based palette, but this function gives the
+    user more control over the look of the palette and has a different set of
+    defaults.
+
+    Parameters
+    ----------
+    n_colors : int
+        Number of colors in the palette.
+    start : float, 0 <= start <= 3
+        The hue at the start of the helix.
+    rot : float
+        Rotations around the hue wheel over the range of the palette.
+    gamma : float 0 <= gamma
+        Gamma factor to emphasize darker (gamma < 1) or lighter (gamma > 1)
+        colors.
+    hue : float, 0 <= hue <= 1
+        Saturation of the colors.
+    dark : float 0 <= dark <= 1
+        Intensity of the darkest color in the palette.
+    light : float 0 <= light <= 1
+        Intensity of the lightest color in the palette.
+    reverse : bool
+        If True, the palette will go from dark to light.
+    as_cmap : bool
+        If True, return a matplotlib colormap instead of a list of colors.
+
+    Returns
+    -------
+    palette : list or colormap
+
+    References
+    ----------
+    Green, D. A. (2011). "A colour scheme for the display of astronomical
+    intensity images". Bulletin of the Astromical Society of India, Vol. 39,
+    p. 289-295.
+
+    """
+    cdict = mpl._cm.cubehelix(gamma, start, rot, hue)
+    cmap = mpl.colors.LinearSegmentedColormap("cubehelix", cdict)
+
+    x = np.linspace(light, dark, n_colors)
+    pal = cmap(x)[:, :3].tolist()
+    if reverse:
+        pal = pal[::-1]
+
+    if as_cmap:
+        x_256 = np.linspace(light, dark, 256)
+        if reverse:
+            x_256 = x_256[::-1]
+        pal_256 = cmap(x_256)
+        cmap = mpl.colors.ListedColormap(pal_256)
+        return cmap
+    else:
+        return pal

--- a/seaborn/tests/test_palettes.py
+++ b/seaborn/tests/test_palettes.py
@@ -165,3 +165,39 @@ class TestColorPalettes(object):
         colors = ["red", "yellow", "white"]
         pal_cmap = palettes.blend_palette(colors, as_cmap=True)
         nt.assert_is_instance(pal_cmap, mpl.colors.LinearSegmentedColormap)
+
+    def test_cubehelix_against_matplotlib(self):
+
+        x = np.linspace(0, 1, 8)
+        mpl_pal = mpl.cm.cubehelix(x)[:, :3].tolist()
+
+        sns_pal = palettes.cubehelix_palette(8, start=0.5, rot=-1.5, hue=1,
+                                             dark=0, light=1, reverse=True)
+
+        nt.assert_list_equal(sns_pal, mpl_pal)
+
+    def test_cubehelix_n_colors(self):
+
+        for n in [3, 5, 8]:
+            pal = palettes.cubehelix_palette(n)
+            nt.assert_equal(len(pal), n)
+
+    def test_cubehelix_reverse(self):
+
+        pal_forward = palettes.cubehelix_palette()
+        pal_reverse = palettes.cubehelix_palette(reverse=True)
+        nt.assert_list_equal(pal_forward, pal_reverse[::-1])
+
+    def test_cubehelix_cmap(self):
+
+        cmap = palettes.cubehelix_palette(as_cmap=True)
+        nt.assert_is_instance(cmap, mpl.colors.ListedColormap)
+        pal = palettes.cubehelix_palette()
+        x = np.linspace(0, 1, 6)
+        npt.assert_array_equal(cmap(x)[:, :3], pal)
+
+        cmap_rev = palettes.cubehelix_palette(as_cmap=True, reverse=True)
+        x = np.linspace(0, 1, 6)
+        pal_forward = cmap(x).tolist()
+        pal_reverse = cmap_rev(x[::-1]).tolist()
+        nt.assert_list_equal(pal_forward, pal_reverse)


### PR DESCRIPTION
This provides a flexible interface to the cubehelix palette system, which exists in matplotlib but is for some reason hidden.

Here are a few examples:

``` python
f, axes = plt.subplots(9, figsize=(8, 8))
for ax, s in zip(axes, np.linspace(0, 3, 10)):
    pal = sns.cubehelix_palette(10, s)
    ax.imshow([pal], interpolation="nearest")
    ax.set(yticks=[], xticklabels=[])
```

![cubehelix_pal](https://cloud.githubusercontent.com/assets/315810/2803265/02a27a2c-cc99-11e3-9d44-edbef2f36ffa.png)

``` python
f, axes = plt.subplots(3, 3, figsize=(8, 8))
x, y = np.random.multivariate_normal([0, 0], [(1, .5), (.5, 1)], 1000).T
for ax, s in zip(axes.flat, np.linspace(0, 3, 9)):
    cmap = sns.cubehelix_palette(start=s, rot=-.3, light=.98, as_cmap=True)
    ax.hexbin(x, y, gridsize=20, cmap=cmap)
    ax.set_axis_off()
f.tight_layout(h_pad=.5, w_pad=.5)
```

![cubehelix_hex](https://cloud.githubusercontent.com/assets/315810/2803292/6913c84c-cc99-11e3-9091-28b7de32c119.png)
