### PR TITLE
Do not attempt ordering unless it's needed

### DIFF
--- a/seaborn/linearmodels.py
+++ b/seaborn/linearmodels.py
@@ -106,11 +106,16 @@ class _DiscretePlotter(_LinearPlotter):
         self.establish_variables(data, x=x, y=y, hue=hue, units=units)
 
         # Figure out the order of the variables on the x axis
-        x_sorted = np.sort(pd.unique(self.x))
-        self.x_order = x_sorted if x_order is None else x_order
+        self.x_order = x_order
+        if x_order is None:
+            self.x_order = np.sort(pd.unique(self.x))
+
+
         if self.hue is not None:
-            hue_sorted = np.sort(pd.unique(self.hue))
-            self.hue_order = hue_sorted if hue_order is None else hue_order
+            self.hue_order = hue_order
+            if hue_order is None:
+                self.hue_order = np.sort(pd.unique(self.hue))
+
         else:
             self.hue_order = [None]
 


### PR DESCRIPTION
Hi,

The point of this PR is to start a discussion rather than to introduce a change into the codebase.

I spotted an issue when mixing object types in a data frame. Here is an example:

```
df = pd.DataFrame({'name': [1] * 5 + ['b'] * 5 + ['c'] * 5,
                    'rep': [1,2,3,4,5,1,2,3,4,5,1,2,3,4,5],
                    'score' : [1,2,3,4,5,1,2,3,4,5,1,2,3,4,5]})
sns.factorplot(x='name', y='score', hue='rep', data=df, kind='bar');
```

This fails because the `name`s cannot be sorted- which  think is reasonable. However, the same call fails when providing an explicit ordering like so:

```
df = pd.DataFrame({'name': [1] * 5 + ['b'] * 5 + ['c'] * 5,
                    'rep': [1,2,3,4,5,1,2,3,4,5,1,2,3,4,5],
                    'score' : [1,2,3,4,5,1,2,3,4,5,1,2,3,4,5]})
xorder = 1, 'b', 'c'
sns.factorplot(x='name', y='score', hue='rep', data=df, kind='bar', x_order=xorder);
```

The problem seems to be that the unique values are sorted even though there isn't a need for that, as an explicit ordering is provided. I first tried to fixes the crash as shown in the diff. 

On second thought, this doesn't really resolve the underlying problem (`int` and `string` cannot be sorted).  Here is an example of why this PR isn't such a great idea:

```
df = pd.DataFrame({
    'name': ['a'] * 5 + ['b'] * 5 + ['c'] * 5,
    'rep': [1, 2, 3, 4, 'avg', 1, 2, 3, 4, 'avg', 1, 2, 3, 4, 'avg'],
    'score': [1, 2, 3, 4, 5, 1, 2, 3, 4, 5, 1, 2, 3, 4, 5]
})
order = 'avg', 4, 3, 2, 1
sns.factorplot(x='name', y='score', hue='rep',
               data=df, kind='bar', hue_order=order);
```
Note some bits are missing from the legend. I had a look and it seems this is because `matplotlib` converts all labels to str, so `_update_legend_data` in `axisgrid.py` builds the wrong dict (keys are of type `str`, but need to be `int` to match the ordering provided). 

I'm inclined to say the correct solution here is to document this behaviour and tell the user not to do what I've done, or to convert all names to string first.

![tmp](https://cloud.githubusercontent.com/assets/937114/6149372/53fbccbe-b200-11e4-8c0e-743b4ecc36eb.png)