### PR TITLE
Convert two tests to almost_equal variant

### DIFF
--- a/seaborn/tests/test_categorical.py
+++ b/seaborn/tests/test_categorical.py
@@ -513,7 +513,7 @@ class TestCategoricalStatPlotter(CategoricalFixture):
         sem = stats.sem(y[g == "b"])
         half_ci = stats.norm.ppf(.975) * sem
         ci = mean - half_ci, mean + half_ci
-        npt.assert_equal(p.statistic[1], mean)
+        npt.assert_almost_equal(p.statistic[1], mean)
         npt.assert_array_almost_equal(p.confint[1], ci, 2)
 
         npt.assert_equal(p.statistic[2], np.nan)
@@ -588,7 +588,7 @@ class TestCategoricalStatPlotter(CategoricalFixture):
         sem = stats.sem(y[(g == "b") & (h == "x")])
         half_ci = stats.norm.ppf(.975) * sem
         ci = mean - half_ci, mean + half_ci
-        npt.assert_equal(p.statistic[1, 2], mean)
+        npt.assert_almost_equal(p.statistic[1, 2], mean)
         npt.assert_array_almost_equal(p.confint[1, 2], ci, 2)
 
         npt.assert_array_equal(p.statistic[:, 0], [np.nan] * 4)


### PR DESCRIPTION
Prevent the tests below from failing with very close values:

    ======================================================================
    FAIL: seaborn.tests.test_categorical.TestCategoricalStatPlotter.test_nested_stats_with_missing_data
    ----------------------------------------------------------------------
    [...]
    Items are not equal:
     ACTUAL: -0.018721526986487352
     DESIRED: -0.018721526986487342

    ======================================================================
    FAIL: seaborn.tests.test_categorical.TestCategoricalStatPlotter.test_single_layer_stats_with_missing_data
    ----------------------------------------------------------------------
    [...]
    AssertionError:
    Items are not equal:
     ACTUAL: 0.082012970747837352
     DESIRED: 0.08201297074783731