### PR TITLE
Skip annotating masked values in heatmaps

### DIFF
--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -148,11 +148,12 @@ class _HeatMapper(object):
         xpos, ypos = np.meshgrid(ax.get_xticks(), ax.get_yticks())
         for x, y, val, color in zip(xpos.flat, ypos.flat,
                                     mesh.get_array(), mesh.get_facecolors()):
-            _, l, _ = colorsys.rgb_to_hls(*color[:3])
-            text_color = ".15" if l > .5 else "w"
-            val = ("{:" + self.fmt + "}").format(val)
-            ax.text(x, y, val, color=text_color,
-                    ha="center", va="center", **self.annot_kws)
+            if not val is np.ma.masked:
+                _, l, _ = colorsys.rgb_to_hls(*color[:3])
+                text_color = ".15" if l > .5 else "w"
+                val = ("{:" + self.fmt + "}").format(val)
+                ax.text(x, y, val, color=text_color,
+                        ha="center", va="center", **self.annot_kws)
 
     def plot(self, ax, cax, kws):
         """Draw the heatmap on the provided Axes."""

--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -148,7 +148,7 @@ class _HeatMapper(object):
         xpos, ypos = np.meshgrid(ax.get_xticks(), ax.get_yticks())
         for x, y, val, color in zip(xpos.flat, ypos.flat,
                                     mesh.get_array(), mesh.get_facecolors()):
-            if not val is np.ma.masked:
+            if val is not np.ma.masked:
                 _, l, _ = colorsys.rgb_to_hls(*color[:3])
                 text_color = ".15" if l > .5 else "w"
                 val = ("{:" + self.fmt + "}").format(val)

--- a/seaborn/tests/test_matrix.py
+++ b/seaborn/tests/test_matrix.py
@@ -215,7 +215,6 @@ class TestHeatmap(object):
                                 'c': [3, 3, np.nan]})
         mask = np.isnan(df.values)
         df_masked = np.ma.masked_where(mask, df)
-    
         ax = mat.heatmap(df, annot=True, fmt='.1f', mask=mask)
         nt.assert_equal(len(df_masked[::-1].compressed()), len(ax.texts))
         for val, text in zip(df_masked[::-1].compressed(), ax.texts):

--- a/seaborn/tests/test_matrix.py
+++ b/seaborn/tests/test_matrix.py
@@ -209,13 +209,13 @@ class TestHeatmap(object):
             nt.assert_equal(text.get_fontsize(), 14)
 
     def test_heatmap_annotation_with_mask(self):
-        
+
         df = pd.DataFrame(data={'a': [1, 1, 1],
                                 'b': [2, np.nan, 2],
                                 'c': [3, 3, np.nan]})
         mask = np.isnan(df.values)
         df_masked = np.ma.masked_where(mask, df)
-        
+    
         ax = mat.heatmap(df, annot=True, fmt='.1f', mask=mask)
         nt.assert_equal(len(df_masked[::-1].compressed()), len(ax.texts))
         for val, text in zip(df_masked[::-1].compressed(), ax.texts):

--- a/seaborn/tests/test_matrix.py
+++ b/seaborn/tests/test_matrix.py
@@ -216,7 +216,6 @@ class TestHeatmap(object):
         mask = np.isnan(df.values)
         df_masked = np.ma.masked_where(mask, df)
         ax = mat.heatmap(df, annot=True, fmt='.1f', mask=mask)
-        nt.assert_equal(len(df_masked[::-1].compressed()), len(ax.texts))
         for val, text in zip(df_masked[::-1].compressed(), ax.texts):
             nt.assert_equal("{:.1f}".format(val), text.get_text())
 

--- a/seaborn/tests/test_matrix.py
+++ b/seaborn/tests/test_matrix.py
@@ -208,6 +208,19 @@ class TestHeatmap(object):
             nt.assert_equal(text.get_text(), "{:.1f}".format(val))
             nt.assert_equal(text.get_fontsize(), 14)
 
+    def test_heatmap_annotation_with_mask(self):
+        
+        df = pd.DataFrame(data={'a': [1, 1, 1],
+                                'b': [2, np.nan, 2],
+                                'c': [3, 3, np.nan]})
+        mask = np.isnan(df.values)
+        df_masked = np.ma.masked_where(mask, df)
+        
+        ax = mat.heatmap(df, annot=True, fmt='.1f', mask=mask)
+        nt.assert_equal(len(df_masked[::-1].compressed()), len(ax.texts))
+        for val, text in zip(df_masked[::-1].compressed(), ax.texts):
+            nt.assert_equal("{:.1f}".format(val), text.get_text())
+
     def test_heatmap_cbar(self):
 
         f = plt.figure()

--- a/seaborn/tests/test_matrix.py
+++ b/seaborn/tests/test_matrix.py
@@ -207,6 +207,7 @@ class TestHeatmap(object):
         for val, text in zip(self.x_norm[::-1].flat, ax.texts):
             nt.assert_equal(text.get_text(), "{:.1f}".format(val))
             nt.assert_equal(text.get_fontsize(), 14)
+        plt.close("all")
 
     def test_heatmap_annotation_with_mask(self):
 

--- a/seaborn/tests/test_matrix.py
+++ b/seaborn/tests/test_matrix.py
@@ -216,8 +216,10 @@ class TestHeatmap(object):
         mask = np.isnan(df.values)
         df_masked = np.ma.masked_where(mask, df)
         ax = mat.heatmap(df, annot=True, fmt='.1f', mask=mask)
+        nt.assert_equal(len(df_masked[::-1].compressed()), len(ax.texts))
         for val, text in zip(df_masked[::-1].compressed(), ax.texts):
             nt.assert_equal("{:.1f}".format(val), text.get_text())
+        plt.close("all")
 
     def test_heatmap_cbar(self):
 


### PR DESCRIPTION
There is an issue with heatmap annotations when when there are masked values in the data. Formatting fails for these masked values. 
Discussed in #375.

http://nbviewer.ipython.org/github/JWarmenhoven/ipython_notebooks/blob/master/Seaborn_heatmap_issue.ipynb