### PR TITLE
Updating .travis to reflect recent miniconda changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,10 +28,15 @@ before_install:
   - sudo apt-get update -yq
   - sudo sh -c "echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | debconf-set-selections"
   - sudo apt-get install msttcorefonts -qq
-  - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
-  - chmod +x miniconda.sh
-  - ./miniconda.sh -b
-  - export PATH=/home/travis/miniconda/bin:$PATH
+
+  # http://conda.pydata.org/docs/travis.html#the-travis-yml-file
+  - wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - export PATH="$HOME/miniconda/bin:$PATH"
+  - hash -r
+  - conda config --set always_yes yes --set changeps1 no
+  - conda update -q conda
+  - conda info -a
 
 before_script:
   - if [ ${PYTHON:0:1} == "2" ]; then


### PR DESCRIPTION
Miniconda's default prefix changed recently causing all travis builds failing.

