### PR TITLE
Fix bug in Grid legends

### DIFF
--- a/doc/releases/v0.6.0.txt
+++ b/doc/releases/v0.6.0.txt
@@ -18,6 +18,8 @@ This is a major release from 0.5. The main objective of this release is to unify
 
 - Added the ``line_kws`` parameter to :func:`residplot` to change the style of the lowess line, when used.
 
+- Added open-ended ``**kwargs`` to the ``add_legend`` method on :class:`FacetGrid` and :class:`PairGrid`, which will pass additional keyword arguments through when calling the legend function on the ``Figure`` or ``Axes``.
+
 - Added a catch in :func:`distplot` when calculating a default number of bins. For highly skewed data it will now use 10 bins, where previously the reference rule would return "infinite" bins and cause an exception in matplotlib.
 
 - Fixed a bug in :class:`FacetGrid` and :class:`PairGrid` that lead to incorrect legend labels when levels of the ``hue`` variable appeared in ``hue_order`` but not in the data.

--- a/doc/releases/v0.6.0.txt
+++ b/doc/releases/v0.6.0.txt
@@ -20,3 +20,4 @@ This is a major release from 0.5. The main objective of this release is to unify
 
 - Added a catch in :func:`distplot` when calculating a default number of bins. For highly skewed data it will now use 10 bins, where previously the reference rule would return "infinite" bins and cause an exception in matplotlib.
 
+- Fixed a bug in :class:`FacetGrid` and :class:`PairGrid` that lead to incorrect legend labels when levels of the ``hue`` variable appeared in ``hue_order`` but not in the data.

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -27,10 +27,30 @@ class Grid(object):
         """Save the figure."""
         self.fig.savefig(*args, **kwargs)
 
-    # TODO use figure/axes legend methods
-    # TODO pass kwargs to legend functions
-    def add_legend(self, legend_data=None, title=None, label_order=None):
-        """Draw a legend, possibly resizing the figure."""
+    def add_legend(self, legend_data=None, title=None, label_order=None,
+                   **kwargs):
+        """Draw a legend, maybe placing it outside axes and resizing the figure.
+
+        Parameters
+        ----------
+        legend_data : dict, optional
+            Dictionary mapping label names to matplotlib artist handles. The
+            default reads from ``self._legend_data``.
+        title : string, optional
+            Title for the legend. The default reads from ``self._hue_var``.
+        label_order : list of labels, optional
+            The order that the legend entries should appear in. The default
+            reads from ``self.hue_names`` or sorts the keys in ``legend_data``.
+        kwargs : key, value pairings
+            Other keyword arguments are passed to the underlying legend methods
+            on the Figure or Axes object.
+
+        Returns
+        -------
+        self : Grid instance
+            Returns self for easy chaining.
+
+        """
         # Find the data for the legend
         legend_data = self._legend_data if legend_data is None else legend_data
         if label_order is None:
@@ -47,10 +67,13 @@ class Grid(object):
         except TypeError:  # labelsize is something like "large"
             title_size = mpl.rcParams["axes.labelsize"]
 
+        # Set default legend kwargs
+        kwargs.setdefault("scatterpoints", 1)
+
         if self._legend_out:
             # Draw a full-figure legend outside the grid
-            figlegend = plt.figlegend(handles, label_order, "center right",
-                                      scatterpoints=1)
+            figlegend = self.fig.legend(handles, label_order, "center right",
+                                        **kwargs)
             self._legend = figlegend
             figlegend.set_title(title)
 
@@ -82,13 +105,16 @@ class Grid(object):
 
         else:
             # Draw a legend in the first axis
-            leg = self.axes.flat[0].legend(handles, label_order, loc="best")
+            ax = self.axes.flat[0]
+            leg = ax.legend(handles, label_order, loc="best", **kwargs)
             leg.set_title(title)
 
             # Set the title size a roundabout way to maintain
             # compatability with matplotlib 1.1
             prop = mpl.font_manager.FontProperties(size=title_size)
             leg._legend_title_box._text.set_font_properties(prop)
+
+        return self
 
     def _clean_axis(self, ax):
         """Turn off axis labels and legend."""

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -27,6 +27,8 @@ class Grid(object):
         """Save the figure."""
         self.fig.savefig(*args, **kwargs)
 
