### PR TITLE
Fix kwarg issue with plot_marginals

### DIFF
--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -1220,6 +1220,7 @@ class JointGrid(object):
             Returns `self`.
 
         """
+        kwargs["vertical"] = False
         plt.sca(self.ax_marg_x)
         func(self.x, **kwargs)
 


### PR DESCRIPTION
Current version requires that the user pass `vertical=False` for the plotting to work correctly.