### PR TITLE
Add a ceiling to the default number of bins used in distplot

### DIFF
--- a/doc/releases/v0.6.0.txt
+++ b/doc/releases/v0.6.0.txt
@@ -59,6 +59,8 @@ Other additions
 
 - The various property dictionaries that can be passed to ``plt.boxplot`` are now applied after the seaborn restyling to allow for full customizability.
 
+- Added a ceiling (50) to the default number of bins used for :func:`distplot` histograms. This will help avoid confusing errors with certain kinds of datasets that heavily violate the assumptions of the reference rule used to get a default number of bins. The ceiling is not applied when passing a specific number of bins.
+
 Bug fixes
 ~~~~~~~~~
 

--- a/seaborn/distributions.py
+++ b/seaborn/distributions.py
@@ -123,7 +123,7 @@ def distplot(a, bins=None, hist=True, kde=True, rug=False, fit=None,
 
     if hist:
         if bins is None:
-            bins = _freedman_diaconis_bins(a)
+            bins = min(_freedman_diaconis_bins(a), 50)
         hist_kws.setdefault("alpha", 0.4)
         hist_kws.setdefault("normed", norm_hist)
         orientation = "horizontal" if vertical else "vertical"


### PR DESCRIPTION
This should help avoid confusing issues with certain datasets that cause the reference rule to return ridiculous values. It also in general avoids drawing too many bars, which usually isn't helpful and just slows things down. The ceiling is not applied when a specific number of bins is requested.

Fixes #503 