### PR TITLE
Change luminance calculations for Annotation color choice

### DIFF
--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -210,8 +210,12 @@ class _HeatMapper(object):
         for x, y, val, color in zip(xpos.flat, ypos.flat,
                                     mesh.get_array(), mesh.get_facecolors()):
             if val is not np.ma.masked:
-                _, l, _ = colorsys.rgb_to_hls(*color[:3])
-                text_color = ".15" if l > .5 else "w"
+                r_s, g_s, b_s = color[:3]
+                r = r_s/12.92 if r_s <= 0.03928 else ((r_s+0.055)/1.055) ** 2.4
+                g = g_s/12.92 if g_s <= 0.03928 else ((g_s+0.055)/1.055) ** 2.4
+                b = b_s/12.92 if b_s <= 0.03928 else ((b_s+0.055)/1.055) ** 2.4
+                l = 0.2126 * r + 0.7152 * g + 0.0722 * b
+                text_color = ".15" if l > .408 else "w"
                 val = ("{:" + self.fmt + "}").format(val)
                 text_kwargs = dict(color=text_color, ha="center", va="center")
                 text_kwargs.update(self.annot_kws)

--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -1,7 +1,6 @@
 """Functions to visualize matrices of data."""
 import itertools
 
-import colorsys
 import matplotlib as mpl
 from matplotlib.collections import LineCollection
 import matplotlib.pyplot as plt
@@ -13,7 +12,7 @@ from scipy.cluster import hierarchy
 
 from .axisgrid import Grid
 from .palettes import cubehelix_palette
-from .utils import despine, axis_ticklabels_overlap
+from .utils import despine, axis_ticklabels_overlap, relative_luminance
 from .external.six.moves import range
 
 
@@ -210,11 +209,7 @@ class _HeatMapper(object):
         for x, y, val, color in zip(xpos.flat, ypos.flat,
                                     mesh.get_array(), mesh.get_facecolors()):
             if val is not np.ma.masked:
-                r_s, g_s, b_s = color[:3]
-                r = r_s/12.92 if r_s <= 0.03928 else ((r_s+0.055)/1.055) ** 2.4
-                g = g_s/12.92 if g_s <= 0.03928 else ((g_s+0.055)/1.055) ** 2.4
-                b = b_s/12.92 if b_s <= 0.03928 else ((b_s+0.055)/1.055) ** 2.4
-                l = 0.2126 * r + 0.7152 * g + 0.0722 * b
+                l = relative_luminance(color)
                 text_color = ".15" if l > .408 else "w"
                 val = ("{:" + self.fmt + "}").format(val)
                 text_kwargs = dict(color=text_color, ha="center", va="center")

--- a/seaborn/tests/test_utils.py
+++ b/seaborn/tests/test_utils.py
@@ -368,3 +368,14 @@ if LooseVersion(pd.__version__) >= "0.15":
             # does not get in effect, so we need to call explicitly
             # yield check_load_dataset, name
             check_load_cached_dataset(name)
+
+def test_relative_luminance():
+        """Test relative luminance."""
+        out1 = utils.relative_luminance("white")
+        assert_equal(out1, 1)
+
+        out2 = utils.relative_luminance("#000000")
+        assert_equal(out2, 0)
+
+        out3 = utils.relative_luminance((.25,.5,.75))
+        nose.tools.assert_almost_equal(out3, 0.201624536)

--- a/seaborn/tests/test_utils.py
+++ b/seaborn/tests/test_utils.py
@@ -369,6 +369,7 @@ if LooseVersion(pd.__version__) >= "0.15":
             # yield check_load_dataset, name
             check_load_cached_dataset(name)
 
+
 def test_relative_luminance():
         """Test relative luminance."""
         out1 = utils.relative_luminance("white")
@@ -377,5 +378,5 @@ def test_relative_luminance():
         out2 = utils.relative_luminance("#000000")
         assert_equal(out2, 0)
 
-        out3 = utils.relative_luminance((.25,.5,.75))
+        out3 = utils.relative_luminance((.25, .5, .75))
         nose.tools.assert_almost_equal(out3, 0.201624536)

--- a/seaborn/utils.py
+++ b/seaborn/utils.py
@@ -541,3 +541,27 @@ def get_color_cycle():
         except KeyError:
             pass  # just return axes.color style below
     return mpl.rcParams['axes.color_cycle']
