### PR TITLE
use teardown method in PlotTestCase for most tests

### DIFF
--- a/seaborn/tests/__init__.py
+++ b/seaborn/tests/__init__.py
@@ -1,7 +1,11 @@
+import numpy as np
 from matplotlib.pyplot import close
 
 
 class PlotTestCase(object):
+
+    def setUp(self):
+        np.random.seed(49)
 
     def tearDown(self):
         close('all')

--- a/seaborn/tests/__init__.py
+++ b/seaborn/tests/__init__.py
@@ -1,0 +1,7 @@
+from matplotlib.pyplot import close
+
+
+class PlotTestCase(object):
+
+    def tearDown(self):
+        close('all')

--- a/seaborn/tests/test_axisgrid.py
+++ b/seaborn/tests/test_axisgrid.py
@@ -12,6 +12,7 @@ import numpy.testing as npt
 from numpy.testing.decorators import skipif
 import pandas.util.testing as tm
 
+from . import PlotTestCase
 from .. import axisgrid as ag
 from .. import rcmod
 from ..palettes import color_palette
@@ -25,7 +26,7 @@ rs = np.random.RandomState(0)
 old_matplotlib = LooseVersion(mpl.__version__) < "1.4"
 
 
-class TestFacetGrid(object):
+class TestFacetGrid(PlotTestCase):
 
     df = pd.DataFrame(dict(x=rs.normal(size=60),
                            y=rs.gamma(4, size=60),
@@ -38,21 +39,17 @@ class TestFacetGrid(object):
 
         g = ag.FacetGrid(self.df)
         nt.assert_is(g.data, self.df)
-        plt.close("all")
 
     def test_self_fig(self):
 
         g = ag.FacetGrid(self.df)
         nt.assert_is_instance(g.fig, plt.Figure)
-        plt.close("all")
 
     def test_self_axes(self):
 
         g = ag.FacetGrid(self.df, row="a", col="b", hue="c")
         for ax in g.axes.flat:
             nt.assert_is_instance(ax, plt.Axes)
-
-        plt.close("all")
 
     def test_axes_array_size(self):
 
@@ -73,8 +70,6 @@ class TestFacetGrid(object):
 
         for ax in g5.axes.flat:
             nt.assert_is_instance(ax, plt.Axes)
-
-        plt.close("all")
 
     def test_single_axes(self):
 
@@ -116,8 +111,6 @@ class TestFacetGrid(object):
         g_missing_wrap = ag.FacetGrid(df, col="d", col_wrap=4)
         nt.assert_equal(g_missing_wrap.axes.shape, (9,))
 
-        plt.close("all")
-
     def test_normal_axes(self):
 
         null = np.empty(0, object).flat
@@ -150,8 +143,6 @@ class TestFacetGrid(object):
         npt.assert_array_equal(g._not_left_axes, g.axes[:, 1:].flat)
         npt.assert_array_equal(g._inner_axes, g.axes[:-1, 1:].flat)
 
-        plt.close("all")
-
     def test_wrapped_axes(self):
 
         null = np.empty(0, object).flat
@@ -164,8 +155,6 @@ class TestFacetGrid(object):
         npt.assert_array_equal(g._not_left_axes, g.axes[np.array([1])].flat)
         npt.assert_array_equal(g._inner_axes, null)
 
-        plt.close("all")
-
     def test_figure_size(self):
 
         g = ag.FacetGrid(self.df, row="a", col="b")
@@ -176,8 +165,6 @@ class TestFacetGrid(object):
 
         g = ag.FacetGrid(self.df, col="c", size=4, aspect=.5)
         npt.assert_array_equal(g.fig.get_size_inches(), (6, 4))
-
-        plt.close("all")
 
     def test_figure_size_with_legend(self):
 
@@ -191,8 +178,6 @@ class TestFacetGrid(object):
         npt.assert_array_equal(g2.fig.get_size_inches(), (6, 4))
         g2.add_legend()
         npt.assert_array_equal(g2.fig.get_size_inches(), (6, 4))
-
-        plt.close("all")
 
     def test_legend_data(self):
 
@@ -216,8 +201,6 @@ class TestFacetGrid(object):
 
         for label, level in zip(labels, a_levels):
             nt.assert_equal(label.get_text(), level)
-
-        plt.close("all")
 
     def test_legend_data_missing_level(self):
 
@@ -244,8 +227,6 @@ class TestFacetGrid(object):
         for label, level in zip(labels, list("azbc")):
             nt.assert_equal(label.get_text(), level)
 
-        plt.close("all")
-
     def test_get_boolean_legend_data(self):
 
         self.df["b_bool"] = self.df.b == "m"
@@ -269,8 +250,6 @@ class TestFacetGrid(object):
 
         for label, level in zip(labels, b_levels):
             nt.assert_equal(label.get_text(), level)
-
-        plt.close("all")
 
     def test_legend_options(self):
 
@@ -382,8 +361,6 @@ class TestFacetGrid(object):
         nt.assert_equal(tup, (0, 0, 1))
         nt.assert_true((data["c"] == "u").all())
 
-        plt.close("all")
-
     def test_map(self):
 
         g = ag.FacetGrid(self.df, row="a", col="b", hue="c")
@@ -429,8 +406,6 @@ class TestFacetGrid(object):
             npt.assert_array_equal(ax.get_xticks(), xticks)
             npt.assert_array_equal(ax.get_yticks(), yticks)
 
-        plt.close("all")
-
     def test_set_titles(self):
 
         g = ag.FacetGrid(self.df, row="a", col="b")
@@ -459,8 +434,6 @@ class TestFacetGrid(object):
         g = ag.FacetGrid(self.df, col="b", hue="b", dropna=False)
         g.map(plt.plot, 'x', 'y')
 
-        plt.close("all")
-
     def test_set_titles_margin_titles(self):
 
         g = ag.FacetGrid(self.df, row="a", col="b", margin_titles=True)
@@ -480,8 +453,6 @@ class TestFacetGrid(object):
         nt.assert_equal(g.axes[0, 0].get_title(), "b == m")
         nt.assert_equal(g.axes[0, 1].get_title(), "b == n")
         nt.assert_equal(g.axes[1, 0].get_title(), "")
-
-        plt.close("all")
 
     def test_set_ticklabels(self):
 
@@ -515,7 +486,6 @@ class TestFacetGrid(object):
         for ax in g._left_axes:
             for l in ax.get_yticklabels():
                 nt.assert_equal(l.get_rotation(), 75)
-        plt.close("all")
 
     def test_set_axis_labels(self):
 
@@ -530,14 +500,12 @@ class TestFacetGrid(object):
         got_y = [ax.get_ylabel() for ax in g.axes[:, 0]]
         npt.assert_array_equal(got_x, xlab)
         npt.assert_array_equal(got_y, ylab)
-        plt.close("all")
 
     def test_axis_lims(self):
 
         g = ag.FacetGrid(self.df, row="a", col="b", xlim=(0, 4), ylim=(-2, 3))
         nt.assert_equal(g.axes[0, 0].get_xlim(), (0, 4))
         nt.assert_equal(g.axes[0, 0].get_ylim(), (-2, 3))
-        plt.close("all")
 
     def test_data_orders(self):
 
@@ -568,8 +536,6 @@ class TestFacetGrid(object):
         nt.assert_equal(g.hue_names, list("qvtu"))
         nt.assert_equal(g.axes.shape, (4, 3))
 
-        plt.close("all")
-
     def test_palette(self):
 
         rcmod.set()
@@ -593,8 +559,6 @@ class TestFacetGrid(object):
                          palette=dict_pal)
         nt.assert_equal(g._colors, list_pal)
 
-        plt.close("all")
-
     def test_hue_kws(self):
 
         kws = dict(marker=["o", "s", "D"])
@@ -616,15 +580,8 @@ class TestFacetGrid(object):
         g = ag.FacetGrid(df, dropna=True, row="hasna")
         nt.assert_equal(g._not_na.sum(), 50)
 
-        plt.close("all")
 
-    @classmethod
-    def teardown_class(cls):
-        """Ensure that all figures are closed on exit."""
-        plt.close("all")
-
-
-class TestPairGrid(object):
+class TestPairGrid(PlotTestCase):
 
     rs = np.random.RandomState(sum(map(ord, "PairGrid")))
     df = pd.DataFrame(dict(x=rs.normal(size=80),
@@ -637,7 +594,6 @@ class TestPairGrid(object):
 
         g = ag.PairGrid(self.df)
         nt.assert_is(g.data, self.df)
-        plt.close("all")
 
     def test_ignore_datelike_data(self):
 
@@ -646,21 +602,17 @@ class TestPairGrid(object):
         result = ag.PairGrid(self.df).data
         expected = df.drop('date', axis=1)
         tm.assert_frame_equal(result, expected)
-        plt.close("all")
 
     def test_self_fig(self):
 
         g = ag.PairGrid(self.df)
         nt.assert_is_instance(g.fig, plt.Figure)
-        plt.close("all")
 
     def test_self_axes(self):
 
         g = ag.PairGrid(self.df)
         for ax in g.axes.flat:
             nt.assert_is_instance(ax, plt.Axes)
-
-        plt.close("all")
 
     def test_default_axes(self):
 
@@ -670,8 +622,6 @@ class TestPairGrid(object):
         nt.assert_equal(g.y_vars, ["x", "y", "z"])
         nt.assert_true(g.square_grid)
 
-        plt.close("all")
-
     def test_specific_square_axes(self):
 
         vars = ["z", "x"]
@@ -680,8 +630,6 @@ class TestPairGrid(object):
         nt.assert_equal(g.x_vars, vars)
         nt.assert_equal(g.y_vars, vars)
         nt.assert_true(g.square_grid)
-
-        plt.close("all")
 
     def test_specific_nonsquare_axes(self):
 
@@ -701,8 +649,6 @@ class TestPairGrid(object):
         nt.assert_equal(g.y_vars, list(y_vars))
         nt.assert_true(not g.square_grid)
 
-        plt.close("all")
-
     def test_specific_square_axes_with_array(self):
 
         vars = np.array(["z", "x"])
@@ -711,8 +657,6 @@ class TestPairGrid(object):
         nt.assert_equal(g.x_vars, list(vars))
         nt.assert_equal(g.y_vars, list(vars))
         nt.assert_true(g.square_grid)
-
-        plt.close("all")
 
     def test_specific_nonsquare_axes_with_array(self):
 
@@ -723,8 +667,6 @@ class TestPairGrid(object):
         nt.assert_equal(g.x_vars, list(x_vars))
         nt.assert_equal(g.y_vars, list(y_vars))
         nt.assert_true(not g.square_grid)
-
-        plt.close("all")
 
     def test_size(self):
 
@@ -737,8 +679,6 @@ class TestPairGrid(object):
         g3 = ag.PairGrid(self.df, y_vars=["z"], x_vars=["x", "y"],
                          size=2, aspect=2)
         npt.assert_array_equal(g3.fig.get_size_inches(), (8, 2))
-
-        plt.close("all")
 
     def test_map(self):
 
@@ -768,8 +708,6 @@ class TestPairGrid(object):
                 npt.assert_array_equal(x_in_k, x_out)
                 npt.assert_array_equal(y_in_k, y_out)
 
-        plt.close("all")
-
     def test_map_nonsquare(self):
 
         x_vars = ["x"]
@@ -784,8 +722,6 @@ class TestPairGrid(object):
             x_out, y_out = ax.collections[0].get_offsets().T
             npt.assert_array_equal(x_in, x_out)
             npt.assert_array_equal(y_in, y_out)
-
-        plt.close("all")
 
     def test_map_lower(self):
 
@@ -805,8 +741,6 @@ class TestPairGrid(object):
             ax = g.axes[i, j]
             nt.assert_equal(len(ax.collections), 0)
 
-        plt.close("all")
-
     def test_map_upper(self):
 
         vars = ["x", "y", "z"]
@@ -824,8 +758,6 @@ class TestPairGrid(object):
         for i, j in zip(*np.tril_indices_from(g.axes)):
             ax = g.axes[i, j]
             nt.assert_equal(len(ax.collections), 0)
-
-        plt.close("all")
 
     @skipif(old_matplotlib)
     def test_map_diag(self):
@@ -847,8 +779,6 @@ class TestPairGrid(object):
 
         for ax in g3.diag_axes:
             nt.assert_equal(len(ax.patches), 40)
-
-        plt.close("all")
 
     @skipif(old_matplotlib)
     def test_map_diag_and_offdiag(self):
@@ -881,8 +811,6 @@ class TestPairGrid(object):
             ax = g.axes[i, j]
             nt.assert_equal(len(ax.collections), 0)
 
-        plt.close("all")
-
     def test_palette(self):
 
         rcmod.set()
@@ -906,8 +834,6 @@ class TestPairGrid(object):
                         palette=dict_pal)
         nt.assert_equal(g.palette, list_pal)
 
-        plt.close("all")
-
     def test_hue_kws(self):
 
         kws = dict(marker=["o", "s", "d", "+"])
@@ -923,8 +849,6 @@ class TestPairGrid(object):
 
         for line, marker in zip(g.axes[0, 0].lines, kws["marker"]):
             nt.assert_equal(line.get_marker(), marker)
-
-        plt.close("all")
 
     @skipif(old_matplotlib)
     def test_hue_order(self):
@@ -1044,8 +968,6 @@ class TestPairGrid(object):
                 npt.assert_array_equal(x_in_k, x_out)
                 npt.assert_array_equal(y_in_k, y_out)
 
-        plt.close("all")
-
     @skipif(old_matplotlib)
     def test_pairplot(self):
 
@@ -1074,8 +996,6 @@ class TestPairGrid(object):
         for i, j in zip(*np.diag_indices_from(g.axes)):
             ax = g.axes[i, j]
             nt.assert_equal(len(ax.collections), 0)
-
-        plt.close("all")
 
     @skipif(old_matplotlib)
     def test_pairplot_reg(self):
@@ -1112,8 +1032,6 @@ class TestPairGrid(object):
             ax = g.axes[i, j]
             nt.assert_equal(len(ax.collections), 0)
 
-        plt.close("all")
-
     @skipif(old_matplotlib)
     def test_pairplot_kde(self):
 
@@ -1143,8 +1061,6 @@ class TestPairGrid(object):
             ax = g.axes[i, j]
             nt.assert_equal(len(ax.collections), 0)
 
-        plt.close("all")
-
     @skipif(old_matplotlib)
     def test_pairplot_markers(self):
 
@@ -1157,13 +1073,8 @@ class TestPairGrid(object):
         with nt.assert_raises(ValueError):
             g = pairplot(self.df, hue="a", vars=vars, markers=markers[:-2])
 
-    @classmethod
-    def teardown_class(cls):
-        """Ensure that all figures are closed on exit."""
-        plt.close("all")
 
-
-class TestJointGrid(object):
+class TestJointGrid(PlotTestCase):
 
     rs = np.random.RandomState(sum(map(ord, "JointGrid")))
     x = rs.randn(100)
@@ -1178,21 +1089,18 @@ class TestJointGrid(object):
         g = ag.JointGrid(self.x, self.y)
         npt.assert_array_equal(g.x, self.x)
         npt.assert_array_equal(g.y, self.y)
-        plt.close("all")
 
     def test_margin_grid_from_series(self):
 
         g = ag.JointGrid(self.data.x, self.data.y)
         npt.assert_array_equal(g.x, self.x)
         npt.assert_array_equal(g.y, self.y)
-        plt.close("all")
 
     def test_margin_grid_from_dataframe(self):
 
         g = ag.JointGrid("x", "y", self.data)
         npt.assert_array_equal(g.x, self.x)
         npt.assert_array_equal(g.y, self.y)
-        plt.close("all")
 
     def test_margin_grid_axis_labels(self):
 
@@ -1206,7 +1114,6 @@ class TestJointGrid(object):
         xlabel, ylabel = g.ax_joint.get_xlabel(), g.ax_joint.get_ylabel()
         nt.assert_equal(xlabel, "x variable")
         nt.assert_equal(ylabel, "y variable")
-        plt.close("all")
 
     def test_dropna(self):
 
@@ -1215,7 +1122,6 @@ class TestJointGrid(object):
 
         g = ag.JointGrid("x_na", "y", self.data, dropna=True)
         nt.assert_equal(len(g.x), pd.notnull(self.x_na).sum())
-        plt.close("all")
 
     def test_axlims(self):
 
@@ -1233,7 +1139,6 @@ class TestJointGrid(object):
         g = ag.JointGrid("x", "y", self.data)
         nt.assert_true(~len(g.ax_marg_x.get_xticks()))
         nt.assert_true(~len(g.ax_marg_y.get_yticks()))
-        plt.close("all")
 
     def test_bivariate_plot(self):
 
@@ -1243,7 +1148,6 @@ class TestJointGrid(object):
         x, y = g.ax_joint.lines[0].get_xydata().T
         npt.assert_array_equal(x, self.x)
         npt.assert_array_equal(y, self.y)
-        plt.close("all")
 
     def test_univariate_plot(self):
 
@@ -1253,7 +1157,6 @@ class TestJointGrid(object):
         _, y1 = g.ax_marg_x.lines[0].get_xydata().T
         y2, _ = g.ax_marg_y.lines[0].get_xydata().T
         npt.assert_array_equal(y1, y2)
-        plt.close("all")
 
     def test_plot(self):
 
@@ -1267,8 +1170,6 @@ class TestJointGrid(object):
         _, y1 = g.ax_marg_x.lines[0].get_xydata().T
         y2, _ = g.ax_marg_y.lines[0].get_xydata().T
         npt.assert_array_equal(y1, y2)
-
-        plt.close("all")
 
     def test_annotate(self):
 
@@ -1297,8 +1198,6 @@ class TestJointGrid(object):
         nt.assert_equal(annotation, template.format(stat="pearsonr",
                                                     val=rp[0], p=rp[1]))
 
-        plt.close("all")
-
     def test_space(self):
 
         g = ag.JointGrid("x", "y", self.data, space=0)
@@ -1309,8 +1208,3 @@ class TestJointGrid(object):
 
         nt.assert_equal(joint_bounds[2], marg_x_bounds[2])
         nt.assert_equal(joint_bounds[3], marg_y_bounds[3])
-
-    @classmethod
-    def teardown_class(cls):
-        """Ensure that all figures are closed on exit."""
-        plt.close("all")

--- a/seaborn/tests/test_categorical.py
+++ b/seaborn/tests/test_categorical.py
@@ -12,11 +12,12 @@ import nose.tools as nt
 import numpy.testing as npt
 from numpy.testing.decorators import skipif
 
+from . import PlotTestCase
 from .. import categorical as cat
 from .. import palettes
 
 
-class CategoricalFixture(object):
+class CategoricalFixture(PlotTestCase):
     """Test boxplot (also base class for things like violinplots)."""
     rs = np.random.RandomState(30)
     n_total = 60
@@ -725,7 +726,6 @@ class TestBoxPlotter(CategoricalFixture):
         ax = cat.boxplot("g", "y", data=self.df,
                          order=["a", "b", "c", "d"])
         nt.assert_equal(len(ax.artists), 3)
-        plt.close("all")
 
     def test_missing_data(self):
 
@@ -1191,7 +1191,6 @@ class TestViolinPlotter(CategoricalFixture):
         for val, line in zip(np.percentile(self.y, [25, 50, 75]), ax.lines):
             _, y = line.get_xydata().T
             npt.assert_array_equal(y, [val, val])
-        plt.close("all")
 
     def test_draw_points(self):
 
@@ -1434,8 +1433,6 @@ class TestStripPlotter(CategoricalFixture):
 
             npt.assert_equal(ax.collections[i].get_facecolors()[0, :3], pal[i])
 
-        plt.close("all")
-
     @skipif(not pandas_has_categoricals)
     def test_stripplot_horiztonal(self):
 
@@ -1449,8 +1446,6 @@ class TestStripPlotter(CategoricalFixture):
 
             npt.assert_array_equal(x, vals)
             npt.assert_array_equal(y, np.ones(len(x)) * i)
-
-        plt.close("all")
 
     def test_stripplot_jitter(self):
 
@@ -1466,8 +1461,6 @@ class TestStripPlotter(CategoricalFixture):
             npt.assert_array_equal(y, vals)
 
             npt.assert_equal(ax.collections[i].get_facecolors()[0, :3], pal[i])
-
-        plt.close("all")
 
     def test_split_nested_stripplot_vertical(self):
 
@@ -1485,8 +1478,6 @@ class TestStripPlotter(CategoricalFixture):
                 fc = ax.collections[i * 2 + j].get_facecolors()[0, :3]
                 npt.assert_equal(fc, pal[j])
 
-        plt.close("all")
-
     @skipif(not pandas_has_categoricals)
     def test_split_nested_stripplot_horizontal(self):
 
@@ -1501,8 +1492,6 @@ class TestStripPlotter(CategoricalFixture):
 
                 npt.assert_array_equal(x, vals)
                 npt.assert_array_equal(y, np.ones(len(x)) * i + [-.2, .2][j])
-
-        plt.close("all")
 
     def test_unsplit_nested_stripplot_vertical(self):
 
@@ -1521,8 +1510,6 @@ class TestStripPlotter(CategoricalFixture):
                 fc = ax.collections[i * 2 + j].get_facecolors()[0, :3]
                 npt.assert_equal(fc, pal[j])
 
-        plt.close("all")
-
     @skipif(not pandas_has_categoricals)
     def test_unsplit_nested_stripplot_horizontal(self):
 
@@ -1537,8 +1524,6 @@ class TestStripPlotter(CategoricalFixture):
 
                 npt.assert_array_equal(x, vals)
                 npt.assert_array_equal(y, np.ones(len(x)) * i)
-
-        plt.close("all")
 
 
 class TestBarPlotter(CategoricalFixture):
@@ -1583,8 +1568,6 @@ class TestBarPlotter(CategoricalFixture):
             nt.assert_equal(bar.get_height(), abs(stat))
             nt.assert_equal(bar.get_width(), p.width)
 
-        plt.close("all")
-
     def test_draw_horizontal_bars(self):
 
         kws = self.default_kws.copy()
@@ -1606,8 +1589,6 @@ class TestBarPlotter(CategoricalFixture):
             nt.assert_equal(bar.get_y(), pos)
             nt.assert_equal(bar.get_height(), p.width)
             nt.assert_equal(bar.get_width(), abs(stat))
-
-        plt.close("all")
 
     def test_draw_nested_vertical_bars(self):
 
@@ -1636,8 +1617,6 @@ class TestBarPlotter(CategoricalFixture):
             nt.assert_almost_equal(bar.get_x(), pos - p.width / 2)
             nt.assert_almost_equal(bar.get_width(), p.nested_width)
 
-        plt.close("all")
-
     def test_draw_nested_horizontal_bars(self):
 
         kws = self.default_kws.copy()
@@ -1664,8 +1643,6 @@ class TestBarPlotter(CategoricalFixture):
         for bar, stat in zip(ax.patches, p.statistic.T.flat):
             nt.assert_almost_equal(bar.get_x(), min(0, stat))
             nt.assert_almost_equal(bar.get_width(), abs(stat))
-
-        plt.close("all")
 
     def test_draw_missing_bars(self):
 
@@ -1835,8 +1812,6 @@ class TestPointPlotter(CategoricalFixture):
                                          p.colors):
             npt.assert_array_equal(got_color[:-1], want_color)
 
-        plt.close("all")
-
     def test_draw_horizontal_points(self):
 
         kws = self.default_kws.copy()
@@ -1858,8 +1833,6 @@ class TestPointPlotter(CategoricalFixture):
         for got_color, want_color in zip(points.get_facecolors(),
                                          p.colors):
             npt.assert_array_equal(got_color[:-1], want_color)
-
-        plt.close("all")
 
     def test_draw_vertical_nested_points(self):
 
@@ -1887,8 +1860,6 @@ class TestPointPlotter(CategoricalFixture):
             for got_color in points.get_facecolors():
                 npt.assert_array_equal(got_color[:-1], color)
 
-        plt.close("all")
-
     def test_draw_horizontal_nested_points(self):
 
         kws = self.default_kws.copy()
@@ -1914,8 +1885,6 @@ class TestPointPlotter(CategoricalFixture):
 
             for got_color in points.get_facecolors():
                 npt.assert_array_equal(got_color[:-1], color)
-
-        plt.close("all")
 
     def test_pointplot_colors(self):
 
@@ -2066,8 +2035,6 @@ class TestFactorPlot(CategoricalFixture):
         g = cat.factorplot("g", "y", col="u", row="h", data=self.df)
         nt.assert_equal(g.axes.shape, (2, 3))
 
-        plt.close("all")
-
     def test_plot_elements(self):
 
         g = cat.factorplot("g", "y", data=self.df)
@@ -2126,8 +2093,6 @@ class TestFactorPlot(CategoricalFixture):
         g = cat.factorplot("g", "y", "h", data=self.df, kind="strip")
         want_elements = self.g.unique().size * self.h.unique().size
         nt.assert_equal(len(g.ax.collections), want_elements)
-
-        plt.close("all")
 
     def test_bad_plot_kind_error(self):
 

--- a/seaborn/tests/test_distributions.py
+++ b/seaborn/tests/test_distributions.py
@@ -7,6 +7,7 @@ import nose.tools as nt
 import numpy.testing as npt
 from numpy.testing.decorators import skipif
 
+from . import PlotTestCase
 from .. import distributions as dist
 
 try:
@@ -17,7 +18,7 @@ except ImportError:
     _no_statsmodels = True
 
 
-class TestKDE(object):
+class TestKDE(PlotTestCase):
 
     rs = np.random.RandomState(0)
     x = rs.randn(50)
@@ -108,10 +109,9 @@ class TestKDE(object):
                         len(ax_values.collections))
         nt.assert_equal(ax_series.collections[0].get_paths(),
                         ax_values.collections[0].get_paths())
