### PR TITLE
Do not create heatmap labels, when labels are false

### DIFF
--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -111,19 +111,19 @@ class _HeatMapper(object):
         if isinstance(xticklabels, int) and xticklabels > 1:
             xtickevery = xticklabels
             xticklabels = _index_to_ticklabels(data.columns)
-        elif isinstance(xticklabels, bool) and xticklabels:
+        elif xticklabels is True:
             xticklabels = _index_to_ticklabels(data.columns)
-        elif isinstance(xticklabels, bool) and not xticklabels:
-            xticklabels = ['' for _ in range(data.shape[1])]
+        elif xticklabels is False:
+            xticklabels = []
 
         ytickevery = 1
         if isinstance(yticklabels, int) and yticklabels > 1:
             ytickevery = yticklabels
             yticklabels = _index_to_ticklabels(data.index)
-        elif isinstance(yticklabels, bool) and yticklabels:
+        elif yticklabels is True:
             yticklabels = _index_to_ticklabels(data.index)
-        elif isinstance(yticklabels, bool) and not yticklabels:
-            yticklabels = ['' for _ in range(data.shape[0])]
+        elif yticklabels is False:
+            yticklabels = []
         else:
             yticklabels = yticklabels[::-1]
 

--- a/seaborn/tests/test_matrix.py
+++ b/seaborn/tests/test_matrix.py
@@ -185,10 +185,8 @@ class TestHeatmap(object):
         kws['xticklabels'] = False
         kws['yticklabels'] = False
         p = mat._HeatMapper(self.df_norm, **kws)
-        nt.assert_equal(p.xticklabels, ['' for _ in range(
-            self.df_norm.shape[1])])
-        nt.assert_equal(p.yticklabels, ['' for _ in range(
-            self.df_norm.shape[0])])
+        nt.assert_equal(p.xticklabels, [])
+        nt.assert_equal(p.yticklabels, [])
 
     def test_custom_ticklabels(self):
         kws = self.default_kws.copy()


### PR DESCRIPTION
This PR changes the behaviour of `xticklabels=False` (also `yticklabels=False`).
Instead of creating a list of empty tick labels (as it did before), it now just operates on an empty list.
This has the effect that `axis_ticklabels_overlap` does not do the expensive overlap calculation downstream. And thus the code runs faster.

For instance, try out the following code snippet:

```python
import numpy as np
import fastcluster
import pandas as pd
import seaborn
ROWS, COLS = 1000, 10
np.random.seed(10)
random_data = np.random.randn(ROWS, COLS)
random_data = pd.DataFrame(random_data, 
                           index=['Row {}'.format(i) for i in range(ROWS)], 
                           columns=['Column {}'.format(i) for i in range(COLS)])
row_linkage = fastcluster.complete(random_data)
col_linkage = fastcluster.complete(random_data.T)
seaborn.clustermap(random_data, 
                   row_linkage=row_linkage, 
                   col_linkage=col_linkage, yticklabels=False)
```

Naively timing the `seaborn.clustermap` command at the end of the code, I get 5.7s using the code in master, whereas the PR drops it to roughly 3.8s.  Even more time is gained when the number of rows being plotted is even larger. This is quite important as in these situations one would want to have `yticklabels` off anyway (as nobody would be able to read them anyway...)

I am attaching figures as well to show that the outputs look identical visually.

master:

![master.png](https://cloud.githubusercontent.com/assets/108413/9424964/b0e9acbc-4908-11e5-8bab-601fd2f54213.png)

PR:
![pr.png](https://cloud.githubusercontent.com/assets/108413/9424967/bab6110e-4908-11e5-99dd-c5c4f140490d.png)


