### PR TITLE
Use `LineCollection` when plotting dendrograms.

### DIFF
--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -603,13 +603,13 @@ class _DendrogramPlotter(object):
 
         if self.rotate and self.axis == 0:
             ax.yaxis.set_ticks_position('right')
-            ax.invert_yaxis()
 
             # Constants 10 and 1.05 come from _plot_dendrogram in scipy.cluster.hierarchy
             ax.set_ylim(0, number_of_leaves * 10)
             ax.set_xlim(0, max_dependent_coord * 1.05)
 
             ax.invert_xaxis()
+            ax.invert_yaxis()
         else:
             # Constants 10 and 1.05 come from _plot_dendrogram in scipy.cluster.hierarchy
             ax.set_xlim(0, number_of_leaves * 10)

--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -515,13 +515,6 @@ class _DendrogramPlotter(object):
         self.dependent_coord = self.dendrogram['dcoord']
         self.independent_coord = self.dendrogram['icoord']
 
-        if self.rotate:
-            self.X = self.dendrogram['dcoord']
-            self.Y = self.dendrogram['icoord']
-        else:
-            self.X = self.dendrogram['icoord']
-            self.Y = self.dendrogram['dcoord']
-
     def _calculate_linkage_scipy(self):
         if np.product(self.shape) >= 10000:
             UserWarning('This will be slow... (gentle suggestion: '

--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -594,7 +594,7 @@ class _DendrogramPlotter(object):
         number_of_leaves = len(self.reordered_ind)
         max_dependent_coord = max(map(max, self.dependent_coord))
 
-        if self.rotate and self.axis == 0:
+        if self.rotate:
             ax.yaxis.set_ticks_position('right')
 
             # Constants 10 and 1.05 come from _plot_dendrogram in scipy.cluster.hierarchy

--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -582,12 +582,14 @@ class _DendrogramPlotter(object):
         """
         line_kwargs = dict(linewidths=.5, colors='k')
         if self.rotate and self.axis == 0:
-            lines = LineCollection([list(zip(x, y)) for x, y in zip(self.dependent_coord,
-                                                                    self.independent_coord)],
+            lines = LineCollection([list(zip(x, y))
+                                    for x, y in zip(self.dependent_coord,
+                                                    self.independent_coord)],
                                    **line_kwargs)
         else:
-            lines = LineCollection([list(zip(x, y)) for x, y in zip(self.independent_coord,
-                                                                    self.dependent_coord)],
+            lines = LineCollection([list(zip(x, y))
+                                    for x, y in zip(self.independent_coord,
+                                                    self.dependent_coord)],
                                    **line_kwargs)
 
         ax.add_collection(lines)
@@ -597,14 +599,16 @@ class _DendrogramPlotter(object):
         if self.rotate:
             ax.yaxis.set_ticks_position('right')
 
-            # Constants 10 and 1.05 come from _plot_dendrogram in scipy.cluster.hierarchy
+            # Constants 10 and 1.05 come from
+            # `scipy.cluster.hierarchy._plot_dendrogram`
             ax.set_ylim(0, number_of_leaves * 10)
             ax.set_xlim(0, max_dependent_coord * 1.05)
 
             ax.invert_xaxis()
             ax.invert_yaxis()
         else:
-            # Constants 10 and 1.05 come from _plot_dendrogram in scipy.cluster.hierarchy
+            # Constants 10 and 1.05 come from
+            # `scipy.cluster.hierarchy._plot_dendrogram`
             ax.set_xlim(0, number_of_leaves * 10)
             ax.set_ylim(0, max_dependent_coord * 1.05)
 

--- a/seaborn/tests/test_matrix.py
+++ b/seaborn/tests/test_matrix.py
@@ -546,7 +546,8 @@ class TestDendrogram(object):
         nt.assert_equal(xlim[0], 0)
         nt.assert_equal(xlim[1], xmax)
 
-        nt.assert_equal(len(ax.collections[0].get_paths()), len(d.dependent_coord))
+        nt.assert_equal(len(ax.collections[0].get_paths()),
+                        len(d.dependent_coord))
 
         plt.close('all')
 
@@ -562,7 +563,8 @@ class TestDendrogram(object):
         # 10 comes from _plot_dendrogram in scipy.cluster.hierarchy
         ymax = len(d.reordered_ind) * 10
 
-        # Since y axis is inverted, ylim is (80, 0) and not (0, 80) as expected:
+        # Since y axis is inverted, ylim is (80, 0)
+        # and therefore not (0, 80) as usual:
         nt.assert_equal(ylim[1], 0)
         nt.assert_equal(ylim[0], ymax)
         plt.close('all')

--- a/seaborn/tests/test_matrix.py
+++ b/seaborn/tests/test_matrix.py
@@ -539,13 +539,15 @@ class TestDendrogram(object):
         d = mat.dendrogram(self.x_norm, **self.default_kws)
 
         ax = plt.gca()
-        d.xmin, d.xmax = ax.get_xlim()
-        xmax = min(map(min, d.X)) + max(map(max, d.X))
-        nt.assert_equal(d.xmin, 0)
-        nt.assert_equal(d.xmax, xmax)
+        xlim = ax.get_xlim()
+        # 10 comes from _plot_dendrogram in scipy.cluster.hierarchy
+        xmax = len(d.reordered_ind) * 10
 
-        nt.assert_equal(len(ax.get_lines()), len(d.X))
-        nt.assert_equal(len(ax.get_lines()), len(d.Y))
+        nt.assert_equal(xlim[0], 0)
+        nt.assert_equal(xlim[1], xmax)
+
+        nt.assert_equal(len(ax.collections[0].get_paths()), len(d.dependent_coord))
+
         plt.close('all')
 
     def test_dendrogram_rotate(self):
@@ -555,10 +557,14 @@ class TestDendrogram(object):
         d = mat.dendrogram(self.x_norm, **kws)
 
         ax = plt.gca()
-        d.ymin, d.ymax = ax.get_ylim()
-        ymax = min(map(min, d.Y)) + max(map(max, d.Y))
-        nt.assert_equal(d.ymin, 0)
-        nt.assert_equal(d.ymax, ymax)
+        ylim = ax.get_ylim()
+
+        # 10 comes from _plot_dendrogram in scipy.cluster.hierarchy
+        ymax = len(d.reordered_ind) * 10
+
+        # Since y axis is inverted, ylim is (80, 0) and not (0, 80) as expected:
+        nt.assert_equal(ylim[1], 0)
+        nt.assert_equal(ylim[0], ymax)
         plt.close('all')
 
     def test_dendrogram_ticklabel_rotation(self):
@@ -824,10 +830,10 @@ class TestClustermap(object):
     def test_plot_dendrograms(self):
         cm = mat.clustermap(self.df_norm, **self.default_kws)
 
-        nt.assert_equal(len(cm.ax_row_dendrogram.get_lines()),
-                        len(cm.dendrogram_row.X))
-        nt.assert_equal(len(cm.ax_col_dendrogram.get_lines()),
-                        len(cm.dendrogram_col.X))
+        nt.assert_equal(len(cm.ax_row_dendrogram.collections[0].get_paths()),
+                        len(cm.dendrogram_row.independent_coord))
+        nt.assert_equal(len(cm.ax_col_dendrogram.collections[0].get_paths()),
+                        len(cm.dendrogram_col.independent_coord))
         data2d = self.df_norm.iloc[cm.dendrogram_row.reordered_ind,
                                    cm.dendrogram_col.reordered_ind]
         pdt.assert_frame_equal(cm.data2d, data2d)


### PR DESCRIPTION
Instead of plotting the dendrogram lines one by one using standard `ax.plot()`, this PR makes use  of the `LineCollection` object from `matplotlib` to draw them all at once.

This has the effect of significantly speeding up the time needed to draw the clustermap.

For instance, the following script:
```python
import numpy as np
import fastcluster
import pandas as pd
import seaborn
from matplotlib import pyplot as plt

ROWS, COLS = 10000, 10
np.random.seed(10)
random_data = np.random.randn(ROWS, COLS)
random_data[ROWS/5: 2*ROWS/5, :] *= 10
random_data = pd.DataFrame(random_data, 
                           index=['Row {}'.format(i) for i in range(ROWS)], 
                           columns=['Column {}'.format(i) for i in range(COLS)])
row_linkage = fastcluster.complete(random_data)
col_linkage = fastcluster.complete(random_data.T)
seaborn.clustermap(random_data,
                   row_linkage=row_linkage,
                   col_linkage=col_linkage, yticklabels=False)

plt.savefig('test.png')
plt.close()
```

Takes 0m35.323s on my computer when dendrogram is drawn as `LineCollection` (note that 10k rows are being plotted!)
Meanwhile code on master branch takes 0m53.243s on the same machine. Meaning we get 30% improvement with the new code.

If you look at the actual diff -- quite a few things had to change because of the new way of plotting.
Most notably, the axes do not autoscale when plotting using `LineCollection`, thus I had to manually put the scaling in. I used a similar approach to scaling that `scipy.cluster.hierarchy` use for their dendrogram plotting.

If we consider the `flights` example, that is given in the documentation:
```python
>>> import seaborn as sns; sns.set()
>>> flights = sns.load_dataset("flights")
>>> flights = flights.pivot("month", "year", "passengers")
>>> g = sns.clustermap(flights)
```
The plots generated are identical, thus I believe I did not screw anything up with this new scaling.

master branch:
![flights master](https://cloud.githubusercontent.com/assets/108413/9492379/e646a82c-4bee-11e5-8294-4d29b4e39341.png)

my branch:
![flights faster_dendrograms](https://cloud.githubusercontent.com/assets/108413/9492382/ed007a80-4bee-11e5-9cf1-a9c4f1bbe43e.png)

The time improvement for this example is less severe, of course. 0m2.896s vs 0m2.987s on my machine (including the time to savefig). Nevertheless, it is still an improvement.