### PR TITLE
Ability to override histtype when plotting PairGrid histograms

### DIFF
--- a/examples/custom_map_diag_hist.py
+++ b/examples/custom_map_diag_hist.py
@@ -12,9 +12,9 @@ sns.set(style="white", palette="muted", color_codes=True)
 rs = np.random.RandomState(10)
 
 # make some test data with a boolean label of unequal sample size
-df = pd.DataFrame({'data1':np.random.randn(2000),
-                   'data2':np.random.randn(2000),
-                   'label': np.random.randn(2000) > 0})
+df = pd.DataFrame({'data1':np.random.randn(20000),
+                   'data2':np.random.randn(20000),
+                   'label': np.random.randn(20000) > 0})
 
 # Default barstacked histogram
 g = sns.PairGrid(df, x_vars= ['data1', 'data2'],

--- a/examples/custom_map_diag_hist.py
+++ b/examples/custom_map_diag_hist.py
@@ -12,25 +12,27 @@ sns.set(style="white", palette="muted", color_codes=True)
 rs = np.random.RandomState(10)
 
 # make some test data with a boolean label of unequal sample size
-df = pd.DataFrame({'data1':np.random.randn(20000),
-                   'data2':np.random.randn(20000),
-                   'label': np.random.randn(20000) > 0})
+df = pd.DataFrame({'data1':np.random.randn(2000),
+                   'data2':np.random.randn(2000),
+                   'label': np.random.randn(2000) > 0})
 
 # Default barstacked histogram
-g = sns.PairGrid(df, x_vars= ['data1', 'data2'],
+g1 = sns.PairGrid(df, x_vars= ['data1', 'data2'],
                  y_vars= ['data1', 'data2'],
                  hue = "label", diag_sharey = False,
                  palette = "Set1")
 
-g.map_diag(plt.hist, normed = False, bins = np.arange(-5,5,.25))
+g1.map_offdiag(plt.scatter)
+g1.map_diag(plt.hist, normed = False, bins = np.arange(-5,5,.25))
 
 # Updated custom histtype, and also illustrate how normalization should appear
-g = sns.PairGrid(df, x_vars= ['data1', 'data2'],
+g2 = sns.PairGrid(df, x_vars= ['data1', 'data2'],
                  y_vars= ['data1', 'data2'],
                  hue = "label", diag_sharey = False,
                  palette = "Set1")
 
-g.map_diag(plt.hist, normed = True,
+g2.map_offdiag(plt.scatter)
+g2.map_diag(plt.hist, normed = True,
                      alpha = 0.8,
                      histtype = 'step',
                      linewidth = 3,

--- a/examples/custom_map_diag_hist.py
+++ b/examples/custom_map_diag_hist.py
@@ -1,0 +1,37 @@
+"""
+Example of alternative map_diag histograms
+=========================
+
+"""
+import numpy as np
+import matplotlib.pyplot as plt
+import seaborn as sns
+import pandas as pd
+
+sns.set(style="white", palette="muted", color_codes=True)
+rs = np.random.RandomState(10)
+
+# make some test data with a boolean label of unequal sample size
+df = pd.DataFrame({'data1':np.random.randn(2000),
+                   'data2':np.random.randn(2000),
+                   'label': np.random.randn(2000) > 0})
+
+# Default barstacked histogram
+g = sns.PairGrid(df, x_vars= ['data1', 'data2'],
+                 y_vars= ['data1', 'data2'],
+                 hue = "label", diag_sharey = False,
+                 palette = "Set1")
+
+g.map_diag(plt.hist, normed = False, bins = np.arange(-5,5,.25))
+
+# Updated custom histtype, and also illustrate how normalization should appear
+g = sns.PairGrid(df, x_vars= ['data1', 'data2'],
+                 y_vars= ['data1', 'data2'],
+                 hue = "label", diag_sharey = False,
+                 palette = "Set1")
+
+g.map_diag(plt.hist, normed = True,
+                     alpha = 0.8,
+                     histtype = 'step',
+                     linewidth = 3,
+                     bins = np.arange(-5,5,.25))

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -1323,8 +1323,13 @@ class PairGrid(Grid):
                         vals.append(np.asarray(hue_grouped.get_group(label)))
                     except KeyError:
                         vals.append(np.array([]))
-                func(vals, color=self.palette, histtype="barstacked",
-                     **kwargs)
+                
+                # check and see if histtype override was provided in kwargs
+                if 'histtype' in kwargs:
+                    func(vals, color=self.palette, **kwargs)
+                else:
+                    func(vals, color=self.palette, histtype="barstacked",
+                         **kwargs)
             else:
                 for k, label_k in enumerate(self.hue_names):
                     # Attempt to get data for this level, allowing for empty

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -1323,7 +1323,7 @@ class PairGrid(Grid):
                         vals.append(np.asarray(hue_grouped.get_group(label)))
                     except KeyError:
                         vals.append(np.array([]))
-                
+
                 # check and see if histtype override was provided in kwargs
                 if 'histtype' in kwargs:
                     func(vals, color=self.palette, **kwargs)

--- a/seaborn/tests/test_axisgrid.py
+++ b/seaborn/tests/test_axisgrid.py
@@ -787,7 +787,6 @@ class TestPairGrid(PlotTestCase):
             for ptch in ax.patches:
                 nt.assert_equal(ptch.fill, False)
 
-
     @skipif(old_matplotlib)
     def test_map_diag_and_offdiag(self):
 

--- a/seaborn/tests/test_axisgrid.py
+++ b/seaborn/tests/test_axisgrid.py
@@ -780,6 +780,14 @@ class TestPairGrid(PlotTestCase):
         for ax in g3.diag_axes:
             nt.assert_equal(len(ax.patches), 40)
 
+        g4 = ag.PairGrid(self.df, hue="a")
+        g4.map_diag(plt.hist, histtype='step')
+
+        for ax in g4.diag_axes:
+            for ptch in ax.patches:
+                nt.assert_equal(ptch.fill, False)
+
+
     @skipif(old_matplotlib)
     def test_map_diag_and_offdiag(self):
 


### PR DESCRIPTION
This change gives the ability to pass in a specific histtype to map_diag to override the default behavior. The default barstacked behavior is retained if no histtype is passed into the function. This feature gives added functionality to map_diag without having to write a custom hist function just to use a different histtype. 

As a side note I wonder if barstacked is the best default behavior, barstacked has the annoying behavior that when passing in an array of samples the histograms are normalized to the total sample size instead of each histogram being independently normalized. Thus distributions with larger numbers of samples are larger in the resulting histogram. For my use cases this seems backwards, since a point of normalization is to compare distribution shape independent of sample size. 

A simple working example of this

```python
import numpy as np
import matplotlib.pyplot as plt
import seaborn as sns
import pandas as pd

# make some test data with a boolean label of unequal sample size
df = pd.DataFrame({'data1':np.random.randn(2000), 
                   'data2':np.random.randn(2000), 
                   'label': np.random.randn(2000) > 0.2})

# Default seaborn/barstacked behavior
g = sns.PairGrid(df, x_vars= ['data1', 'data2'], 
                 y_vars= ['data1', 'data2'], 
                 hue = "label", diag_sharey = False, 
                 palette = "Set1")
                 
g.map_diag(plt.hist, normed = True, bins = np.arange(-10,10,.5))
                     

# Updated custom histtype, and also illustrate how normalization should appear
g = sns.PairGrid(df, x_vars= ['data1', 'data2'], 
                 y_vars= ['data1', 'data2'], 
                 hue = "label", diag_sharey = False, 
                 palette = "Set1")
                 
g.map_diag(plt.hist, normed = True, 
                     alpha = 0.8, 
                     histtype = 'step',
                     linewidth = 3, 
                     bins = np.arange(-10,10,.5))
                     
```

Default seaborn/barstacked normalization behavior
![image](https://cloud.githubusercontent.com/assets/4388231/13119189/d65e6c2c-d575-11e5-8699-b6f5eb16e220.png)

Updated function to illustrate stepped histogram, and also highlight correct normalization of distributions with different sample sizes.
![image](https://cloud.githubusercontent.com/assets/4388231/13119197/e96d493c-d575-11e5-8bb0-43a473cb5d0a.png)






