### PR TITLE
Pass hex colors to regression scatterplot

### DIFF
--- a/seaborn/linearmodels.py
+++ b/seaborn/linearmodels.py
@@ -313,6 +313,9 @@ class _RegressionPlotter(_LinearPlotter):
         else:
             color = self.color
 
+        # Ensure that color is hex to avoid matplotlib weidness
+        color = mpl.colors.rgb2hex(mpl.colors.colorConverter.to_rgb(color))
+
         # Let color in keyword arguments override overall plot color
         scatter_kws.setdefault("color", color)
         line_kws.setdefault("color", color)

--- a/seaborn/tests/test_linearmodels.py
+++ b/seaborn/tests/test_linearmodels.py
@@ -556,3 +556,11 @@ class TestRegressionPlots(PlotTestCase):
 
         x, y = ax.lines[1].get_xydata().T
         npt.assert_array_equal(x, np.sort(self.df.x))
+
+    def test_three_point_colors(self):
+
+        x, y = np.random.randn(2, 3)
+        ax = lm.regplot(x, y, color=(1, 0, 0))
+        color = ax.collections[0].get_facecolors()
+        npt.assert_almost_equal(color[0, :3],
+                                (1, 0, 0))


### PR DESCRIPTION
Avoids problem where matplotlib interprets rgb colors with three scatter
points as a variable to be colormapped.

Closes #802