### PR TITLE
Do not draw ticks at all if ticklabels are disabled

### DIFF
--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -130,12 +130,22 @@ class _HeatMapper(object):
 
         # Get the positions and used label for the ticks
         nx, ny = data.T.shape
-        xstart, xend, xstep = 0, nx, xtickevery
-        self.xticks = np.arange(xstart, xend, xstep) + .5
-        self.xticklabels = xticklabels[xstart:xend:xstep]
-        ystart, yend, ystep = (ny - 1) % ytickevery, ny, ytickevery
-        self.yticks = np.arange(ystart, yend, ystep) + .5
-        self.yticklabels = yticklabels[ystart:yend:ystep]
+
+        if xticklabels == []:
+            self.xticks = []
+            self.xticklabels = []
+        else:
+            xstart, xend, xstep = 0, nx, xtickevery
+            self.xticks = np.arange(xstart, xend, xstep) + .5
+            self.xticklabels = xticklabels[xstart:xend:xstep]
+
+        if yticklabels == []:
+            self.yticks = []
+            self.yticklabels = []
+        else:
+            ystart, yend, ystep = (ny - 1) % ytickevery, ny, ytickevery
+            self.yticks = np.arange(ystart, yend, ystep) + .5
+            self.yticklabels = yticklabels[ystart:yend:ystep]
 
         # Get good names for the axis labels
         xlabel = _index_to_label(data.columns)


### PR DESCRIPTION
This PR actually does something I should have done in PR #683 that is already merged.

After PR #685 was merged, I ran the profiler again and noticed that quite peculiarly most of the time is now spent setting `yticks` when plotting a large number of rows. I never thought this would be the bottleneck, but disabling the ticks completely, when no ticklabels are given, brings down the runtime of the same test script as given in #685 to 5.7s (from around 30s, and from around 60s before dendrogram fix...). 

What is even better, `fastcluster` is now the biggest bottleneck of that example, not plotting!
As it should be! Woo-hoo!

Not really sure how I missed this when pushing #683. Anyway, it is an easy fix, and all tests seem to pass, so have yet  another PR (sorry for such a pile-up)!

Again, the plots are identical:
master:
![master](https://cloud.githubusercontent.com/assets/108413/9545489/8189e738-4d82-11e5-89d8-66839ad2f23b.png)

PR
![pr](https://cloud.githubusercontent.com/assets/108413/9545502/8db2fe6e-4d82-11e5-9371-c3cef7d715c6.png)


