### PR TITLE
Fix deprecation warning for matplotlib >= 1.5.0

### DIFF
--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -607,7 +607,7 @@ class FacetGrid(Grid):
         .. plot::
             :context: close-figs
 
-            >>> g = sns.FacetGrid(tips.sort("size"), col="size", col_wrap=3)
+            >>> g = sns.FacetGrid(tips.sort_values(by="size"), col="size", col_wrap=3)
             >>> g = (g.map(plt.hist, "tip", bins=np.arange(0, 13), color="c")
             ...       .set_titles("{{col_name}} diners"))
 

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -1963,7 +1963,7 @@ boxplot.__doc__ = dedent("""\
     .. plot::
         :context: close-figs
 
-        >>> ax = sns.boxplot(x="size", y="tip", data=tips.sort("size"))
+        >>> ax = sns.boxplot(x="size", y="tip", data=tips.sort_values(by="size"))
 
     Control box order by passing an explicit order:
 
@@ -2164,7 +2164,7 @@ violinplot.__doc__ = dedent("""\
     .. plot::
         :context: close-figs
 
-        >>> ax = sns.violinplot(x="size", y="tip", data=tips.sort("size"))
+        >>> ax = sns.violinplot(x="size", y="tip", data=tips.sort_values(by="size"))
 
     Control violin order by passing an explicit order:
 
@@ -2375,7 +2375,7 @@ stripplot.__doc__ = dedent("""\
     .. plot::
         :context: close-figs
 
-        >>> ax = sns.stripplot(x="size", y="tip", data=tips.sort("size"))
+        >>> ax = sns.stripplot(x="size", y="tip", data=tips.sort_values(by="size"))
 
     Control strip order by passing an explicit order:
 
@@ -2526,7 +2526,7 @@ barplot.__doc__ = dedent("""\
     .. plot::
         :context: close-figs
 
-        >>> ax = sns.barplot(x="size", y="tip", data=tips.sort("size"))
+        >>> ax = sns.barplot(x="size", y="tip", data=tips.sort_values(by="size"))
 
     Control bar order by passing an explicit order:
 
@@ -2556,7 +2556,7 @@ barplot.__doc__ = dedent("""\
     .. plot::
         :context: close-figs
 
-        >>> ax = sns.barplot("size", y="total_bill", data=tips.sort("size"),
+        >>> ax = sns.barplot("size", y="total_bill", data=tips.sort_values(by="size"),
         ...                  palette="Blues_d")
 
     Plot all bars in a single color:
@@ -2564,7 +2564,7 @@ barplot.__doc__ = dedent("""\
     .. plot::
         :context: close-figs
 
-        >>> ax = sns.barplot("size", y="total_bill", data=tips.sort("size"),
+        >>> ax = sns.barplot("size", y="total_bill", data=tips.sort_values(by="size"),
         ...                  color="salmon", saturation=.5)
 
     Use ``plt.bar`` keyword arguments to further change the aesthetic:
@@ -2740,7 +2740,7 @@ pointplot.__doc__ = dedent("""\
     .. plot::
         :context: close-figs
 
-        >>> ax = sns.pointplot(x="size", y="tip", data=tips.sort("size"))
+        >>> ax = sns.pointplot(x="size", y="tip", data=tips.sort_values(by="size"))
 
     Control point order by passing an explicit order:
 
@@ -3233,7 +3233,7 @@ lvplot.__doc__ = dedent("""\
     .. plot::
         :context: close-figs
 
-        >>> ax = sns.lvplot(x="size", y="tip", data=tips.sort("size"))
+        >>> ax = sns.lvplot(x="size", y="tip", data=tips.sort_values(by="size"))
 
     Control box order by passing an explicit order:
 

--- a/seaborn/rcmod.py
+++ b/seaborn/rcmod.py
@@ -498,7 +498,7 @@ def set_palette(palette, n_colors=None, desat=None, color_codes=False):
         cyl = cycler('color', colors)
         mpl.rcParams['axes.prop_cycle'] = cyl
     else:
-        mpl.rcParams["axes.prop_cycle"] = list(colors)
+        mpl.rcParams["axes.color_cycle"] = list(colors)
     mpl.rcParams["patch.facecolor"] = colors[0]
     if color_codes:
         palettes.set_color_codes(palette)

--- a/seaborn/rcmod.py
+++ b/seaborn/rcmod.py
@@ -498,7 +498,7 @@ def set_palette(palette, n_colors=None, desat=None, color_codes=False):
         cyl = cycler('color', colors)
         mpl.rcParams['axes.prop_cycle'] = cyl
     else:
-        mpl.rcParams["axes.color_cycle"] = list(colors)
+        mpl.rcParams["axes.prop_cycle"] = list(colors)
     mpl.rcParams["patch.facecolor"] = colors[0]
     if color_codes:
         palettes.set_color_codes(palette)

--- a/seaborn/tests/test_palettes.py
+++ b/seaborn/tests/test_palettes.py
@@ -293,5 +293,5 @@ class TestColorPalettes(object):
         with warnings.catch_warnings():
             warnings.simplefilter('ignore')
             result = utils.get_color_cycle()
-            expected = mpl.rcParams['axes.color_cycle']
+            expected = mpl.rcParams['axes.prop_cycle']
         nt.assert_equal(result, expected)

--- a/seaborn/utils.py
+++ b/seaborn/utils.py
@@ -540,4 +540,4 @@ def get_color_cycle():
             return [x['color'] for x in cyl]
         except KeyError:
             pass  # just return axes.color style below
-    return mpl.rcParams['axes.color_cycle']
+    return mpl.rcParams['axes.prop_cycle']


### PR DESCRIPTION
	modified:   seaborn/rcmod.py
	modified:   seaborn/tests/test_palettes.py
	modified:   seaborn/utils.py

Minor fix to replace all occurrences of `axes.color_cycle` with `axes.prop_cycle`. Fixes #778 