### PR TITLE
Avoid crash in clustermap with matplotlib OSX backend

### DIFF
--- a/seaborn/utils.py
+++ b/seaborn/utils.py
@@ -464,9 +464,13 @@ def axis_ticklabels_overlap(labels):
     """
     if not labels:
         return False
-    bboxes = [l.get_window_extent() for l in labels]
-    overlaps = [b.count_overlaps(bboxes) for b in bboxes]
-    return max(overlaps) > 1
+    try:
+        bboxes = [l.get_window_extent() for l in labels]
+        overlaps = [b.count_overlaps(bboxes) for b in bboxes]
+        return max(overlaps) > 1
+    except RuntimeError:
+        # Issue on macosx backend rasies an error in the above code
+        return False
 
 
 def axes_ticklabels_overlap(ax):


### PR DESCRIPTION
Avoid a crash at the cost of having overlapping ticklabels in some plots when using the OSX backend.

This is a replacement for #546 and addresses the issues in #545 