### PR TITLE
Two fixes to avoid matplotlib osx backend issues

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -137,3 +137,4 @@ Utility functions
     set_hls_values
     ci_to_errsize
     axlabel
+    load_dataset

--- a/doc/installing.rst
+++ b/doc/installing.rst
@@ -4,11 +4,12 @@ Installing and getting started
 ------------------------------
 
 To install the released version of seaborn, you can use ``pip`` (i.e. ``pip install seaborn``). 
-Alternatively, you can use ``pip`` to install the development version, with the command ``pip install
-git+git://github.com/mwaskom/seaborn.git#egg=seaborn``. Another option would be
-to to clone the `github repository <https://github.com/mwaskom/seaborn>`_ and
-install with ``pip install .`` from the source directory. Seaborn itself is pure
-Python, so installation should be reasonably straightforward.
+
+Alternatively, you can use ``pip`` to install the development version, with the command ``pip install git+git://github.com/mwaskom/seaborn.git#egg=seaborn``.
+
+Another option would be to to clone the `github repository <https://github.com/mwaskom/seaborn>`_ and install with ``pip install .`` from the source directory. Seaborn itself is pure Python, so installation should be reasonably straightforward.
+
+When using the development version, you may want to refer to the `development docs <http://stanford.edu/~mwaskom/software/seaborn-dev/>`_. Note that these are not built automatically and may at times fall out of sync with the actual master branch on github.
 
 Dependencies 
 ~~~~~~~~~~~~
@@ -32,8 +33,6 @@ Recommended dependencies
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 -  `statsmodels <http://statsmodels.sourceforge.net/>`__
-
--  `patsy <http://patsy.readthedocs.org/en/latest/>`__
 
 Version-wise, we make an attempt to keep seaborn working on the stable Debian
 channels. There may be cases where some more advanced features only work with
@@ -60,6 +59,6 @@ Bugs
 
 Please report any bugs you encounter through the github `issue tracker
 <https://github.com/mwaskom/seaborn/issues/new>`_. It will be most helpful to
-upload an IPython notebook that can reproduce the error in a `gist
-<http://gist.github.com>`_ and link to that gist in the bug report.
-
+include a reproducible example on one of the example datasets (accessed through
+:func:`load_dataset`) and to include the version of matplotlib that you are
+using when you encounter the error.

--- a/doc/releases/v0.6.0.txt
+++ b/doc/releases/v0.6.0.txt
@@ -71,3 +71,5 @@ Bug fixes
 - Fixed a bug in :class:`FacetGrid` and :class:`PairGrid` that lead to incorrect legend labels when levels of the ``hue`` variable appeared in ``hue_order`` but not in the data.
 
 - Fixed a bug in :meth:`FacetGrid.set_xticklabels` or :meth:`FacetGrid.set_yticklabels` when ``col_wrap`` is being used.
+
+- Fixed various functions that were affected by `issues <https://github.com/matplotlib/matplotlib/issues/2654>`_ with the matplotlib OSX backend. For :func:`heatmap` and :func:`clustermap`, this means that the functions should no longer crash, but overlapping tick labels will not be automatically rotated as might happen using other backends.

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -398,7 +398,7 @@ class FacetGrid(Grid):
         self._not_na = not_na
 
         # Make the axes look good
-        fig.tight_layout()
+        fig.set_tight_layout(True)
         if despine:
             self.despine()
 
@@ -594,7 +594,7 @@ class FacetGrid(Grid):
         """Finalize the annotations and layout."""
         self.set_axis_labels(*axlabels)
         self.set_titles()
-        self.fig.tight_layout()
+        self.fig.set_tight_layout(True)
 
     def facet_axis(self, row_i, col_j):
         """Make the axis identified by these indices active and return it."""
@@ -938,7 +938,7 @@ class PairGrid(Grid):
         # Make the plot look nice
         if despine:
             utils.despine(fig=fig)
-        fig.tight_layout()
+        fig.set_tight_layout(True)
 
     def map(self, func, **kwargs):
         """Plot with the same function in every subplot.
@@ -1218,7 +1218,7 @@ class JointGrid(object):
         utils.despine(f)
         utils.despine(ax=ax_marg_x, left=True)
         utils.despine(ax=ax_marg_y, bottom=True)
-        f.tight_layout()
+        f.set_tight_layout(True)
         f.subplots_adjust(hspace=space, wspace=space)
 
     def plot(self, joint_func, marginal_func, annot_func=None):

--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -311,6 +311,11 @@ def heatmap(data, vmin=None, vmax=None, cmap=None, center=None, robust=False,
     ax : matplotlib Axes
         Axes object with the heatmap.
 
+    Notes
+    -----
+    There is an issue with the matplotlib MacOSX backend that will interferes
+    with the ability to automatically rotate overlapping tick labels.
+
     """
     # Initialize the plotter object
     plotter = _HeatMapper(data, vmin, vmax, cmap, center, robust, annot, fmt,
@@ -918,15 +923,18 @@ def clustermap(data, pivot_kws=None, method='average', metric='euclidean',
         A ClusterGrid instance.
 
     Notes
-    ----
-    The returned object has a ``savefig`` method that should be used if you
-    want to save the figure object without clipping the dendrograms.
+    -----
+    The returned ``clustergrid`` object has a ``savefig`` method that should be
+    used if you want to save the figure object without clipping the dendrograms.
 
     To access the reordered row indices, use:
     ``clustergrid.dendrogram_row.reordered_ind``
 
     Column indices, use:
     ``clustergrid.dendrogram_col.reordered_ind``
+
+    There is an issue with the matplotlib MacOSX backend that will interferes
+    with the ability to automatically rotate overlapping tick labels.
 
     """
     plotter = ClusterGrid(data, pivot_kws=pivot_kws, figsize=figsize,

--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -925,7 +925,7 @@ def clustermap(data, pivot_kws=None, method='average', metric='euclidean',
     Notes
     -----
     The returned ``clustergrid`` object has a ``savefig`` method that should be
-    used if you want to save the figure object without clipping the dendrograms.
+    used to save the figure without clipping the dendrograms.
 
     To access the reordered row indices, use:
     ``clustergrid.dendrogram_row.reordered_ind``

--- a/seaborn/utils.py
+++ b/seaborn/utils.py
@@ -423,9 +423,13 @@ def axis_ticklabels_overlap(labels):
         True if any of the labels overlap.
 
     """
-    bboxes = [l.get_window_extent() for l in labels]
-    overlaps = [b.count_overlaps(bboxes) for b in bboxes]
-    return max(overlaps) > 1
+    try:
+        bboxes = [l.get_window_extent() for l in labels]
+        overlaps = [b.count_overlaps(bboxes) for b in bboxes]
+        return max(overlaps) > 1
+    except RuntimeError:
+        # Issue on macosx backend raises an error in the above code
+        return False
 
 
 def axes_ticklabels_overlap(ax):


### PR DESCRIPTION
This changes some things in `FacetGrid` and `heatmap` to avoid two common and very annoying issues caused by the the matplotlib osx backend.

I believe this is the root matplotlib issue: https://github.com/matplotlib/matplotlib/issues/2654

This has come up a few times in seaborn: #545, #408, #231, and elsewhere.

The fix to `FacetGrid` should, I believe, simply make that work. The fix to `heatmap` is a compromise where the exception that is raised when trying to determine if the ticklabels overlap gets caught and the labels are not rotated. That means that the plots might not look as good for everyone, but this feels better than the plot simply not working.

I haven't tested this extensively, but I seem to be able to plot using the OSX backend without running into these common issues.