### PR TITLE
Fix bug in PairGrid missing data handling

### DIFF
--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -937,7 +937,8 @@ class PairGrid(Grid):
                     try:
                         data_k = hue_grouped.get_group(label_k)
                     except KeyError:
-                        data_k = np.array([])
+                        data_k = pd.DataFrame(columns=self.data.columns,
+                                              dtype=np.float)
 
                     ax = self.axes[i, j]
                     plt.sca(ax)
@@ -996,7 +997,7 @@ class PairGrid(Grid):
                 for label in self.hue_names:
                     # Attempt to get data for this level, allowing for empty
                     try:
-                        vals.append(hue_grouped.get_group(label))
+                        vals.append(np.asarray(hue_grouped.get_group(label)))
                     except KeyError:
                         vals.append(np.array([]))
                 func(vals, color=self.palette, histtype="barstacked",
@@ -1035,7 +1036,8 @@ class PairGrid(Grid):
                 try:
                     data_k = hue_grouped.get_group(label_k)
                 except KeyError:
-                    data_k = np.array([])
+                    data_k = pd.DataFrame(columns=self.data.columns,
+                                          dtype=np.float)
 
                 ax = self.axes[i, j]
                 plt.sca(ax)
@@ -1079,7 +1081,8 @@ class PairGrid(Grid):
                 try:
                     data_k = hue_grouped.get_group(label_k)
                 except KeyError:
-                    data_k = np.array([])
+                    data_k = pd.DataFrame(columns=self.data.columns,
+                                          dtype=np.float)
 
                 ax = self.axes[i, j]
                 plt.sca(ax)

--- a/seaborn/tests/test_axisgrid.py
+++ b/seaborn/tests/test_axisgrid.py
@@ -944,6 +944,50 @@ class TestPairGrid(object):
 
         plt.close("all")
 
+    @skipif(old_matplotlib)
+    def test_hue_order_missing_level(self):
+
+        order = list("dcaeb")
+        g = ag.PairGrid(self.df, hue="a", hue_order=order)
+        g.map(plt.plot)
+
+        for line, level in zip(g.axes[1, 0].lines, order):
+            x, y = line.get_xydata().T
+            npt.assert_array_equal(x, self.df.loc[self.df.a == level, "x"])
+            npt.assert_array_equal(y, self.df.loc[self.df.a == level, "y"])
+
+        plt.close("all")
+
+        g = ag.PairGrid(self.df, hue="a", hue_order=order)
+        g.map_diag(plt.plot)
+
+        for line, level in zip(g.axes[0, 0].lines, order):
+            x, y = line.get_xydata().T
+            npt.assert_array_equal(x, self.df.loc[self.df.a == level, "x"])
+            npt.assert_array_equal(y, self.df.loc[self.df.a == level, "x"])
+
+        plt.close("all")
+
+        g = ag.PairGrid(self.df, hue="a", hue_order=order)
+        g.map_lower(plt.plot)
+
+        for line, level in zip(g.axes[1, 0].lines, order):
+            x, y = line.get_xydata().T
+            npt.assert_array_equal(x, self.df.loc[self.df.a == level, "x"])
+            npt.assert_array_equal(y, self.df.loc[self.df.a == level, "y"])
+
+        plt.close("all")
+
+        g = ag.PairGrid(self.df, hue="a", hue_order=order)
+        g.map_upper(plt.plot)
+
+        for line, level in zip(g.axes[0, 1].lines, order):
+            x, y = line.get_xydata().T
+            npt.assert_array_equal(x, self.df.loc[self.df.a == level, "y"])
+            npt.assert_array_equal(y, self.df.loc[self.df.a == level, "x"])
+
+        plt.close("all")
+
     def test_nondefault_index(self):
 
         df = self.df.copy().set_index("b")


### PR DESCRIPTION
Fix a bug introduced in #547 (that caused PairGrid to crash on missing data).