### PR TITLE
BUG: col row and hue names should always be lists

### DIFF
--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -522,7 +522,7 @@ class FacetGrid(object):
                 template = " | ".join([row_template, col_template])
 
         if self._margin_titles:
-            if self.row_names:
+            if self.row_names is not None:
                 # Draw the row titles on the right edge of the grid
                 for i, row_name in enumerate(self.row_names):
                     ax = self.axes[i, -1]
@@ -534,7 +534,7 @@ class FacetGrid(object):
                     y = bbox.ymax - (bbox.height / 2)
                     self.fig.text(x, y, title, rotation=270,
                                   ha="left", va="center", **kwargs)
-            if self.col_names:
+            if self.col_names is not None:
                 # Draw the column titles  as normal titles
                 for j, col_name in enumerate(self.col_names):
                     args.update(dict(col_name=col_name))
@@ -550,12 +550,12 @@ class FacetGrid(object):
                     args.update(dict(row_name=row_name, col_name=col_name))
                     title = template.format(**args)
                     self.axes[i, j].set_title(title, **kwargs)
-        elif self.row_names:
+        elif self.row_names is not None and len(self.row_names):
             for i, row_name in enumerate(self.row_names):
                 args.update(dict(row_name=row_name))
                 title = template.format(**args)
                 self.axes[i, 0].set_title(title, **kwargs)
-        elif self.col_names:
+        elif self.col_names is not None and len(self.col_names):
             for i, col_name in enumerate(self.col_names):
                 args.update(dict(col_name=col_name))
                 title = template.format(**args)

--- a/seaborn/tests/test_axisgrid.py
+++ b/seaborn/tests/test_axisgrid.py
@@ -322,6 +322,10 @@ class TestFacetGrid(object):
         nt.assert_equal(g.axes[0, 0].get_title(), "b = m")
         nt.assert_equal(g.axes[0, 1].get_title(), "b = n")
 
+        # test with dropna=False
+        g = ag.FacetGrid(self.df, col="b", hue="b", dropna=False)
+        g.map(plt.plot, 'x', 'y')
+
         plt.close("all")
 
     def test_set_titles_margin_titles(self):


### PR DESCRIPTION
I found this while trying to plot a facet grid without dropping nans
