### PR TITLE
COMPAT: compat with mpl 1.5 color cycle

### DIFF
--- a/matplotlibrc
+++ b/matplotlibrc
@@ -1,0 +1,1 @@
+backend : Agg

--- a/matplotlibrc
+++ b/matplotlibrc
@@ -1,1 +1,0 @@
-backend : Agg

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -146,7 +146,7 @@ class Grid(object):
 
             # By default use either the current color palette or HUSL
             if palette is None:
-                current_palette = mpl.rcParams["axes.color_cycle"]
+                current_palette = utils.get_color_cycle()
                 if n_colors > len(current_palette):
                     colors = color_palette("husl", n_colors)
                 else:

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -573,7 +573,8 @@ class FacetGrid(Grid):
             >>> df = pd.DataFrame(
             ...     data=np.random.randn(90, 4),
             ...     columns=pd.Series(list("ABCD"), name="walk"),
-            ...     index=pd.date_range("Jan 1", "March 31", name="date"))
+            ...     index=pd.date_range("2015-01-01", "2015-03-31",
+            ...                         name="date"))
             >>> df = df.cumsum(axis=0).stack().reset_index(name="val")
             >>> def dateplot(x, y, **kwargs):
             ...     ax = plt.gca()

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -261,7 +261,7 @@ class _CategoricalPlotter(object):
         if color is None and palette is None:
             # Determine whether the current palette will have enough values
             # If not, we'll default to the husl palette so each is distinct
-            current_palette = mpl.rcParams["axes.color_cycle"]
+            current_palette = utils.get_color_cycle()
             if n_colors <= len(current_palette):
                 colors = color_palette(n_colors=n_colors)
             else:

--- a/seaborn/palettes.py
+++ b/seaborn/palettes.py
@@ -11,11 +11,10 @@ from .external import husl
 from .external.six import string_types
 from .external.six.moves import range
 
-from .utils import desaturate, set_hls_values
+from .utils import desaturate, set_hls_values, get_color_cycle
 from .xkcd_rgb import xkcd_rgb
 from .crayons import crayons
 from .miscplot import palplot
-
 
 SEABORN_PALETTES = dict(
     deep=["#4C72B0", "#55A868", "#C44E52",
@@ -148,7 +147,7 @@ def color_palette(palette=None, n_colors=None, desat=None):
 
     """
     if palette is None:
-        palette = mpl.rcParams["axes.color_cycle"]
+        palette = get_color_cycle()
         if n_colors is None:
             n_colors = len(palette)
 

--- a/seaborn/rcmod.py
+++ b/seaborn/rcmod.py
@@ -1,9 +1,12 @@
 """Functions that alter the matplotlib rc dictionary on the fly."""
+from distutils.version import LooseVersion
+
 import numpy as np
 import matplotlib as mpl
 
 from . import palettes
 
+mpl_ge_150 = LooseVersion(mpl.__version__) >= '1.5.0'
 
 _style_keys = (
 
@@ -490,7 +493,12 @@ def set_palette(palette, n_colors=None, desat=None, color_codes=False):
 
     """
     colors = palettes.color_palette(palette, n_colors, desat)
-    mpl.rcParams["axes.color_cycle"] = list(colors)
+    if mpl_ge_150:
+        from cycler import cycler
+        cyl = cycler('color', colors)
+        mpl.rcParams['axes.prop_cycle'] = cyl
+    else:
+        mpl.rcParams["axes.color_cycle"] = list(colors)
     mpl.rcParams["patch.facecolor"] = colors[0]
     if color_codes:
         palettes.set_color_codes(palette)

--- a/seaborn/tests/test_linearmodels.py
+++ b/seaborn/tests/test_linearmodels.py
@@ -33,7 +33,7 @@ class TestLinearPlotter(PlotTestCase):
                            s=np.tile(list("abcdefghij"), 6)))
     df["z"] = df.y + rs.randn(60)
     df["y_na"] = df.y.copy()
-    df.y_na.ix[[10, 20, 30]] = np.nan
+    df.loc[[10, 20, 30], 'y_na'] = np.nan
 
     def test_establish_variables_from_frame(self):
 
@@ -109,7 +109,7 @@ class TestRegressionPlotter(PlotTestCase):
 
     p = 1 / (1 + np.exp(-(df.x * 2 + rs.randn(60))))
     df["c"] = [rs.binomial(1, p_i) for p_i in p]
-    df.y_na.ix[[10, 20, 30]] = np.nan
+    df.loc[[10, 20, 30], 'y_na'] = np.nan
 
     def test_variables_from_frame(self):
 

--- a/seaborn/tests/test_palettes.py
+++ b/seaborn/tests/test_palettes.py
@@ -1,3 +1,4 @@
+import warnings
 import colorsys
 import numpy as np
 import matplotlib as mpl
@@ -16,7 +17,7 @@ class TestColorPalettes(object):
 
         pal = palettes.color_palette(["red", "blue", "green"], 3)
         rcmod.set_palette(pal, 3)
-        nt.assert_equal(pal, mpl.rcParams["axes.color_cycle"])
+        nt.assert_equal(pal, utils.get_color_cycle())
         rcmod.set()
 
     def test_palette_context(self):
@@ -25,9 +26,9 @@ class TestColorPalettes(object):
         context_pal = palettes.color_palette("muted")
 
         with palettes.color_palette(context_pal):
