### PR TITLE
End caps on barplot confidence intervals

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,7 @@ The documentation has an [example gallery](http://stanford.edu/~mwaskom/software
 Citing
 ------
 
-Seaborn can be cited using a DOI provided through Zenodo: [![DOI](https://zenodo.org/badge/doi/10.5072/zenodo.12710.png)](http://dx.doi.org/10.5072/zenodo.12710)
-
+Seaborn can be cited using a DOI provided through Zenodo: [![DOI](https://zenodo.org/badge/doi/10.5281/zenodo.19108.svg)](http://dx.doi.org/10.5281/zenodo.19108)
 
 Dependencies
 ------------

--- a/doc/releases/v0.6.0.txt
+++ b/doc/releases/v0.6.0.txt
@@ -83,6 +83,8 @@ Other additions and changes
 
 - You can now pass an integer to the ``xticklabels`` and ``yticklabels`` parameter of :func:`heatmap` (and, by extension, :func:`clustermap`). This will make the plot use the ticklabels inferred from the data, but only plot every ``n`` label, where ``n`` is the number you pass. This can help when visualizing larger matrices with some sensible ordering to the rows or columns of the dataframe.
 
+- Added `"figure.facecolor"` to the style parameters and set the default to white.
+
 - The :func:`load_dataset` function now caches datasets locally after downloading them, and uses the local copy on subsequent calls.
 
 Bug fixes

--- a/doc/releases/v0.6.0.txt
+++ b/doc/releases/v0.6.0.txt
@@ -1,17 +1,17 @@
 
-v0.6.0 (Unreleased)
--------------------
+v0.6.0 (June 2015)
+------------------
 
-This is a major release from 0.5. The main objective of this release is to unify the API for categorical plots, which means that there are some relatively large API changes in some of the older functions. See below for details of those changes, which may break code written for older versions of seaborn. There are also some new functions (:func:`stripplot`,  and :func:`countplot`), enhancements to existing functions, and bug fixes.
+This is a major release from 0.5. The main objective of this release was to unify the API for categorical plots, which means that there are some relatively large API changes in some of the older functions. See below for details of those changes, which may break code written for older versions of seaborn. There are also some new functions (:func:`stripplot`,  and :func:`countplot`), numerous enhancements to existing functions, and bug fixes.
 
-Additionally, the structure of the docs is changing in version 0.6. The API docs page for each function will have numerous examples with embedded plots showing how to use the various options. These pages should be considered the most comprehensive resource for examples, as the tutorial pages are going to be streamlined to provide a higher-level introduction.
+Additionally, the documentation has been completely revamped and expanded for the 0.6 release. Now, the API docs page for each function has multiple examples with embedded plots showing how to use the various options. These pages should be considered the most comprehensive resource for examples, and the tutorial pages are now streamlined and oriented towards a higher-level overview of the various features.
 
 Changes and updates to categorical plots
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-In version 0.6, the "categorical" plots have been unified with a common API. This new category of functions groups together plots that show the relationship between one numeric variable and one or two categorical variables. This includes plots that show distribution of the numeric variable in each bin (:func:`boxplot`, :func:`violinplot`, and :func:`stripplot`) and plots that apply a statistical estimation within each bin (:func:`pointplot`, :func:`barplot`, and :func:`countplot`).
+In version 0.6, the "categorical" plots have been unified with a common API. This new category of functions groups together plots that show the relationship between one numeric variable and one or two categorical variables. This includes plots that show distribution of the numeric variable in each bin (:func:`boxplot`, :func:`violinplot`, and :func:`stripplot`) and plots that apply a statistical estimation within each bin (:func:`pointplot`, :func:`barplot`, and :func:`countplot`). There is a new :ref:`tutorial chapter <categorical_tutorial>` that introduces these functions.
 
-These functions now each accept the same formats of input data and can be invoked in the same way. They can plot using long- or wide-form data, and can be drawn vertically or horizontally. When long-form data is used, the orientation of the plots is inferred from the types of the input data. Additionally, all functions natively take a ``hue`` variable to add a second layer of categorization.
+The categorical functions now each accept the same formats of input data and can be invoked in the same way. They can plot using long- or wide-form data, and can be drawn vertically or horizontally. When long-form data is used, the orientation of the plots is inferred from the types of the input data. Additionally, all functions natively take a ``hue`` variable to add a second layer of categorization.
 
 With the (in some cases new) API, these functions can all be drawn correctly by :class:`FacetGrid`. However, :func:`factorplot` can also now create faceted verisons of any of these kinds of plots, so in most cases it will be unnecessary to use :class:`FacetGrid` directly. By default, :func:`factorplot` draws a point plot, but this is controlled by the ``kind`` parameter.
 
@@ -43,7 +43,7 @@ New plotting functions
 Other additions and changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- The :func:`corrplot` and underlying :func:`symmatplot` have been deprecated in favor of :func:`heatmap`, which is much more flexible and robust. These two functions are still available in version 0.6, but they will be removed in a future version.
+- The :func:`corrplot` and underlying :func:`symmatplot` functions have been deprecated in favor of :func:`heatmap`, which is much more flexible and robust. These two functions are still available in version 0.6, but they will be removed in a future version.
 
 - Added the :func:`set_color_codes` function and the ``color_codes`` argument to :func:`set` and :func:`set_palette`. This changes the interpretation of shorthand color codes (i.e. "b", "g", k", etc.) within matplotlib to use the values from one of the named seaborn palettes (i.e. "deep", "muted", etc.). That makes it easier to have a more uniform look when using matplotlib functions directly with seaborn imported. This could be disruptive to existing plots, so it does not happen by default. It is possible this could change in the future.
 

--- a/seaborn/__init__.py
+++ b/seaborn/__init__.py
@@ -12,4 +12,4 @@ from .xkcd_rgb import xkcd_rgb
 from .crayons import crayons
 set()
 
-__version__ = "0.6.dev"
+__version__ = "0.6.0"

--- a/seaborn/__init__.py
+++ b/seaborn/__init__.py
@@ -12,4 +12,4 @@ from .xkcd_rgb import xkcd_rgb
 from .crayons import crayons
 set()
 
-__version__ = "0.6.0"
+__version__ = "0.7.dev"

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -1244,44 +1244,38 @@ class _CategoricalStatPlotter(_CategoricalPlotter):
                       at_group,
                       confint,
                       colors,
-                      draw_perp=False,
-                      thickness=1.8,
+                      conf_lw=1,
+                      capsize=0,
                       **kws):
 
-        kws.setdefault("lw", mpl.rcParams["lines.linewidth"] * thickness)
+        kws.setdefault("lw", mpl.rcParams["lines.linewidth"] * conf_lw)
 
         for at, (ci_low, ci_high), color in zip(at_group,
                                                 confint,
                                                 colors):
             if self.orient == "v":
                 ax.plot([at, at], [ci_low, ci_high], color=color, **kws)
-                if draw_perp:
-                    ax.plot([at - 0.05, at + 0.05],
-                            [ci_low, ci_low],
-                            color=color,
-                            **kws)
-                    ax.plot([at - 0.05, at + 0.05],
-                            [ci_high, ci_high],
-                            color=color,
-                            **kws)
+                ax.plot([at - capsize / 2, at + capsize / 2],
+                        [ci_low, ci_low], color=color, **kws)
+                ax.plot([at - capsize / 2, at + capsize / 2],
+                        [ci_high, ci_high], color=color, **kws)
+
             else:
                 ax.plot([ci_low, ci_high], [at, at], color=color, **kws)
-                if draw_perp:
-                    ax.plot([ci_low, ci_low],
-                            [at - 0.05, at + 0.05],
-                            color=color,
-                            **kws)
-                    ax.plot([ci_high, ci_high],
-                            [at - 0.05, at + 0.05],
-                            color=color,
-                            **kws)
+                ax.plot([ci_low, ci_low],
+                        [at - capsize / 2, at + capsize / 2],
+                        color=color, **kws)
+                ax.plot([ci_high, ci_high],
+                        [at - capsize / 2, at + capsize / 2],
+                        color=color, **kws)
 
 
 class _BarPlotter(_CategoricalStatPlotter):
     """Show point estimates and confidence intervals with bars."""
     def __init__(self, x, y, hue, data, order, hue_order,
                  estimator, ci, n_boot, units,
-                 orient, color, palette, saturation, errcolor, draw_perp):
+                 orient, color, palette, saturation, errcolor, conf_lw,
+                 capsize):
         """Initialize the plotter."""
         self.establish_variables(x, y, hue, data, orient,
                                  order, hue_order, units)
@@ -1289,7 +1283,8 @@ class _BarPlotter(_CategoricalStatPlotter):
         self.estimate_statistic(estimator, ci, n_boot)
 
         self.errcolor = errcolor
-        self.draw_perp = draw_perp
+        self.conf_lw = conf_lw
+        self.capsize = capsize
 
     def draw_bars(self, ax, kws):
         """Draw the bars onto `ax`."""
@@ -1308,7 +1303,8 @@ class _BarPlotter(_CategoricalStatPlotter):
             self.draw_confints(ax, barpos,
                                self.confint,
                                errcolors,
-                               draw_perp=self.draw_perp)
+                               self.conf_lw,
+                               self.capsize)
 
         else:
 
@@ -1327,7 +1323,8 @@ class _BarPlotter(_CategoricalStatPlotter):
                     self.draw_confints(ax, offpos,
                                        confint,
                                        errcolors,
-                                       draw_perp=self.draw_perp)
+                                       self.conf_lw,
+                                       self.capsize)
 
     def plot(self, ax, bar_kws):
         """Make the plot."""
@@ -1552,10 +1549,16 @@ _categorical_docs = dict(
         ``1`` if you want the plot colors to perfectly match the input color
         spec.\
     """),
-    draw_perp=dedent("""\
-    draw_perp : boolean, optional
-        Whether or not to draw perpendicular lines on the confidence
-        intervals for a barplot. Also known as endcaps on error bars.\
+    capsize=dedent("""\
+    capsize : float, optional
+        Length of caps on confidence interval (drawn perpendicular to primary
+        line. If 0.0 (default), no caps will be drawn. Typical values are
+        between 0.03 and 0.1.\
+    """),
+    conf_lw=dedent("""\
+    conf_lw : float, optional
+        Thickness of lines draw for the confidence interval (and caps).
+        Default is 1.8.\
     """),
     width=dedent("""\
     width : float, optional
@@ -2203,7 +2206,7 @@ stripplot.__doc__ = dedent("""\
 def barplot(x=None, y=None, hue=None, data=None, order=None, hue_order=None,
             estimator=np.mean, ci=95, n_boot=1000, units=None,
             orient=None, color=None, palette=None, saturation=.75,
-            errcolor=".26", ax=None, draw_perp=False, **kwargs):
+            errcolor=".26", conf_lw=1.8, capsize=0, ax=None, **kwargs):
 
     # Handle some deprecated arguments
     if "hline" in kwargs:
@@ -2222,7 +2225,7 @@ def barplot(x=None, y=None, hue=None, data=None, order=None, hue_order=None,
     plotter = _BarPlotter(x, y, hue, data, order, hue_order,
                           estimator, ci, n_boot, units,
                           orient, color, palette, saturation,
-                          errcolor, draw_perp)
+                          errcolor, conf_lw, capsize)
 
     if ax is None:
         ax = plt.gca()
@@ -2266,7 +2269,8 @@ barplot.__doc__ = dedent("""\
     errcolor : matplotlib color
         Color for the lines that represent the confidence interval.
     {ax_in}
-    {draw_perp}
+    {conf_lw}
+    {capsize}
     kwargs : key, value mappings
         Other keyword arguments are passed through to ``plt.bar`` at draw
         time.

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -1249,25 +1249,28 @@ class _CategoricalStatPlotter(_CategoricalPlotter):
                       **kws):
 
         kws.setdefault("lw", mpl.rcParams["lines.linewidth"] * conf_lw)
+        kws.pop('lw')
 
         for at, (ci_low, ci_high), color in zip(at_group,
                                                 confint,
                                                 colors):
             if self.orient == "v":
-                ax.plot([at, at], [ci_low, ci_high], color=color, **kws)
+                ax.plot([at, at], [ci_low, ci_high], color=color,
+                        lw=conf_lw, **kws)
                 ax.plot([at - capsize / 2, at + capsize / 2],
-                        [ci_low, ci_low], color=color, **kws)
+                        [ci_low, ci_low], color=color, lw=conf_lw, **kws)
                 ax.plot([at - capsize / 2, at + capsize / 2],
-                        [ci_high, ci_high], color=color, **kws)
+                        [ci_high, ci_high], color=color, lw=conf_lw, **kws)
 
             else:
-                ax.plot([ci_low, ci_high], [at, at], color=color, **kws)
+                ax.plot([ci_low, ci_high], [at, at], color=color,
+                        lw=conf_lw, **kws)
                 ax.plot([ci_low, ci_low],
                         [at - capsize / 2, at + capsize / 2],
-                        color=color, **kws)
+                        color=color, lw=conf_lw, **kws)
                 ax.plot([ci_high, ci_high],
                         [at - capsize / 2, at + capsize / 2],
-                        color=color, **kws)
+                        color=color, lw=conf_lw, **kws)
 
 
 class _BarPlotter(_CategoricalStatPlotter):
@@ -1339,7 +1342,7 @@ class _PointPlotter(_CategoricalStatPlotter):
     def __init__(self, x, y, hue, data, order, hue_order,
                  estimator, ci, n_boot, units,
                  markers, linestyles, dodge, join, scale,
-                 orient, color, palette):
+                 orient, color, palette, conf_lw, capsize):
         """Initialize the plotter."""
         self.establish_variables(x, y, hue, data, orient,
                                  order, hue_order, units)
@@ -1372,6 +1375,8 @@ class _PointPlotter(_CategoricalStatPlotter):
         self.dodge = dodge
         self.join = join
         self.scale = scale
+        self.conf_lw = conf_lw
+        self.capsize = capsize
 
     @property
     def hue_offsets(self):
@@ -1404,7 +1409,8 @@ class _PointPlotter(_CategoricalStatPlotter):
                             color=color, ls=ls, lw=lw)
 
             # Draw the confidence intervals
-            self.draw_confints(ax, pointpos, self.confint, self.colors, lw=lw)
+            self.draw_confints(ax, pointpos, self.confint, self.colors,
+                               self.conf_lw, self.capsize, lw=lw)
 
             # Draw the estimate points
             marker = self.markers[0]
@@ -1445,6 +1451,7 @@ class _PointPlotter(_CategoricalStatPlotter):
                     confint = self.confint[:, j]
                     errcolors = [self.colors[j]] * len(offpos)
                     self.draw_confints(ax, offpos, confint, errcolors,
+                                       self.conf_lw, self.capsize,
                                        zorder=z, lw=lw)
 
                 # Draw the estimate points
@@ -2373,7 +2380,8 @@ barplot.__doc__ = dedent("""\
 def pointplot(x=None, y=None, hue=None, data=None, order=None, hue_order=None,
               estimator=np.mean, ci=95, n_boot=1000, units=None,
               markers="o", linestyles="-", dodge=False, join=True, scale=1,
-              orient=None, color=None, palette=None, ax=None, **kwargs):
+              orient=None, color=None, palette=None, conf_lw=1.8,
+              capsize=0, ax=None, **kwargs):
 
     # Handle some deprecated arguments
     if "hline" in kwargs:
@@ -2392,7 +2400,7 @@ def pointplot(x=None, y=None, hue=None, data=None, order=None, hue_order=None,
     plotter = _PointPlotter(x, y, hue, data, order, hue_order,
                             estimator, ci, n_boot, units,
                             markers, linestyles, dodge, join, scale,
-                            orient, color, palette)
+                            orient, color, palette, conf_lw, capsize)
 
     if ax is None:
         ax = plt.gca()
@@ -2578,12 +2586,12 @@ def countplot(x=None, y=None, hue=None, data=None, order=None, hue_order=None,
     elif x is not None and y is not None:
         raise TypeError("Cannot pass values for both `x` and `y`")
     else:
-        raise TypeError("Must pass valus for either `x` or `y`")
+        raise TypeError("Must pass values for either `x` or `y`")
 
     plotter = _BarPlotter(x, y, hue, data, order, hue_order,
                           estimator, ci, n_boot, units,
                           orient, color, palette, saturation,
-                          errcolor)
+                          errcolor, None, None)
 
     plotter.value_label = "count"
 

--- a/seaborn/rcmod.py
+++ b/seaborn/rcmod.py
@@ -6,12 +6,15 @@ from . import palettes
 
 
 _style_keys = (
+
     "axes.facecolor",
     "axes.edgecolor",
     "axes.grid",
     "axes.axisbelow",
     "axes.linewidth",
     "axes.labelcolor",
+
+    "figure.facecolor",
 
     "grid.color",
     "grid.linestyle",
@@ -188,6 +191,7 @@ def axes_style(style=None, rc=None):
 
         # Common parameters
         style_dict = {
+            "figure.facecolor": "white",
             "text.color": dark_gray,
             "axes.labelcolor": dark_gray,
             "legend.frameon": False,

--- a/seaborn/tests/test_utils.py
+++ b/seaborn/tests/test_utils.py
@@ -6,10 +6,11 @@ import shutil
 import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
-from numpy.testing import assert_array_equal
 import nose
 import nose.tools as nt
 from nose.tools import assert_equal, raises
+import numpy.testing as npt
+import pandas.util.testing as pdt
 
 from distutils.version import LooseVersion
 pandas_has_categoricals = LooseVersion(pd.__version__) >= "0.15"
@@ -71,7 +72,7 @@ def test_ci_to_errsize():
                                [.25, 0]])
 
     test_errsize = utils.ci_to_errsize(cis, heights)
-    assert_array_equal(actual_errsize, test_errsize)
+    npt.assert_array_equal(actual_errsize, test_errsize)
 
 
 def test_desaturate():
@@ -336,7 +337,7 @@ if LooseVersion(pd.__version__) >= "0.15":
 
             # use cached version
             ds2 = load_dataset(name, cache=True, data_home=tmpdir)
-            assert_array_equal(ds, ds2)
+            pdt.assert_frame_equal(ds, ds2)
 
         finally:
             shutil.rmtree(tmpdir)

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ MAINTAINER_EMAIL = 'mwaskom@stanford.edu'
 URL = 'http://stanford.edu/~mwaskom/software/seaborn/'
 LICENSE = 'BSD (3-clause)'
 DOWNLOAD_URL = 'https://github.com/mwaskom/seaborn/'
-VERSION = '0.6.0'
+VERSION = '0.7.0.dev'
 
 try:
     from setuptools import setup

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ MAINTAINER_EMAIL = 'mwaskom@stanford.edu'
 URL = 'http://stanford.edu/~mwaskom/software/seaborn/'
 LICENSE = 'BSD (3-clause)'
 DOWNLOAD_URL = 'https://github.com/mwaskom/seaborn/'
-VERSION = '0.6.dev'
+VERSION = '0.6.0'
 
 try:
     from setuptools import setup


### PR DESCRIPTION
This is something I have been using on my own plots, and I figured it might be of use to others. 

Added a simple switch to `barplot` that allows for perpendicular lines to be drawn on the confidence intervals (which could be nicer for display, depending on your preference).

This changes the default behavior from this:
![001-without_perp](https://cloud.githubusercontent.com/assets/1278301/8293614/ba28d8ea-1904-11e5-984d-e612ff798a6c.png)

To this:
![001-with_perp](https://cloud.githubusercontent.com/assets/1278301/8293616/bdc63bc8-1904-11e5-881a-6d38385ce9d0.png)

Since it's a totally optional argument, and I don't think it breaks anything, hopefully it's not too painful to incorporate :smiley:

- Josh
