### PR TITLE
Add option to specity heatmap tick locator

### DIFF
--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -167,7 +167,7 @@ class _HeatMapper(object):
         self.cbar_kws = {} if cbar_kws is None else cbar_kws
         self.cbar_kws.setdefault('ticks', mpl.ticker.MaxNLocator(6))
 
-        def _determine_cmap_params(self, plot_data, vmin, vmax,
+    def _determine_cmap_params(self, plot_data, vmin, vmax,
                                cmap, center, robust):
         """Use some heuristics to set good defaults for colorbar and range."""
         calc_data = plot_data.data[~np.isnan(plot_data.data)]

--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -165,8 +165,9 @@ class _HeatMapper(object):
         self.annot_kws = {} if annot_kws is None else annot_kws
         self.cbar = cbar
         self.cbar_kws = {} if cbar_kws is None else cbar_kws
+        self.cbar_kws.setdefault('ticks', mpl.ticker.MaxNLocator(6))
 
-    def _determine_cmap_params(self, plot_data, vmin, vmax,
+        def _determine_cmap_params(self, plot_data, vmin, vmax,
                                cmap, center, robust):
         """Use some heuristics to set good defaults for colorbar and range."""
         calc_data = plot_data.data[~np.isnan(plot_data.data)]
@@ -250,9 +251,7 @@ class _HeatMapper(object):
 
         # Possibly add a colorbar
         if self.cbar:
-            ticker = mpl.ticker.MaxNLocator(6)
-            cb = ax.figure.colorbar(mesh, cax, ax,
-                                    ticks=ticker, **self.cbar_kws)
+            cb = ax.figure.colorbar(mesh, cax, ax, **self.cbar_kws)
             cb.outline.set_linewidth(0)
             # If rasterized is passed to pcolormesh, also rasterize the
             # colorbar to avoid white lines on the PDF rendering

--- a/seaborn/tests/test_matrix.py
+++ b/seaborn/tests/test_matrix.py
@@ -352,11 +352,13 @@ class TestHeatmap(PlotTestCase):
         npt.assert_array_equal(mask_out, [[True, True], [False, False]])
 
     def test_cbar_ticks(self):
-        locator = mpl.ticker.MaxNLocator(4)
+        max_n_ticks = 3
+
+        locator = mpl.ticker.MaxNLocator(max_n_ticks)
         f, (ax1, ax2) = plt.subplots(2)
         mat.heatmap(self.df_norm, ax=ax1, cbar_ax=ax2,
                     cbar_kws=dict(ticks=locator))
-        nt.assert_equal(len(ax2.yaxis.get_ticklabels()), 4)
+        nt.assert_equal(len(ax2.yaxis.get_ticklabels()), max_n_ticks)
         plt.close(f)
 
 

--- a/seaborn/tests/test_matrix.py
+++ b/seaborn/tests/test_matrix.py
@@ -351,6 +351,13 @@ class TestHeatmap(PlotTestCase):
         mask_out = mat._matrix_mask(data, mask_in)
         npt.assert_array_equal(mask_out, [[True, True], [False, False]])
 
+    def test_cbar_ticks(self):
+        locator = mpl.ticker.MaxNLocator(4)
+        f, (ax1, ax2) = plt.subplots(2)
+        mat.heatmap(self.df_norm, ax=ax1, cbar_ax=ax2,
+                    cbar_kws=dict(ticks=locator))
+        nt.assert_equal(len(ax2.yaxis.get_ticklabels()), 4)
+        plt.close(f)
 
 class TestDendrogram(PlotTestCase):
     rs = np.random.RandomState(sum(map(ord, "dendrogram")))
@@ -886,3 +893,4 @@ class TestClustermap(PlotTestCase):
 
         npt.assert_array_equal(xtl_actual, xtl_want)
         npt.assert_array_equal(ytl_actual, ytl_want)
+

--- a/seaborn/tests/test_matrix.py
+++ b/seaborn/tests/test_matrix.py
@@ -359,6 +359,7 @@ class TestHeatmap(PlotTestCase):
         nt.assert_equal(len(ax2.yaxis.get_ticklabels()), 4)
         plt.close(f)
 
+
 class TestDendrogram(PlotTestCase):
     rs = np.random.RandomState(sum(map(ord, "dendrogram")))
 
@@ -893,4 +894,3 @@ class TestClustermap(PlotTestCase):
 
         npt.assert_array_equal(xtl_actual, xtl_want)
         npt.assert_array_equal(ytl_actual, ytl_want)
-


### PR DESCRIPTION
Right now, if you want to `n_ticks != 6` for the heatmap colorbar ticks, e.g. 4 then you can try:

```
locator = mpl.ticker.MaxNLocator(4)
sns.heatmap(basewise_statistics_2d, cmap=cmap, ax=ax, vmin=0, vmax=10,
                    cbar_kws=dict(label='$-\log_{10}(q)$', ticks=locator), 
                    cbar_ax=cbar_ax)
```

But then there's a `TypeError`:

```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-131-6996a9c91914> in <module>()
      2 sns.heatmap(basewise_statistics_2d, cmap=cmap, ax=ax, vmin=0, vmax=10,
      3                     cbar_kws=dict(label='$-\log_{10}(q)$', ticks=locator),
----> 4                     cbar_ax=cbar_ax)

/home/obotvinnik/anaconda/lib/python2.7/site-packages/seaborn/matrix.pyc in heatmap(data, vmin, vmax, cmap, center, robust, annot, fmt, annot_kws, linewidths, linecolor, cbar, cbar_kws, cbar_ax, square, ax, xticklabels, yticklabels, mask, **kwargs)
    461     if square:
    462         ax.set_aspect("equal")
--> 463     plotter.plot(ax, cbar_ax, kwargs)
    464     return ax
    465 

/home/obotvinnik/anaconda/lib/python2.7/site-packages/seaborn/matrix.pyc in plot(self, ax, cax, kws)
    253             ticker = mpl.ticker.MaxNLocator(6)
    254             cb = ax.figure.colorbar(mesh, cax, ax,
--> 255                                     ticks=ticker, **self.cbar_kws)
    256             cb.outline.set_linewidth(0)
    257             # If rasterized is passed to pcolormesh, also rasterize the

TypeError: colorbar() got multiple values for keyword argument 'ticks'
```

To get around this, you can do some extra work:

    cbar_ax.locator_params('y', nbins=4)
    cbar_ax.yaxis.set_ticklabels([0, 5, 10])

but who wants to do that?

This uses `set_default` for `'"ticks"` in `cbar_kws` instead of overwriting it outright and not giving the user the option at all.

this PR is preliminary, hasn't been fully tested yet.