### PR TITLE
Changes to seaborn color handling

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -90,6 +90,7 @@ Style frontend
     set_style
     plotting_context
     set_context
+    set_color_codes
     reset_defaults
     reset_orig
 

--- a/doc/releases/v0.6.0.txt
+++ b/doc/releases/v0.6.0.txt
@@ -67,6 +67,8 @@ Other additions
 
 - You can now pass an integer to the ``xticklabels`` and ``yticklabels`` parameter of :func:`heatmap` (and, by extension, :func:`clustermap`). This will make the plot use the ticklabels inferred from the data, but only plot every ``n`` label, where ``n`` is the number you pass. This can help when visualizing larger matrices with some sensible ordering to the rows or columns of the dataframe.
 
+- Added the :func:`set_color_codes` function and the ``color_codes`` argument to :func:`set` and :func:`set_palette`. This changes the interpretation of shorthand color codes (i.e. "b", "g", k", etc.) within matplotlib to use the values from one of the named seaborn palettes (i.e. "deep", "muted", etc.). That makes it easier to have a more uniform look when using matplotlib functions directly with seaborn imported. This could be disruptive to existing plots, so it does not happen by default. It is possible this could change in the future.
+
 - Added the ``as_hex`` method to color palette objects, to return a list of hex codes rather than rgb tuples.
 
 Bug fixes

--- a/doc/releases/v0.6.0.txt
+++ b/doc/releases/v0.6.0.txt
@@ -67,6 +67,8 @@ Other additions
 
 - You can now pass an integer to the ``xticklabels`` and ``yticklabels`` parameter of :func:`heatmap` (and, by extension, :func:`clustermap`). This will make the plot use the ticklabels inferred from the data, but only plot every ``n`` label, where ``n`` is the number you pass. This can help when visualizing larger matrices with some sensible ordering to the rows or columns of the dataframe.
 
+- Added the ``as_hex`` method to color palette objects, to return a list of hex codes rather than rgb tuples.
+
 Bug fixes
 ~~~~~~~~~
 

--- a/doc/releases/v0.6.0.txt
+++ b/doc/releases/v0.6.0.txt
@@ -71,6 +71,8 @@ Other additions
 
 - Added the ``as_hex`` method to color palette objects, to return a list of hex codes rather than rgb tuples.
 
+- The :func:`color_palette` function no longer trims palettes that are longer than 6 colors when passed into it.
+
 Bug fixes
 ~~~~~~~~~
 

--- a/seaborn/palettes.py
+++ b/seaborn/palettes.py
@@ -91,7 +91,8 @@ def color_palette(palette=None, n_colors=None, desat=None):
     -------
     palette : list of RGB tuples.
         Color palette. Behaves like a list, but can be used as a context
-        manager and posses an ``as_hex`` method to convert to hex color codes.
+        manager and possesses an ``as_hex`` method to convert to hex color
+        codes.
 
     See Also
     --------
@@ -144,15 +145,6 @@ def color_palette(palette=None, n_colors=None, desat=None):
         >>> import numpy as np, matplotlib.pyplot as plt
         >>> with sns.color_palette("husl", 8):
         ...    _ = plt.plot(np.c_[np.zeros(8), np.arange(8)].T)
-
-    Convert to hex representation:
-
-    .. plot::
-        :context: close-figs
-
-        >>> pal = sns.color_palette("muted", 4)
-        >>> pal.as_hex()
-        [u'#4878cf', u'#6acc65', u'#d65f5f', u'#b47cc7']
 
     """
     if palette is None:

--- a/seaborn/palettes.py
+++ b/seaborn/palettes.py
@@ -76,7 +76,8 @@ def color_palette(name=None, n_colors=6, desat=None):
         desaturated.
     n_colors : int
         Number of colors in the palette. If larger than the number of
-        colors in the palette, they will cycle.
+        colors in the palette, they will cycle. This is ignored when
+        `name` is `None` or is list-like.
     desat : float
         Value to desaturate each color by.
 
@@ -137,11 +138,22 @@ def color_palette(name=None, n_colors=6, desat=None):
         >>> with sns.color_palette("husl", 8):
         ...    _ = plt.plot(np.c_[np.zeros(8), np.arange(8)].T)
 
+    Convert to hex representation:
+
+    .. plot::
+        :context: close-figs
+
+        >>> pal = sns.color_palette("muted", 3)
+        >>> pal.as_hex()
+        [u'#4878cf', u'#6acc65', u'#d65f5f', u'#b47cc7']
+
     """
     if name is None:
         palette = mpl.rcParams["axes.color_cycle"]
+        n_colors = len(palette)
     elif not isinstance(name, string_types):
         palette = name
+        n_colors = len(palette)
     elif name == "hls":
         palette = hls_palette(n_colors)
     elif name == "husl":
@@ -202,7 +214,7 @@ def hls_palette(n_colors=6, h=.01, l=.6, s=.65):
     hues %= 1
     hues -= hues.astype(int)
     palette = [colorsys.hls_to_rgb(h_i, l, s) for h_i in hues]
-    return palette
+    return _ColorPalette(palette)
 
 
 def husl_palette(n_colors=6, h=.01, s=.9, l=.65):
@@ -235,7 +247,7 @@ def husl_palette(n_colors=6, h=.01, s=.9, l=.65):
     s *= 99
     l *= 99
     palette = [husl.husl_to_rgb(h_i, s, l) for h_i in hues]
-    return palette
+    return _ColorPalette(palette)
 
 
 def mpl_palette(name, n_colors=6):
@@ -278,7 +290,7 @@ def mpl_palette(name, n_colors=6):
         bins = np.linspace(0, 1, n_colors + 2)[1:-1]
     palette = list(map(tuple, cmap(bins)[:, :3]))
 
-    return palette
+    return _ColorPalette(palette)
 
 
 def _color_to_rgb(color, input):
@@ -466,7 +478,7 @@ def blend_palette(colors, n_colors=6, as_cmap=False, input="rgb"):
     name = "blend"
     pal = mpl.colors.LinearSegmentedColormap.from_list(name, colors)
     if not as_cmap:
-        pal = pal(np.linspace(0, 1, n_colors))
+        pal = _ColorPalette(pal(np.linspace(0, 1, n_colors)))
     return pal
 
 
@@ -562,7 +574,7 @@ def cubehelix_palette(n_colors=6, start=0, rot=.4, gamma=1.0, hue=0.8,
         cmap = mpl.colors.ListedColormap(pal_256)
         return cmap
     else:
-        return pal
+        return _ColorPalette(pal)
 
 
 def set_color_codes(palette="deep"):

--- a/seaborn/palettes.py
+++ b/seaborn/palettes.py
@@ -47,6 +47,11 @@ class _ColorPalette(list):
         from .rcmod import set_palette
         set_palette(self._orig_palette, len(self._orig_palette))
 
+    def as_hex(self):
+        """Return a color palette with hex codes instead of RGB values."""
+        hex = [mpl.colors.rgb2hex(rgb) for rgb in self]
+        return _ColorPalette(hex)
+
 
 def color_palette(name=None, n_colors=6, desat=None):
     """Return a list of colors defining a color palette.

--- a/seaborn/palettes.py
+++ b/seaborn/palettes.py
@@ -80,24 +80,57 @@ def color_palette(name=None, n_colors=6, desat=None):
     palette : list of RGB tuples.
         Color palette.
 
-    Examples
-    --------
-    >>> p = color_palette("muted")
-
-    >>> p = color_palette("Blues_d", 10)
-
-    >>> p = color_palette("Set1", desat=.7)
-
-    >>> import matplotlib.pyplot as plt
-    >>> with color_palette("husl", 8):
-    ...     f, ax = plt.subplots()
-    ...     ax.plot(x, y)                  # doctest: +SKIP
-
     See Also
     --------
     set_palette : set the default color cycle for all plots.
     axes_style : define parameters to set the style of plots
     plotting_context : define parameters to scale plot elements
+
+    Examples
+    --------
+
+    Show one of the "seaborn palettes", which have the same basic order of hues
+    as the default matplotlib color cycle but more attractive colors.
+
+    .. plot::
+        :context: close-figs
+
+        >>> import seaborn as sns; sns.set()
+        >>> sns.palplot(sns.color_palette("muted"))
+
+    Use discrete values from one of the built-in matplotlib colormaps.
+
+    .. plot::
+        :context: close-figs
+
+        >>> sns.palplot(sns.color_palette("RdBu", n_colors=7))
+
+    Make a "dark" matplotlib sequential palette variant. (This can be good
+    when coloring multiple lines or points that correspond to an ordered
+    variable, where you don't want the lightest lines to be invisible).
+
+    .. plot::
+        :context: close-figs
+
+        >>> sns.palplot(sns.color_palette("Blues_d"))
+
+    Use a categorical matplotlib palette, add some desaturation. (This can be
+    good when making plots with large patches, which look best with dimmer
+    colors).
+
+    .. plot::
+        :context: close-figs
+
+        >>> sns.palplot(sns.color_palette("Set1", n_colors=8, desat=.7))
+
+    Use as a context manager:
+
+    .. plot::
+        :context: close-figs
+
+        >>> import numpy as np, matplotlib.pyplot as plt
+        >>> with sns.color_palette("husl", 8):
+        ...    plt.plot(np.c_[np.zeros(8), np.arange(8)].T);
 
     """
     if name is None:
@@ -527,7 +560,7 @@ def cubehelix_palette(n_colors=6, start=0, rot=.4, gamma=1.0, hue=0.8,
         return pal
 
 
-def set_color_shorthands(palette="deep"):
+def set_color_codes(palette="deep"):
     """Change how matplotlib color shorthands are interpreted.
 
     Calling this will change how shorthand codes like "b" or "g"
@@ -535,15 +568,48 @@ def set_color_shorthands(palette="deep"):
 
     Parameters
     ----------
-    palette : string
+    palette : {deep, muted, pastel, dark, bright, colorblind}
         Named seaborn palette to use as the source of colors.
 
+    See Also
+    --------
+    set : Color codes can be set through the high-level seaborn style
+          manager.
+    set_palette : Color codes can also be set through the function that
+                  sets the matplotlib color cycle.
+
+    Examples
+    --------
+
+    Map matplotlib color codes to the default seaborn palette.
+
+    .. plot::
+        :context: close-figs
+
+        >>> import matplotlib.pyplot as plt
+        >>> import seaborn as sns; sns.set()
+        >>> sns.set_color_codes()
+        >>> plt.plot([0, 1, 2], [0, 2, 1], color="r")
+
+    Use a different seaborn palette.
+
+    .. plot::
+        :context: close-figs
+
+        >>> sns.set_color_codes("dark")
+        >>> plt.plot([0, 1, 2], [0, 2, 1], color="k")
+        >>> plt.plot([0, 1, 2], [1, 0, 2], color="m")
+
     """
-    colors = SEABORN_PALETTES[palette]
-    for code, color in zip("bgrmyc", colors):
+    if palette == "reset":
+        colors = [(0., 0., 1.), (0., .5, 0.), (1., 0., 0.), (.75, .75, 0.),
+                  (.75, .75, 0.), (0., .75, .75), (0., 0., 0.)]
+    else:
+        colors = SEABORN_PALETTES[palette] + [(.1, .1, .1)]
+    for code, color in zip("bgrmyck", colors):
         rgb = mpl.colors.colorConverter.to_rgb(color)
         mpl.colors.colorConverter.colors[code] = rgb
-    mpl.colors.colorConverter.colors["k"] = (.1, .1, .1)
+        mpl.colors.colorConverter.cache[code] = rgb
 
 
 def _init_mutable_colormap():

--- a/seaborn/palettes.py
+++ b/seaborn/palettes.py
@@ -135,7 +135,7 @@ def color_palette(name=None, n_colors=6, desat=None):
 
         >>> import numpy as np, matplotlib.pyplot as plt
         >>> with sns.color_palette("husl", 8):
-        ...    plt.plot(np.c_[np.zeros(8), np.arange(8)].T);
+        ...    _ = plt.plot(np.c_[np.zeros(8), np.arange(8)].T)
 
     """
     if name is None:
@@ -594,7 +594,7 @@ def set_color_codes(palette="deep"):
         >>> import matplotlib.pyplot as plt
         >>> import seaborn as sns; sns.set()
         >>> sns.set_color_codes()
-        >>> plt.plot([0, 1, 2], [0, 2, 1], color="r")
+        >>> _ = plt.plot([0, 1, 2], [0, 2, 1], color="r")
 
     Use a different seaborn palette.
 
@@ -602,8 +602,8 @@ def set_color_codes(palette="deep"):
         :context: close-figs
 
         >>> sns.set_color_codes("dark")
-        >>> plt.plot([0, 1, 2], [0, 2, 1], color="k")
-        >>> plt.plot([0, 1, 2], [1, 0, 2], color="m")
+        >>> _ = plt.plot([0, 1, 2], [0, 2, 1], color="k")
+        >>> _ = plt.plot([0, 1, 2], [1, 0, 2], color="m")
 
     """
     if palette == "reset":

--- a/seaborn/palettes.py
+++ b/seaborn/palettes.py
@@ -150,7 +150,7 @@ def color_palette(palette=None, n_colors=None, desat=None):
     .. plot::
         :context: close-figs
 
-        >>> pal = sns.color_palette("muted", 3)
+        >>> pal = sns.color_palette("muted", 4)
         >>> pal.as_hex()
         [u'#4878cf', u'#6acc65', u'#d65f5f', u'#b47cc7']
 

--- a/seaborn/palettes.py
+++ b/seaborn/palettes.py
@@ -17,6 +17,22 @@ from .crayons import crayons
 from .miscplot import palplot
 
 
+SEABORN_PALETTES = dict(
+    deep=["#4C72B0", "#55A868", "#C44E52",
+          "#8172B2", "#CCB974", "#64B5CD"],
+    muted=["#4878CF", "#6ACC65", "#D65F5F",
+           "#B47CC7", "#C4AD66", "#77BEDB"],
+    pastel=["#92C6FF", "#97F0AA", "#FF9F9A",
+            "#D0BBFF", "#FFFEA3", "#B0E0E6"],
+    bright=["#003FFF", "#03ED3A", "#E8000B",
+            "#8A2BE2", "#FFC400", "#00D7FF"],
+    dark=["#001C7F", "#017517", "#8C0900",
+          "#7600A1", "#B8860B", "#006374"],
+    colorblind=["#0072B2", "#009E73", "#D55E00",
+                "#CC79A7", "#F0E442", "#56B4E9"]
+    )
+
+
 class _ColorPalette(list):
     """Set the color palette in a with statement, otherwise be a list."""
     def __enter__(self):
@@ -84,21 +100,6 @@ def color_palette(name=None, n_colors=6, desat=None):
     plotting_context : define parameters to scale plot elements
 
     """
-    seaborn_palettes = dict(
-        deep=["#4C72B0", "#55A868", "#C44E52",
-              "#8172B2", "#CCB974", "#64B5CD"],
-        muted=["#4878CF", "#6ACC65", "#D65F5F",
-               "#B47CC7", "#C4AD66", "#77BEDB"],
-        pastel=["#92C6FF", "#97F0AA", "#FF9F9A",
-                "#D0BBFF", "#FFFEA3", "#B0E0E6"],
-        bright=["#003FFF", "#03ED3A", "#E8000B",
-                "#8A2BE2", "#FFC400", "#00D7FF"],
-        dark=["#001C7F", "#017517", "#8C0900",
-              "#7600A1", "#B8860B", "#006374"],
-        colorblind=["#0072B2", "#009E73", "#D55E00",
-                    "#CC79A7", "#F0E442", "#56B4E9"],
-    )
-
     if name is None:
         palette = mpl.rcParams["axes.color_cycle"]
     elif not isinstance(name, string_types):
@@ -109,8 +110,8 @@ def color_palette(name=None, n_colors=6, desat=None):
         palette = husl_palette(n_colors)
     elif name.lower() == "jet":
         raise ValueError("No.")
-    elif name in seaborn_palettes:
-        palette = seaborn_palettes[name]
+    elif name in SEABORN_PALETTES:
+        palette = SEABORN_PALETTES[name]
     elif name in dir(mpl.cm):
         palette = mpl_palette(name, n_colors)
     elif name[:-2] in dir(mpl.cm):
@@ -524,6 +525,25 @@ def cubehelix_palette(n_colors=6, start=0, rot=.4, gamma=1.0, hue=0.8,
         return cmap
     else:
         return pal
+
+
+def set_color_shorthands(palette="deep"):
+    """Change how matplotlib color shorthands are interpreted.
+
+    Calling this will change how shorthand codes like "b" or "g"
+    are interpreted by matplotlib in subsequent plots.
+
+    Parameters
+    ----------
+    palette : string
+        Named seaborn palette to use as the source of colors.
+
+    """
+    colors = SEABORN_PALETTES[palette]
+    for code, color in zip("bgrmyc", colors):
+        rgb = mpl.colors.colorConverter.to_rgb(color)
+        mpl.colors.colorConverter.colors[code] = rgb
+    mpl.colors.colorConverter.colors["k"] = (.1, .1, .1)
 
 
 def _init_mutable_colormap():

--- a/seaborn/rcmod.py
+++ b/seaborn/rcmod.py
@@ -64,7 +64,7 @@ _context_keys = (
 
 
 def set(context="notebook", style="darkgrid", palette="deep",
-        font="sans-serif", font_scale=1, rc=None):
+        font="sans-serif", font_scale=1, color_codes=False, rc=None):
     """Set aesthetic parameters in one step.
 
     Each set of parameters can be set directly or temporarily, see the
@@ -83,13 +83,16 @@ def set(context="notebook", style="darkgrid", palette="deep",
     font_scale : float, optional
         Separate scaling factor to independently scale the size of the
         font elements.
+    color_codes : bool
+        If ``True`` and ``palette`` is a seaborn palette, remap the shorthand
+        color codes (e.g. "b", "g", "r", etc.) to the colors from this palette.
     rc : dict or None
         Dictionary of rc parameter mappings to override the above.
 
     """
     set_context(context, font_scale)
     set_style(style, rc={"font.family": font})
-    set_palette(palette)
+    set_palette(palette, color_codes=color_codes)
     if rc is not None:
         mpl.rcParams.update(rc)
 
@@ -448,7 +451,7 @@ def set_context(context=None, font_scale=1, rc=None):
     mpl.rcParams.update(context_object)
 
 
-def set_palette(name, n_colors=6, desat=None):
+def set_palette(name, n_colors=6, desat=None, color_codes=False):
     """Set the matplotlib color cycle using a seaborn palette.
 
     Parameters
@@ -460,6 +463,9 @@ def set_palette(name, n_colors=6, desat=None):
         Number of colors in the cycle.
     desat : float
         Factor to desaturate each color by.
+    color_codes : bool
+        If ``True`` and ``palette`` is a seaborn palette, remap the shorthand
+        color codes (e.g. "b", "g", "r", etc.) to the colors from this palette.
 
     Examples
     --------
@@ -478,3 +484,5 @@ def set_palette(name, n_colors=6, desat=None):
     colors = palettes.color_palette(name, n_colors, desat)
     mpl.rcParams["axes.color_cycle"] = list(colors)
     mpl.rcParams["patch.facecolor"] = colors[0]
+    if color_codes:
+        palettes.set_color_codes(name)

--- a/seaborn/rcmod.py
+++ b/seaborn/rcmod.py
@@ -451,18 +451,20 @@ def set_context(context=None, font_scale=1, rc=None):
     mpl.rcParams.update(context_object)
 
 
-def set_palette(name, n_colors=6, desat=None, color_codes=False):
+def set_palette(palette, n_colors=None, desat=None, color_codes=False):
     """Set the matplotlib color cycle using a seaborn palette.
 
     Parameters
     ----------
-    name : hls | husl | matplotlib colormap | seaborn color palette
+    palette : hls | husl | matplotlib colormap | seaborn color palette
         Palette definition. Should be something that :func:`color_palette`
         can process.
     n_colors : int
-        Number of colors in the cycle.
+        Number of colors in the cycle. The default number of colors will depend
+        on the format of ``palette``, see the :func:`color_palette`
+        documentation for more information.
     desat : float
-        Factor to desaturate each color by.
+        Proportion to desaturate each color by.
     color_codes : bool
         If ``True`` and ``palette`` is a seaborn palette, remap the shorthand
         color codes (e.g. "b", "g", "r", etc.) to the colors from this palette.
@@ -481,8 +483,8 @@ def set_palette(name, n_colors=6, desat=None, color_codes=False):
     set_style : set the default parameters for figure style
 
     """
-    colors = palettes.color_palette(name, n_colors, desat)
+    colors = palettes.color_palette(palette, n_colors, desat)
     mpl.rcParams["axes.color_cycle"] = list(colors)
     mpl.rcParams["patch.facecolor"] = colors[0]
     if color_codes:
-        palettes.set_color_codes(name)
+        palettes.set_color_codes(palette)

--- a/seaborn/tests/test_categorical.py
+++ b/seaborn/tests/test_categorical.py
@@ -391,7 +391,7 @@ class TestCategoricalPlotter(CategoricalFixture):
         # Test a color-based blend for the hue mapping
         p.establish_variables("g", "y", "h", data=self.df)
         p.establish_colors("#ff0022", None, 1)
-        rgba_array = palettes.light_palette("#ff0022", 2)
+        rgba_array = np.array(palettes.light_palette("#ff0022", 2))
         npt.assert_array_almost_equal(p.colors,
                                       rgba_array[:, :3])
 

--- a/seaborn/tests/test_palettes.py
+++ b/seaborn/tests/test_palettes.py
@@ -271,3 +271,9 @@ class TestColorPalettes(object):
             rgb_got = mpl.colors.colorConverter.to_rgb(code)
             nt.assert_equal(rgb_want, rgb_got)
         palettes.set_color_codes("reset")
+
+    def test_as_hex(self):
+
+        pal = palettes.color_palette("deep")
+        for rgb, hex in zip(pal, pal.as_hex()):
+            nt.assert_equal(mpl.colors.rgb2hex(rgb), hex)

--- a/seaborn/tests/test_palettes.py
+++ b/seaborn/tests/test_palettes.py
@@ -31,13 +31,17 @@ class TestColorPalettes(object):
 
     def test_big_palette_context(self):
 
-        default_pal = palettes.color_palette(n_colors=8)
+        original_pal = palettes.color_palette("deep", n_colors=8)
         context_pal = palettes.color_palette("husl", 10)
 
+        rcmod.set_palette(original_pal)
         with palettes.color_palette(context_pal, 10):
             nt.assert_equal(mpl.rcParams["axes.color_cycle"], context_pal)
 
-        nt.assert_equal(mpl.rcParams["axes.color_cycle"], default_pal)
+        nt.assert_equal(mpl.rcParams["axes.color_cycle"], original_pal)
+
+        # Reset default
+        rcmod.set()
 
     def test_seaborn_palettes(self):
 

--- a/seaborn/tests/test_palettes.py
+++ b/seaborn/tests/test_palettes.py
@@ -31,7 +31,7 @@ class TestColorPalettes(object):
 
     def test_big_palette_context(self):
 
-        default_pal = palettes.color_palette()
+        default_pal = palettes.color_palette(n_colors=8)
         context_pal = palettes.color_palette("husl", 10)
 
         with palettes.color_palette(context_pal, 10):
@@ -277,3 +277,9 @@ class TestColorPalettes(object):
         pal = palettes.color_palette("deep")
         for rgb, hex in zip(pal, pal.as_hex()):
             nt.assert_equal(mpl.colors.rgb2hex(rgb), hex)
+
+    def test_preserved_palette_length(self):
+
+        pal_in = palettes.color_palette("Set1", 10)
+        pal_out = palettes.color_palette(pal_in)
+        nt.assert_equal(pal_in, pal_out)

--- a/seaborn/tests/test_palettes.py
+++ b/seaborn/tests/test_palettes.py
@@ -261,3 +261,13 @@ class TestColorPalettes(object):
         for name, color in zip(names, colors):
             as_hex = mpl.colors.rgb2hex(color)
             nt.assert_equal(as_hex, crayons[name].lower())
+
+    def test_color_codes(self):
+
+        palettes.set_color_codes("deep")
+        colors = palettes.color_palette("deep") + [".1"]
+        for code, color in zip("bgrmyck", colors):
+            rgb_want = mpl.colors.colorConverter.to_rgb(color)
+            rgb_got = mpl.colors.colorConverter.to_rgb(code)
+            nt.assert_equal(rgb_want, rgb_got)
+        palettes.set_color_codes("reset")


### PR DESCRIPTION
Several changes wrapped up here:

### Introduction of `set_color_codes` function.

This function will reach into matplotlib and change the interpretation of matplotlib color codes (i.e. `"b"`, "`g"`) to match the colors from the seaborn palettes. This makes it easier to generate attractive figures when calling matplotlib functions directly. As this is borderline abuse of the matplotlib API, this doesn't currently happen by default when importing seaborn. It's possible that will change in the future. You can also pass `color_codes=True` to `set()` or `set_palette()` to do this in one step.

Closes #293

### Overhaul of how the length of the palette is determined

This addresses a surprising issue that comes up when you do something like

```python
len(color_palette(color_palette("Blues", 8)))
```

Now, the length of the current color cycle or input palette is respected. This makes the code messier and the behavior of the function a bit less predictable (imo), but it produces behavior that seems to be closer to what most users expect.

Closes #314 
Closes #452

### Addition of the `as_hex` method to color palette objects.

```python
        >>> pal = sns.color_palette("muted", 3)
        >>> pal.as_hex()
        [u'#4878cf', u'#6acc65', u'#d65f5f', u'#b47cc7']
```

Also includes some documentation enhancements to the color functions.