### PR TITLE
fixing issue where setting vmin/vmax affects row/col_colors

### DIFF
--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -771,6 +771,8 @@ class ClusterGrid(Grid):
         kws = kws.copy()
         kws.pop('cmap', None)
         kws.pop('center', None)
+        kws.pop('vmin', None)
+        kws.pop('vmax', None)
         if self.row_colors is not None:
             matrix, cmap = self.color_list_to_matrix_and_cmap(
                 self.row_colors, yind, axis=0)


### PR DESCRIPTION
When setting vmin/vmax and row/col_colors in clustermap, the row/col_colors are affected (I set vmax=0.5 here):
![ipython](https://cloud.githubusercontent.com/assets/381464/5688560/9285c622-980d-11e4-983f-12a668c42796.png)

This pull request should fix that.