-        plt.close("all")
 
 
-class TestJointPlot(object):
+class TestJointPlot(PlotTestCase):
 
     rs = np.random.RandomState(sum(map(ord, "jointplot")))
     x = rs.randn(100)
@@ -133,8 +133,6 @@ class TestJointPlot(object):
         y_bins = dist._freedman_diaconis_bins(self.y)
         nt.assert_equal(len(g.ax_marg_y.patches), y_bins)
 
-        plt.close("all")
-
     def test_reg(self):
 
         g = dist.jointplot("x", "y", self.data, kind="reg")
@@ -154,8 +152,6 @@ class TestJointPlot(object):
         nt.assert_equal(len(g.ax_marg_x.lines), 1)
         nt.assert_equal(len(g.ax_marg_y.lines), 1)
 
-        plt.close("all")
-
     def test_resid(self):
 
         g = dist.jointplot("x", "y", self.data, kind="resid")
@@ -163,8 +159,6 @@ class TestJointPlot(object):
         nt.assert_equal(len(g.ax_joint.lines), 1)
         nt.assert_equal(len(g.ax_marg_x.lines), 0)
         nt.assert_equal(len(g.ax_marg_y.lines), 1)
-
-        plt.close("all")
 
     def test_hex(self):
 
@@ -177,8 +171,6 @@ class TestJointPlot(object):
         y_bins = dist._freedman_diaconis_bins(self.y)
         nt.assert_equal(len(g.ax_marg_y.patches), y_bins)
 
