### PR TITLE
Changed what qualifies as a 'numeric' type in PairGrid

### DIFF
--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -1082,15 +1082,13 @@ class PairGrid(Grid):
 
     def _find_numeric_cols(self, data):
         """Find which variables in a DataFrame are numeric."""
-        # This can't be the best way to do this, but  I do not
-        # know what the best way might be, so this seems ok
+        # This marks int, unsigned int, float and complex
+        # as numeric types. Booleans are not numeric anymore
         numeric_cols = []
         for col in data:
-            try:
-                data[col].astype(np.float)
+            if col.dtype.kind in "iufc":
                 numeric_cols.append(col)
-            except (ValueError, TypeError):
-                pass
+                
         return numeric_cols
 
 

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -1085,9 +1085,9 @@ class PairGrid(Grid):
         # This marks int, unsigned int, float and complex
         # as numeric types. Booleans are not numeric anymore
         numeric_cols = []
-        for col in data:
-            if col.dtype.kind in "iufc":
-                numeric_cols.append(col)
+        for name,col_type in zip(data.columns, data.dtypes):
+            if col_type.kind in "iufc":
+                numeric_cols.append(name)
                 
         return numeric_cols
 


### PR DESCRIPTION
Instead of classing everything which can be converted
to a float as 'numeric' we now check the dtype.kind
attribute.

int, unsigned int, float and complex are numeric, but
bool has stopped being classed as numeric type.

Try out the following:
```
df = pd.DataFrame(dict(A=np.arange(3),
                       B=np.random.randn(3),
                       C=['foo','bar','bah'],
                       D=pd.Timestamp('20130101'),
                       E=[False, True, False]
                       ))
for (name,col) in df.iteritems():
    print name, col.dtype.kind,
    try:
        col.astype(np.float)
        print "numeric"
    except:
        print "not numeric"
```

With the old definition this prints:
```
A i numeric
B f numeric
C O not numeric
D M not numeric
E b numeric```
```

I am not sure if a bool should be a numeric or not. I propose this change as I often use bools to specify a category and then have to specify all columns by hand because `sns.pairplot(dataframe, hue="boolean_col")` classes the column boolean_col as numeric and will an extra row/col to the pair grid for that variable.

Maybe the better fix would be to remove the variable used for `hue` from the list of columns used in the pair plot?

I can not decide if I think a boolean should be numeric or not. In the case of `pairplot()` it seems you would not expect it to be "numeric" though.

Thoughts?