### PR TITLE
API: Accept Series for kdeplot

### DIFF
--- a/doc/releases/v0.5.0.txt
+++ b/doc/releases/v0.5.0.txt
@@ -23,3 +23,6 @@ Bug fixes
 - Fixed a bug in :class:`PairGrid` where passing columns with a date-like datatype raised an exception.
 
 - Worked around a matplotlib bug that was forcing outliers in :func:`boxplot` to appear as blue.
+
+- :func:`kdeplot` now accepts pandas Series for the ``data`` and ``data2``
+- arguments.

--- a/seaborn/distributions.py
+++ b/seaborn/distributions.py
@@ -759,6 +759,12 @@ def _statsmodels_bivariate_kde(x, y, bw, gridsize, cut, clip):
         bw = [x_bw, y_bw]
     elif np.isscalar(bw):
         bw = [bw, bw]
+
+    if isinstance(x, pd.Series):
+        x = x.values
+    if isinstance(y, pd.Series):
+        y = y.values
+
     kde = sm.nonparametric.KDEMultivariate([x, y], "cc", bw)
     x_support = _kde_support(x, kde.bw[0], gridsize, cut, clip[0])
     y_support = _kde_support(y, kde.bw[1], gridsize, cut, clip[1])

--- a/seaborn/tests/test_distributions.py
+++ b/seaborn/tests/test_distributions.py
@@ -244,6 +244,18 @@ class TestKDE(object):
         with npt.assert_raises(TypeError):
             dist.kdeplot(self.x, data2=self.y, cumulative=True)
 
+    def test_bivariate_kde_series(self):
+        df = pd.DataFrame({'x': self.x, 'y': self.y})
+
+        ax_series = dist.kdeplot(df.x, df.y)
+        ax_values = dist.kdeplot(df.x.values, df.y.values)
+
+        nt.assert_equal(len(ax_series.collections),
+                        len(ax_values.collections))
+        nt.assert_equal(ax_series.collections[0].get_paths(),
+                        ax_values.collections[0].get_paths())
+        plt.close("all")
+
 
 class TestViolinPlot(object):
 


### PR DESCRIPTION
This is useful when your using `FacetGrid`, and don't have direct control over what exactly gets passed in.

```
In [1]: tips = sns.load_dataset("tips")

In [5]: g = sns.FacetGrid(tips, row='sex', col='smoker')

In [6]: g.map(sns.kdeplot, "total_bill", "tip")
Out[6]: <seaborn.axisgrid.FacetGrid at 0x114275d68>
```

Previously it would raise a `ValueError`:

```
In [90]: g.map(sns.kdeplot, "total_bill", "tip")
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-90-6c621e17f38a> in <module>()
----> 1 g.map(sns.kdeplot, "total_bill", "tip")

/Users/tom/Envs/py3/lib/python3.4/site-packages/seaborn-0.5.dev-py3.4.egg/seaborn/axisgrid.py in map(self, func, *args, **kwargs)
    433 
    434             # Draw the plot
--> 435             self._facet_plot(func, ax, plot_args, kwargs)
    436 
    437         # Finalize the annotations and layout

/Users/tom/Envs/py3/lib/python3.4/site-packages/seaborn-0.5.dev-py3.4.egg/seaborn/axisgrid.py in _facet_plot(self, func, ax, plot_args, plot_kwargs)
    513 
    514         # Draw the plot
--> 515         func(*plot_args, **plot_kwargs)
    516 
    517         # Sort out the supporting information

/Users/tom/Envs/py3/lib/python3.4/site-packages/seaborn-0.5.dev-py3.4.egg/seaborn/distributions.py in kdeplot(data, data2, shade, vertical, kernel, bw, gridsize, cut, clip, legend, ax, cumulative, **kwargs)
    854     if bivariate:
    855         ax = _bivariate_kdeplot(x, y, shade, kernel, bw, gridsize,
--> 856                                 cut, clip, legend, ax, **kwargs)
    857     else:
    858         ax = _univariate_kdeplot(data, shade, vertical, kernel, bw,

/Users/tom/Envs/py3/lib/python3.4/site-packages/seaborn-0.5.dev-py3.4.egg/seaborn/distributions.py in _bivariate_kdeplot(x, y, filled, kernel, bw, gridsize, cut, clip, axlabel, ax, **kwargs)
    725     # Calculate the KDE
    726     if _has_statsmodels:
--> 727         xx, yy, z = _statsmodels_bivariate_kde(x, y, bw, gridsize, cut, clip)
    728     else:
    729         xx, yy, z = _scipy_bivariate_kde(x, y, bw, gridsize, cut, clip)

/Users/tom/Envs/py3/lib/python3.4/site-packages/seaborn-0.5.dev-py3.4.egg/seaborn/distributions.py in _statsmodels_bivariate_kde(x, y, bw, gridsize, cut, clip)
    760     elif np.isscalar(bw):
    761         bw = [bw, bw]
--> 762     kde = sm.nonparametric.KDEMultivariate([x, y], "cc", bw)
    763     x_support = _kde_support(x, kde.bw[0], gridsize, cut, clip[0])
    764     y_support = _kde_support(y, kde.bw[1], gridsize, cut, clip[1])

/Users/tom/Envs/py3/lib/python3.4/site-packages/statsmodels-0.6.0-py3.4-macosx-10.9-x86_64.egg/statsmodels/nonparametric/kernel_density.py in __init__(self, data, var_type, bw, defaults)
    109         self.nobs, self.k_vars = np.shape(self.data)
    110         if self.nobs <= self.k_vars:
--> 111             raise ValueError("The number of observations must be larger " \
    112                              "than the number of variables.")
    113 

ValueError: The number of observations must be larger than the number of variables.
```