+
+def relative_luminance(color):
+    """Calculate the relative luminance of a color according to W3C standards
+
+    Parameters
+    ----------
+    color : matplotlib color
+        hex, rgb-tuple, or html color name
+
+    Returns
+    -------
+    luminance : float between 0 and 1
+
+    """
+    # Get rgb tuple rep
+    r_s, g_s, b_s = mplcol.colorConverter.to_rgb(color)
+
+    #Calculate relative luminance
+    r = r_s/12.92 if r_s <= 0.03928 else ((r_s+0.055)/1.055) ** 2.4
+    g = g_s/12.92 if g_s <= 0.03928 else ((g_s+0.055)/1.055) ** 2.4
+    b = b_s/12.92 if b_s <= 0.03928 else ((b_s+0.055)/1.055) ** 2.4
+    luminance =  0.2126 * r + 0.7152 * g + 0.0722 * b
+
+    return luminance

--- a/seaborn/utils.py
+++ b/seaborn/utils.py
@@ -542,6 +542,7 @@ def get_color_cycle():
             pass  # just return axes.color style below
     return mpl.rcParams['axes.color_cycle']
 
+
 def relative_luminance(color):
     """Calculate the relative luminance of a color according to W3C standards
 
@@ -558,10 +559,10 @@ def relative_luminance(color):
     # Get rgb tuple rep
     r_s, g_s, b_s = mplcol.colorConverter.to_rgb(color)
 
-    #Calculate relative luminance
+    # Calculate relative luminance
     r = r_s/12.92 if r_s <= 0.03928 else ((r_s+0.055)/1.055) ** 2.4
     g = g_s/12.92 if g_s <= 0.03928 else ((g_s+0.055)/1.055) ** 2.4
     b = b_s/12.92 if b_s <= 0.03928 else ((b_s+0.055)/1.055) ** 2.4
-    luminance =  0.2126 * r + 0.7152 * g + 0.0722 * b
+    luminance = 0.2126 * r + 0.7152 * g + 0.0722 * b
 
     return luminance


### PR DESCRIPTION
### Adjustment to luminance calculation when annotating heatmaps

Currently when annotating heatmaps the color of the text annotation is either white or gray based upon a contrast calculation. This pull request contains an improved contrast calculation to address an issue when using the viridis heatmap.

Currently the luminance is calculated by conversion to HSL and extraction of the luminance term, which is simply [the average of the highest and lowest RGB values](http://www.niwa.nu/2013/05/math-behind-colorspace-conversions-rgb-hsl/). This is then compared to a 50% cutoff to decide when to use white or gray text.

I am proposing adherence to the WC3 standards for [luminance](https://www.w3.org/TR/WCAG20/#relativeluminancedef) and [optimal contrast](https://www.w3.org/TR/WCAG20/#relativeluminancedef). Importantly these take into account how people view luminance and contrast of different colors.

Excerpt describing relative luminance calculation:

> For the sRGB colorspace, the relative luminance of a color is defined as L = 0.2126 * R + 0.7152 * G + 0.0722 * B where R, G and B are defined as:

> if RsRGB <= 0.03928 then R = RsRGB/12.92 else R = ((RsRGB+0.055)/1.055) ^ 2.4
> if GsRGB <= 0.03928 then G = GsRGB/12.92 else G = ((GsRGB+0.055)/1.055) ^ 2.4
> if BsRGB <= 0.03928 then B = BsRGB/12.92 else B = ((BsRGB+0.055)/1.055) ^ 2.4

> and RsRGB, GsRGB, and BsRGB are defined as:

> RsRGB = R8bit/255
> GsRGB = G8bit/255
> BsRGB = B8bit/255

Excerpt for luminance calculation:

> (L1 + 0.05) / (L2 + 0.05), where
> L1 is the relative luminance of the lighter of the colors, and
> L2 is the relative luminance of the darker of the colors.

To calculate the text color, either grey (luminance = 0.15) or white (luminance = 1), I calculate which has the maximal contrast to the background luminance:

````
".15" if ((l+0.05)/(0.15+0.05))>((1+0.05)/(l+0.05)) else "w"
````

This simplifies to 

````
text_color = ".15" if l > .408 else "w"
````

This fix was motivated by the following issue with the viridis heatmap (matplotlib 2.0 default) where 19 is difficult to read. 

![image](https://cloud.githubusercontent.com/assets/2424677/12569459/c187228c-c394-11e5-9ef8-fc3aa9236232.png)

This is addressed in this pull request.

![image](https://cloud.githubusercontent.com/assets/2424677/12569463/c735267a-c394-11e5-9620-f3d2501735d3.png)


To get a better undestranding of the change I ploted luminance of both viridis and RdBu_r compared to the cutoff. This shows the weird dip in viridis that gave rise to the previously described issue/

### Viridis

![image](https://cloud.githubusercontent.com/assets/2424677/12569483/f0b9d5f4-c394-11e5-827f-11bed47f6bb5.png)

### RdBu_r

![image](https://cloud.githubusercontent.com/assets/2424677/12569473/dd9601dc-c394-11e5-8706-e7d86c9a73b6.png)
