### PR TITLE
Add gridspec_kws to FacetGrid

### DIFF
--- a/doc/tutorial/axis_grids.ipynb
+++ b/doc/tutorial/axis_grids.ipynb
@@ -17,7 +17,8 @@
    "pygments_lexer": "ipython2",
    "version": "2.7.9"
   },
-  "name": ""
+  "name": "",
+  "signature": "sha256:ffdf022dac85d5aaba2889be22ac97de8e6d2cd088de9d561bde24f4049cc126"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -209,6 +210,27 @@
      "metadata": {},
      "outputs": [],
      "prompt_number": null
+    },
+    {
+     "cell_type": "raw",
+     "metadata": {},
+     "source": [
+      "With versions of matplotlib > 1.4, you can pass parameters to be used in the `gridspec` module. The can be used to draw attention to a particular facet by increasing its size. It's particularly useful when visualizing distributions of datasets with unequal numbers of groups in each facet."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "titanic = sns.load_dataset(\"titanic\")\n",
+      "titanic = titanic.sort(\"deck\")\n",
+      "g = sns.FacetGrid(titanic, col=\"class\", sharex=False,\n",
+      "                  gridspec_kws={\"width_ratios\": [5, 3, 3]})\n",
+      "g.map(sns.boxplot, \"deck\", \"age\")"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
     },
     {
      "cell_type": "raw",

--- a/seaborn/tests/test_axisgrid.py
+++ b/seaborn/tests/test_axisgrid.py
@@ -1,3 +1,5 @@
+import warnings
+
 import numpy as np
 import pandas as pd
 from scipy import stats
@@ -259,6 +261,57 @@ class TestFacetGrid(object):
         for ax in g.axes.flat:
             nt.assert_equal(ax.get_axis_bgcolor(), "blue")
 
+    @skipif(old_matplotlib)
+    def test_gridspec_kws(self):
+        ratios = [3, 1, 2]
+        sizes = [0.46, 0.15, 0.31]
+
+        gskws = dict(width_ratios=ratios, height_ratios=ratios)
+        g = ag.FacetGrid(self.df, col='c', row='a', gridspec_kws=gskws)
+
+        # clear out all ticks
+        for ax in g.axes.flat:
+            ax.set_xticks([])
+            ax.set_yticks([])
+
+        g.fig.tight_layout()
+        widths, heights = np.meshgrid(sizes, sizes)
+        for n, ax in enumerate(g.axes.flat):
+            npt.assert_almost_equal(
+                ax.get_position().width,
+                widths.flatten()[n],
+                decimal=2
+            )
+            npt.assert_almost_equal(
+                ax.get_position().height,
+                heights.flatten()[n],
+                decimal=2
+            )
+
+    @skipif(old_matplotlib)
+    def test_gridspec_kws_col_wrap(self):
+        ratios = [3, 1, 2, 1, 1]
+        sizes = [0.46, 0.15, 0.31]
+
+        gskws = dict(width_ratios=ratios)
+        with warnings.catch_warnings():
+            warnings.resetwarnings()
+            warnings.simplefilter("always")
+            npt.assert_warns(UserWarning, ag.FacetGrid, self.df, col='d',
+                             col_wrap=5, gridspec_kws=gskws)
+
+    @skipif(not old_matplotlib)
+    def test_gridsic_kws_old_mpl(self):
+        ratios = [3, 1, 2]
+        sizes = [0.46, 0.15, 0.31]
+
+        gskws = dict(width_ratios=ratios, height_ratios=ratios)
+        with warnings.catch_warnings():
+            warnings.resetwarnings()
+            warnings.simplefilter("always")
+            npt.assert_warns(UserWarning, ag.FacetGrid, self.df, col='c',
+                             row='a', gridspec_kws=gskws)
+
     def test_data_generator(self):
 
         g = ag.FacetGrid(self.df, row="a")
@@ -432,7 +485,7 @@ class TestFacetGrid(object):
         npt.assert_array_equal(got_x, xlab)
         npt.assert_array_equal(got_y, ylab)
 
-    def test_subplot_kws(self):
+    def test_axis_lims(self):
 
         g = ag.FacetGrid(self.df, row="a", col="b", xlim=(0, 4), ylim=(-2, 3))
         nt.assert_equal(g.axes[0, 0].get_xlim(), (0, 4))


### PR DESCRIPTION
I force-pushed #436 and now I can't reopen that issue. 

Anyway, I thought about this some more and here's a stab at handling old versions of MPL and instances when `col_wrap` is used. the TODO list still applies:

- [x] testing
- [x] docstring
- [x] documentation
- [x] refine the warning messages
- [x] clear up PEP8/linting stuff

Here's a rough example:
```python
from io import StringIO

import pandas
import matplotlib.pyplot as plt
import seaborn


datafile = StringIO("""\
location,date,parameter,matrix,units,res
SHP-99-31C,2007-10-17 00:00:00,Iron,WG,ug/L,44000.0
SHP-99-31C,2007-10-17 00:00:00,Arsenic,WG,ug/L,292.1
SHP-99-31C,2009-10-01 00:00:00,Oxidation Reduction Potential,WG,mV,-84.0
SHP-99-31C,2009-10-01 00:00:00,pH,WG,SU,6.57
SHP-99-31C,2009-10-01 00:00:00,Arsenic,WG,ug/L,223.5
SHP-99-31C,2009-10-01 00:00:00,Iron,WG,ug/L,26000.0
SHP-99-31C,2010-10-13 00:00:00,Arsenic,WG,ug/L,239.4
SHP-99-31C,2010-10-13 00:00:00,Iron,WG,ug/L,22000.0
SHP-99-31C,2010-10-13 00:00:00,pH,WG,SU,6.46
SHP-99-31C,2010-10-13 00:00:00,Oxidation Reduction Potential,WG,mV,-80.0
SHP-99-31C,2011-10-05 00:00:00,Iron,WG,ug/L,22000.0
SHP-99-31C,2011-10-05 00:00:00,Arsenic,WG,ug/L,244.0
SHP-99-31C,2011-10-05 00:00:00,Oxidation Reduction Potential,WG,mV,-59.2
SHP-99-31C,2011-10-05 00:00:00,pH,WG,SU,6.5
SHP-99-31C,2012-10-18 00:00:00,Arsenic,WG,ug/L,206.4
SHP-99-31C,2012-10-18 00:00:00,Iron,WG,ug/L,17000.0
SHP-99-31C,2012-10-18 00:00:00,pH,WG,SU,6.75
SHP-99-31C,2012-10-18 00:00:00,Oxidation Reduction Potential,WG,mV,-117.1
SHP-99-31C,2013-10-23 00:00:00,Oxidation Reduction Potential,WG,mV,-95.7
SHP-99-31C,2013-10-23 00:00:00,pH,WG,SU,6.7
""")
df = pandas.read_csv(datafile, parse_dates=['date'])
seaborn.set_style('ticks')
fg = seaborn.FacetGrid(
    data=df, row='units', row_order=['ug/L', 'mV', 'SU'],
    hue='parameter', hue_kws={"marker": ["o", "s", '^', 'd']},
    sharey=False, size=2, aspect=4, margin_titles=True,
    gridspec_kws={'height_ratios': [3.5, 1, 1]}  # <---- right here
)
fg.map(plt.plot, 'date', 'res', linestyle='--', marker='o', clip_on=False)
fg.axes.flat[0].set_yscale('log')
fg.axes.flat[-1].set_ylim(bottom=4.75, top=9)
```
![test](https://cloud.githubusercontent.com/assets/1163939/5986026/39fb4776-a8a1-11e4-988a-38e9728249d1.png)