### PR TITLE
Fix hue_order in PairGrid

### DIFF
--- a/doc/releases/v0.6.0.txt
+++ b/doc/releases/v0.6.0.txt
@@ -71,3 +71,5 @@ Bug fixes
 - Fixed a bug in :class:`FacetGrid` and :class:`PairGrid` that lead to incorrect legend labels when levels of the ``hue`` variable appeared in ``hue_order`` but not in the data.
 
 - Fixed a bug in :meth:`FacetGrid.set_xticklabels` or :meth:`FacetGrid.set_yticklabels` when ``col_wrap`` is being used.
+
+- Fixed a bug in :class:`PairGrid` where the ``hue_order`` parameter was ignored.

--- a/seaborn/tests/test_axisgrid.py
+++ b/seaborn/tests/test_axisgrid.py
@@ -900,6 +900,7 @@ class TestPairGrid(object):
 
         plt.close("all")
 
+    @skipif(old_matplotlib)
     def test_hue_order(self):
 
         order = list("dcab")

--- a/seaborn/tests/test_axisgrid.py
+++ b/seaborn/tests/test_axisgrid.py
@@ -891,6 +891,58 @@ class TestPairGrid(object):
         for line, marker in zip(g.axes[0, 0].lines, kws["marker"]):
             nt.assert_equal(line.get_marker(), marker)
 
+        g = ag.PairGrid(self.df, hue="a", hue_kws=kws,
+                        hue_order=list("dcab"))
+        g.map(plt.plot)
+
+        for line, marker in zip(g.axes[0, 0].lines, kws["marker"]):
+            nt.assert_equal(line.get_marker(), marker)
+
+        plt.close("all")
+
+    def test_hue_order(self):
+
+        order = list("dcab")
+        g = ag.PairGrid(self.df, hue="a", hue_order=order)
+        g.map(plt.plot)
+
+        for line, level in zip(g.axes[1, 0].lines, order):
+            x, y = line.get_xydata().T
+            npt.assert_array_equal(x, self.df.loc[self.df.a == level, "x"])
+            npt.assert_array_equal(y, self.df.loc[self.df.a == level, "y"])
+
+        plt.close("all")
+
+        g = ag.PairGrid(self.df, hue="a", hue_order=order)
+        g.map_diag(plt.plot)
+
+        for line, level in zip(g.axes[0, 0].lines, order):
+            x, y = line.get_xydata().T
+            npt.assert_array_equal(x, self.df.loc[self.df.a == level, "x"])
+            npt.assert_array_equal(y, self.df.loc[self.df.a == level, "x"])
+
+        plt.close("all")
+
+        g = ag.PairGrid(self.df, hue="a", hue_order=order)
+        g.map_lower(plt.plot)
+
+        for line, level in zip(g.axes[1, 0].lines, order):
+            x, y = line.get_xydata().T
+            npt.assert_array_equal(x, self.df.loc[self.df.a == level, "x"])
+            npt.assert_array_equal(y, self.df.loc[self.df.a == level, "y"])
+
+        plt.close("all")
+
+        g = ag.PairGrid(self.df, hue="a", hue_order=order)
+        g.map_upper(plt.plot)
+
+        for line, level in zip(g.axes[0, 1].lines, order):
+            x, y = line.get_xydata().T
+            npt.assert_array_equal(x, self.df.loc[self.df.a == level, "y"])
+            npt.assert_array_equal(y, self.df.loc[self.df.a == level, "x"])
+
+        plt.close("all")
+
     def test_nondefault_index(self):
 
         df = self.df.copy().set_index("b")


### PR DESCRIPTION
This fixes #472.

This also changes the default `hue_order` to use the same `category_order`
rules as elsewhere in seaborn (cf #361).