### PR TITLE
List the files that go in the source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,9 @@
+include *.md
+include *.txt
+include LICENSE
+include Makefile
+include ipnbdoctest.py
+recursive-include licences *
+recursive-include doc *
+recursive-include examples *
+recursive-include testing *

--- a/setup.py
+++ b/setup.py
@@ -58,10 +58,6 @@ def check_dependencies():
 
 if __name__ == "__main__":
 
-    import os
-    if os.path.exists('MANIFEST'):
-        os.remove('MANIFEST')
-
     install_requires = check_dependencies()
 
     setup(name=DISTNAME,


### PR DESCRIPTION
This PR addreses the problem in #378 
MANIFEST.in contains the list of files to be distributed. Initially MANIFEST.in contains all the files in the repository, with the exception of the dotfiles. If a file is not intended to be distributed, it's enough to remove it from MANIFEST.in
