### PR TITLE
Some changes to help heatmap and clustermap plot large matrices

### DIFF
--- a/doc/releases/v0.6.0.txt
+++ b/doc/releases/v0.6.0.txt
@@ -63,10 +63,14 @@ Other additions
 
 - Added a ``savefig`` method to :class:`JointGrid` that defaults to a tight bounding box to make it easier to save figures using this class.
 
+- Changed the default ``linewidths`` in :func:`heatmap` and :`clustermap` to 0 so that larger matrices plot correctly. This parameter still exists and can be used to get the old effect of lines demarcating each cell in the heatmap (the old default ``linewidths`` was 0.5).
+
+- You can now pass an integer to the ``xticklabels`` and ``yticklabels`` parameter of :func:`heatmap` (and, by extension, :func:`clustermap`). This will make the plot use the ticklabels inferred from the data, but only plot every ``n`` label, where ``n`` is the number you pass. This can help when visualizing larger matrices with some sensible ordering to the rows or columns of the dataframe.
+
 Bug fixes
 ~~~~~~~~~
 
-- Fixed a bug in :func:`clustermap` where the mask was not being reorganized using the dendrograms.
+- Fixed bugs in :func:`clustermap` where the mask and specified ticklabels were not being reorganized using the dendrograms.
 
 - Fixed a bug in :class:`FacetGrid` and :class:`PairGrid` that lead to incorrect legend labels when levels of the ``hue`` variable appeared in ``hue_order`` but not in the data.
 

--- a/seaborn/tests/test_matrix.py
+++ b/seaborn/tests/test_matrix.py
@@ -200,6 +200,22 @@ class TestHeatmap(object):
         nt.assert_equal(p.xticklabels, xticklabels)
         nt.assert_equal(p.yticklabels, yticklabels[::-1])
 
+    def test_custom_ticklabel_interval(self):
+
+        kws = self.default_kws.copy()
+        kws['xticklabels'] = 2
+        kws['yticklabels'] = 3
+        p = mat._HeatMapper(self.df_norm, **kws)
+
+        nx, ny = self.df_norm.T.shape
+        ystart = (ny - 1) % 3
+        npt.assert_array_equal(p.xticks, np.arange(0, nx, 2) + .5)
+        npt.assert_array_equal(p.yticks, np.arange(ystart, ny, 3) + .5)
+        npt.assert_array_equal(p.xticklabels,
+                               self.df_norm.columns[::2])
+        npt.assert_array_equal(p.yticklabels,
+                               self.df_norm.index[::-1][ystart:ny:3])
+
     def test_heatmap_annotation(self):
 
         ax = mat.heatmap(self.df_norm, annot=True, fmt=".1f",
@@ -877,5 +893,26 @@ class TestClustermap(object):
         npt.assert_array_equal(g.mask.columns,
                                self.df_norm.columns[
                                    g.dendrogram_col.reordered_ind])
+
+        plt.close("all")
+
+    def test_ticklabel_reorganization(self):
+
+        kws = self.default_kws.copy()
+        xtl = np.arange(self.df_norm.shape[1])
+        kws["xticklabels"] = list(xtl)
+        ytl = self.letters.ix[:self.df_norm.shape[0]]
+        kws["yticklabels"] = ytl
+
+        g = mat.clustermap(self.df_norm, **kws)
+
+        xtl_actual = [t.get_text() for t in g.ax_heatmap.get_xticklabels()]
+        ytl_actual = [t.get_text() for t in g.ax_heatmap.get_yticklabels()]
+
+        xtl_want = xtl[g.dendrogram_col.reordered_ind].astype("<U1")
+        ytl_want = ytl[g.dendrogram_row.reordered_ind].astype("<U1")[::-1]
+
+        npt.assert_array_equal(xtl_actual, xtl_want)
+        npt.assert_array_equal(ytl_actual, ytl_want)
 
         plt.close("all")


### PR DESCRIPTION
- Changed the default `linewidths` to 0 so that large matrices don't have a confusing white-out from the cell lines. Ideally this would have been accomplished with an adaptive linewidth, but for reasonably sized matrices the smallest lines that could be drawn still messed up the plots in, at least, the notebook. Closes #445.

- Added the ability to pass an integer to `xticklabels` and `yticklabels` which will plot every `n` label to help with larger matrices.

- Fixed a bug where specified ticklabel arrays were not being reordered to reflect the clustering in `clustermap`. Closes #550.