### PR TITLE
Set rcmod.py to create translucent legend frames

### DIFF
--- a/seaborn/rcmod.py
+++ b/seaborn/rcmod.py
@@ -188,7 +188,7 @@ def axes_style(style=None, rc=None):
         style_dict = {
             "text.color": dark_gray,
             "axes.labelcolor": dark_gray,
-            "legend.frameon": False,
+            "legend.frameon": True,
             "legend.framealpha": 0.7,
             "legend.numpoints": 1,
             "legend.scatterpoints": 1,


### PR DESCRIPTION
As of 1.4.1, matplotlib includes a key for the default transparency of
legend frames: "legend.framealpha". _Personally,_ I prefer the look of
this when a plot doesn't have much free space for the legend to avoid
overlap with data, but I leave it to others to accept or not. I also
don't know how to best handle compatibility with earlier versions of
mpl.

Here's a contrived example of the current behavior vs. what this change would look like:

Default settings:
![default](https://cloud.githubusercontent.com/assets/6894112/4775769/62e6fb9a-5bbb-11e4-90c4-25e038102a97.png)

Frame on, Alpha=0.7
![framealpha](https://cloud.githubusercontent.com/assets/6894112/4775771/68da6aa0-5bbb-11e4-9800-4c4d21f55fdb.png)
