### PR TITLE
Fix broken reference in dataset_exploration.ipynb

### DIFF
--- a/doc/tutorial/dataset_exploration.ipynb
+++ b/doc/tutorial/dataset_exploration.ipynb
@@ -156,7 +156,7 @@
      "cell_type": "raw",
      "metadata": {},
      "source": [
-      "Because the color is an encoding of the data, it's very important to use an appropriate colormap. (See the :link:`palette tutorial <palette_tutorial>` for more information about different kinds of color palettes and how to choose one that is appropriate for your data). :func:`heatmap` tries to choose good defaults for your data based off some heuristics about it. For example, if your dataset spans 0, it is assumed that a diverging colormap is more appropriate."
+      "Because the color is an encoding of the data, it's very important to use an appropriate colormap. (See the :ref:`palette tutorial <palette_tutorial>` for more information about different kinds of color palettes and how to choose one that is appropriate for your data). :func:`heatmap` tries to choose good defaults for your data based off some heuristics about it. For example, if your dataset spans 0, it is assumed that a diverging colormap is more appropriate."
      ]
     },
     {


### PR DESCRIPTION
Replaced `:link:` with `:ref:` in [tutorial/dataset_exploration](http://web.stanford.edu/~mwaskom/software/seaborn/tutorial/dataset_exploration.html)

Old | New
-----|-------
![Before](https://cloud.githubusercontent.com/assets/4936897/6145706/094e6926-b1e5-11e4-8b5f-aa9de9744773.png) | ![After](https://cloud.githubusercontent.com/assets/4936897/6145713/1b9864ce-b1e5-11e4-9311-070c9e458aa1.png)