### PR TITLE
Update linearmodels.py

### DIFF
--- a/seaborn/linearmodels.py
+++ b/seaborn/linearmodels.py
@@ -557,8 +557,7 @@ def lmplot(x, y, data, hue=None, col=None, row=None, palette=None,
     # by the limits of the plot
     if sharex:
         for ax in facets.axes.flat:
-            scatter = ax.scatter(data[x], np.ones(len(data)) * data[y].mean())
-            scatter.remove()
+            ax.scatter(data[x], np.ones(len(data)) * data[y].mean()).remove()
 
     # Draw the regression plot on each facet
     regplot_kws = dict(


### PR DESCRIPTION
Fixes a bug in lmplot. When `sharex=True`, the `scatter` argument was being overwritten and evaluating as True. Therefore, when lmplot was called with `scatter=False` a scatterplot would be drawn unless `sharex=False`.