### PR TITLE
Trivial typo fix in example (fix keyword pluralization)

### DIFF
--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -535,7 +535,7 @@ class FacetGrid(Grid):
 
             >>> g = sns.FacetGrid(tips, col="sex", hue="time", palette=pal,
             ...                   hue_order=["Dinner", "Lunch"],
-            ...                   hue_kws=dict(marker=["^", "v"]))
+            ...                   hue_kws=dict(markers=["^", "v"]))
             >>> g = (g.map(plt.scatter, "total_bill", "tip", **kws)
             ...      .add_legend())
 


### PR DESCRIPTION
Resolves issue #713, by fixing the keyword argument for the specification of markers from [`FacetGrid`](http://stanford.edu/~mwaskom/software/seaborn/generated/seaborn.FacetGrid.html) via the `hue_kws` parameter. The keyword `marker` was erroneously provided in singular, instead of plural form (i.e. `markers`).