### PR TITLE
Have factorplot handle unbalanced data better

### DIFF
--- a/doc/releases/v0.4.0.txt
+++ b/doc/releases/v0.4.0.txt
@@ -7,6 +7,8 @@ Plotting functions
 
 - Added a keyword argument ``hist_norm`` to :func:`distplot`. When a :func:`distplot` is now drawn without a KDE or parametric density, the histogram is drawn as counts instead of a density. This can be overridden by by setting ``hist_norm`` to ``True``.
 
+- Made some changes to :func:``factorplot`` so that it behaves better when not all levels of the ``x`` variable are represented in each facet.
+
 - Added the ``logx`` option to :func:`regplot` for fitting the regression in log space.
 
 Style and color palettes

--- a/seaborn/linearmodels.py
+++ b/seaborn/linearmodels.py
@@ -238,6 +238,13 @@ class _DiscretePlotter(_LinearPlotter):
 
                 # This is where the main computation happens
                 height.append(self.estimator(y_data))
+
+                # Only bootstrap with multple values
+                if current_data.sum() < 2:
+                    ci.append((None, None))
+                    continue
+
+                # Get the confidence intervals
                 if self.ci is not None:
                     boots = algo.bootstrap(y_data, func=self.estimator,
                                            n_boot=self.n_boot,
@@ -311,6 +318,8 @@ class _DiscretePlotter(_LinearPlotter):
 
             # The error bars
             for x, (low, high) in zip(pos, ci):
+                if low is None:
+                    continue
                 ax.plot([x, x], [low, high], linewidth=self.lw, color=ecolor)
 
         # Set the x limits
@@ -349,6 +358,8 @@ class _DiscretePlotter(_LinearPlotter):
 
             # The error bars
             for j, (x, (low, high)) in enumerate(zip(pos, ci)):
+                if low is None:
+                    continue
                 ecolor = err_palette[j] if self.x_palette else err_palette[i]
                 ax.plot([x, x], [low, high], linewidth=self.lw,
                         color=ecolor, zorder=z)
@@ -876,6 +887,11 @@ def factorplot(x, y=None, hue=None, data=None, row=None, col=None,
             kind = "bar"
         else:
             kind = "point"
+
+    # Always use an x_order so that the plot is drawn properly when
+    # not all of the x variables are represented in each facet
+    if x_order is None:
+        x_order = np.sort(pd.unique(data[x]))
 
     # Draw the plot on each facet
     kwargs = dict(estimator=estimator, ci=ci, n_boot=n_boot, units=units,

--- a/seaborn/tests/test_linearmodels.py
+++ b/seaborn/tests/test_linearmodels.py
@@ -790,6 +790,24 @@ class TestDiscretePlots(object):
 
         plt.close("all")
 
+    def test_factorplot_missing(self):
+
+        d = pd.DataFrame(dict(a=["a", "a", "b", "c", "c"],
+                              b=["x", "y", "x", "x", "y"],
+                              c=[1, 2, 3, 4, 5]))
+
+        g = lm.factorplot("a", "c", data=d, col="b", kind="point")
+
+        ax = g.axes[0, 0]
+        x1, y1 = ax.collections[0].get_offsets().T
+        npt.assert_array_equal(x1, [0, 1, 2])
+        npt.assert_array_equal(y1, [1, 3, 4])
+
+        ax = g.axes[0, 1]
+        x1, y1 = ax.collections[0].get_offsets().T
+        npt.assert_array_equal(x1, [0, 2])
+        npt.assert_array_equal(y1, [2, 5])
+
     def test_factorplot_hline(self):
 
         g = lm.factorplot("x", "v", data=self.df, kind="bar", hline=0)


### PR DESCRIPTION
Two changes to `factorplot` here:
- Always pass an explicit `x_order` to `jointplot`/`barplot`/`boxplot` so that labels correspond properly.
- Skip bootstrapping when an `x` level is missing on one of the facets or when it only has one observation

This closes #239 and closes #216
