### PR TITLE
Pass 'rasterized' to colorbar in sns.heatmap

### DIFF
--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -253,6 +253,10 @@ class _HeatMapper(object):
             cb = ax.figure.colorbar(mesh, cax, ax,
                                     ticks=ticker, **self.cbar_kws)
             cb.outline.set_linewidth(0)
+            # If rasterized is passed to pcolormesh, also rasterize the
+            # colorbar to avoid white lines on the PDF rendering
+            if kws.get('rasterized', False):
+                cb.solids.set_rasterized(True)
 
 
 def heatmap(data, vmin=None, vmax=None, cmap=None, center=None, robust=False,


### PR DESCRIPTION
This fixes white lines appearing in the rendered PDF. See #373 .

Rendered PDF before :
![sns_colorbar_pdf_before](https://cloud.githubusercontent.com/assets/506602/11187746/f0cf0d46-8c87-11e5-81f1-b9dcbc4c93f9.png)

Rendered PDF after :
![sns_colorbar_pdf_after](https://cloud.githubusercontent.com/assets/506602/11187749/f429c4e0-8c87-11e5-9c1e-cea55ddb3fa1.png)