+    # TODO use figure/axes legend methods
+    # TODO pass kwargs to legend functions
     def add_legend(self, legend_data=None, title=None, label_order=None):
         """Draw a legend, possibly resizing the figure."""
         # Find the data for the legend
@@ -36,8 +38,9 @@ class Grid(object):
                 label_order = np.sort(list(legend_data.keys()))
             else:
                 label_order = list(map(str, self.hue_names))
-        handles = [legend_data[l] for l in label_order if l in legend_data]
-        labels = [l for l in label_order if l in legend_data]
+
+        blank_handle = mpl.patches.Patch(alpha=0, linewidth=0)
+        handles = [legend_data.get(l, blank_handle) for l in label_order]
         title = self._hue_var if title is None else title
         try:
             title_size = mpl.rcParams["axes.labelsize"] * .85
@@ -46,7 +49,7 @@ class Grid(object):
 
         if self._legend_out:
             # Draw a full-figure legend outside the grid
-            figlegend = plt.figlegend(handles, labels, "center right",
+            figlegend = plt.figlegend(handles, label_order, "center right",
                                       scatterpoints=1)
             self._legend = figlegend
             figlegend.set_title(title)
@@ -79,7 +82,7 @@ class Grid(object):
 
         else:
             # Draw a legend in the first axis
-            leg = self.axes.flat[0].legend(handles, labels, loc="best")
+            leg = self.axes.flat[0].legend(handles, label_order, loc="best")
             leg.set_title(title)
 
             # Set the title size a roundabout way to maintain

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -37,6 +37,7 @@ class Grid(object):
             else:
                 label_order = list(map(str, self.hue_names))
         handles = [legend_data[l] for l in label_order if l in legend_data]
+        labels = [l for l in label_order if l in legend_data]
         title = self._hue_var if title is None else title
         try:
             title_size = mpl.rcParams["axes.labelsize"] * .85
@@ -45,7 +46,7 @@ class Grid(object):
 
         if self._legend_out:
             # Draw a full-figure legend outside the grid
-            figlegend = plt.figlegend(handles, label_order, "center right",
+            figlegend = plt.figlegend(handles, labels, "center right",
                                       scatterpoints=1)
             self._legend = figlegend
             figlegend.set_title(title)
@@ -78,7 +79,7 @@ class Grid(object):
 
         else:
             # Draw a legend in the first axis
-            leg = self.axes.flat[0].legend(handles, label_order, loc="best")
+            leg = self.axes.flat[0].legend(handles, labels, loc="best")
             leg.set_title(title)
 
             # Set the title size a roundabout way to maintain

--- a/seaborn/distributions.py
+++ b/seaborn/distributions.py
@@ -1271,7 +1271,7 @@ boxplot.__doc__ = dedent("""\
         >>> g = sns.FacetGrid(tips, col="time", size=4, aspect=.7)
         >>> (g.map(sns.boxplot, "sex", "total_bill", "smoker")
         ...   .despine(left=True)
-        ...   .add_legend(title="smoker"))
+        ...   .add_legend(title="smoker"));
 
     """).format(**_boxplot_docs)
 
@@ -1464,7 +1464,7 @@ violinplot.__doc__ = dedent("""\
         >>> g = sns.FacetGrid(tips, col="time", size=4, aspect=.7)
         >>> (g.map(sns.violinplot, "sex", "total_bill", "smoker", split=True)
         ...   .despine(left=True)
-        ...   .add_legend(title="smoker"))
+        ...   .add_legend(title="smoker"));
 
     """).format(**_boxplot_docs)
 

--- a/seaborn/distributions.py
+++ b/seaborn/distributions.py
@@ -1271,7 +1271,8 @@ boxplot.__doc__ = dedent("""\
         >>> g = sns.FacetGrid(tips, col="time", size=4, aspect=.7)
         >>> (g.map(sns.boxplot, "sex", "total_bill", "smoker")
         ...   .despine(left=True)
-        ...   .add_legend(title="smoker"));
+        ...   .add_legend(title="smoker"))  #doctest: +ELLIPSIS
+        <seaborn.axisgrid.FacetGrid object at 0x...>
 
     """).format(**_boxplot_docs)
 
@@ -1464,7 +1465,8 @@ violinplot.__doc__ = dedent("""\
         >>> g = sns.FacetGrid(tips, col="time", size=4, aspect=.7)
         >>> (g.map(sns.violinplot, "sex", "total_bill", "smoker", split=True)
         ...   .despine(left=True)
-        ...   .add_legend(title="smoker"));
+        ...   .add_legend(title="smoker"))  # doctest: +ELLIPSIS
+        <seaborn.axisgrid.FacetGrid object at 0x...>
 
     """).format(**_boxplot_docs)
 

--- a/seaborn/tests/test_axisgrid.py
+++ b/seaborn/tests/test_axisgrid.py
@@ -207,9 +207,9 @@ class TestFacetGrid(object):
             nt.assert_equal(line.get_color(), hue)
 
         labels = g1._legend.get_texts()
-        nt.assert_equal(len(labels), len(a_levels))
+        nt.assert_equal(len(labels), 4)
 
-        for label, level in zip(labels, a_levels):
+        for label, level in zip(labels, list("azbc")):
             nt.assert_equal(label.get_text(), level)
 
         plt.close("all")

--- a/seaborn/tests/test_axisgrid.py
+++ b/seaborn/tests/test_axisgrid.py
@@ -187,6 +187,33 @@ class TestFacetGrid(object):
 
         plt.close("all")
 
+    def test_legend_data_missing_level(self):
+
+        g1 = ag.FacetGrid(self.df, hue="a", hue_order=list("azbc"))
+        g1.map(plt.plot, "x", "y")
+        g1.add_legend()
+
+        b, g, r, p = color_palette(n_colors=4)
+        palette = [b, r, p]
+
+        nt.assert_equal(g1._legend.get_title().get_text(), "a")
+
+        a_levels = sorted(self.df.a.unique())
+
+        lines = g1._legend.get_lines()
+        nt.assert_equal(len(lines), len(a_levels))
+
+        for line, hue in zip(lines, palette):
+            nt.assert_equal(line.get_color(), hue)
+
+        labels = g1._legend.get_texts()
+        nt.assert_equal(len(labels), len(a_levels))
+
+        for label, level in zip(labels, a_levels):
+            nt.assert_equal(label.get_text(), level)
+
+        plt.close("all")
+
     def test_get_boolean_legend_data(self):
 
         self.df["b_bool"] = self.df.b == "m"


### PR DESCRIPTION
Previously, `add_legend` was passing a list of handles for the plots that had been drawn and the list of all hue levels to the matplotlib legend code. Because matplotlib just zipped these and didn't raise
when they were of differenet lengths, this meant that sometimes the right colors but wrong labels were used.

This isn't globablly optimal, because I think the behavior we want is to show the hue levels that could have existed in the plot (because they are in `hue_order` but don't, because they weren't in the DataFrame.

However, doing that is a bit tricky because we'll have to make a proxy artist, you can't just pass `None` or something similar as a handle.

This fixes the bug identified in https://github.com/mwaskom/seaborn/issues/361#issuecomment-71140105. @shoyer, this does make the labels correct, but doesn't address the broader point that all levels of the variable should show up in the legend even when they're not in the plot data. Opening now but holding off on merge until I can think a little bit about what could be done to get a "full legend".

Thanks for the complete test case :+1:

```
import pandas as pd
import numpy as np
import seaborn as sns
import matplotlib.pyplot as plt

def cut_diverging(array, n=9):
    mag = max(-array.min(), array.max())
    return pd.cut(array, np.linspace(-mag, mag, num=(n + 1)))

rs = np.random.RandomState(0)
df = pd.DataFrame({'x': rs.rand(100),
                   'y': rs.rand(100),
                   'z': 1 + rs.randn(100)})
df['z_cat'] = cut_diverging(df.z, 9)

categories = df.z_cat.cat.categories
palette = sns.color_palette('RdBu_r', 9)

g = sns.FacetGrid(df, hue='z_cat', hue_order=categories,
                  palette=palette, aspect=1.3, size=3)
g.map(plt.scatter, 'x', 'y', s=50)
g.add_legend()
```
![shoyer](https://cloud.githubusercontent.com/assets/315810/5869340/8bed01ae-a26c-11e4-89d8-5bfa936d6202.png)
