### PR TITLE
BUG: PairGrid should ignore datelike columns

### DIFF
--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -1025,7 +1025,7 @@ class PairGrid(Grid):
             try:
                 data[col].astype(np.float)
                 numeric_cols.append(col)
-            except ValueError:
+            except (ValueError, TypeError):
                 pass
         return numeric_cols
 

--- a/seaborn/tests/test_axisgrid.py
+++ b/seaborn/tests/test_axisgrid.py
@@ -8,6 +8,7 @@ from distutils.version import LooseVersion
 import nose.tools as nt
 import numpy.testing as npt
 from numpy.testing.decorators import skipif
+import pandas.util.testing as tm
 
 from .. import axisgrid as ag
 from .. import rcmod
@@ -481,6 +482,15 @@ class TestPairGrid(object):
 
         g = ag.PairGrid(self.df)
         nt.assert_is(g.data, self.df)
+        plt.close("all")
+
+    def test_ignore_datelike_data(self):
+
+        df = self.df.copy()
+        df['date'] = pd.date_range('2010-01-01', periods=len(df), freq='d')
+        result = ag.PairGrid(self.df).data
+        expected = df.drop('date', axis=1)
+        tm.assert_frame_equal(result, expected)
         plt.close("all")
 
     def test_self_fig(self):


### PR DESCRIPTION
Closes https://github.com/mwaskom/seaborn/issues/275

All I added was the checking for `TypError` in the except block.
