### PR TITLE
Fix failing matplotlib rc test

### DIFF
--- a/seaborn/rcmod.py
+++ b/seaborn/rcmod.py
@@ -197,7 +197,7 @@ def axes_style(style=None, rc=None):
             "ytick.color": dark_gray,
             "axes.axisbelow": True,
             "image.cmap": "Greys",
-            "font.family": "sans-serif",
+            "font.family": ["sans-serif"],
             "font.sans-serif": ["Arial", "Liberation Sans",
                                 "Bitstream Vera Sans", "sans-serif"],
             "grid.linestyle": "-",


### PR DESCRIPTION
At some point matplotlib started forcing the font.family parameter to be
a list, but they accept strings (doing the conversion internally), so
everthing was working but the rc parameter validation failed. This updated
the style definitions to be in line with the matplotlib spec.
