### PR TITLE
Force color of plot in grid diagonal

### DIFF
--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -1309,6 +1309,7 @@ class PairGrid(Grid):
             self.diag_axes = np.array(diag_axes, np.object)
 
         # Plot on each of the diagonal axes
+        color = kwargs.pop('color', None)
         for i, var in enumerate(self.x_vars):
             ax = self.diag_axes[i]
             hue_grouped = self.data[var].groupby(self.hue_vals)
@@ -1323,7 +1324,9 @@ class PairGrid(Grid):
                         vals.append(np.asarray(hue_grouped.get_group(label)))
                     except KeyError:
                         vals.append(np.array([]))
-                func(vals, color=self.palette, histtype="barstacked",
+                if color is None:
+                    color = self.palette
+                func(vals, color=color, histtype="barstacked",
                      **kwargs)
             else:
                 for k, label_k in enumerate(self.hue_names):
@@ -1333,8 +1336,10 @@ class PairGrid(Grid):
                     except KeyError:
                         data_k = np.array([])
                     plt.sca(ax)
+                    if color is None:
+                        color = self.palette[k]
                     func(data_k, label=label_k,
-                         color=self.palette[k], **kwargs)
+                         color=color, **kwargs)
 
             self._clean_axis(ax)
 

--- a/seaborn/tests/test_axisgrid.py
+++ b/seaborn/tests/test_axisgrid.py
@@ -781,6 +781,29 @@ class TestPairGrid(PlotTestCase):
             nt.assert_equal(len(ax.patches), 40)
 
     @skipif(old_matplotlib)
+    def test_map_diag_color(self):
+        color_set = {mpl.colors.cnames[x].lower()
+                     for x in ['red', 'white', 'black']}
+
+        g1 = ag.PairGrid(self.df)
+        g1.map_diag(plt.hist, color='red')
+
+        for ax in g1.diag_axes:
+            colors = [mpl.colors.rgb2hex(patch.get_facecolor()).lower()
+                      for patch in ax.patches]
+            for color in colors:
+                nt.assert_true(color in color_set, color)
+
+        g2 = ag.PairGrid(self.df)
+        g2.map_diag(kdeplot, color='red')
+
+        for ax in g2.diag_axes:
+            colors = [mpl.colors.rgb2hex(patch.get_facecolor()).lower()
+                      for patch in ax.patches]
+            for color in colors:
+                nt.assert_true(color in color_set, color)
+
+    @skipif(old_matplotlib)
     def test_map_diag_and_offdiag(self):
 
         vars = ["x", "y", "z"]


### PR DESCRIPTION
Allows setting the `color` kwarg in `map_diag`, which then overrides seaborn's attempt to set the colors via the palette.
Example:

``` py
#1
g = sns.PairGrid(data)
g.map_diag(plt.hist, color=color)
#2
g.map_diag(sns.distplot, color=color)
```

The first (`plt.hist`) was possible before by giving `facecolor=color`; the second (`sns.distplot`) wasn't possible AFAIK.
