### PR TITLE
Use IPython 2.X for testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,11 @@ install:
     pip install pillow;
     fi
   - conda install --yes --file testing/deps_${DEPS}_${PYTHON}.txt
+  - conda install ipython-notebook=2 --yes
   #- pip install sphinx numpydoc sphinx_bootstrap_theme runipy
   #- sudo apt-get install pandoc
   - pip install pep8==1.5  # Later versions get stricter...
-  - pip install https://github.com/dcramer/pyflakes/tarball/master  
+  - pip install https://github.com/dcramer/pyflakes/tarball/master
   - pip install .
   - cp testing/matplotlibrc .
 


### PR DESCRIPTION
There seems to be problems with IPython 3 and the testing workflow right now.

https://github.com/mwaskom/seaborn/pull/462#issuecomment-77439356