### PR TITLE
fixed alpha setting bug in _RegressionPlotter scatter

### DIFF
--- a/seaborn/linearmodels.py
+++ b/seaborn/linearmodels.py
@@ -26,14 +26,12 @@ from .axisgrid import FacetGrid
 
 
 class _LinearPlotter(object):
-
     """Base class for plotting relational data in tidy format.
 
     To get anything useful done you'll have to inherit from this, but setup
     code that can be abstracted out should be put here.
 
     """
-
     def establish_variables(self, data, **kws):
         """Extract variables from data or use directly."""
         self.data = data
@@ -65,7 +63,6 @@ class _LinearPlotter(object):
 
 
 class _DiscretePlotter(_LinearPlotter):
-
     """Plotter for data with discrete independent variable(s).
 
     This will be used by the `barplot` and `pointplot` functions, and
@@ -77,7 +74,6 @@ class _DiscretePlotter(_LinearPlotter):
     with `box` doing something similar but skipping the estimation).
 
     """
-
     def __init__(self, x, y=None, hue=None, data=None, units=None,
                  x_order=None, hue_order=None, color=None, palette=None,
                  kind="auto", markers=None, linestyles=None, dodge=0,
@@ -373,7 +369,6 @@ class _DiscretePlotter(_LinearPlotter):
 
 
 class _RegressionPlotter(_LinearPlotter):
-
     """Plotter for numeric independent variables with regression model.
 
     This does the computations and drawing for the `regplot` function, and
@@ -384,7 +379,6 @@ class _RegressionPlotter(_LinearPlotter):
     extrapolations beyond the observed datapoints.
 
     """
-
     def __init__(self, x, y, data=None, x_estimator=None, x_bins=None,
                  x_ci="ci", scatter=True, fit_reg=True, ci=95, n_boot=1000,
                  units=None, order=1, logistic=False, lowess=False,

--- a/seaborn/tests/test_linearmodels.py
+++ b/seaborn/tests/test_linearmodels.py
@@ -833,6 +833,29 @@ class TestRegressionPlots(object):
 
         plt.close("all")
 
+    def test_regplot_scatter_kws_alpha(self):
+
+        f, ax = plt.subplots()
+        color = np.array([[0.3, 0.8, 0.5, 0.5]])
+        ax = lm.regplot("x", "y", self.df, scatter_kws={'color': color})
+        nt.assert_is(ax.collections[0]._alpha, None)
+        nt.assert_equal(ax.collections[0]._facecolors[0,3], 0.5)
+
+        f, ax = plt.subplots()
+        color = np.array([[0.3, 0.8, 0.5]])
+        ax = lm.regplot("x", "y", self.df, scatter_kws={'color': color})
+        nt.assert_equal(ax.collections[0]._alpha, 0.8)
+
+        f, ax = plt.subplots()
+        color = np.array([[0.3, 0.8, 0.5]])
+        ax = lm.regplot("x", "y", self.df, scatter_kws={'color': color, 'alpha': 0.4})
+        nt.assert_equal(ax.collections[0]._alpha, 0.4)
+
+        f, ax = plt.subplots()
+        color = 'r'
+        ax = lm.regplot("x", "y", self.df, scatter_kws={'color': color})
+        nt.assert_equal(ax.collections[0]._alpha, 0.8)
+
     def test_regplot_binned(self):
 
         ax = lm.regplot("x", "y", self.df, x_bins=5)


### PR DESCRIPTION
There's a known issue in matplotlib where if alpha is explicitly set for an axis globally, the 4th column in an RGBA array passed to the color argument in plots is ignored. Because seaborn sets a default alpha value in _RegressionPlotter, the alpha is always ignored even when passed. This PR just adds a check to see if the color property in scatter_kws is 4D (i.e., RGBA), and omits setting the default if so. All tests pass.
