### PR TITLE
Add font.size to plotting context

### DIFF
--- a/seaborn/rcmod.py
+++ b/seaborn/rcmod.py
@@ -44,6 +44,7 @@ _style_keys = (
 _context_keys = (
     "figure.figsize",
 
+    "font.size",
     "axes.labelsize",
     "axes.titlesize",
     "xtick.labelsize",

--- a/seaborn/rcmod.py
+++ b/seaborn/rcmod.py
@@ -365,6 +365,7 @@ def plotting_context(context=None, font_scale=1, rc=None):
         base_context = {
 
             "figure.figsize": np.array([8, 5.5]),
+            "font.size": 12,
             "axes.labelsize": 11,
             "axes.titlesize": 12,
             "xtick.labelsize": 10,
@@ -392,7 +393,7 @@ def plotting_context(context=None, font_scale=1, rc=None):
 
         # Now independently scale the fonts
         font_keys = ["axes.labelsize", "axes.titlesize", "legend.fontsize",
-                     "xtick.labelsize", "ytick.labelsize"]
+                     "xtick.labelsize", "ytick.labelsize", "font.size"]
         font_dict = {k: context_dict[k] * font_scale for k in font_keys}
         context_dict.update(font_dict)
 

--- a/seaborn/tests/test_rcmod.py
+++ b/seaborn/tests/test_rcmod.py
@@ -133,7 +133,7 @@ class TestPlottingContext(RCParamTester):
         notebook_big = rcmod.plotting_context("notebook", 2)
 
         font_keys = ["axes.labelsize", "axes.titlesize", "legend.fontsize",
-                     "xtick.labelsize", "ytick.labelsize"]
+                     "xtick.labelsize", "ytick.labelsize", "font.size"]
 
         for k in font_keys:
             nt.assert_equal(notebook_ref[k] * 2, notebook_big[k])


### PR DESCRIPTION
Resolves #635. 

`font.size` was not being set by `rcmod`, which meant that text generated by `plt.text` and, e.g. tick labels in scientific notation were not scaled by `font_scale`. This is addressed by using matplotlib's default `font.size: 12` and scaling accordingly.