### PR TITLE
Fix missing shade label in kdeplot

### DIFF
--- a/seaborn/distributions.py
+++ b/seaborn/distributions.py
@@ -670,9 +670,11 @@ def _univariate_kdeplot(data, shade, vertical, kernel, bw, gridsize, cut,
     alpha = kwargs.get("alpha", 0.25)
     if shade:
         if vertical:
-            ax.fill_betweenx(y, 1e-12, x, color=color, alpha=alpha, label=label)
+            ax.fill_betweenx(y, 1e-12, x, color=color, alpha=alpha, 
+                             label=label)
         else:
-            ax.fill_between(x, 1e-12, y, color=color, alpha=alpha, label=label)
+            ax.fill_between(x, 1e-12, y, color=color, alpha=alpha, 
+                            label=label)
 
     # Draw the legend here
     if legend:

--- a/seaborn/linearmodels.py
+++ b/seaborn/linearmodels.py
@@ -622,10 +622,10 @@ class _RegressionPlotter(_LinearPlotter):
     def plot(self, ax, scatter_kws, line_kws):
         """Draw the full plot."""
         # Insert the plot label into the correct set of keyword arguments
-        if self.scatter:
-            scatter_kws["label"] = self.label
-        else:
-            line_kws["label"] = self.label
+        #if self.scatter:
+        scatter_kws["label"] = self.label
+        #else:
+        line_kws["label"] = self.label
 
         # Use the current color cycle state as a default
         if self.color is None:


### PR DESCRIPTION
Here's a small fix:
The `_univariate_kdeplot` function doesn't set the shade label, which causes problems down the line when using labels for automated grouping. An example of such a problem is provided in [this notebook](http://nbviewer.ipython.org/urls/dl.dropbox.com/s/28s4ip4g63opmqi/Issue-seaborn-mpld3-legend.ipynb?dl=0). 
It uses `mpld3` (latest development version) to create an interactive legend, which toggles the transparency of plot elements by clicking on the corresponding legend item. The function `connect_sns` in the notebook relies on labels to connect plot elements to legend items, and clearly does something strange since the shade does not have a label.
