### PR TITLE
Fix two FacetGrid problems

### DIFF
--- a/doc/releases/v0.6.0.txt
+++ b/doc/releases/v0.6.0.txt
@@ -57,3 +57,5 @@ Bug fixes
 ~~~~~~~~~
 
 - Fixed a bug in :class:`FacetGrid` and :class:`PairGrid` that lead to incorrect legend labels when levels of the ``hue`` variable appeared in ``hue_order`` but not in the data.
+
+- Fixed a bug in :meth:`FacetGrid.set_xticklabels` or :meth:`FacetGrid.set_yticklabels` when ``col_wrap`` is being used.

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -249,6 +249,9 @@ class FacetGrid(Grid):
 
         self._col_wrap = col_wrap
         if col_wrap is not None:
+            if row is not None:
+                err = "Cannot use `row` and `col_wrap` together."
+                raise ValueError(err)
             ncol = col_wrap
             nrow = int(np.ceil(len(data[col].unique()) / col_wrap))
         self._ncol = ncol

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -639,7 +639,7 @@ class FacetGrid(Grid):
 
     def set_xticklabels(self, labels=None, step=None, **kwargs):
         """Set x axis tick labels on the bottom row of the grid."""
-        for ax in self.axes[-1, :]:
+        for ax in self._bottom_axes:
             if labels is None:
                 labels = [l.get_text() for l in ax.get_xticklabels()]
                 if step is not None:
@@ -651,7 +651,7 @@ class FacetGrid(Grid):
 
     def set_yticklabels(self, labels=None, **kwargs):
         """Set y axis tick labels on the left column of the grid."""
-        for ax in self.axes[-1, :]:
+        for ax in self._left_axes:
             if labels is None:
                 labels = [l.get_text() for l in ax.get_yticklabels()]
             ax.set_yticklabels(labels, **kwargs)

--- a/seaborn/tests/test_axisgrid.py
+++ b/seaborn/tests/test_axisgrid.py
@@ -104,6 +104,9 @@ class TestFacetGrid(object):
         nt.assert_equal(g_wrap._ncol, 4)
         nt.assert_equal(g_wrap._nrow, 3)
 
+        with nt.assert_raises(ValueError):
+            g = ag.FacetGrid(self.df, row="b", col="d", col_wrap=4)
+
         plt.close("all")
 
     def test_normal_axes(self):

--- a/seaborn/tests/test_axisgrid.py
+++ b/seaborn/tests/test_axisgrid.py
@@ -489,6 +489,18 @@ class TestFacetGrid(object):
         got_x = [int(l.get_text()) for l in g.axes[0, 0].get_xticklabels()]
         npt.assert_array_equal(x[::2], got_x)
 
+        g = ag.FacetGrid(self.df, col="d", col_wrap=5)
+        g.map(plt.plot, "x", "y")
+        g.set_xticklabels(rotation=45)
+        g.set_yticklabels(rotation=75)
+        for ax in g._bottom_axes:
+            for l in ax.get_xticklabels():
+                nt.assert_equal(l.get_rotation(), 45)
+        for ax in g._left_axes:
+            for l in ax.get_yticklabels():
+                nt.assert_equal(l.get_rotation(), 75)
+        plt.close("all")
+
     def test_set_axis_labels(self):
 
         g = ag.FacetGrid(self.df, row="a", col="b")
@@ -502,6 +514,7 @@ class TestFacetGrid(object):
         got_y = [ax.get_ylabel() for ax in g.axes[:, 0]]
         npt.assert_array_equal(got_x, xlab)
         npt.assert_array_equal(got_y, ylab)
+        plt.close("all")
 
     def test_axis_lims(self):
 


### PR DESCRIPTION
Fix bug in accessing side marginal axes with `col_wrap`, closes #464
Raise a better error when `row` and `col_wrap` are used together, closes #465