### PR TITLE
factorplot: Extend input check when kind="count"

### DIFF
--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -2666,6 +2666,8 @@ def factorplot(x=None, y=None, hue=None, data=None, row=None, col=None,
             x_, y_, orient = y, y, "h"
         elif y is None and x is not None:
             x_, y_, orient = x, x, "v"
+        else:
+            raise ValueError("Either `x` or `y` must be None for count plots")
     else:
         x_, y_ = x, y
 

--- a/seaborn/tests/test_categorical.py
+++ b/seaborn/tests/test_categorical.py
@@ -2134,6 +2134,11 @@ class TestFactorPlot(CategoricalFixture):
         with nt.assert_raises(ValueError):
             cat.factorplot("g", "y", data=self.df, kind="not_a_kind")
 
+    def test_count_x_and_y(self):
+
+        with nt.assert_raises(ValueError):
+            cat.factorplot("g", "y", data=self.df, kind="count")
+
     def test_plot_colors(self):
 
         ax = cat.barplot("g", "y", data=self.df)


### PR DESCRIPTION
When kind is "count" for factorplot, raise ValueError if both x and y
are given.  Otherwise, x_ and _y will not be defined, leading to an
UnboundLocalError.