-        plt.close("all")
-
     def test_kde(self):
 
         g = dist.jointplot("x", "y", self.data, kind="kde")
@@ -189,8 +181,6 @@ class TestJointPlot(object):
 
         nt.assert_equal(len(g.ax_marg_x.lines), 1)
         nt.assert_equal(len(g.ax_marg_y.lines), 1)
-
-        plt.close("all")
 
     def test_color(self):
 
@@ -203,8 +193,6 @@ class TestJointPlot(object):
         hist_color = g.ax_marg_x.patches[0].get_facecolor()[:3]
         nt.assert_equal(hist_color, purple)
 
-        plt.close("all")
-
     def test_annotation(self):
 
         g = dist.jointplot("x", "y", self.data)
@@ -212,8 +200,6 @@ class TestJointPlot(object):
 
         g = dist.jointplot("x", "y", self.data, stat_func=None)
         nt.assert_is(g.ax_joint.legend_, None)
-
-        plt.close("all")
 
     def test_hex_customise(self):
 
@@ -224,14 +210,7 @@ class TestJointPlot(object):
         a = g.ax_joint.collections[0].get_array()
         nt.assert_equal(28, a.shape[0])  # 28 hexagons expected for gridsize 5
 
-        plt.close("all")
-
     def test_bad_kind(self):
 
         with nt.assert_raises(ValueError):
             dist.jointplot("x", "y", self.data, kind="not_a_kind")
