### PR TITLE
add lowess bootstrap/ci functionality

### DIFF
--- a/seaborn/tests/test_linearmodels.py
+++ b/seaborn/tests/test_linearmodels.py
@@ -213,6 +213,10 @@ class TestRegressionPlotter(object):
         _, boots_smod = p.fit_statsmodels(self.grid, smlm.OLS)
         npt.assert_equal(boots_smod.shape, (self.n_boot, self.grid.size))
 
+        # Lowess
+        grid, _, boots_lowess = p.fit_lowess()
+        npt.assert_equal(boots_lowess.shape, (self.n_boot, grid.size))
+
     @skipif(_no_statsmodels)
     def test_regress_without_bootstrap(self):
 
@@ -368,7 +372,6 @@ class TestRegressionPlotter(object):
         grid, yhat, err_bands = p.fit_regression(x_range=(-3, 3))
 
         nt.assert_equal(len(grid), len(yhat))
-        nt.assert_is(err_bands, None)
 
     def test_regression_options(self):
 


### PR DESCRIPTION
I gave #552 a quick try.  Comments, suggestions, and critiques are welcome.  

Fitting the `lowess` model is pretty slow when `n_boots` is large but I guess that is expected.  

[Example ipython notebook](http://nbviewer.ipython.org/urls/dl.dropbox.com/s/22n3ksv2cny7pd9/seaborn_bootstrap_lowess_example.ipynb/%3Fdl%3D0)

Fixes #552 
