### PR TITLE
Redirect matplotlib config directory to avoid issues with easy install sanboxing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,11 @@
 #! /usr/bin/env python
 #
 # Copyright (C) 2012-2014 Michael Waskom <mwaskom@stanford.edu>
+import os
+# temporarily redirect config directory to prevent matplotlib importing
+# testing that for writeable directory which results in sandbox error in
+# certain easy_install versions
+os.environ["MPLCONFIGDIR"] = "."
 
 DESCRIPTION = "Seaborn: statistical data visualization"
 LONG_DESCRIPTION = """\


### PR DESCRIPTION
Importing matplotlib at install time leads to the following error for me:

```
Getting distribution for 'seaborn==0.5.1'.
error: SandboxViolation: os.open('/Users/dimazest/.matplotlib/tmpovybswqd', 2818, 384) {}

The package setup script has attempted to modify files on your system
that are not within the EasyInstall build area, and has been aborted.

This package cannot be safely installed by EasyInstall, and may not
support alternate installation locations even if you run its setup
script by hand.  Please inform the package's author and the EasyInstall
maintainers to find out if a fix or workaround is available.
An error occurred when trying to install seaborn 0.5.1. Look above this message for any errors that were output by easy_install.
While:
  Updating fowler.corpora.
  Getting distribution for 'seaborn==0.5.1'.
Error: Couldn't install: seaborn 0.5.1
```

this fix is borrowed from https://code.google.com/p/mplh5canvas/source/diff?spec=svn32&r=32&format=side&path=/trunk/setup.py&old_path=/trunk/setup.py&old=29
