### PR TITLE
Force number of bins to be an integer.

### DIFF
--- a/seaborn/distributions.py
+++ b/seaborn/distributions.py
@@ -27,9 +27,9 @@ def _freedman_diaconis_bins(a):
     h = 2 * iqr(a) / (len(a) ** (1 / 3))
     # fall back to sqrt(a) bins if iqr is 0
     if h == 0:
-        return np.sqrt(a.size)
+        return int(np.sqrt(a.size))
     else:
-        return np.ceil((a.max() - a.min()) / h)
+        return int(np.ceil((a.max() - a.min()) / h))
 
 
 def distplot(a, bins=None, hist=True, kde=True, rug=False, fit=None,


### PR DESCRIPTION
I get an error if I try to use jointplot.  
np.ceil returns a float, which causes  np.histogram(x[i], bins, weights=w[i], **hist_kwargs) to throw an error.

This is probably because I am using numpy version 1.11.0.dev0+cbc14f0 and not whatever version seaborn is built for.  In any case this is a simple fix and should help with future compatibility.