### PR TITLE
stop _freedman_diaconis_bins returning inf

### DIFF
--- a/seaborn/distributions.py
+++ b/seaborn/distributions.py
@@ -471,7 +471,11 @@ def _freedman_diaconis_bins(a):
     # From http://stats.stackexchange.com/questions/798/
     a = np.asarray(a)
     h = 2 * iqr(a) / (len(a) ** (1 / 3))
-    return np.ceil((a.max() - a.min()) / h)
+    # fall back to 10 bins if iqr is 0
+    if h == 0:
+        return 10.
+    else:
+        return np.ceil((a.max() - a.min()) / h)
 
 
 def distplot(a, bins=None, hist=True, kde=True, rug=False, fit=None,


### PR DESCRIPTION
This stops _freedman_diaconis_bins from returning inf when iqr of the data returns 0

see https://github.com/mwaskom/seaborn/issues/402 for details

Not sure if this is the best solution, I am definitely open to suggestions.
It does however stop seaborn from exploding ;-)
