### PR TITLE
add a small error message if an invalid kind was passed to jointplot

### DIFF
--- a/seaborn/distributions.py
+++ b/seaborn/distributions.py
@@ -972,7 +972,8 @@ def jointplot(x, y, data=None, kind="scatter", stat_func=stats.pearsonr,
                  **marginal_kws)
         stat_func = None
     else:
-        raise ValueError("kind must be one of the following: ['scatter', 'reg', 'resid', 'kde', 'hex']")
+        raise ValueError("kind must be one of the following: ['scatter', \
+	        'reg', 'resid', 'kde', 'hex']")
 
     if stat_func is not None:
         grid.annotate(stat_func, **annot_kws)


### PR DESCRIPTION
In case you used an invalid value for joinplot you get back just an empty plot.
Let's add a really simple help message for the user, see http://nbviewer.ipython.org/b2bf2c98d8339b39000d
