### PR TITLE
Unify rules for default color palettes

### DIFF
--- a/doc/releases/v0.4.0.txt
+++ b/doc/releases/v0.4.0.txt
@@ -5,6 +5,8 @@ v0.4.0 (??)
 Plotting functions
 ~~~~~~~~~~~~~~~~~~
 
+- The rules for choosing default color palettes when variables are mapped to different colors have been unified (and thus changed in some cases). Now when no specific palette is requested, the current global color palette will be used, unless the number of variables to be mapped exceeds the number of unique colors in the palette, in which case the ``"husl"`` palette will be used to avoid cycling.
+
 - Added a keyword argument ``hist_norm`` to :func:`distplot`. When a :func:`distplot` is now drawn without a KDE or parametric density, the histogram is drawn as counts instead of a density. This can be overridden by by setting ``hist_norm`` to ``True``.
 
 - Made some changes to :func:``factorplot`` so that it behaves better when not all levels of the ``x`` variable are represented in each facet.

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -13,7 +13,7 @@ class FacetGrid(object):
     """Subplot grid for applying plotting functions to subsets of data."""
 
     def __init__(self, data, row=None, col=None, hue=None, col_wrap=None,
-                 sharex=True, sharey=True, size=3, aspect=1, palette="husl",
+                 sharex=True, sharey=True, size=3, aspect=1, palette=None,
                  row_order=None, col_order=None, hue_order=None,
                  dropna=True, legend=True, legend_out=True, despine=True,
                  margin_titles=False, xlim=None, ylim=None):
@@ -143,11 +143,23 @@ class FacetGrid(object):
             if dropna:
                 # Filter NA from the list of unique hue names
                 hue_names = list(filter(pd.notnull, hue_names))
-            if isinstance(palette, dict):
-                # Allow for palette to map from hue variable names
-                palette = [palette[h] for h in hue_names]
             hue_masks = [data[hue] == val for val in hue_names]
-            colors = color_palette(palette, len(hue_masks))
+            n_colors = len(hue_masks)
+
+            # Now we are ready to determine the palette
+            if palette is None:
+                # By default use either the current color palette or HUSL
+                current_palette = mpl.rcParams["axes.color_cycle"]
+                if n_colors > len(current_palette):
+                    colors = color_palette("husl", n_colors)
+                else:
+                    colors = color_palette(n_colors=n_colors)
+            elif isinstance(palette, dict):
+                # Allow for palette to map from hue variable names
+                color_names = [palette[h] for h in hue_names]
+                colors = color_palette(color_names, n_colors)
+            else:
+                colors = color_palette(palette, n_colors)
 
         # Make a boolean mask that is True anywhere there is an NA
         # value in one of the faceting variables, but only if dropna is True

--- a/seaborn/distributions.py
+++ b/seaborn/distributions.py
@@ -104,7 +104,12 @@ def _box_reshape(vals, groupby, names, order):
 def _box_colors(vals, color, sat):
     """Find colors to use for boxplots or violinplots."""
     if color is None:
-        colors = husl_palette(len(vals), l=.7)
+        # Default uses either the current palette or husl
+        current_palette = mpl.rcParams["axes.color_cycle"]
+        if len(vals) <= len(current_palette):
+            colors = color_palette(n_colors=len(vals))
+        else:
+            colors = husl_palette(len(vals), l=.7)
     else:
         try:
             color = mpl.colors.colorConverter.to_rgb(color)

--- a/seaborn/linearmodels.py
+++ b/seaborn/linearmodels.py
@@ -151,7 +151,11 @@ class _DiscretePlotter(_LinearPlotter):
                 color = color_palette()[0]
             palette = [color for _ in self.x_order]
         elif palette is None:
-            palette = color_palette(n_colors=n_hues)
+            current_palette = mpl.rcParams["axes.color_cycle"]
+            if len(current_palette) <= n_hues:
+                palette = color_palette("husl", n_hues)
+            else:
+                palette = color_palette(n_colors=n_hues)
         elif isinstance(palette, dict):
             palette = [palette[k] for k in hue_names]
             palette = color_palette(palette, n_hues)
