### PR TITLE
Heatmap missing fixes

### DIFF
--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -55,7 +55,7 @@ class _HeatMapper(object):
         if mask is not None:
             try:
                 mask = mask.ix[::-1]
-            except:
+            except AttributeError:
                 mask = mask[::-1]
 
         plot_data = np.ma.masked_where(mask, plot_data)


### PR DESCRIPTION
This snippet shows a bug in the current implementation of heatmaps over masked arrays

``` python
import seaborn as sns
import numpy as np
import pandas as pd

cmap = sns.cubehelix_palette(light=.95, as_cmap=True)
cmap.set_bad('k', 1.)  # masked elements are black

df = pd.DataFrame(data={'a': [1, 1, 1],
                        'b': [2, np.nan, 2],
                        'c': [3, 3, np.nan]})

sns.heatmap(df, mask=df.isnull(), cmap=cmap)
```

With the current implementation, we get this inverted mask:

![mask-not-reversed](https://cloud.githubusercontent.com/assets/642252/5127578/60141c98-70d5-11e4-89a1-e6094f60ad3c.png)

These commits fix it, so we get the expected heatmap

![mask-properlly-reversed](https://cloud.githubusercontent.com/assets/642252/5127589/75f1e040-70d5-11e4-9034-83b08b66039b.png)

They also add a comment for the _mask_ parameter to heatmap.

A different issue is that, if no mask is passed, missing values seem to be represented by the color of the minimum, which arguably is not correct. I will open an issue to discuss.