-            nt.assert_equal(mpl.rcParams["axes.color_cycle"], context_pal)
+            nt.assert_equal(utils.get_color_cycle(), context_pal)
 
-        nt.assert_equal(mpl.rcParams["axes.color_cycle"], default_pal)
+        nt.assert_equal(utils.get_color_cycle(), default_pal)
 
     def test_big_palette_context(self):
 
@@ -36,9 +37,9 @@ class TestColorPalettes(object):
 
         rcmod.set_palette(original_pal)
         with palettes.color_palette(context_pal, 10):
-            nt.assert_equal(mpl.rcParams["axes.color_cycle"], context_pal)
+            nt.assert_equal(utils.get_color_cycle(), context_pal)
 
-        nt.assert_equal(mpl.rcParams["axes.color_cycle"], original_pal)
+        nt.assert_equal(utils.get_color_cycle(), original_pal)
 
         # Reset default
         rcmod.set()
@@ -287,3 +288,10 @@ class TestColorPalettes(object):
         pal_in = palettes.color_palette("Set1", 10)
         pal_out = palettes.color_palette(pal_in)
         nt.assert_equal(pal_in, pal_out)
+
+    def test_get_color_cycle(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            result = utils.get_color_cycle()
+            expected = mpl.rcParams['axes.color_cycle']
+        nt.assert_equal(result, expected)

--- a/seaborn/timeseries.py
+++ b/seaborn/timeseries.py
@@ -257,7 +257,7 @@ def tsplot(data, time=None, unit=None, condition=None, value=None,
 
     # Set up the color palette
     if color is None:
-        current_palette = mpl.rcParams["axes.color_cycle"]
+        current_palette = utils.get_color_cycle()
         if len(current_palette) < n_cond:
             colors = color_palette("husl", n_cond)
         else:

--- a/seaborn/utils.py
+++ b/seaborn/utils.py
@@ -7,12 +7,13 @@ import os
 import numpy as np
 from scipy import stats
 import pandas as pd
+import matplotlib as mpl
 import matplotlib.colors as mplcol
 import matplotlib.pyplot as plt
 
 from distutils.version import LooseVersion
 pandas_has_categoricals = LooseVersion(pd.__version__) >= "0.15"
-
+mpl_ge_150 = LooseVersion(mpl.__version__) >= "1.5.0"
 from .external.six.moves.urllib.request import urlopen, urlretrieve
 
 
@@ -527,3 +528,16 @@ def categorical_order(values, order=None):
                     order = order
         order = filter(pd.notnull, order)
     return list(order)
+
+
+def get_color_cycle():
+    if mpl_ge_150:
+        cyl = mpl.rcParams['axes.prop_cycle']
+        # matplotlib 1.5 verifies that axes.prop_cycle *is* a cycler
+        # but no garuantee that there's a `color` key.
+        # so users could have a custom rcParmas w/ no color...
+        try:
+            return [x['color'] for x in cyl]
+        except KeyError:
+            pass  # just return axes.color style below
+    return mpl.rcParams['axes.color_cycle']


### PR DESCRIPTION
Closes https://github.com/mwaskom/seaborn/issues/711 and #732 

One oddity here is if a user has modified their `axes.prop_cycler` to be a cycler that doesn't include the `color` key. In this case we just fall back to `axes.color_cycle` and they'll get the warning. I actually think the changes I made to pandas missed this possibility and will just break :shrug:.

For Travis, want me to modify one of the `testing/deps_modern`? https://anaconda.org/conda-forge/matplotlib/files has RC1... not sure about a more up to date version.

I've got a couple (seemingly unrelated) failures to cleanup too. They fail for me on master so I'm not sure if that's another mpl 1.5 thing or what. Not sure if I'll get to that any time soon.
For the record, those failures are

```
======================================================================
FAIL: seaborn.tests.test_matrix.TestDendrogram.test_dendrogram_ticklabel_rotation
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/tom.augspurger/Envs/dev/lib/python3.4/site-packages/nose/case.py", line 198, in runTest
    self.test(*self.arg)
  File "/Users/tom.augspurger/Envs/dev/lib/python3.4/site-packages/seaborn/seaborn/tests/test_matrix.py", line 579, in test_dendrogram_ticklabel_rotation
    nt.assert_equal(t.get_rotation(), 90)
AssertionError: 0.0 != 90

======================================================================
FAIL: seaborn.tests.test_matrix.TestHeatmap.test_heatmap_annotation_with_mask
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/tom.augspurger/Envs/dev/lib/python3.4/site-packages/nose/case.py", line 198, in runTest
    self.test(*self.arg)
  File "/Users/tom.augspurger/Envs/dev/lib/python3.4/site-packages/seaborn/seaborn/tests/test_matrix.py", line 244, in test_heatmap_annotation_with_mask
    nt.assert_equal(len(df_masked[::-1].compressed()), len(ax.texts))
AssertionError: 7 != 1

======================================================================
FAIL: seaborn.tests.test_matrix.TestHeatmap.test_heatmap_ticklabel_rotation
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/tom.augspurger/Envs/dev/lib/python3.4/site-packages/nose/case.py", line 198, in runTest
    self.test(*self.arg)
  File "/Users/tom.augspurger/Envs/dev/lib/python3.4/site-packages/seaborn/seaborn/tests/test_matrix.py", line 301, in test_heatmap_ticklabel_rotation
    nt.assert_equal(t.get_rotation(), 90)
AssertionError: 0.0 != 90
```