### PR TITLE
Better handling of masks in heatmap and clustermap

### DIFF
--- a/doc/releases/v0.6.0.txt
+++ b/doc/releases/v0.6.0.txt
@@ -55,8 +55,12 @@ Other additions
 
 - Added a catch in :func:`distplot` when calculating a default number of bins. For highly skewed data it will now use 10 bins, where previously the reference rule would return "infinite" bins and cause an exception in matplotlib.
 
+- :func:`heatmap` and :func:`clustermap` now automatically use a mask for missing values, which previously were shown with the "under" value of the colormap per default `plt.pcolormesh` behavior.
+
 Bug fixes
 ~~~~~~~~~
+
+- Fixed a bug in :func:`clustermap` where the mask was not being reorganized using the dendrograms.
 
 - Fixed a bug in :class:`FacetGrid` and :class:`PairGrid` that lead to incorrect legend labels when levels of the ``hue`` variable appeared in ``hue_order`` but not in the data.
 

--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -795,8 +795,9 @@ class ClusterGrid(Grid):
             despine(self.ax_col_colors, left=True, bottom=True)
 
     def plot_matrix(self, colorbar_kws, mask, xind, yind, **kws):
-        self.data2d = self.data2d.iloc[yind, xind]
-        heatmap(self.data2d, ax=self.ax_heatmap, cbar_ax=self.cax,
+        data2d = self.data2d.iloc[yind, xind]
+        mask = np.asarray(mask, np.bool)[yind][:, xind]
+        heatmap(data2d, ax=self.ax_heatmap, cbar_ax=self.cax,
                 cbar_kws=colorbar_kws, mask=mask, **kws)
         self.ax_heatmap.yaxis.set_ticks_position('right')
         self.ax_heatmap.yaxis.set_label_position('right')

--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -44,6 +44,43 @@ def _convert_colors(colors):
         return [list(map(to_rgb, l)) for l in colors]
 
 
+def _matrix_mask(data, mask):
+    """Ensure that data and mask are compatabile and add missing values.
+
+    Values will be plotted for cells where ``mask`` is ``False``.
+
+    ``data`` is expected to be a DataFrame; ``mask`` can be an array or
+    a DataFrame.
+
+    """
+    if mask is None:
+        mask = np.zeros(data.shape, np.bool)
+
+    if isinstance(mask, np.ndarray):
+        # For array masks, ensure that shape matches data then convert
+        if mask.shape != data.shape:
+            raise ValueError("Mask must have the same shape as data.")
+
+        mask = pd.DataFrame(mask,
+                            index=data.index,
+                            columns=data.columns,
+                            dtype=np.bool)
+
+    elif isinstance(mask, pd.DataFrame):
+        # For DataFrame masks, ensure that semantic labels match data
+        if (mask.index != data.index).any() \
+           or (mask.columns != data.columns).any():
+            err = "Mask must have the same index and columns as data."
+            raise ValueError(err)
+
+    # Add any cells with missing data to the mask
+    # This works around an issue where `plt.pcolormesh` doesn't represent
+    # missing data properly
+    mask = mask | data.isnull()
+
+    return mask
+
+
 class _HeatMapper(object):
     """Draw a heatmap plot of a matrix with nice labels and colormaps."""
 
@@ -59,16 +96,15 @@ class _HeatMapper(object):
             plot_data = np.asarray(data)
             data = pd.DataFrame(plot_data)
 
+        # Validate the mask and convet to DataFrame
+        mask = _matrix_mask(data, mask)
+
         # Reverse the rows so the plot looks like the matrix
         plot_data = plot_data[::-1]
         data = data.ix[::-1]
-        if mask is not None:
-            try:
-                mask = mask.ix[::-1]
-            except AttributeError:
-                mask = mask[::-1]
+        mask = mask.ix[::-1]
 
-        plot_data = np.ma.masked_where(mask, plot_data)
+        plot_data = np.ma.masked_where(np.asarray(mask), plot_data)
 
         # Get good names for the rows and columns
         if isinstance(xticklabels, bool) and xticklabels:
@@ -264,9 +300,9 @@ def heatmap(data, vmin=None, vmax=None, cmap=None, center=None, robust=False,
         If True, plot the row names of the dataframe. If False, don't plot
         the row names. If list-like, plot these alternate labels as the
         yticklabels
-    mask : boolean numpy.array, optional
-        A boolean array indicating where to mask the data so it is not
-        plotted on the heatmap. Only used for visualizing, not for calculating.
+    mask : boolean array or DataFrame, optional
+        If passed, data will not be shown in cells where ``mask`` is True.
+        Cells with missing values are automatically masked.
     kwargs : other keyword arguments
         All other keyword arguments are passed to ``ax.pcolormesh``.
 
@@ -506,7 +542,7 @@ def dendrogram(data, linkage=None, axis=1, label=True, metric='euclidean',
 
 class ClusterGrid(Grid):
     def __init__(self, data, pivot_kws=None, z_score=None, standard_scale=None,
-                 figsize=None, row_colors=None, col_colors=None):
+                 figsize=None, row_colors=None, col_colors=None, mask=None):
         """Grid object for organizing clustered heatmap input on to axes"""
 
         if isinstance(data, pd.DataFrame):
@@ -516,6 +552,8 @@ class ClusterGrid(Grid):
 
         self.data2d = self.format_data(self.data, pivot_kws, z_score,
                                        standard_scale)
+
+        self.mask = _matrix_mask(self.data2d, mask)
 
         if figsize is None:
             width, height = 10, 10
@@ -794,16 +832,16 @@ class ClusterGrid(Grid):
         else:
             despine(self.ax_col_colors, left=True, bottom=True)
 
-    def plot_matrix(self, colorbar_kws, mask, xind, yind, **kws):
-        data2d = self.data2d.iloc[yind, xind]
-        mask = np.asarray(mask, np.bool)[yind][:, xind]
-        heatmap(data2d, ax=self.ax_heatmap, cbar_ax=self.cax,
-                cbar_kws=colorbar_kws, mask=mask, **kws)
+    def plot_matrix(self, colorbar_kws, xind, yind, **kws):
+        self.data2d = self.data2d.iloc[yind, xind]
+        self.mask = self.mask.iloc[yind, xind]
+        heatmap(self.data2d, ax=self.ax_heatmap, cbar_ax=self.cax,
+                cbar_kws=colorbar_kws, mask=self.mask, **kws)
         self.ax_heatmap.yaxis.set_ticks_position('right')
         self.ax_heatmap.yaxis.set_label_position('right')
 
     def plot(self, metric, method, colorbar_kws, row_cluster, col_cluster,
-             row_linkage, col_linkage, mask, **kws):
+             row_linkage, col_linkage, **kws):
         colorbar_kws = {} if colorbar_kws is None else colorbar_kws
         self.plot_dendrograms(row_cluster, col_cluster, metric, method,
                               row_linkage=row_linkage, col_linkage=col_linkage)
@@ -817,7 +855,7 @@ class ClusterGrid(Grid):
             yind = np.arange(self.data2d.shape[0])
 
         self.plot_colors(xind, yind, **kws)
-        self.plot_matrix(colorbar_kws, mask, xind, yind, **kws)
+        self.plot_matrix(colorbar_kws, xind, yind, **kws)
         return self
 
 
@@ -867,9 +905,10 @@ def clustermap(data, pivot_kws=None, method='average', metric='euclidean',
         List of colors to label for either the rows or columns. Useful to
         evaluate whether samples within a group are clustered together. Can
         use nested lists for multiple color levels of labeling.
-    mask : boolean numpy.array, optional
-        A boolean array indicating where to mask the data so it is not
-        plotted on the heatmap. Only used for visualizing, not for calculating.
+    mask : boolean array or DataFrame, optional
+        If passed, data will not be shown in cells where ``mask`` is True.
+        Cells with missing values are automatically masked. Only used for
+        visualizing, not for calculating.
     kwargs : other keyword arguments
         All other keyword arguments are passed to ``sns.heatmap``
 
@@ -892,11 +931,11 @@ def clustermap(data, pivot_kws=None, method='average', metric='euclidean',
     """
     plotter = ClusterGrid(data, pivot_kws=pivot_kws, figsize=figsize,
                           row_colors=row_colors, col_colors=col_colors,
-                          z_score=z_score, standard_scale=standard_scale)
+                          z_score=z_score, standard_scale=standard_scale,
+                          mask=mask)
 
     return plotter.plot(metric=metric, method=method,
                         colorbar_kws=cbar_kws,
                         row_cluster=row_cluster, col_cluster=col_cluster,
                         row_linkage=row_linkage, col_linkage=col_linkage,
-                        mask=mask,
                         **kwargs)

--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -76,7 +76,7 @@ def _matrix_mask(data, mask):
     # Add any cells with missing data to the mask
     # This works around an issue where `plt.pcolormesh` doesn't represent
     # missing data properly
-    mask = mask | data.isnull()
+    mask = mask | pd.isnull(data)
 
     return mask
 

--- a/seaborn/tests/test_matrix.py
+++ b/seaborn/tests/test_matrix.py
@@ -868,13 +868,13 @@ class TestClustermap(object):
         kws["mask"] = self.df_norm > 0
 
         g = mat.clustermap(self.df_norm, **kws)
-        pdt.assert_index_equal(g.data2d.index, g.mask.index)
-        pdt.assert_index_equal(g.data2d.columns, g.mask.columns)
+        npt.assert_array_equal(g.data2d.index, g.mask.index)
+        npt.assert_array_equal(g.data2d.columns, g.mask.columns)
 
-        pdt.assert_index_equal(g.mask.index,
+        npt.assert_array_equal(g.mask.index,
                                self.df_norm.index[
                                    g.dendrogram_row.reordered_ind])
-        pdt.assert_index_equal(g.mask.columns,
+        npt.assert_array_equal(g.mask.columns,
                                self.df_norm.columns[
                                    g.dendrogram_col.reordered_ind])
 

--- a/seaborn/tests/test_matrix.py
+++ b/seaborn/tests/test_matrix.py
@@ -300,6 +300,31 @@ class TestHeatmap(object):
         nt.assert_equal(ax.get_aspect(), "equal")
         plt.close("all")
 
+    def test_mask_validation(self):
+
+        mask = mat._matrix_mask(self.df_norm, None)
+        nt.assert_equal(mask.shape, self.df_norm.shape)
+        nt.assert_equal(mask.values.sum(), 0)
+
+        with nt.assert_raises(ValueError):
+            bad_array_mask = self.rs.randn(3, 6) > 0
+            mat._matrix_mask(self.df_norm, bad_array_mask)
+
+        with nt.assert_raises(ValueError):
+            bad_df_mask = pd.DataFrame(self.rs.randn(4, 8) > 0)
+            mat._matrix_mask(self.df_norm, bad_df_mask)
+
+    def test_missing_data_mask(self):
+
+        data = pd.DataFrame(np.arange(4, dtype=np.float).reshape(2, 2))
+        data.loc[0, 0] = np.nan
+        mask = mat._matrix_mask(data, None)
+        npt.assert_array_equal(mask, [[True, False], [False, False]])
+
+        mask_in = np.array([[False, True], [False, False]])
+        mask_out = mat._matrix_mask(data, mask_in)
+        npt.assert_array_equal(mask_out, [[True, True], [False, False]])
+
 
 class TestDendrogram(object):
     rs = np.random.RandomState(sum(map(ord, "dendrogram")))
@@ -573,7 +598,7 @@ class TestClustermap(object):
     default_plot_kws = dict(metric='euclidean', method='average',
                             colorbar_kws=None,
                             row_cluster=True, col_cluster=True,
-                            row_linkage=None, col_linkage=None, mask=None)
+                            row_linkage=None, col_linkage=None)
 
     row_colors = color_palette('Set2', df_norm.shape[0])
     col_colors = color_palette('Dark2', df_norm.shape[1])
@@ -836,3 +861,21 @@ class TestClustermap(object):
 
         pdt.assert_frame_equal(cm.data2d, self.df_norm)
         plt.close('all')
+
+    def test_mask_reorganization(self):
+
+        kws = self.default_kws.copy()
+        kws["mask"] = self.df_norm > 0
+
+        g = mat.clustermap(self.df_norm, **kws)
+        pdt.assert_index_equal(g.data2d.index, g.mask.index)
+        pdt.assert_index_equal(g.data2d.columns, g.mask.columns)
+
+        pdt.assert_index_equal(g.mask.index,
+                               self.df_norm.index[
+                                   g.dendrogram_row.reordered_ind])
+        pdt.assert_index_equal(g.mask.columns,
+                               self.df_norm.columns[
+                                   g.dendrogram_col.reordered_ind])
+
+        plt.close("all")


### PR DESCRIPTION
The main change here is to reorganize the mask in `clustermap` using the dendrograms, which fixes the bug in #512.

This also automatically adds cells with missing values in `heatmap` (and hence) `clustermap` to the mask matrix, thus addressing the issue in #375 (yikes that's old).

Also adds some helpful validation of the mask to make sure it's the right shape and that the semantic information matches that in `data` if a pandas object is used.