### PR TITLE
Update mesh colors before drawing annotations

### DIFF
--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -205,6 +205,7 @@ class _HeatMapper(object):
 
     def _annotate_heatmap(self, ax, mesh):
         """Add textual labels with the value in each cell."""
+        mesh.update_scalarmappable()
         xpos, ypos = np.meshgrid(ax.get_xticks(), ax.get_yticks())
         for x, y, val, color in zip(xpos.flat, ypos.flat,
                                     mesh.get_array(), mesh.get_facecolors()):

--- a/seaborn/tests/test_matrix.py
+++ b/seaborn/tests/test_matrix.py
@@ -249,7 +249,7 @@ class TestHeatmap(PlotTestCase):
 
         ax = mat.heatmap(self.df_norm, annot=True)
         mesh = ax.collections[0]
-        nt.assert_equal(len(mesh.get_facecolors()), 4 * 8)
+        nt.assert_equal(len(mesh.get_facecolors()), self.df_norm.size)
 
         plt.close("all")
 

--- a/seaborn/tests/test_matrix.py
+++ b/seaborn/tests/test_matrix.py
@@ -245,6 +245,14 @@ class TestHeatmap(PlotTestCase):
         for val, text in zip(df_masked[::-1].compressed(), ax.texts):
             nt.assert_equal("{:.1f}".format(val), text.get_text())
 
+    def test_heatmap_annotation_mesh_colors(self):
+
+        ax = mat.heatmap(self.df_norm, annot=True)
+        mesh = ax.collections[0]
+        nt.assert_equal(len(mesh.get_facecolors()), 4 * 8)
+
+        plt.close("all")
+
     def test_heatmap_cbar(self):
 
         f = plt.figure()

--- a/seaborn/tests/test_matrix.py
+++ b/seaborn/tests/test_matrix.py
@@ -249,7 +249,7 @@ class TestHeatmap(PlotTestCase):
 
         ax = mat.heatmap(self.df_norm, annot=True)
         mesh = ax.collections[0]
-        nt.assert_equal(len(mesh.get_facecolors()), self.df_norm.size)
+        nt.assert_equal(len(mesh.get_facecolors()), self.df_norm.values.size)
 
         plt.close("all")
 


### PR DESCRIPTION
This commit fixes Issue #830. Currently, ```mesh.get_facecolors()``` returns only the color code for one cell in the grid, but calling ```mesh.update_scalarmappable()``` changes this so that the color information is shown for all cells.