### PR TITLE
Sort numerical category levels by default

### DIFF
--- a/doc/releases/v0.6.1.txt
+++ b/doc/releases/v0.6.1.txt
@@ -1,0 +1,6 @@
+
+v0.6.1 (Unreleased)
+-------------------
+
+- Added an additional rule when determining category order in categorical plots. Now, when numeric variables are used in a categorical role, the default behavior is to sort the unique levels of the variable (i.e they will be in proper numerical order). This can still be overriden by the appropriate ``{*_}order`` parameter, and variables with a ``category`` dtype will still follow the category order even if the levels are strictly numerical.
+

--- a/seaborn/tests/test_axisgrid.py
+++ b/seaborn/tests/test_axisgrid.py
@@ -18,6 +18,7 @@ from ..palettes import color_palette
 from ..distributions import kdeplot
 from ..categorical import pointplot
 from ..linearmodels import pairplot
+from ..utils import categorical_order
 
 rs = np.random.RandomState(0)
 
@@ -255,7 +256,7 @@ class TestFacetGrid(object):
 
         nt.assert_equal(g1._legend.get_title().get_text(), "b_bool")
 
-        b_levels = list(map(str, self.df.b_bool.unique()))
+        b_levels = list(map(str, categorical_order(self.df.b_bool)))
 
         lines = g1._legend.get_lines()
         nt.assert_equal(len(lines), len(b_levels))

--- a/seaborn/tests/test_utils.py
+++ b/seaborn/tests/test_utils.py
@@ -286,6 +286,7 @@ def test_ticklabels_overlap():
 def test_categorical_order():
 
     x = ["a", "c", "c", "b", "a", "d"]
+    y = [3, 2, 5, 1, 4]
     order = ["a", "b", "c", "d"]
 
     out = utils.categorical_order(x)
@@ -302,6 +303,15 @@ def test_categorical_order():
 
     out = utils.categorical_order(pd.Series(x))
     nt.assert_equal(out, ["a", "c", "b", "d"])
+
+    out = utils.categorical_order(y)
+    nt.assert_equal(out, [1, 2, 3, 4, 5])
+
+    out = utils.categorical_order(np.array(y))
+    nt.assert_equal(out, [1, 2, 3, 4, 5])
+
+    out = utils.categorical_order(pd.Series(y))
+    nt.assert_equal(out, [1, 2, 3, 4, 5])
 
     if pandas_has_categoricals:
         x = pd.Categorical(x, order)

--- a/seaborn/utils.py
+++ b/seaborn/utils.py
@@ -521,7 +521,8 @@ def categorical_order(values, order=None):
                 except AttributeError:
                     order = pd.unique(values)
                 try:
-                    order = np.sort(order.astype(np.float))
+                    np.asarray(values).astype(np.float)
+                    order = np.sort(order)
                 except (ValueError, TypeError):
                     order = order
         order = filter(pd.notnull, order)

--- a/seaborn/utils.py
+++ b/seaborn/utils.py
@@ -520,5 +520,9 @@ def categorical_order(values, order=None):
                     order = values.unique()
                 except AttributeError:
                     order = pd.unique(values)
+                try:
+                    order = np.sort(order.astype(np.float))
+                except (ValueError, TypeError):
+                    order = order
         order = filter(pd.notnull, order)
     return list(order)


### PR DESCRIPTION
Adds an additional rule when determining category order in categorical plots.
Now, when numeric variables are used in a categorical role, the default
behavior is to sort the unique levels of the variable (i.e they will be in
proper numerical order). This can still be overriden by the appropriate
``{*_}order`` parameter, and variables with a ``category`` dtype will still
follow the category order even if the levels are strictly numerical.

Closes #626