### PR TITLE
Fixed an issue with factorplot when plotting data that contains different categories across columns

### DIFF
--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -365,6 +365,7 @@ class FacetGrid(Grid):
         self._y_var = None
         self._dropna = dropna
         self._not_na = not_na
+        self._sharex = sharex
 
         # Make the axes look good
         fig.tight_layout()
@@ -787,6 +788,12 @@ class FacetGrid(Grid):
             if self._dropna:
                 data_ijk = data_ijk.dropna()
             kwargs["data"] = data_ijk
+            
+            #if sharex is False, set the order for each subplot separatly 
+            if not self._sharex:
+                groups = data_ijk.get(x, x)
+                group_names = utils.categorical_order(groups)
+                kwargs["order"] = group_names
 
             # Draw the plot
             self._facet_plot(func, ax, args, kwargs)


### PR DESCRIPTION
Using the factorplot for plots with categorical data that contain different categories across columns (e.g. first column has categories 'A', 'B', 'C', and second column has categories 'A', 'B', 'D') would add all the categories to all subplots (e.g. all plots would have 'A', 'B', 'C', 'D' categories in spite of missing data). Hence, I have added a re-computation of the "order" variable (lines 793 - 796) for each subplot, if the sharex is set to false (Setting sharex = True already assumes that the data in all subplots contains same categories). I have also introduced a new private variable self._sharex.