@@ -684,7 +688,7 @@ class _RegressionPlotter(_LinearPlotter):
         ax.set_xlim(*xlim)
 
 
-def lmplot(x, y, data, hue=None, col=None, row=None, palette="husl",
+def lmplot(x, y, data, hue=None, col=None, row=None, palette=None,
            col_wrap=None, size=5, aspect=1, sharex=True, sharey=True,
            hue_order=None, col_order=None, row_order=None, dropna=True,
            legend=True, legend_out=True, **kwargs):

--- a/seaborn/tests/test_axisgrid.py
+++ b/seaborn/tests/test_axisgrid.py
@@ -159,7 +159,7 @@ class TestFacetGrid(object):
 
         g1 = ag.FacetGrid(self.df, hue="a")
         g1.map(plt.plot, "x", "y")
-        palette = color_palette("husl", 3)
+        palette = color_palette(n_colors=3)
 
         nt.assert_equal(g1._legend.get_title().get_text(), "a")
 
@@ -184,7 +184,7 @@ class TestFacetGrid(object):
         self.df["b_bool"] = self.df.b == "m"
         g1 = ag.FacetGrid(self.df, hue="b_bool")
         g1.map(plt.plot, "x", "y")
-        palette = color_palette("husl", 2)
+        palette = color_palette(n_colors=2)
 
         nt.assert_equal(g1._legend.get_title().get_text(), "b_bool")
 
@@ -416,7 +416,10 @@ class TestFacetGrid(object):
     def test_palette(self):
 
         g = ag.FacetGrid(self.df, hue="c")
-        nt.assert_equal(g._colors, color_palette("husl", 3))
+        nt.assert_equal(g._colors, color_palette(n_colors=3))
+
+        g = ag.FacetGrid(self.df, hue="d")
+        nt.assert_equal(g._colors, color_palette("husl", 10))
 
         g = ag.FacetGrid(self.df, hue="c", palette="Set2")
         nt.assert_equal(g._colors, color_palette("Set2", 3))

--- a/seaborn/tests/test_linearmodels.py
+++ b/seaborn/tests/test_linearmodels.py
@@ -937,7 +937,7 @@ class TestRegressionPlots(object):
         g = lm.lmplot("x", "y", hue="h", data=self.df, ci=None)
         red_scatter, blue_scatter = g.axes[0, 0].collections
 
-        red, blue = color_palette("husl", 2)
+        red, blue = color_palette(n_colors=2)
         npt.assert_array_equal(red, red_scatter.get_facecolors()[0, :3])
         npt.assert_array_equal(blue, blue_scatter.get_facecolors()[0, :3])
 

--- a/seaborn/timeseries.py
+++ b/seaborn/timeseries.py
@@ -173,7 +173,7 @@ def tsplot(data, time=None, unit=None, condition=None, value=None,
                                  unit=units,
                                  cond=conds))
 
-    # Set up the err_style and ci arguments for teh loop below
+    # Set up the err_style and ci arguments for the loop below
     if isinstance(err_style, string_types):
         err_style = [err_style]
     elif err_style is None:
@@ -183,7 +183,11 @@ def tsplot(data, time=None, unit=None, condition=None, value=None,
 
     # Set up the color palette
     if color is None:
-        colors = color_palette()
+        current_palette = mpl.rcParams["axes.color_cycle"]
+        if len(current_palette) < n_cond:
+            colors = color_palette("husl", n_cond)
+        else:
+            colors = color_palette(n_colors=n_cond)
     elif isinstance(color, dict):
         colors = [color[c] for c in data[condition].unique()]
     else:


### PR DESCRIPTION
The rules for choosing default color palettes when variables are mapped to different colors have been unified (and thus changed somewhat). Now when no specific palette is requested, the current global color palette will be used, unless the number of variables to be mapped exceeds the number of unique colors in the palette, in which case the `"husl"` palette will be used to avoid cycling.
