### PR TITLE
PERF: Speed up test for empty facet (trivial)

### DIFF
--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -695,7 +695,7 @@ class FacetGrid(Grid):
         for (row_i, col_j, hue_k), data_ijk in self.facet_data():
 
             # If this subset is null, move on
-            if not data_ijk.values.tolist():
+            if not data_ijk.values.size:
                 continue
 
             # Get the current axis
@@ -767,7 +767,7 @@ class FacetGrid(Grid):
         for (row_i, col_j, hue_k), data_ijk in self.facet_data():
 
             # If this subset is null, move on
-            if not data_ijk.values.tolist():
+            if not data_ijk.values.size:
                 continue
 
             # Get the current axis


### PR DESCRIPTION
Using the cached `size` property on an `ndarray` must be faster than converting the array to a list, and it's more obvious what's going on to boot.

I can't imagine this makes much difference, but it might speed up plotting large datasets.