### PR TITLE
Fix clustermap annotation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
   - conda install --yes --file testing/deps_${DEPS}_${PYTHON}.txt
   #- pip install sphinx numpydoc sphinx_bootstrap_theme runipy
   #- sudo apt-get install pandoc
-  - pip install pep8
+  - pip install pep8==1.5.7
   - pip install https://github.com/dcramer/pyflakes/tarball/master  
   - pip install .
   - cp testing/matplotlibrc .

--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -923,10 +923,13 @@ def clustermap(data, pivot_kws=None, method='average', metric='euclidean',
     {row,col}_linkage : numpy.array, optional
         Precomputed linkage matrix for the rows or columns. See
         scipy.cluster.hierarchy.linkage for specific formats.
-    {row,col}_colors : list-like, optional
+    {row,col}_colors : list-like or DataFrame, optional
         List of colors to label for either the rows or columns. Useful to
         evaluate whether samples within a group are clustered together. Can
-        use nested lists for multiple color levels of labeling.
+        use nested lists for multiple color levels of labeling. Colors can
+        also be provided as a pandas DataFrame, of which each column specifies
+        an entry for the corresponding side color. The column labels of the
+        DataFrame are used to label the colors.
     {row,col}_colors_ratio: float, optional
         A float value indicating the relative proportion of the axes that
         should be used for plotting the {row,col}_colors.

--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -514,7 +514,7 @@ def dendrogram(data, linkage=None, axis=1, label=True, metric='euclidean',
 class ClusterGrid(Grid):
     def __init__(self, data, pivot_kws=None, z_score=None, standard_scale=None,
                  figsize=None, row_colors=None, col_colors=None,
-                 row_cluster=True, col_cluster=True, 
+                 row_cluster=True, col_cluster=True,
                  row_colors_ratio=0.05, col_colors_ratio=0.05):
         """Grid object for organizing clustered heatmap input on to axes"""
 
@@ -539,15 +539,15 @@ class ClusterGrid(Grid):
         self.col_colors = col_colors
 
         # Setup axes for current configuration.
-        axes = self.setup_axes(self.fig, figsize, 
+        axes = self.setup_axes(self.fig, figsize,
                                row_colors, col_colors,
                                row_cluster, col_cluster,
                                col_colors_ratio=col_colors_ratio,
                                row_colors_ratio=row_colors_ratio)
 
         self.ax_row_dendrogram, self.ax_col_dendrogram, \
-        self.ax_row_colors, self.ax_col_colors, \
-        self.ax_heatmap, self.cax = axes
+            self.ax_row_colors, self.ax_col_colors, \
+            self.ax_heatmap, self.cax = axes
 
         self.dendrogram_row = None
         self.dendrogram_col = None
@@ -643,10 +643,9 @@ class ClusterGrid(Grid):
         else:
             return standardized.T
 
-
-    def setup_axes(self, fig, figsize, 
+    def setup_axes(self, fig, figsize,
                    row_colors, col_colors,
-                   row_cluster, col_cluster, 
+                   row_cluster, col_cluster,
                    row_colors_ratio, col_colors_ratio):
         """Setup the different axes that make up the ClusterGrid.
            Axes that are not required under the passed arguments,
@@ -696,7 +695,7 @@ class ClusterGrid(Grid):
         ax_cbar = fig.add_subplot(gs[nrows - 1, ncols - 1])
 
         return ax_row_dendrogram, ax_col_dendrogram, \
-               ax_row_colors, ax_col_colors, ax_heatmap, ax_cbar
+            ax_row_colors, ax_col_colors, ax_heatmap, ax_cbar
 
     def _ax_index_dendrogram(self, side_colors, cluster):
         """Calculate index of dendrogram axis, depending on presence
@@ -722,7 +721,7 @@ class ClusterGrid(Grid):
 
         # Add room for the colors
         if side_colors is not None:
-           ratios.append(side_colors_ratio)
+            ratios.append(side_colors_ratio)
 
         # Add the ratio for the heatmap itself.
         ratios.append(0.8)
@@ -761,7 +760,7 @@ class ClusterGrid(Grid):
         # check for nested lists/color palettes.
         # Will fail if matplotlib color is list not tuple
         if isinstance(colors, pd.DataFrame):
-            colors = colors.values 
+            colors = colors.values
             all_colors = set(itertools.chain(*colors))
             n, m = colors.shape
         elif any(issubclass(type(x), list) for x in colors):
@@ -800,13 +799,13 @@ class ClusterGrid(Grid):
             self.dendrogram_row = dendrogram(
                 self.data2d, metric=metric, method=method, label=False, axis=0,
                 ax=self.ax_row_dendrogram, rotate=True, linkage=row_linkage)
-        
+
         # Plot the column dendrogram
         if col_cluster:
             self.dendrogram_col = dendrogram(
                 self.data2d, metric=metric, method=method, label=False,
                 axis=1, ax=self.ax_col_dendrogram, linkage=col_linkage)
-        
+
         despine(ax=self.ax_row_dendrogram, bottom=True, left=True)
         despine(ax=self.ax_col_dendrogram, bottom=True, left=True)
 
@@ -833,7 +832,7 @@ class ClusterGrid(Grid):
                     xticklabels=False, yticklabels=False,
                     **kws)
 
-            if isinstance(self.row_colors, pd.DataFrame): 
+            if isinstance(self.row_colors, pd.DataFrame):
                 self.ax_row_colors.xaxis.tick_top()
                 self.ax_row_colors.set_xticklabels(self.row_colors.index[::-1],
                                                    rotation=90)
@@ -846,7 +845,7 @@ class ClusterGrid(Grid):
             heatmap(matrix, cmap=cmap, cbar=False, ax=self.ax_col_colors,
                     xticklabels=False, yticklabels=False, **kws)
 
-            if isinstance(self.col_colors, pd.DataFrame): 
+            if isinstance(self.col_colors, pd.DataFrame):
                 self.ax_col_colors.set_yticklabels(self.col_colors.index[::-1])
                 self.ax_col_colors.yaxis.tick_right()
         else:
@@ -882,7 +881,7 @@ def clustermap(data, pivot_kws=None, method='average', metric='euclidean',
                z_score=None, standard_scale=None, figsize=None, cbar_kws=None,
                row_cluster=True, col_cluster=True,
                row_linkage=None, col_linkage=None,
-               row_colors=None, col_colors=None, 
+               row_colors=None, col_colors=None,
                row_colors_ratio=0.05, col_colors_ratio=0.05,
                mask=None, **kwargs):
     """Plot a hierarchically clustered heatmap of a pandas DataFrame
@@ -951,7 +950,7 @@ def clustermap(data, pivot_kws=None, method='average', metric='euclidean',
     """
     plotter = ClusterGrid(data, pivot_kws=pivot_kws, figsize=figsize,
                           row_colors=row_colors, col_colors=col_colors,
-                          row_colors_ratio=row_colors_ratio, 
+                          row_colors_ratio=row_colors_ratio,
                           col_colors_ratio=col_colors_ratio,
                           row_cluster=row_cluster, col_cluster=col_cluster,
                           z_score=z_score, standard_scale=standard_scale)

--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -706,7 +706,8 @@ class ClusterGrid(Grid):
             index += 1
         return index
 
-    def dim_ratios(self, side_colors, dendrogram, axis, figsize, side_colors_ratio):
+    def dim_ratios(self, side_colors, dendrogram, axis,
+                   figsize, side_colors_ratio):
         """Get the proportions of the figure taken up by each axis
         """
 

--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -47,7 +47,8 @@ def _convert_colors(colors):
 def _convert_colors_frame(colors):
     if isinstance(colors, pd.DataFrame):
         converted = {col: _convert_colors(colors[col]) for col in colors}
-        return pd.DataFrame(converted, index=colors.index)
+        converted_frame = pd.DataFrame(converted, index=colors.index)
+        return converted_frame[colors.columns]
     else:
         return _convert_colors(colors)
 

--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -46,8 +46,8 @@ def _convert_colors(colors):
 
 def _convert_colors_frame(colors):
     if isinstance(colors, pd.DataFrame):
-        converted = _convert_colors(colors.values)
-        return pd.DataFrame(colors, index=colors.index, columns=colors.columns)
+        converted = {col: _convert_colors(colors[col]) for col in colors}
+        return pd.DataFrame(converted, index=colors.index)
     else:
         return _convert_colors(colors)
 
@@ -836,7 +836,7 @@ class ClusterGrid(Grid):
             if isinstance(self.row_colors, pd.DataFrame):
                 self.ax_row_colors.xaxis.tick_top()
                 self.ax_row_colors.set_xticklabels(
-                    self.row_colors.columns[::-1], rotation=90)
+                    self.row_colors.columns, rotation=90)
         else:
             despine(self.ax_row_colors, left=True, bottom=True)
 

--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -549,9 +549,6 @@ class ClusterGrid(Grid):
         self.ax_row_colors, self.ax_col_colors, \
         self.ax_heatmap, self.cax = axes
 
-        # colorbar for scale to left corner
-        # self.cax = self.fig.add_subplot(self.gs[0, 0])
-
         self.dendrogram_row = None
         self.dendrogram_col = None
 
@@ -733,13 +730,6 @@ class ClusterGrid(Grid):
         # Add the colorbar
         if axis == 1:
             ratios += [0.05, 0.02]
-
-        #colorbar_width = .8 * dendrogram
-        #colorbar_height = .2 * dendrogram
-        #if axis == 0:
-        #    ratios = [colorbar_width, colorbar_height]
-        #else:
-        #    ratios = [colorbar_height, colorbar_width]
 
         return ratios
 

--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -643,6 +643,11 @@ class ClusterGrid(Grid):
                    row_colors, col_colors,
                    row_cluster, col_cluster, 
                    row_colors_ratio, col_colors_ratio):
+        """Setup the different axes that make up the ClusterGrid.
+           Axes that are not required under the passed arguments,
+           (missing side_colors or disabled dendrograms for example)
+           are ommitted and returned empty (as None).
+        """
         width_ratios = self.dim_ratios(row_colors, row_cluster,
                                        figsize=figsize, axis=1,
                                        side_colors_ratio=row_colors_ratio)
@@ -689,13 +694,16 @@ class ClusterGrid(Grid):
                ax_row_colors, ax_col_colors, ax_heatmap, ax_cbar
 
     def _ax_index_dendrogram(self, side_colors, cluster):
+        """Calculate index of dendrogram axis, depending on presence
+           of side_colors and/or dendrogram on the OTHER axis.
+        """
         index = 1 if cluster else 0
         if side_colors is not None:
             index += 1
         return index
 
     def dim_ratios(self, side_colors, dendrogram, axis, figsize, side_colors_ratio):
-        """Get the proportions of the figure taken up by each axes
+        """Get the proportions of the figure taken up by each axis
         """
 
         ratios = []

--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -761,7 +761,7 @@ class ClusterGrid(Grid):
         # check for nested lists/color palettes.
         # Will fail if matplotlib color is list not tuple
         if isinstance(colors, pd.DataFrame):
-            colors = colors.values
+            colors = colors.T.values
             all_colors = set(itertools.chain(*colors))
             n, m = colors.shape
         elif any(issubclass(type(x), list) for x in colors):
@@ -835,8 +835,8 @@ class ClusterGrid(Grid):
 
             if isinstance(self.row_colors, pd.DataFrame):
                 self.ax_row_colors.xaxis.tick_top()
-                self.ax_row_colors.set_xticklabels(self.row_colors.index[::-1],
-                                                   rotation=90)
+                self.ax_row_colors.set_xticklabels(
+                    self.row_colors.columns[::-1], rotation=90)
         else:
             despine(self.ax_row_colors, left=True, bottom=True)
 
@@ -847,7 +847,8 @@ class ClusterGrid(Grid):
                     xticklabels=False, yticklabels=False, **kws)
 
             if isinstance(self.col_colors, pd.DataFrame):
-                self.ax_col_colors.set_yticklabels(self.col_colors.index[::-1])
+                self.ax_col_colors.set_yticklabels(
+                    self.col_colors.columns[::-1])
                 self.ax_col_colors.yaxis.tick_right()
         else:
             despine(self.ax_col_colors, left=True, bottom=True)
@@ -926,6 +927,9 @@ def clustermap(data, pivot_kws=None, method='average', metric='euclidean',
         List of colors to label for either the rows or columns. Useful to
         evaluate whether samples within a group are clustered together. Can
         use nested lists for multiple color levels of labeling.
+    {row,col}_colors_ratio: float, optional
+        A float value indicating the relative proportion of the axes that
+        should be used for plotting the {row,col}_colors.
     mask : boolean numpy.array, optional
         A boolean array indicating where to mask the data so it is not
         plotted on the heatmap. Only used for visualizing, not for calculating.

--- a/seaborn/tests/test_matrix.py
+++ b/seaborn/tests/test_matrix.py
@@ -779,13 +779,9 @@ class TestClustermap(object):
         kws['col_cluster'] = False
 
         cm = mat.clustermap(self.df_norm, **kws)
-        nt.assert_equal(len(cm.ax_row_dendrogram.lines), 0)
-        nt.assert_equal(len(cm.ax_col_dendrogram.lines), 0)
 
-        nt.assert_equal(len(cm.ax_row_dendrogram.get_xticks()), 0)
-        nt.assert_equal(len(cm.ax_row_dendrogram.get_yticks()), 0)
-        nt.assert_equal(len(cm.ax_col_dendrogram.get_xticks()), 0)
-        nt.assert_equal(len(cm.ax_col_dendrogram.get_yticks()), 0)
+        nt.assert_is_none(cm.ax_row_dendrogram)
+        nt.assert_is_none(cm.ax_col_dendrogram)
 
         pdt.assert_frame_equal(cm.data2d, self.df_norm)
         plt.close('all')
@@ -810,13 +806,9 @@ class TestClustermap(object):
         kws['col_colors'] = self.col_colors
 
         cm = mat.clustermap(self.df_norm, **kws)
-        nt.assert_equal(len(cm.ax_row_dendrogram.lines), 0)
-        nt.assert_equal(len(cm.ax_col_dendrogram.lines), 0)
-
-        nt.assert_equal(len(cm.ax_row_dendrogram.get_xticks()), 0)
-        nt.assert_equal(len(cm.ax_row_dendrogram.get_yticks()), 0)
-        nt.assert_equal(len(cm.ax_col_dendrogram.get_xticks()), 0)
-        nt.assert_equal(len(cm.ax_col_dendrogram.get_yticks()), 0)
+        nt.assert_is_none(cm.ax_row_dendrogram)
+        nt.assert_is_none(cm.ax_col_dendrogram)
+        
         nt.assert_equal(len(cm.ax_row_colors.collections), 1)
         nt.assert_equal(len(cm.ax_col_colors.collections), 1)
 

--- a/seaborn/tests/test_matrix.py
+++ b/seaborn/tests/test_matrix.py
@@ -808,7 +808,7 @@ class TestClustermap(object):
         cm = mat.clustermap(self.df_norm, **kws)
         nt.assert_is_none(cm.ax_row_dendrogram)
         nt.assert_is_none(cm.ax_col_dendrogram)
-        
+
         nt.assert_equal(len(cm.ax_row_colors.collections), 1)
         nt.assert_equal(len(cm.ax_col_colors.collections), 1)
 

--- a/seaborn/tests/test_matrix.py
+++ b/seaborn/tests/test_matrix.py
@@ -4,6 +4,7 @@ import tempfile
 import numpy as np
 import matplotlib as mpl
 import matplotlib.pyplot as plt
+from matplotlib.colors import rgb2hex
 import pandas as pd
 from scipy.spatial import distance
 from scipy.cluster import hierarchy
@@ -795,6 +796,31 @@ class TestClustermap(object):
 
         nt.assert_equal(len(cm.ax_row_colors.collections), 1)
         nt.assert_equal(len(cm.ax_col_colors.collections), 1)
+
+        plt.close('all')
+
+    def test_row_col_colors_df(self):
+        kws = self.default_kws.copy()
+
+        kws['row_colors'] = pd.DataFrame(
+            [rgb2hex(c) for c in self.row_colors], columns=['row_label'])
+        kws['col_colors'] = pd.DataFrame(
+            [rgb2hex(c) for c in self.col_colors], columns=['col_label'])
+
+        cm = mat.clustermap(self.df_norm, **kws)
+
+        nt.assert_equal(len(cm.ax_row_colors.collections), 1)
+        nt.assert_equal(len(cm.ax_col_colors.collections), 1)
+
+        # Test labels of row_colors.
+        tick_labels = cm.ax_row_colors.get_xticklabels()
+        nt.assert_equal(len(tick_labels), 1)
+        nt.assert_equal(tick_labels[0].get_text(), 'row_label')
+
+        # Test labels of col_colors.
+        tick_labels = cm.ax_col_colors.get_yticklabels()
+        nt.assert_equal(len(tick_labels), 1)
+        nt.assert_equal(tick_labels[0].get_text(), 'col_label')
 
         plt.close('all')
 


### PR DESCRIPTION
I added some changes to the generation of the clustermap axes, which now avoids excessive whitespace if any of the two dendrograms are omitted. Additionally, I added to extra parameters to the clustermap function, col_colors_ratio and row_colors_ratio, which essentially sets a relative size for the side_color axes in the generation of the overall grid. I also added a small update to include annotation from the index of a passed dataframe containing side_colors for rows and/or columns.

See issue https://github.com/mwaskom/seaborn/issues/437 for more details.