### PR TITLE
Make setup behave more politely about dependencies (GH #169)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,12 +24,45 @@ LICENSE = 'BSD (3-clause)'
 DOWNLOAD_URL = 'https://github.com/mwaskom/seaborn/'
 VERSION = '0.4.dev'
 
-from setuptools import setup
+try:
+    from setuptools import setup
+    _has_setuptools = True
+except ImportError:
+    from disutils import setup
+
+
+def check_dependencies():
+
+    # Just make sure dependencies exist, I haven't rigorously
+    # tested what the minimal versions that will work are
+    # (help on that would be awesome)
+    try:
+        import numpy
+    except ImportError:
+        raise ImportError("seaborn requires numpy")
+    try:
+        import scipy
+    except ImportError:
+        raise ImportError("seaborn requires scipy")
+    try:
+        import matplotlib
+    except ImportError:
+        raise ImportError("seaborn requires matplotlib")
+    try:
+        import pandas
+    except ImportError:
+        raise ImportError("seaborn requires pandas")
 
 if __name__ == "__main__":
     import os
     if os.path.exists('MANIFEST'):
         os.remove('MANIFEST')
+
+    import sys
+    if not (len(sys.argv) >= 2 and ('--help' in sys.argv[1:] or
+            sys.argv[1] in ('--help-commands', 'egg_info', '--version',
+                            'clean'))):
+        check_dependencies()
 
     setup(name=DISTNAME,
         maintainer=MAINTAINER,
@@ -52,5 +85,4 @@ if __name__ == "__main__":
                      'Operating System :: POSIX',
                      'Operating System :: Unix',
                      'Operating System :: MacOS'],
-        install_requires=["pandas"],
           )


### PR DESCRIPTION
This raises ImportErrors when dependencies don't exist, but doesn't try to install them. This is better than default setuptools behavior because all of the required dependencies are annoying to install with pip.

Closes #169 
