### PR TITLE
Extend new categorical ordering rules to FacetGrid

### DIFF
--- a/doc/releases/v0.6.0.txt
+++ b/doc/releases/v0.6.0.txt
@@ -27,7 +27,7 @@ Here are details on what has changed in the process of unifying these APIs:
 
 Along with these API changes, the following changes/enhancements were made to the plotting functions:
 
-- The default rules for ordering the categories has changed. Instead of automatically sorting the category levels, the plots now show the levels in the order the appear in the input data (i.e., the order given by ``Series.unique()``). Order can be specified when plotting with the ``order`` and ``hue_order`` parameters. Additionally, when variables are pandas objects with a "categorical" dtype, the category order is inferred from the data object.
+- The default rules for ordering the categories has changed. Instead of automatically sorting the category levels, the plots now show the levels in the order the appear in the input data (i.e., the order given by ``Series.unique()``). Order can be specified when plotting with the ``order`` and ``hue_order`` parameters. Additionally, when variables are pandas objects with a "categorical" dtype, the category order is inferred from the data object. This change also affects :class:`FacetGrid` and :class:`PairGrid`.
 
 - Added the ``scale`` and ``scale_hue`` parameters to :func:`violinplot`. These control how the width of the violins are scaled. The default is ``area``, which is different from how the violins used to be drawn. Use ``scale='width'`` to get the old behavior.
 

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -132,20 +132,13 @@ class Grid(object):
         data = {l: h for h, l in zip(handles, labels)}
         self._legend_data.update(data)
 
-    def _get_palette(self, data, hue, hue_order, palette, dropna):
+    def _get_palette(self, data, hue, hue_order, palette):
         """Get a list of colors for the hue variable."""
         if hue is None:
             palette = color_palette(n_colors=1)
 
         else:
-            if hue_order is None:
-                hue_names = np.unique(np.sort(data[hue]))
-            else:
-                hue_names = hue_order
-            if dropna:
-                # Filter NA from the list of unique hue names
-                hue_names = list(filter(pd.notnull, hue_names))
-
+            hue_names = utils.categorical_order(data[hue], hue_order)
             n_colors = len(hue_names)
 
             # By default use either the current color palette or HUSL
@@ -202,7 +195,8 @@ class FacetGrid(Grid):
             should be values  in the `hue` variable.
         {row, col, hue}_order: sequence of strings
             Order to plot the values in the faceting variables in, otherwise
-            sorts the unique values.
+            infer from the input data using pandas Category order or the
+            order of appearance.
         hue_kws : dictionary of param -> list of values mapping
             Other keyword arguments to insert into the plotting call to let
             other plot attributes vary across levels of the hue variable (e.g.
@@ -323,15 +317,9 @@ class FacetGrid(Grid):
         if hue is None:
             hue_names = None
         else:
-            if hue_order is None:
-                hue_names = np.unique(np.sort(data[hue]))
-            else:
-                hue_names = hue_order
-            if dropna:
-                # Filter NA from the list of unique hue names
-                hue_names = list(filter(pd.notnull, hue_names))
+            hue_names = utils.categorical_order(data[hue], hue_order)
 
-        colors = self._get_palette(data, hue, hue_order, palette, dropna)
+        colors = self._get_palette(data, hue, hue_order, palette)
 
         # Additional dict of kwarg -> list of values for mapping the hue var
         hue_kws = hue_kws if hue_kws is not None else {}
@@ -350,21 +338,13 @@ class FacetGrid(Grid):
         # Set up the lists of names for the row and column facet variables
         if row is None:
             row_names = []
-        elif row_order is None:
-            row_names = np.unique(np.sort(data[row]))
         else:
-            row_names = row_order
-        if dropna:
-            row_names = list(filter(pd.notnull, row_names))
+            row_names = utils.categorical_order(data[row], row_order)
 
         if col is None:
             col_names = []
-        elif col_order is None:
-            col_names = np.unique(np.sort(data[col]))
         else:
-            col_names = col_order
-        if dropna:
-            col_names = list(filter(pd.notnull, col_names))
+            col_names = utils.categorical_order(data[col], col_order)
 
         # Set up the class attributes
         # ---------------------------
@@ -929,7 +909,7 @@ class PairGrid(Grid):
         # Additional dict of kwarg -> list of values for mapping the hue var
         self.hue_kws = hue_kws if hue_kws is not None else {}
 
-        self.palette = self._get_palette(data, hue, hue_order, palette, dropna)
+        self.palette = self._get_palette(data, hue, hue_order, palette)
         self._legend_data = {}
 
         # Make the plot look nice

--- a/seaborn/tests/test_axisgrid.py
+++ b/seaborn/tests/test_axisgrid.py
@@ -247,7 +247,7 @@ class TestFacetGrid(object):
 
         nt.assert_equal(g1._legend.get_title().get_text(), "b_bool")
 
-        b_levels = sorted(map(str, self.df.b_bool.unique()))
+        b_levels = list(map(str, self.df.b_bool.unique()))
 
         lines = g1._legend.get_lines()
         nt.assert_equal(len(lines), len(b_levels))

--- a/seaborn/tests/test_utils.py
+++ b/seaborn/tests/test_utils.py
@@ -290,7 +290,7 @@ def test_categorical_order():
         out = utils.categorical_order(x, ["b", "a"])
         nt.assert_equal(out, ["b", "a"])
 
-    x = x.tolist() + [np.nan]
+    x = ["a", np.nan, "c", "c", "b", "a", "d"]
     out = utils.categorical_order(x)
     nt.assert_equal(out, ["a", "c", "b", "d"])
 

--- a/seaborn/tests/test_utils.py
+++ b/seaborn/tests/test_utils.py
@@ -258,7 +258,7 @@ def test_ticklabels_overlap():
     assert not y
 
 
-def test_category_order():
+def test_categorical_order():
 
     x = ["a", "c", "c", "b", "a", "d"]
     order = ["a", "b", "c", "d"]
@@ -289,6 +289,10 @@ def test_category_order():
 
         out = utils.categorical_order(x, ["b", "a"])
         nt.assert_equal(out, ["b", "a"])
+
+    x = x.tolist() + [np.nan]
+    out = utils.categorical_order(x)
+    nt.assert_equal(out, ["a", "c", "b", "d"])
 
 
 if LooseVersion(pd.__version__) >= "0.15":

--- a/seaborn/utils.py
+++ b/seaborn/utils.py
@@ -461,7 +461,7 @@ def categorical_order(values, order=None):
     Returns
     -------
     order : list
-        Ordered list of category levels
+        Ordered list of category levels not including null values.
 
     """
     if order is None:
@@ -475,5 +475,5 @@ def categorical_order(values, order=None):
                     order = values.unique()
                 except AttributeError:
                     order = pd.unique(values)
-
+        order = filter(pd.notnull, order)
     return list(order)


### PR DESCRIPTION
`FacetGrid` now uses `utils.categorical_order` to determine default order for the `row`, `color`, and `hue` variables. This means that all categorical ordering in seaborn should follow the same rules. Please open an issue if you run into something that doesn't.

Closes #361 