### PR TITLE
clustermap: side colors should ignore custom centering

### DIFF
--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -767,9 +767,10 @@ class ClusterGrid(Grid):
         heatmap_kws : dict
             Keyword arguments heatmap
         """
-        # Remove any custom colormap
+        # Remove any custom colormap and centering
         kws = kws.copy()
         kws.pop('cmap', None)
+        kws.pop('center', None)
         if self.row_colors is not None:
             matrix, cmap = self.color_list_to_matrix_and_cmap(
                 self.row_colors, yind, axis=0)


### PR DESCRIPTION
Currently the `center` keyword is passed to the side color heatmaps. This can cause some unexpected formatting of the side colors. Since `center` is defining a custom colormap and should only affect the heatmap, best to pop it off.

For example. using the `flight_rect` example from the documentation:

```
sns.clustermap(flights_rect, col_colors=col_colors, row_colors=row_colors)
```

![fig1](https://cloud.githubusercontent.com/assets/755664/5189369/49033082-74ab-11e4-8314-3db6d837d91f.png)

```
sns.clustermap(flights_rect, center=flights_rect.loc["January", 1955],
                    col_colors=col_colors, row_colors=row_colors)
```

![fig2](https://cloud.githubusercontent.com/assets/755664/5189372/4d91403a-74ab-11e4-93a4-e334d2d7cfc0.png)
