### PR TITLE
Compute linkage correctly when fastcluster is not installed

### DIFF
--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -522,8 +522,7 @@ class _DendrogramPlotter(object):
             UserWarning('This will be slow... (gentle suggestion: '
                         '"pip install fastcluster")')
 
-        pairwise_dists = distance.squareform(
-            distance.pdist(self.array, metric=self.metric))
+        pairwise_dists = distance.pdist(self.array, metric=self.metric)
         linkage = hierarchy.linkage(pairwise_dists, method=self.method)
         del pairwise_dists
         return linkage

--- a/seaborn/tests/test_matrix.py
+++ b/seaborn/tests/test_matrix.py
@@ -358,8 +358,7 @@ class TestDendrogram(object):
                                                     metric='euclidean',
                                                     method='single')
     except ImportError:
-        x_norm_distances = distance.squareform(
-            distance.pdist(x_norm.T, metric='euclidean'))
+        x_norm_distances = distance.pdist(x_norm.T, metric='euclidean')
         x_norm_linkage = hierarchy.linkage(x_norm_distances, method='single')
     x_norm_dendrogram = hierarchy.dendrogram(x_norm_linkage, no_plot=True,
                                              color_list=['k'],
@@ -499,9 +498,7 @@ class TestDendrogram(object):
         from scipy.spatial import distance
         from scipy.cluster import hierarchy
 
-        dists = distance.squareform(distance.pdist(self.x_norm.T,
-                                                   metric=self.default_kws[
-                                                       'metric']))
+        dists = distance.pdist(self.x_norm.T, metric=self.default_kws['metric'])
         linkage = hierarchy.linkage(dists, method=self.default_kws['method'])
 
         npt.assert_array_equal(scipy_linkage, linkage)

--- a/seaborn/tests/test_matrix.py
+++ b/seaborn/tests/test_matrix.py
@@ -467,8 +467,7 @@ class TestDendrogram(object):
             linkage = fastcluster.linkage_vector(self.x_norm, method='single',
                                                  metric='euclidean')
         except ImportError:
-            d = distance.squareform(distance.pdist(self.x_norm,
-                                                   metric='euclidean'))
+            d = distance.pdist(self.x_norm, metric='euclidean')
             linkage = hierarchy.linkage(d, method='single')
         dendrogram = hierarchy.dendrogram(linkage, no_plot=True,
                                           color_list=['k'],
@@ -597,8 +596,7 @@ class TestClustermap(object):
                                                     metric='euclidean',
                                                     method='single')
     except ImportError:
-        x_norm_distances = distance.squareform(
-            distance.pdist(x_norm.T, metric='euclidean'))
+        x_norm_distances = distance.pdist(x_norm.T, metric='euclidean')
         x_norm_linkage = hierarchy.linkage(x_norm_distances, method='single')
     x_norm_dendrogram = hierarchy.dendrogram(x_norm_linkage, no_plot=True,
                                              color_list=['k'],

--- a/seaborn/tests/test_matrix.py
+++ b/seaborn/tests/test_matrix.py
@@ -498,7 +498,8 @@ class TestDendrogram(object):
         from scipy.spatial import distance
         from scipy.cluster import hierarchy
 
-        dists = distance.pdist(self.x_norm.T, metric=self.default_kws['metric'])
+        dists = distance.pdist(self.x_norm.T,
+                               metric=self.default_kws['metric'])
         linkage = hierarchy.linkage(dists, method=self.default_kws['method'])
 
         npt.assert_array_equal(scipy_linkage, linkage)


### PR DESCRIPTION
To reproduce the problem this PR tries to fix, create a virtualenv without fastcluster and run [the code in this clustermap example](http://stanford.edu/~mwaskom/software/seaborn/examples/structured_heatmap.html). The rows and columns will be sorted in a different way than what is shown on that page.

When fastcluster is not installed, `_calculate_linkage_scipy` is used to
compute linkages. It contains an erroneous call to squareform().
distance.pdist() already returns a condensed distance matrix that is
required as input for the linkage() function. Converting it to a matrix
with squareform() is possible and linkage() will accept the resulting
matrix, but consider it to be a list of vectors of observations and run
distance.pdist() again on it. Thus, we get a linkage based on distances
between distances.

