### PR TITLE
Draw margin titles with ax.annotate instead of f.text

### DIFF
--- a/doc/releases/v0.6.0.txt
+++ b/doc/releases/v0.6.0.txt
@@ -79,7 +79,7 @@ Other additions and changes
 
 - The various property dictionaries that can be passed to ``plt.boxplot`` are now applied after the seaborn restyling to allow for full customizability.
 
-- Added a ``savefig`` method to :class:`JointGrid` that defaults to a tight bounding box to make it easier to save figures using this class.
+- Added a ``savefig`` method to :class:`JointGrid` that defaults to a tight bounding box to make it easier to save figures using this class, and set a tight bbox as the default for the ``savefig`` method on other Grid objects.
 
 - You can now pass an integer to the ``xticklabels`` and ``yticklabels`` parameter of :func:`heatmap` (and, by extension, :func:`clustermap`). This will make the plot use the ticklabels inferred from the data, but only plot every ``n`` label, where ``n`` is the number you pass. This can help when visualizing larger matrices with some sensible ordering to the rows or columns of the dataframe.
 
@@ -97,3 +97,5 @@ Bug fixes
 - Fixed a bug in :class:`PairGrid` where the ``hue_order`` parameter was ignored.
 
 - Fixed two bugs in :func:`despine` that caused errors when trying to trim the spines on plots that had inverted axes or no ticks.
+
+- Improved support for the ``margin_titles`` option in :class:`FacetGrid`, which can now be used with a legend.

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -205,9 +205,7 @@ _facet_docs = dict(
     margin_titles : bool, optional
         If ``True``, the titles for the row variable are drawn to the right of
         the last column. This option is experimental and may not work in all
-        cases. If you call ``map`` multiple times when using this option, the
-        titles will stack; to avoid this, remove figure texts before the final
-        call to ``map``. See ``set_titles`` for more information.\
+        cases.\
     """),
     )
 
@@ -905,15 +903,6 @@ class FacetGrid(Grid):
         self: object
             Returns self.
 
-        Note
-        ----
-
-        When using margin titles for the row facets, calling this directly
-        will add titles on top of the existing titles (because the margin
-        titles aren't really "titles", just figure texts). To avoid that,
-        you should remove the existing titles first by doing, e.g.,
-        ``plt.setp(fig.texts, text="")``.
-
         """
         args = dict(row_var=self._row_var, col_var=self._col_var)
         kwargs["size"] = kwargs.pop("size", mpl.rcParams["axes.labelsize"])
@@ -938,12 +927,11 @@ class FacetGrid(Grid):
                     ax = self.axes[i, -1]
                     args.update(dict(row_name=row_name))
                     title = row_template.format(**args)
-                    trans = self.fig.transFigure.inverted()
-                    bbox = ax.bbox.transformed(trans)
-                    x = bbox.xmax + 0.01
-                    y = bbox.ymax - (bbox.height / 2)
-                    self.fig.text(x, y, title, rotation=270,
-                                  ha="left", va="center", **kwargs)
+                    bgcolor = self.fig.get_facecolor()
+                    ax.annotate(title, xy=(1.02, .5), xycoords="axes fraction",
+                                rotation=270, ha="left", va="center",
+                                backgroundcolor=bgcolor, **kwargs)
+
             if self.col_names is not None:
                 # Draw the column titles  as normal titles
                 for j, col_name in enumerate(self.col_names):

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -29,6 +29,8 @@ class Grid(object):
 
     def savefig(self, *args, **kwargs):
         """Save the figure."""
+        kwargs = kwargs.copy()
+        kwargs.setdefault("bbox_inches", "tight")
         self.fig.savefig(*args, **kwargs)
 
     def add_legend(self, legend_data=None, title=None, label_order=None,

--- a/seaborn/tests/test_axisgrid.py
+++ b/seaborn/tests/test_axisgrid.py
@@ -462,6 +462,10 @@ class TestFacetGrid(object):
         nt.assert_equal(g.axes[0, 1].get_title(), "b = n")
         nt.assert_equal(g.axes[1, 0].get_title(), "")
 
+        # Test the row "titles"
+        nt.assert_equal(g.axes[0, 1].texts[0].get_text(), "a = a")
+        nt.assert_equal(g.axes[1, 1].texts[0].get_text(), "a = b")
+
         # Test a provided title
         g.set_titles(col_template="{col_var} == {col_name}")
         nt.assert_equal(g.axes[0, 0].get_title(), "b == m")


### PR DESCRIPTION
This should keep the titles tighter to the axes when the figure
layout changes, such as adding a legend. This PR therefore fixes #303.

Also added a background to the text, which should prevent the issue
where adding multiple titles "stacks" the row titles (#509).

Also changed the default `savefig` `bbox_inches` to "tight" in Grid objects, so these texts won't get clipped when saving.