### PR TITLE
Factor Heatmaps

### DIFF
--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -401,10 +401,12 @@ def heatmap(data, vmin=None, vmax=None, cmap=None, center=None, robust=False,
         Values to anchor the colormap, otherwise they are inferred from the
         data and other keyword arguments. When a diverging dataset is inferred,
         one of these values may be ignored.
-    cmap : matplotlib colormap name or object, optional
+    cmap : matplotlib colormap name or object, or list, optional
         The mapping from data values to color space. If not provided, this
         will be either a cubehelix map (if the function infers a sequential
         dataset) or ``RdBu_r`` (if the function infers a diverging dataset).
+        If list is passed and ``as_factors=True`, the colors in thel ist
+        will be used as the legend colors for the factors
     center : float, optional
         The value at which to center the colormap. Passing this value implies
         use of a diverging colormap.
@@ -447,9 +449,10 @@ def heatmap(data, vmin=None, vmax=None, cmap=None, center=None, robust=False,
     mask : boolean array or DataFrame, optional
         If passed, data will not be shown in cells where ``mask`` is True.
         Cells with missing values are automatically masked.
-    as_factors: boolean, optional
+    as_factors: boolean, or list, optional
         If passed, data in cells will be treated as discrete factors
-        (rather than numeric values)
+        (rather than numeric values). If a list is passed, the factors
+         will be ordered in the order provided.
     kwargs : other keyword arguments
         All other keyword arguments are passed to ``ax.pcolormesh``.
 

--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -86,7 +86,7 @@ class _HeatMapper(object):
 
     def __init__(self, data, vmin, vmax, cmap, center, robust, annot, fmt,
                  annot_kws, cbar, cbar_kws,
-                 xticklabels=True, yticklabels=True, mask=None):
+                 xticklabels=True, yticklabels=True, mask=None, as_factors=None):
         """Initialize the plotting object."""
         # We always want to have a DataFrame with semantic information
         # and an ndarray to pass to matplotlib
@@ -144,7 +144,7 @@ class _HeatMapper(object):
 
         # Determine good default values for the colormapping
         self._determine_cmap_params(plot_data, vmin, vmax,
-                                    cmap, center, robust)
+                                    cmap, center, robust, as_factors)
 
         # Save other attributes to the object
         self.data = data
@@ -155,9 +155,12 @@ class _HeatMapper(object):
         self.cbar = cbar
         self.cbar_kws = {} if cbar_kws is None else cbar_kws
 
+
     def _determine_cmap_params(self, plot_data, vmin, vmax,
-                               cmap, center, robust):
+                               cmap, center, robust, as_factors):
         """Use some heuristics to set good defaults for colorbar and range."""
+
+        self.as_factors = as_factors
         calc_data = plot_data.data[~np.isnan(plot_data.data)]
         if vmin is None:
             vmin = np.percentile(calc_data, 2) if robust else calc_data.min()

--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -3,7 +3,8 @@ import itertools
 
 import colorsys
 import matplotlib as mpl
-from matplotlib.colors import ListedColormap
+from matplotlib.cm import get_cmap
+from matplotlib.colors import ListedColormap, Colormap
 from matplotlib.patches import Patch
 import matplotlib.pyplot as plt
 from matplotlib import gridspec
@@ -276,8 +277,22 @@ class _HeatMapper(object):
                     cmap = cubehelix_palette(light=.95, as_cmap=True)
 
         self.divergent = divergent
+
+        if isinstance(cmap, basestring):
+            if as_factors:
+                cmap = ListedColormap(color_palette(cmap, n_colors=len(self.unique_values)))
+            else:
+                cmap = get_cmap(cmap)
+        elif isinstance(cmap, list):
+            if not as_factors:
+                raise ValueError('Using list of colors as cmap supported only when `as_factors` is True')
+            else:
+                if len(cmap) != len(self.unique_values):
+                    raise ValueError('{} colors specified, while {} unique values exist'.format(len(cmap), len(self.unique_values)))
+                cmap = ListedColormap(cmap)
+
         self.cmap = cmap
-        
+
         # -- cbar ----------
         if self.cbar:
             if not as_factors:

--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -219,12 +219,7 @@ class _HeatMapper(object):
         if as_factors:
             vmin = 0
             vmax = len(self.unique_values) - 1
-            # Choose divergent color scheme for boolean data
-            if self.unique_values == [False, True] or self.unique_values == [0, 1]:
-                divergent = True
-            else:
-                # Choose qualitative for all others
-                divergent = False
+            divergent = False
         else:
             if vmin is None:
                 if robust:
@@ -260,8 +255,12 @@ class _HeatMapper(object):
         # -- cmap
         if as_factors:
             if cmap is None:
-                if divergent:
-                    cmap = ListedColormap(color_palette(self.DIVERGENT_COLOR_PALETTE, n_colors=len(self.unique_values)))
+                # Choose divergent color scheme for boolean data
+                if self.unique_values == [False, True] or self.unique_values == [0, 1] \
+                        or self.unique_values == [0.0, 1.0]:
+                    # Choose a color palette that assigns light square to False
+                    # and dark square to True -- otherwise it just looks horrible
+                    cmap = ListedColormap(cubehelix_palette(light=.95, n_colors=len(self.unique_values)))
                 else:
                     cmap = ListedColormap(color_palette(n_colors=len(self.unique_values)))
 
@@ -275,10 +274,10 @@ class _HeatMapper(object):
                     cmap = self.DIVERGENT_COLOR_PALETTE
                 else:
                     cmap = cubehelix_palette(light=.95, as_cmap=True)
-            else:
-                cmap = cmap
+
         self.divergent = divergent
         self.cmap = cmap
+        
         # -- cbar ----------
         if self.cbar:
             if not as_factors:

--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -18,6 +18,7 @@ from .palettes import cubehelix_palette, color_palette
 from .utils import despine, axis_ticklabels_overlap
 from .external.six.moves import range
 
+
 def _index_to_label(index):
     """Convert a pandas index or multiindex to an axis label."""
     if isinstance(index, pd.MultiIndex):
@@ -190,7 +191,7 @@ class _HeatMapper(object):
                 # Reorder unique values as provided by user
                 unique_values = user_provided_factors
 
-            # Transform data into numeric by mapping each unique value to an int
+            # Transform data into numeric by mapping unique values to ints
             unique_values_map = {val: i for i, val in enumerate(unique_values)}
 
             def _get_func(x):
@@ -386,6 +387,7 @@ class _HeatMapper(object):
 
                     ax.legend(patches, ticker, loc=_loc,
                               bbox_to_anchor=_bbox_to_anchor, **cbar_kwargs)
+
 
 def heatmap(data, vmin=None, vmax=None, cmap=None, center=None, robust=False,
             annot=False, fmt=None, annot_kws=None,

--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -3,6 +3,7 @@ import itertools
 
 import colorsys
 import matplotlib as mpl
+from matplotlib.colors import ListedColormap
 import matplotlib.pyplot as plt
 from matplotlib import gridspec
 import numpy as np
@@ -11,7 +12,7 @@ from scipy.spatial import distance
 from scipy.cluster import hierarchy
 
 from .axisgrid import Grid
-from .palettes import cubehelix_palette
+from .palettes import cubehelix_palette, color_palette
 from .utils import despine, axis_ticklabels_overlap
 from .external.six.moves import range
 
@@ -183,7 +184,10 @@ class _HeatMapper(object):
         if as_factors:
             unique_values = pd.Series(np.ravel(calc_data)).unique()
             self.vmin, self.vmax = 0, len(unique_values) - 1
-            divergent = False
+
+            if cmap is None:
+                cmap = ListedColormap(color_palette(n_colors=len(unique_values)))
+            self.cmap = cmap
         else:
             if vmin is None:
                 vmin = np.percentile(calc_data, 2) if robust else calc_data.min()
@@ -208,16 +212,16 @@ class _HeatMapper(object):
             self.vmin = vmin
             self.vmax = vmax
 
-        self.divergent = divergent
+            self.divergent = divergent
 
-        # Choose default colormaps if not provided
-        if cmap is None:
-            if divergent:
-                self.cmap = "RdBu_r"
+            # Choose default colormaps if not provided
+            if cmap is None:
+                if divergent:
+                    self.cmap = "RdBu_r"
+                else:
+                    self.cmap = cubehelix_palette(light=.95, as_cmap=True)
             else:
-                self.cmap = cubehelix_palette(light=.95, as_cmap=True)
-        else:
-            self.cmap = cmap
+                self.cmap = cmap
 
     def _annotate_heatmap(self, ax, mesh):
         """Add textual labels with the value in each cell."""

--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -379,6 +379,7 @@ class _HeatMapper(object):
                            for i, value in enumerate(ticker)]
                 if cax is not None:
                     cax.legend(patches, ticker, **self.cbar_kws)
+                    cax.axison = False
                 else:
                     cbar_kwargs = self.cbar_kws.copy()
                     _loc = cbar_kwargs.pop('loc', 'center left')

--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -252,13 +252,14 @@ class _HeatMapper(object):
     def _annotate_heatmap(self, ax, mesh):
         """Add textual labels with the value in each cell."""
         xpos, ypos = np.meshgrid(ax.get_xticks(), ax.get_yticks())
-        for x, y, val, color in zip(xpos.flat, ypos.flat,
-                                    mesh.get_array(), mesh.get_facecolors()):
-            if val is not np.ma.masked:
+        for x, y, plot_val, data_val, color in zip(xpos.flat, ypos.flat,
+                                                   mesh.get_array(), self.data.values.flat,
+                                                   mesh.get_facecolors()):
+            if plot_val is not np.ma.masked:
                 _, l, _ = colorsys.rgb_to_hls(*color[:3])
                 text_color = ".15" if l > .5 else "w"
-                val = ("{:" + self.fmt + "}").format(val)
-                ax.text(x, y, val, color=text_color,
+                text = ("{:" + self.fmt + "}").format(data_val)
+                ax.text(x, y, text, color=text_color,
                         ha="center", va="center", **self.annot_kws)
 
     def plot(self, ax, cax, kws):

--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -131,6 +131,8 @@ class _HeatMapper(object):
 
         # Save other attributes to the object
         self.annot = annot
+        if fmt is None:
+            fmt = ".2g" if not self.as_factors else ''
         self.fmt = fmt
         self.annot_kws = {} if annot_kws is None else annot_kws
         self.cbar = cbar
@@ -139,7 +141,7 @@ class _HeatMapper(object):
         # Determine good default values for the colormapping,
         # change data appropriately if needed
         self._prepare_drawing_parameters(vmin, vmax,
-                                         cmap, center, robust, as_factors)
+                                         cmap, center, robust)
 
     def _prepare_data(self, data, mask, as_factors):
 
@@ -174,13 +176,14 @@ class _HeatMapper(object):
         self.plot_data = plot_data
         self.data = data
         self.mask = mask
+        self.as_factors = as_factors
 
     def _prepare_drawing_parameters(self, vmin, vmax,
-                               cmap, center, robust, as_factors):
+                               cmap, center, robust):
         """Heuristic defaults for good colorbar parameters,
            choices of colormap, and ticks"""
 
-        self.as_factors = as_factors
+        as_factors = self.as_factors
         plot_data = self.plot_data
 
         calc_data = plot_data.data[~np.isnan(plot_data.data)]
@@ -298,7 +301,7 @@ class _HeatMapper(object):
 
 
 def heatmap(data, vmin=None, vmax=None, cmap=None, center=None, robust=False,
-            annot=False, fmt=".2g", annot_kws=None,
+            annot=False, fmt=None, annot_kws=None,
             linewidths=0, linecolor="white",
             cbar=True, cbar_kws=None, cbar_ax=None,
             square=False, ax=None, xticklabels=True, yticklabels=True,

--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -175,6 +175,17 @@ class _HeatMapper(object):
 
         if as_factors:
             unique_values = sorted(pd.Series(np.ravel(plot_data)).dropna().unique())
+
+            if isinstance(as_factors, list):
+                user_provided_factors = as_factors
+                as_factors = True
+                if set(user_provided_factors) != set(unique_values):
+                    raise ValueError('The set of provided factors {!r} '
+                                     'does not match actual factors'
+                                     ' in the data: {!r}'.format(user_provided_factors, unique_values))
+                # Reorder unique values as provided by user
+                unique_values = user_provided_factors
+
             # Transform data into numeric one by mapping each unique value to an int
             unique_values_map = {val: i for i, val in enumerate(unique_values)}
 

--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -591,7 +591,7 @@ def heatmap(data, vmin=None, vmax=None, cmap=None, center=None, robust=False,
         >>> import string
         >>> _to_letters = np.vectorize(lambda x: string.uppercase[int(x)])
         >>> data_as_letters = _to_letters(np.round(uniform_data * 2))
-        >>> seaborn.heatmap(data_as_letters, as_factors=True, annot=True)
+        >>> sns.heatmap(data_as_letters, as_factors=True, annot=True)
 
     """
     # Initialize the plotter object

--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -279,7 +279,7 @@ def heatmap(data, vmin=None, vmax=None, cmap=None, center=None, robust=False,
             linewidths=0, linecolor="white",
             cbar=True, cbar_kws=None, cbar_ax=None,
             square=False, ax=None, xticklabels=True, yticklabels=True,
-            mask=None,
+            mask=None, as_factors=None,
             **kwargs):
     """Plot rectangular data as a color-encoded matrix.
 
@@ -348,6 +348,9 @@ def heatmap(data, vmin=None, vmax=None, cmap=None, center=None, robust=False,
     mask : boolean array or DataFrame, optional
         If passed, data will not be shown in cells where ``mask`` is True.
         Cells with missing values are automatically masked.
+    as_factors: boolean, optional
+        If passed, data in cells will be treated as discrete factors
+        (rather than numeric values)
     kwargs : other keyword arguments
         All other keyword arguments are passed to ``ax.pcolormesh``.
 
@@ -463,7 +466,7 @@ def heatmap(data, vmin=None, vmax=None, cmap=None, center=None, robust=False,
     # Initialize the plotter object
     plotter = _HeatMapper(data, vmin, vmax, cmap, center, robust, annot, fmt,
                           annot_kws, cbar, cbar_kws, xticklabels, yticklabels,
-                          mask)
+                          mask, as_factors)
 
     # Add the pcolormesh kwargs here
     kwargs["linewidths"] = linewidths

--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -167,14 +167,11 @@ class _HeatMapper(object):
         plot_data = np.ma.masked_where(np.asarray(mask), plot_data)
 
         if as_factors is None:
-            print data.values.dtype
-
             if data.values.dtype in [np.dtype(bool), np.dtype(object)] \
                     or np.issubdtype(data.values.dtype, str):
                 as_factors = True
             else:
                 as_factors = False
-            print as_factors
 
         if as_factors:
             unique_values = sorted(pd.Series(np.ravel(plot_data)).dropna().unique())

--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -560,6 +560,35 @@ def heatmap(data, vmin=None, vmax=None, cmap=None, center=None, robust=False,
         >>> with sns.axes_style("white"):
         ...     ax = sns.heatmap(corr, mask=mask, vmax=.3, square=True)
 
+    Use `as_factors` to treat values as factors (as opposed to numeric):
+
+    .. plot::
+        :context: close-figs
+
+        >>> integer_data = np.round(uniform_data * 2)
+        >>> ax = sns.heatmap(integer_data, as_factors=True)
+
+    One can specify the ordering of factors in the legend, as well as their
+    colors by providing a list as `as_factors` parameter, as well as
+    a list of colors as `cmap`:
+
+    .. plot::
+        :context: close-figs
+
+        >>> integer_data = np.round(uniform_data * 2)
+        >>> ordered_factors = [2, 0, 1]
+        >>> factor_colors = ['#66c2a5', '#fa8e63', '#8da0cb']
+        >>> ax = sns.heatmap(integer_data, as_factors=ordered_factors, cmap=factor_colors)
+
+    Factor heatmaps also accept non-numeric inputs, for instance string matrices:
+
+    .. plot::
+        :context: close-figs
+
+        >>> import string
+        >>> _to_letters = np.vectorize(lambda x: string.uppercase[int(x)])
+        >>> data_as_letters = _to_letters(np.round(uniform_data * 2))
+        >>> seaborn.heatmap(data_as_letters, as_factors=True, annot=True)
 
     """
     # Initialize the plotter object

--- a/seaborn/tests/test_matrix.py
+++ b/seaborn/tests/test_matrix.py
@@ -191,10 +191,6 @@ class TestHeatmap(object):
                                m.plot_data.mask)
 
     def test_default_as_factors_cmap(self):
-        p = mat._HeatMapper(self.df_unif,
-                            as_factors=True,
-                            **self.default_kws)
-
         factor_datasets = [self.df_bool, self.df_int, self.df_string,
                            self.x_bool, self.x_int, self.x_string]
         for dataset in factor_datasets:

--- a/seaborn/tests/test_matrix.py
+++ b/seaborn/tests/test_matrix.py
@@ -350,6 +350,31 @@ class TestHeatmap(object):
         nt.assert_is_instance(p.cmap, ListedColormap)
         nt.assert_equal(p.cmap.colors, colors)
 
+    def test_heatmap_initialisation_when_a_list_of_factors_provided(self):
+        factors = [True, False]
+        kws = self.default_kws.copy()
+        kws['as_factors'] = factors
+        p = mat._HeatMapper(self.df_bool, **kws)
+
+        nt.assert_true(p.as_factors)
+        # Important -> unique_values should preserve the order of factors specified
+        nt.assert_list_equal(p.unique_values, factors)
+
+    def test_heatmap_initialisation_when_a_list_of_factors_provided_is_wrong(self):
+        kws = self.default_kws.copy()
+
+        # Too many parameters
+        kws['as_factors'] = [True, False, 'FileNotFound']
+        nt.assert_raises(ValueError, mat._HeatMapper, self.df_bool, **kws)
+
+        # Too few parameters
+        kws['as_factors'] = [True]
+        nt.assert_raises(ValueError, mat._HeatMapper, self.df_bool, **kws)
+
+        # Correct number of parameters, but parameters are wrong
+        kws['as_factors'] = [True, 'more True']
+        nt.assert_raises(ValueError, mat._HeatMapper, self.df_bool, **kws)
+
     def test_number_of_colors_in_factor_data_should_be_equal_to_number_of_factors(self):
         kws = self.default_kws.copy()
         kws["cmap"] = ['red', 'blue', 'green']

--- a/seaborn/tests/test_matrix.py
+++ b/seaborn/tests/test_matrix.py
@@ -206,6 +206,22 @@ class TestHeatmap(object):
         npt.assert_array_equal(np.isnan(m.plot_data.data),
                                m.plot_data.mask)
 
+    def test_bool_datasets_default_to_factor(self):
+        bool_datasets = [self.df_bool, self.x_bool]
+        for dataset in bool_datasets:
+            p = mat._HeatMapper(dataset,
+                                as_factors=None,
+                                **self.default_kws)
+            nt.assert_true(p.as_factors)
+
+    def test_string_datasets_default_to_factor(self):
+        bool_datasets = [self.df_string, self.x_string]
+        for dataset in bool_datasets:
+            p = mat._HeatMapper(dataset,
+                                as_factors=None,
+                                **self.default_kws)
+            nt.assert_true(p.as_factors)
+
     def test_default_as_factors_cmap(self):
         factor_datasets = [self.df_bool, self.df_int, self.df_string,
                            self.x_bool, self.x_int, self.x_string]

--- a/seaborn/tests/test_matrix.py
+++ b/seaborn/tests/test_matrix.py
@@ -1,5 +1,6 @@
 import itertools
 import tempfile
+from matplotlib.cm import get_cmap
 from matplotlib.colors import ListedColormap
 
 import numpy as np
@@ -250,7 +251,7 @@ class TestHeatmap(object):
         kws = self.default_kws.copy()
         kws["cmap"] = "BuGn"
         p = mat._HeatMapper(self.df_unif, **kws)
-        nt.assert_equal(p.cmap, "BuGn")
+        nt.assert_equal(p.cmap, get_cmap("BuGn"))
 
     def test_centered_vlims(self):
 
@@ -338,6 +339,26 @@ class TestHeatmap(object):
             ax = mat.heatmap(self.df_string, as_factors=True, cmap='PuOr_r')
         finally:
             plt.close('all')
+
+    def test_heatmap_can_be_initialised_with_list_of_colors_for_factor_data(self):
+        colors = ['red', 'blue']
+        kws = self.default_kws.copy()
+        kws["cmap"] = colors
+        kws['as_factors'] = True
+        p = mat._HeatMapper(self.df_bool, **kws)
+
+        nt.assert_is_instance(p.cmap, ListedColormap)
+        nt.assert_equal(p.cmap.colors, colors)
+
+    def test_number_of_colors_in_factor_data_should_be_equal_to_number_of_factors(self):
+        kws = self.default_kws.copy()
+        kws["cmap"] = ['red', 'blue', 'green']
+        kws['as_factors'] = True
+        # Too many colors
+        nt.assert_raises(ValueError, mat._HeatMapper, self.df_bool, **kws)
+        # Too few colors
+        kws['cmap'] = ['red']
+        nt.assert_raises(ValueError, mat._HeatMapper, self.df_bool, **kws)
 
     def test_heatmap_cbar(self):
 

--- a/seaborn/tests/test_matrix.py
+++ b/seaborn/tests/test_matrix.py
@@ -333,6 +333,21 @@ class TestHeatmap(object):
         finally:
             plt.close("all")
 
+    def test_factor_heatmap_disables_axes_for_colorbar(self):
+        try:
+            fig = plt.figure()
+            ax = plt.subplot(121)
+            cax = plt.subplot(122)
+
+            mat.heatmap(self.df_string, as_factors=True,
+                        ax=ax, cbar_ax=cax)
+            # Disable the default axes for colorbar legend
+            # otherwise clustermap plots look odd
+            nt.assert_false(cax.axison)
+        finally:
+            plt.close('all')
+
+
     def test_factor_heatmap_does_not_crash_when_string_cmap_provided(self):
         # The legend plotting fails if the string cmap
         # is not converted to a colormap object properly

--- a/seaborn/tests/test_matrix.py
+++ b/seaborn/tests/test_matrix.py
@@ -1,5 +1,6 @@
 import itertools
 import tempfile
+from matplotlib.colors import ListedColormap
 
 import numpy as np
 import matplotlib as mpl
@@ -188,6 +189,21 @@ class TestHeatmap(object):
 
         npt.assert_array_equal(np.isnan(m.plot_data.data),
                                m.plot_data.mask)
+
+    def test_default_as_factors_cmap(self):
+        p = mat._HeatMapper(self.df_unif,
+                            as_factors=True,
+                            **self.default_kws)
+
+        factor_datasets = [self.df_bool, self.df_int, self.df_string,
+                           self.x_bool, self.x_int, self.x_string]
+        for dataset in factor_datasets:
+            p = mat._HeatMapper(dataset,
+                                as_factors=True,
+                                **self.default_kws)
+            expected_N = len(pd.Series(np.ravel(dataset)).unique())
+            nt.assert_is_instance(p.cmap, ListedColormap)
+            nt.assert_equals(p.cmap.N, expected_N)
 
     def test_custom_cmap(self):
 

--- a/seaborn/tests/test_matrix.py
+++ b/seaborn/tests/test_matrix.py
@@ -130,10 +130,26 @@ class TestHeatmap(object):
             p = mat._HeatMapper(dataset,
                                 as_factors=True,
                                 **self.default_kws)
-            vmax = len(pd.Series(np.ravel(dataset)).unique()) - 1
+            unique_values = sorted(pd.Series(np.ravel(dataset)).unique())
+            vmax = len(unique_values) - 1
+            nt.assert_equal(p.unique_values, unique_values)
             nt.assert_equal(p.vmin, 0)
             nt.assert_equal(p.vmax, vmax)
             nt.assert_true(p.as_factors)
+
+    def test_asfactor_converts_plot_data_to_ints(self):
+
+        small_dataset = np.array([['a', 'b', 'c'],
+                                  ['c', 'a', 'b']], dtype='str')
+
+        p = mat._HeatMapper(small_dataset,
+                            as_factors=True,
+                            **self.default_kws)
+
+        expected_plot_data = np.array([[0, 1, 2],
+                                       [2, 0, 1]])
+        expected_plot_data = expected_plot_data[::-1] # reverse
+        npt.assert_array_equal(expected_plot_data, p.plot_data)
 
     def test_robust_sequential_vlims(self):
 

--- a/seaborn/tests/test_matrix.py
+++ b/seaborn/tests/test_matrix.py
@@ -36,6 +36,18 @@ class TestHeatmap(object):
     x_unif = rs.rand(20, 13)
     df_unif = pd.DataFrame(x_unif)
 
+    x_string = np.array([['F', 'A', 'C', 'T', 'O', 'R', 'F', 'A'],  # 5 unique values
+                         ['C', 'T', 'O', 'R', 'F', 'A', 'C', 'T'],
+                         ['O', 'R', 'F', 'A', 'C', 'T', 'O', 'R'],
+                         ['F', 'A', 'C', 'T', 'O', 'R', 'F', 'A']], dtype=str)
+    df_string = pd.DataFrame(x_string, index=letters)
+
+    x_bool = x_norm > 0.5
+    df_bool = pd.DataFrame(x_bool, index=letters)
+
+    x_int = np.array(x_norm, dtype=int)
+    df_int = pd.DataFrame(x_int, index=letters)
+
     default_kws = dict(vmin=None, vmax=None, cmap=None, center=None,
                        robust=False, annot=False, fmt=".2f", annot_kws=None,
                        cbar=True, cbar_kws=None, mask=None)
@@ -107,6 +119,20 @@ class TestHeatmap(object):
         nt.assert_equal(p.vmin, -vlim)
         nt.assert_equal(p.vmax, vlim)
         nt.assert_true(p.divergent)
+
+    def test_default_asfactor_vlims(self):
+
+        factor_datasets = [self.df_bool, self.df_int, self.df_string,
+                           self.x_bool, self.x_int, self.x_string]
+        for dataset in factor_datasets:
+            print '{!r}'.format(dataset)
+            p = mat._HeatMapper(dataset,
+                                as_factors=True,
+                                **self.default_kws)
+            vmax = len(pd.Series(np.ravel(dataset)).unique()) - 1
+            nt.assert_equal(p.vmin, 0)
+            nt.assert_equal(p.vmax, vmax)
+            nt.assert_true(p.as_factors)
 
     def test_robust_sequential_vlims(self):
 

--- a/seaborn/tests/test_matrix.py
+++ b/seaborn/tests/test_matrix.py
@@ -214,6 +214,18 @@ class TestHeatmap(object):
                                 **self.default_kws)
             nt.assert_true(p.as_factors)
 
+    def test_nones_are_ignored_from_unique_values(self):
+        bool_datasets = [self.df_bool.copy(), self.x_bool.copy()]
+
+        bool_datasets[0][0:3] = None
+        bool_datasets[1][0:3] = None
+
+        for dataset in bool_datasets:
+            p = mat._HeatMapper(dataset,
+                                as_factors=True,
+                                **self.default_kws)
+            npt.assert_array_equal([False, True], p.unique_values)
+
     def test_string_datasets_default_to_factor(self):
         bool_datasets = [self.df_string, self.x_string]
         for dataset in bool_datasets:

--- a/seaborn/tests/test_matrix.py
+++ b/seaborn/tests/test_matrix.py
@@ -271,26 +271,37 @@ class TestHeatmap(object):
                                self.df_norm.index[::-1][ystart:ny:3])
 
     def test_heatmap_annotation(self):
-
-        ax = mat.heatmap(self.df_norm, annot=True, fmt=".1f",
-                         annot_kws={"fontsize": 14})
-        for val, text in zip(self.x_norm[::-1].flat, ax.texts):
-            nt.assert_equal(text.get_text(), "{:.1f}".format(val))
-            nt.assert_equal(text.get_fontsize(), 14)
-        plt.close("all")
+        try:
+            ax = mat.heatmap(self.df_norm, annot=True, fmt=".1f",
+                             annot_kws={"fontsize": 14})
+            for val, text in zip(self.x_norm[::-1].flat, ax.texts):
+                nt.assert_equal(text.get_text(), "{:.1f}".format(val))
+                nt.assert_equal(text.get_fontsize(), 14)
+        finally:
+            plt.close("all")
 
     def test_heatmap_annotation_with_mask(self):
-
         df = pd.DataFrame(data={'a': [1, 1, 1],
                                 'b': [2, np.nan, 2],
                                 'c': [3, 3, np.nan]})
         mask = np.isnan(df.values)
         df_masked = np.ma.masked_where(mask, df)
         ax = mat.heatmap(df, annot=True, fmt='.1f', mask=mask)
-        nt.assert_equal(len(df_masked[::-1].compressed()), len(ax.texts))
-        for val, text in zip(df_masked[::-1].compressed(), ax.texts):
-            nt.assert_equal("{:.1f}".format(val), text.get_text())
-        plt.close("all")
+        try:
+            nt.assert_equal(len(df_masked[::-1].compressed()), len(ax.texts))
+            for val, text in zip(df_masked[::-1].compressed(), ax.texts):
+                nt.assert_equal("{:.1f}".format(val), text.get_text())
+        finally:
+            plt.close("all")
+
+    def test_heatmap_annotation_from_string_factor(self):
+
+        ax = mat.heatmap(self.df_string, annot=True, as_factors=True)
+        try:
+            for val, text in zip(self.x_string[::-1].flat, ax.texts):
+                nt.assert_equal(text.get_text(), "{:}".format(val))
+        finally:
+            plt.close("all")
 
     def test_heatmap_cbar(self):
 

--- a/seaborn/tests/test_matrix.py
+++ b/seaborn/tests/test_matrix.py
@@ -331,6 +331,14 @@ class TestHeatmap(object):
         finally:
             plt.close("all")
 
+    def test_factor_heatmap_does_not_crash_when_string_cmap_provided(self):
+        # The legend plotting fails if the string cmap is not converted to a colormap
+        # object properly
+        try:
+            ax = mat.heatmap(self.df_string, as_factors=True, cmap='PuOr_r')
+        finally:
+            plt.close('all')
+
     def test_heatmap_cbar(self):
 
         f = plt.figure()

--- a/seaborn/tests/test_matrix.py
+++ b/seaborn/tests/test_matrix.py
@@ -38,7 +38,8 @@ class TestHeatmap(object):
     x_unif = rs.rand(20, 13)
     df_unif = pd.DataFrame(x_unif)
 
-    x_string = np.array([['F', 'A', 'C', 'T', 'O', 'R', 'F', 'A'],  # 5 unique values
+    # 5 unique values
+    x_string = np.array([['F', 'A', 'C', 'T', 'O', 'R', 'F', 'A'],
                          ['C', 'T', 'O', 'R', 'F', 'A', 'C', 'T'],
                          ['O', 'R', 'F', 'A', 'C', 'T', 'O', 'R'],
                          ['F', 'A', 'C', 'T', 'O', 'R', 'F', 'A']], dtype=str)
@@ -149,7 +150,7 @@ class TestHeatmap(object):
 
         expected_plot_data = np.array([[0, 1, 2],
                                        [2, 0, 1]])
-        expected_plot_data = expected_plot_data[::-1] # reverse
+        expected_plot_data = expected_plot_data[::-1]  # reverse
         npt.assert_array_equal(expected_plot_data, p.plot_data)
 
     def test_robust_sequential_vlims(self):
@@ -333,8 +334,8 @@ class TestHeatmap(object):
             plt.close("all")
 
     def test_factor_heatmap_does_not_crash_when_string_cmap_provided(self):
-        # The legend plotting fails if the string cmap is not converted to a colormap
-        # object properly
+        # The legend plotting fails if the string cmap
+        # is not converted to a colormap object properly
         try:
             ax = mat.heatmap(self.df_string, as_factors=True, cmap='PuOr_r')
         finally:
@@ -357,10 +358,11 @@ class TestHeatmap(object):
         p = mat._HeatMapper(self.df_bool, **kws)
 
         nt.assert_true(p.as_factors)
-        # Important -> unique_values should preserve the order of factors specified
+        # Important:
+        # unique_values should preserve the order of factors specified
         nt.assert_list_equal(p.unique_values, factors)
 
-    def test_heatmap_initialisation_when_a_list_of_factors_provided_is_wrong(self):
+    def test_heatmap_initialisation_with_wrong_list_of_factors(self):
         kws = self.default_kws.copy()
 
         # Too many parameters
@@ -375,7 +377,7 @@ class TestHeatmap(object):
         kws['as_factors'] = [True, 'more True']
         nt.assert_raises(ValueError, mat._HeatMapper, self.df_bool, **kws)
 
-    def test_number_of_colors_in_factor_data_should_be_equal_to_number_of_factors(self):
+    def test_no_of_colors_checks_for_factor_data(self):
         kws = self.default_kws.copy()
         kws["cmap"] = ['red', 'blue', 'green']
         kws['as_factors'] = True

--- a/seaborn/tests/test_matrix.py
+++ b/seaborn/tests/test_matrix.py
@@ -341,7 +341,7 @@ class TestHeatmap(object):
         finally:
             plt.close('all')
 
-    def test_heatmap_can_be_initialised_with_list_of_colors_for_factor_data(self):
+    def test_heatmap_initialisation_with_list_of_colors_for_factor_data(self):
         colors = ['red', 'blue']
         kws = self.default_kws.copy()
         kws["cmap"] = colors


### PR DESCRIPTION
This pull request implements the ability to treat heatmap data as factors. 

Namely, the current implementation draws heatmaps as follows:

``` python
import numpy as np; np.random.seed(0)
import seaborn as sns; sns.set()
integer_data = np.round(np.random.rand(10, 12) * 2)
ax = sns.heatmap(integer_data)
```

![01-current](https://cloud.githubusercontent.com/assets/108413/8521929/da135bc6-23e0-11e5-83f0-ece7dafe31af.png)

This is visually nice, but the colorbar on the right hand side is a bit confusing as the values are purely in the set {0, 1, 2}.

This PR adds the `as_factors` option to `seaborn.heatmap`, which (1) treats values as qualitative, rather sequential (2) prints a legend, not colorbar.

``` python
ax = sns.heatmap(integer_data, as_factors=True)
```

![02-as-factors](https://cloud.githubusercontent.com/assets/108413/8521984/5d547132-23e1-11e5-8941-cc829a787732.png)

Boolean data is set to default to `as_factors=True` if not specified (but can be overriden with providing False explicitly):

``` python
boolean_data = np.random.rand(10, 12) > 0.5
ax = sns.heatmap(boolean_data)
```

![03-boolean](https://cloud.githubusercontent.com/assets/108413/8522010/a7d511f8-23e1-11e5-8e90-2002b7b2bf75.png)

This also allows one to plot non-numeric data. For instance, we can plot string data directly (defaults to `as_factor=True` too):

``` python
import string
_to_letters = np.vectorize(lambda x: string.uppercase[int(x)])
data_as_letters = _to_letters(integer_data)
sns.heatmap(data_as_letters, annot=True)
```

![04-string-data](https://cloud.githubusercontent.com/assets/108413/8522060/25ccfeb8-23e2-11e5-9d85-ea26a47dd186.png)

By default the factors are ordered using python's `sorted()`, but the sorting order (and colors) can be overriden directly:

``` python
sns.heatmap(data_as_letters, annot=True, 
                      as_factors=['C', 'A', 'B'], cmap=['red', 'purple', 'blue'])
```

![05-string-data-uglier](https://cloud.githubusercontent.com/assets/108413/8522107/a7fc16c6-23e2-11e5-8214-cc23c12c1359.png)

Well, that's pretty much it.