-
-    @classmethod
-    def teardown_class(cls):
-        """Ensure that all figures are closed on exit."""
-        plt.close("all")

--- a/seaborn/tests/test_linearmodels.py
+++ b/seaborn/tests/test_linearmodels.py
@@ -15,6 +15,7 @@ try:
 except ImportError:
     _no_statsmodels = True
 
+from . import PlotTestCase
 from .. import linearmodels as lm
 from .. import algorithms as algo
 from .. import utils
@@ -23,7 +24,7 @@ from ..palettes import color_palette
 rs = np.random.RandomState(0)
 
 
-class TestLinearPlotter(object):
+class TestLinearPlotter(PlotTestCase):
 
     rs = np.random.RandomState(77)
     df = pd.DataFrame(dict(x=rs.normal(size=60),
@@ -87,7 +88,7 @@ class TestLinearPlotter(object):
         pdt.assert_series_equal(p.y_na, self.df.y_na[mask])
 
 
-class TestRegressionPlotter(object):
+class TestRegressionPlotter(PlotTestCase):
 
     rs = np.random.RandomState(49)
 
@@ -395,10 +396,8 @@ class TestRegressionPlotter(object):
         nt.assert_equal(grid.min(), self.df.x.min())
         nt.assert_equal(grid.max(), self.df.x.max())
 
-        plt.close("all")
 
-
-class TestRegressionPlots(object):
+class TestRegressionPlots(PlotTestCase):
 
     rs = np.random.RandomState(56)
     df = pd.DataFrame(dict(x=rs.randn(90),
@@ -421,8 +420,6 @@ class TestRegressionPlots(object):
         npt.assert_array_equal(x, self.df.x)
         npt.assert_array_equal(y, self.df.y)
 
-        plt.close("all")
-
     def test_regplot_selective(self):
 
         f, ax = plt.subplots()
@@ -442,8 +439,6 @@ class TestRegressionPlots(object):
         nt.assert_equal(len(ax.lines), 1)
         nt.assert_equal(len(ax.collections), 1)
         ax.clear()
-
-        plt.close("all")
 
     def test_regplot_scatter_kws_alpha(self):
 
@@ -469,15 +464,11 @@ class TestRegressionPlots(object):
         ax = lm.regplot("x", "y", self.df, scatter_kws={'color': color})
         nt.assert_equal(ax.collections[0]._alpha, 0.8)
 
-        plt.close("all")
-
     def test_regplot_binned(self):
 
         ax = lm.regplot("x", "y", self.df, x_bins=5)
         nt.assert_equal(len(ax.lines), 6)
         nt.assert_equal(len(ax.collections), 2)
-
-        plt.close("all")
 
     def test_lmplot_basic(self):
 
@@ -490,8 +481,6 @@ class TestRegressionPlots(object):
         npt.assert_array_equal(x, self.df.x)
         npt.assert_array_equal(y, self.df.y)
 
-        plt.close("all")
-
     def test_lmplot_hue(self):
 
         g = lm.lmplot("x", "y", data=self.df, hue="h")
@@ -499,7 +488,6 @@ class TestRegressionPlots(object):
 
         nt.assert_equal(len(ax.lines), 2)
         nt.assert_equal(len(ax.collections), 4)
-        plt.close("all")
 
     def test_lmplot_markers(self):
 
@@ -512,8 +500,6 @@ class TestRegressionPlots(object):
         with nt.assert_raises(ValueError):
             lm.lmplot("x", "y", data=self.df, hue="h", markers=["o", "s", "d"])
 
-        plt.close("all")
-
     def test_lmplot_marker_linewidths(self):
 
         if mpl.__version__ == "1.4.2":
@@ -525,7 +511,6 @@ class TestRegressionPlots(object):
         nt.assert_equal(c[0].get_linewidths()[0], 0)
         rclw = mpl.rcParams["lines.linewidth"]
         nt.assert_equal(c[1].get_linewidths()[0], rclw)
-        plt.close("all")
 
     def test_lmplot_facets(self):
 
@@ -537,13 +522,11 @@ class TestRegressionPlots(object):
 
         g = lm.lmplot("x", "y", data=self.df, hue="h", col="u")
         nt.assert_equal(g.axes.shape, (1, 6))
-        plt.close("all")
 
     def test_lmplot_hue_col_nolegend(self):
 
         g = lm.lmplot("x", "y", data=self.df, col="h", hue="h")
         nt.assert_is(g._legend, None)
-        plt.close("all")
 
     def test_lmplot_scatter_kws(self):
 
@@ -553,8 +536,6 @@ class TestRegressionPlots(object):
         red, blue = color_palette(n_colors=2)
         npt.assert_array_equal(red, red_scatter.get_facecolors()[0, :3])
         npt.assert_array_equal(blue, blue_scatter.get_facecolors()[0, :3])
-
-        plt.close("all")
 
     def test_residplot(self):
 
@@ -566,7 +547,6 @@ class TestRegressionPlots(object):
 
         npt.assert_array_equal(x, x_plot)
         npt.assert_array_almost_equal(resid, y_plot)
-        plt.close("all")
 
     @skipif(_no_statsmodels)
     def test_residplot_lowess(self):
@@ -576,5 +556,3 @@ class TestRegressionPlots(object):
 
         x, y = ax.lines[1].get_xydata().T
         npt.assert_array_equal(x, np.sort(self.df.x))
-
-        plt.close("all")

--- a/seaborn/tests/test_matrix.py
+++ b/seaborn/tests/test_matrix.py
@@ -13,6 +13,7 @@ import numpy.testing as npt
 import pandas.util.testing as pdt
 from numpy.testing.decorators import skipif
 
+from . import PlotTestCase
 from .. import matrix as mat
 from .. import color_palette
 from ..external.six.moves import range
@@ -26,7 +27,7 @@ except ImportError:
     _no_fastcluster = True
 
 
-class TestHeatmap(object):
+class TestHeatmap(PlotTestCase):
     rs = np.random.RandomState(sum(map(ord, "heatmap")))
 
     x_norm = rs.randn(4, 8)
@@ -221,7 +222,6 @@ class TestHeatmap(object):
         for val, text in zip(self.x_norm[::-1].flat, ax.texts):
             nt.assert_equal(text.get_text(), "{:.1f}".format(val))
             nt.assert_equal(text.get_fontsize(), 14)
-        plt.close("all")
 
     def test_heatmap_annotation_overwrite_kws(self):
 
@@ -232,7 +232,6 @@ class TestHeatmap(object):
             nt.assert_equal(text.get_color(), "0.3")
             nt.assert_equal(text.get_ha(), "left")
             nt.assert_equal(text.get_va(), "bottom")
-        plt.close("all")
 
     def test_heatmap_annotation_with_mask(self):
 
@@ -245,7 +244,6 @@ class TestHeatmap(object):
         nt.assert_equal(len(df_masked[::-1].compressed()), len(ax.texts))
         for val, text in zip(df_masked[::-1].compressed(), ax.texts):
             nt.assert_equal("{:.1f}".format(val), text.get_text())
-        plt.close("all")
 
     def test_heatmap_cbar(self):
 
@@ -278,8 +276,6 @@ class TestHeatmap(object):
 
         nt.assert_equal(ax.get_xlim(), (0, 8))
         nt.assert_equal(ax.get_ylim(), (0, 4))
-
-        plt.close("all")
 
     def test_heatmap_ticklabel_rotation(self):
 
@@ -317,13 +313,10 @@ class TestHeatmap(object):
         nt.assert_equal(mesh.get_linewidths()[0], 2)
         nt.assert_equal(tuple(mesh.get_edgecolor()[0]), c)
 
-        plt.close("all")
-
     def test_square_aspect(self):
 
         ax = mat.heatmap(self.df_norm, square=True)
         nt.assert_equal(ax.get_aspect(), "equal")
-        plt.close("all")
 
     def test_mask_validation(self):
 
@@ -351,7 +344,7 @@ class TestHeatmap(object):
         npt.assert_array_equal(mask_out, [[True, True], [False, False]])
 
 
-class TestDendrogram(object):
+class TestDendrogram(PlotTestCase):
     rs = np.random.RandomState(sum(map(ord, "dendrogram")))
 
     x_norm = rs.randn(4, 8) + np.arange(8)
@@ -549,8 +542,6 @@ class TestDendrogram(object):
         nt.assert_equal(len(ax.collections[0].get_paths()),
                         len(d.dependent_coord))
 
-        plt.close('all')
-
     def test_dendrogram_rotate(self):
         kws = self.default_kws.copy()
         kws['rotate'] = True
@@ -567,7 +558,6 @@ class TestDendrogram(object):
         # and therefore not (0, 80) as usual:
         nt.assert_equal(ylim[1], 0)
         nt.assert_equal(ylim[0], ymax)
-        plt.close('all')
 
     def test_dendrogram_ticklabel_rotation(self):
         f, ax = plt.subplots(figsize=(2, 2))
@@ -597,7 +587,7 @@ class TestDendrogram(object):
         plt.close(f)
 
 
-class TestClustermap(object):
+class TestClustermap(PlotTestCase):
     rs = np.random.RandomState(sum(map(ord, "clustermap")))
 
     x_norm = rs.randn(4, 8) + np.arange(8)
@@ -639,13 +629,9 @@ class TestClustermap(object):
         nt.assert_equal(cm.ax_row_colors, None)
         nt.assert_equal(cm.ax_col_colors, None)
 
-        plt.close('all')
-
     def test_df_input(self):
         cm = mat.ClusterGrid(self.df_norm, **self.default_kws)
         pdt.assert_frame_equal(cm.data, self.df_norm)
-
-        plt.close('all')
 
     def test_corr_df_input(self):
         df = self.df_norm.corr()
@@ -653,8 +639,6 @@ class TestClustermap(object):
         cg.plot(**self.default_plot_kws)
         diag = cg.data2d.values[np.diag_indices_from(cg.data2d)]
         npt.assert_array_equal(diag, np.ones(cg.data2d.shape[0]))
-
-        plt.close('all')
 
     def test_pivot_input(self):
         df_norm = self.df_norm.copy()
@@ -668,8 +652,6 @@ class TestClustermap(object):
 
         pdt.assert_frame_equal(cm.data2d, df_norm)
 
-        plt.close('all')
-
     def test_colors_input(self):
         kws = self.default_kws.copy()
 
@@ -681,7 +663,6 @@ class TestClustermap(object):
         npt.assert_array_equal(cm.col_colors, self.col_colors)
 
         nt.assert_equal(len(cm.fig.axes), 6)
-        plt.close('all')
 
     def test_nested_colors_input(self):
         kws = self.default_kws.copy()
@@ -696,7 +677,6 @@ class TestClustermap(object):
         npt.assert_array_equal(cm.col_colors, col_colors)
 
         nt.assert_equal(len(cm.fig.axes), 6)
-        plt.close('all')
 
     def test_colors_input_custom_cmap(self):
         kws = self.default_kws.copy()
@@ -710,7 +690,6 @@ class TestClustermap(object):
         npt.assert_array_equal(cm.col_colors, self.col_colors)
 
         nt.assert_equal(len(cm.fig.axes), 6)
-        plt.close('all')
 
     def test_z_score(self):
         df = self.df_norm.copy()
@@ -720,8 +699,6 @@ class TestClustermap(object):
 
         cm = mat.ClusterGrid(self.df_norm, **kws)
         pdt.assert_frame_equal(cm.data2d, df)
-
-        plt.close('all')
 
     def test_z_score_axis0(self):
         df = self.df_norm.copy()
@@ -734,8 +711,6 @@ class TestClustermap(object):
         cm = mat.ClusterGrid(self.df_norm, **kws)
         pdt.assert_frame_equal(cm.data2d, df)
 
-        plt.close('all')
-
     def test_standard_scale(self):
         df = self.df_norm.copy()
         df = (df - df.min()) / (df.max() - df.min())
@@ -744,8 +719,6 @@ class TestClustermap(object):
 
         cm = mat.ClusterGrid(self.df_norm, **kws)
         pdt.assert_frame_equal(cm.data2d, df)
-
-        plt.close('all')
 
     def test_standard_scale_axis0(self):
         df = self.df_norm.copy()
@@ -758,16 +731,12 @@ class TestClustermap(object):
         cm = mat.ClusterGrid(self.df_norm, **kws)
         pdt.assert_frame_equal(cm.data2d, df)
 
-        plt.close('all')
-
     def test_z_score_standard_scale(self):
         kws = self.default_kws.copy()
         kws['z_score'] = True
         kws['standard_scale'] = True
         with nt.assert_raises(ValueError):
             cm = mat.ClusterGrid(self.df_norm, **kws)
-
-        plt.close('all')
 
     def test_color_list_to_matrix_and_cmap(self):
         matrix, cmap = mat.ClusterGrid.color_list_to_matrix_and_cmap(
@@ -782,8 +751,6 @@ class TestClustermap(object):
         cmap_test = mpl.colors.ListedColormap(colors_set)
         npt.assert_array_equal(matrix, matrix_test)
         npt.assert_array_equal(cmap.colors, cmap_test.colors)
-
-        plt.close('all')
 
     def test_nested_color_list_to_matrix_and_cmap(self):
         colors = [self.col_colors, self.col_colors]
@@ -803,8 +770,6 @@ class TestClustermap(object):
         npt.assert_array_equal(matrix, matrix_test)
         npt.assert_array_equal(cmap.colors, cmap_test.colors)
 
-        plt.close('all')
-
     def test_color_list_to_matrix_and_cmap_axis1(self):
         matrix, cmap = mat.ClusterGrid.color_list_to_matrix_and_cmap(
             self.col_colors, self.x_norm_leaves, axis=1)
@@ -819,15 +784,11 @@ class TestClustermap(object):
         npt.assert_array_equal(matrix, matrix_test)
         npt.assert_array_equal(cmap.colors, cmap_test.colors)
 
-        plt.close('all')
-
     def test_savefig(self):
         # Not sure if this is the right way to test....
         cm = mat.ClusterGrid(self.df_norm, **self.default_kws)
         cm.plot(**self.default_plot_kws)
         cm.savefig(tempfile.NamedTemporaryFile(), format='png')
-
-        plt.close('all')
 
     def test_plot_dendrograms(self):
         cm = mat.clustermap(self.df_norm, **self.default_kws)
@@ -839,7 +800,6 @@ class TestClustermap(object):
         data2d = self.df_norm.iloc[cm.dendrogram_row.reordered_ind,
                                    cm.dendrogram_col.reordered_ind]
         pdt.assert_frame_equal(cm.data2d, data2d)
-        plt.close('all')
 
     def test_cluster_false(self):
         kws = self.default_kws.copy()
@@ -856,7 +816,6 @@ class TestClustermap(object):
         nt.assert_equal(len(cm.ax_col_dendrogram.get_yticks()), 0)
 
         pdt.assert_frame_equal(cm.data2d, self.df_norm)
-        plt.close('all')
 
     def test_row_col_colors(self):
         kws = self.default_kws.copy()
@@ -867,8 +826,6 @@ class TestClustermap(object):
 
         nt.assert_equal(len(cm.ax_row_colors.collections), 1)
         nt.assert_equal(len(cm.ax_col_colors.collections), 1)
-
-        plt.close('all')
 
     def test_cluster_false_row_col_colors(self):
         kws = self.default_kws.copy()
@@ -889,7 +846,6 @@ class TestClustermap(object):
         nt.assert_equal(len(cm.ax_col_colors.collections), 1)
 
         pdt.assert_frame_equal(cm.data2d, self.df_norm)
-        plt.close('all')
 
     def test_mask_reorganization(self):
 
@@ -906,8 +862,6 @@ class TestClustermap(object):
         npt.assert_array_equal(g.mask.columns,
                                self.df_norm.columns[
                                    g.dendrogram_col.reordered_ind])
-
-        plt.close("all")
 
     def test_ticklabel_reorganization(self):
 
@@ -927,5 +881,3 @@ class TestClustermap(object):
 
         npt.assert_array_equal(xtl_actual, xtl_want)
         npt.assert_array_equal(ytl_actual, ytl_want)
-
-        plt.close("all")

--- a/seaborn/tests/test_miscplot.py
+++ b/seaborn/tests/test_miscplot.py
@@ -2,11 +2,12 @@ import nose.tools as nt
 import numpy.testing as npt
 import matplotlib.pyplot as plt
 
+from . import PlotTestCase
 from .. import miscplot as misc
 from seaborn import color_palette
 
 
-class TestPalPlot(object):
+class TestPalPlot(PlotTestCase):
     """Test the function that visualizes a color palette."""
     def test_palplot_size(self):
 
@@ -24,5 +25,3 @@ class TestPalPlot(object):
         misc.palplot(palbig, 2)
         sizebig = plt.gcf().get_size_inches()
         nt.assert_equal(tuple(sizebig), (6, 2))
-
-        plt.close("all")

--- a/seaborn/tests/test_rcmod.py
+++ b/seaborn/tests/test_rcmod.py
@@ -6,6 +6,7 @@ import matplotlib.pyplot as plt
 import nose.tools as nt
 import numpy.testing as npt
 
+from . import PlotTestCase
 from .. import rcmod
 
 
@@ -164,7 +165,7 @@ class TestPlottingContext(RCParamTester):
         self.assert_rc_params(orig_params)
 
 
-class TestFonts(object):
+class TestFonts(PlotTestCase):
 
     def test_set_font(self):
 
@@ -183,7 +184,6 @@ class TestFonts(object):
                 raise nose.SkipTest("Verdana font is not present")
         finally:
             rcmod.set()
-            plt.close("all")
 
     def test_set_serif_font(self):
 
@@ -196,7 +196,6 @@ class TestFonts(object):
                      mpl.rcParams["font.serif"])
 
         rcmod.set()
-        plt.close("all")
 
     def test_different_sans_serif(self):
 
@@ -220,8 +219,6 @@ class TestFonts(object):
                 raise nose.SkipTest("Verdana font is not present")
         finally:
             rcmod.set()
-            plt.close("all")
-
 
 def has_verdana():
     """Helper to verify if Verdana font is present"""

--- a/seaborn/tests/test_rcmod.py
+++ b/seaborn/tests/test_rcmod.py
@@ -220,6 +220,7 @@ class TestFonts(PlotTestCase):
         finally:
             rcmod.set()
 
+
 def has_verdana():
     """Helper to verify if Verdana font is present"""
     # This import is relatively lengthy, so to prevent its import for

--- a/seaborn/tests/test_utils.py
+++ b/seaborn/tests/test_utils.py
@@ -16,14 +16,15 @@ from distutils.version import LooseVersion
 pandas_has_categoricals = LooseVersion(pd.__version__) >= "0.15"
 
 from pandas.util.testing import network
-from ..utils import get_dataset_names, load_dataset
 
 try:
     from bs4 import BeautifulSoup
 except ImportError:
     BeautifulSoup = None
 
+from . import PlotTestCase
 from .. import utils, rcmod
+from ..utils import get_dataset_names, load_dataset
 
 
 a_norm = np.random.randn(100)
@@ -109,7 +110,7 @@ def test_iqr():
     assert_equal(iqr, 2)
 
 
-class TestSpineUtils(object):
+class TestSpineUtils(PlotTestCase):
 
     sides = ["left", "right", "bottom", "top"]
     outer_sides = ["top", "right"]
@@ -134,8 +135,6 @@ class TestSpineUtils(object):
         for side in self.sides:
             nt.assert_true(~ax.spines[side].get_visible())
 
-        plt.close("all")
-
     def test_despine_specific_axes(self):
         f, (ax1, ax2) = plt.subplots(2, 1)
 
@@ -148,8 +147,6 @@ class TestSpineUtils(object):
             nt.assert_true(~ax2.spines[side].get_visible())
         for side in self.inner_sides:
             nt.assert_true(ax2.spines[side].get_visible())
-
-        plt.close("all")
 
     def test_despine_with_offset(self):
         f, ax = plt.subplots()
@@ -168,8 +165,6 @@ class TestSpineUtils(object):
             else:
                 nt.assert_equal(new_position, self.original_position)
 
-        plt.close("all")
-
     def test_despine_with_offset_specific_axes(self):
         f, (ax1, ax2) = plt.subplots(2, 1)
 
@@ -184,7 +179,6 @@ class TestSpineUtils(object):
             else:
                 nt.assert_equal(ax2.spines[side].get_position(),
                                 self.original_position)
-        plt.close("all")
 
     def test_despine_trim_spines(self):
         f, ax = plt.subplots()
@@ -195,8 +189,6 @@ class TestSpineUtils(object):
         for side in self.inner_sides:
             bounds = ax.spines[side].get_bounds()
             nt.assert_equal(bounds, (1, 3))
-
-        plt.close("all")
 
     def test_despine_trim_inverted(self):
 
@@ -209,8 +201,6 @@ class TestSpineUtils(object):
         for side in self.inner_sides:
             bounds = ax.spines[side].get_bounds()
             nt.assert_equal(bounds, (1, 3))
-
-        plt.close("all")
 
     def test_despine_trim_noticks(self):
 
@@ -229,8 +219,6 @@ class TestSpineUtils(object):
             nt.assert_true('deprecated' in str(w[0].message))
             nt.assert_true(issubclass(w[0].category, UserWarning))
 
-        plt.close('all')
-
     def test_offset_spines(self):
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always", category=UserWarning)
@@ -246,8 +234,6 @@ class TestSpineUtils(object):
                 nt.assert_equal(ax.spines[side].get_position(),
                                 self.offset_position)
 
-        plt.close("all")
-
     def test_offset_spines_specific_axes(self):
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always", category=UserWarning)
@@ -260,8 +246,6 @@ class TestSpineUtils(object):
                                 self.original_position)
                 nt.assert_equal(ax2.spines[side].get_position(),
                                 self.offset_position)
-        plt.close("all")
-
 
 def test_ticklabels_overlap():
 

--- a/seaborn/tests/test_utils.py
+++ b/seaborn/tests/test_utils.py
@@ -247,6 +247,7 @@ class TestSpineUtils(PlotTestCase):
                 nt.assert_equal(ax2.spines[side].get_position(),
                                 self.offset_position)
 
+
 def test_ticklabels_overlap():
 
     rcmod.set()


### PR DESCRIPTION
Closes #694.

After this we have:
```
~/dev/seaborn/seaborn/tests $ grep "plt.close" *.py | wc
      98     196    4323
```
So `plt.close` shows up 98 times rather than 241. There are still so many because some tests call `plt.close` several times within one test method. Those can stay.

These tests are now more robust, since the `tearDown` method is called regardless of whether the test causes an unexpected exception.