### PR TITLE
Support dataframes as col/row_colors in clustermap and use columns as annotation

### DIFF
--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -715,19 +715,8 @@ class ClusterGrid(Grid):
             figsize = (width, height)
         self.fig = plt.figure(figsize=figsize)
 
-        # if row_colors is not None:
-        #     if isinstance(row_colors, (pd.DataFrame, pd.Series)):
-        #         # Ensure colors match data indices
-        #         row_colors = row_colors.ix[data.index]
-        #     row_colors = _convert_colors(row_colors)
         self.row_colors, self.row_color_labels = \
             self._preprocess_colors(data, row_colors, axis=0)
-
-        # if col_colors is not None:
-        #     if isinstance(col_colors, (pd.DataFrame, pd.Series)):
-        #         # Ensure colors match data indices
-        #         col_colors = col_colors.ix[data.columns]
-        #     col_colors = _convert_colors(col_colors)
         self.col_colors, self.col_color_labels = \
             self._preprocess_colors(data, col_colors, axis=1)
 

--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -41,6 +41,8 @@ def _convert_colors(colors):
         # Convert dataframe
         return pd.DataFrame({col: colors[col].map(to_rgb)
                             for col in colors})
+    elif isinstance(colors, pd.Series):
+        return colors.map(to_rgb)
     else:
         try:
             to_rgb(colors[0])
@@ -713,14 +715,14 @@ class ClusterGrid(Grid):
         self.fig = plt.figure(figsize=figsize)
 
         if row_colors is not None:
-            if isinstance(row_colors, pd.DataFrame):
+            if isinstance(row_colors, (pd.DataFrame, pd.Series)):
                 # Ensure colors match data indices
                 row_colors = row_colors.ix[data.index]
             row_colors = _convert_colors(row_colors)
         self.row_colors = row_colors
 
         if col_colors is not None:
-            if isinstance(col_colors, pd.DataFrame):
+            if isinstance(col_colors, (pd.DataFrame, pd.Series)):
                 # Ensure colors match data indices
                 col_colors = col_colors.ix[data.columns]
             col_colors = _convert_colors(col_colors)
@@ -984,6 +986,9 @@ class ClusterGrid(Grid):
             # Get labels from colors if given as dataframe
             if isinstance(self.row_colors, pd.DataFrame):
                 xticklabels = self.row_colors.columns
+            elif isinstance(self.row_colors, pd.Series) and \
+                    self.row_colors.name:
+                xticklabels = [self.row_colors.name]
             else:
                 xticklabels = False
 
@@ -1005,6 +1010,9 @@ class ClusterGrid(Grid):
             # Get labels from colors if given as dataframe
             if isinstance(self.col_colors, pd.DataFrame):
                 yticklabels = self.col_colors.columns
+            elif isinstance(self.col_colors, pd.Series) and \
+                    self.col_colors.name:
+                yticklabels = [self.col_colors.name]
             else:
                 yticklabels = False
 

--- a/seaborn/tests/test_matrix.py
+++ b/seaborn/tests/test_matrix.py
@@ -852,6 +852,120 @@ class TestClustermap(PlotTestCase):
 
         pdt.assert_frame_equal(cm.data2d, self.df_norm)
 
+    def test_row_col_colors_df(self):
+        kws = self.default_kws.copy()
+        kws['row_colors'] = pd.DataFrame({'row_annot': list(self.row_colors)},
+                                         index=self.df_norm.index)
+        kws['col_colors'] = pd.DataFrame({'col_annot': list(self.col_colors)},
+                                         index=self.df_norm.columns)
+
+        cm = mat.clustermap(self.df_norm, **kws)
+
+        row_labels = [l.get_text() for l in
+                      cm.ax_row_colors.get_xticklabels()]
+        nt.assert_equal(row_labels, ['row_annot'])
+
+        col_labels = [l.get_text() for l in
+                      cm.ax_col_colors.get_yticklabels()]
+        nt.assert_equal(col_labels, ['col_annot'])
+
+    def test_row_col_colors_df_shuffled(self):
+        # Tests if colors are properly matched, even if given in wrong order
+
+        m, n = self.df_norm.shape
+        shuffled_inds = [self.df_norm.index[i] for i in
+                         list(range(0, m, 2)) + list(range(1, m, 2))]
+        shuffled_cols = [self.df_norm.columns[i] for i in
+                         list(range(0, n, 2)) + list(range(1, n, 2))]
+
+        kws = self.default_kws.copy()
+
+        row_colors = pd.DataFrame({'row_annot': list(self.row_colors)},
+                                  index=self.df_norm.index)
+        kws['row_colors'] = row_colors.ix[shuffled_inds]
+
+        col_colors = pd.DataFrame({'col_annot': list(self.col_colors)},
+                                  index=self.df_norm.columns)
+        kws['col_colors'] = col_colors.ix[shuffled_cols]
+
+        cm = mat.clustermap(self.df_norm, **kws)
+        nt.assert_equal(list(cm.col_colors)[0], list(self.col_colors))
+        nt.assert_equal(list(cm.row_colors)[0], list(self.row_colors))
+
+    def test_row_col_colors_df_missing(self):
+        kws = self.default_kws.copy()
+        row_colors = pd.DataFrame({'row_annot': list(self.row_colors)},
+                                  index=self.df_norm.index)
+        kws['row_colors'] = row_colors.drop(self.df_norm.index[0])
+
+        col_colors = pd.DataFrame({'col_annot': list(self.col_colors)},
+                                  index=self.df_norm.columns)
+        kws['col_colors'] = col_colors.drop(self.df_norm.columns[0])
+
+        cm = mat.clustermap(self.df_norm, **kws)
+
+        nt.assert_equal(list(cm.col_colors)[0],
+                        [(1.0, 1.0, 1.0)] + list(self.col_colors[1:]))
+        nt.assert_equal(list(cm.row_colors)[0],
+                        [(1.0, 1.0, 1.0)] + list(self.row_colors[1:]))
+
+    def test_row_col_colors_series(self):
+        kws = self.default_kws.copy()
+        kws['row_colors'] = pd.Series(list(self.row_colors), name='row_annot',
+                                      index=self.df_norm.index)
+        kws['col_colors'] = pd.Series(list(self.col_colors), name='col_annot',
+                                      index=self.df_norm.columns)
+
+        cm = mat.clustermap(self.df_norm, **kws)
+
+        row_labels = [l.get_text() for l in
+                      cm.ax_row_colors.get_xticklabels()]
+        nt.assert_equal(row_labels, ['row_annot'])
+
+        col_labels = [l.get_text() for l in
+                      cm.ax_col_colors.get_yticklabels()]
+        nt.assert_equal(col_labels, ['col_annot'])
+
+    def test_row_col_colors_series_shuffled(self):
+        # Tests if colors are properly matched, even if given in wrong order
+
+        m, n = self.df_norm.shape
+        shuffled_inds = [self.df_norm.index[i] for i in
+                         list(range(0, m, 2)) + list(range(1, m, 2))]
+        shuffled_cols = [self.df_norm.columns[i] for i in
+                         list(range(0, n, 2)) + list(range(1, n, 2))]
+
+        kws = self.default_kws.copy()
+
+        row_colors = pd.Series(list(self.row_colors), name='row_annot',
+                               index=self.df_norm.index)
+        kws['row_colors'] = row_colors.ix[shuffled_inds]
+
+        col_colors = pd.Series(list(self.col_colors), name='col_annot',
+                               index=self.df_norm.columns)
+        kws['col_colors'] = col_colors.ix[shuffled_cols]
+
+        cm = mat.clustermap(self.df_norm, **kws)
+
+        nt.assert_equal(list(cm.col_colors), list(self.col_colors))
+        nt.assert_equal(list(cm.row_colors), list(self.row_colors))
+
+    def test_row_col_colors_series_missing(self):
+        kws = self.default_kws.copy()
+        row_colors = pd.Series(list(self.row_colors), name='row_annot',
+                               index=self.df_norm.index)
+        kws['row_colors'] = row_colors.drop(self.df_norm.index[0])
+
+        col_colors = pd.Series(list(self.col_colors), name='col_annot',
+                               index=self.df_norm.columns)
+        kws['col_colors'] = col_colors.drop(self.df_norm.columns[0])
+
+        cm = mat.clustermap(self.df_norm, **kws)
+        nt.assert_equal(list(cm.col_colors),
+                        [(1.0, 1.0, 1.0)] + list(self.col_colors[1:]))
+        nt.assert_equal(list(cm.row_colors),
+                        [(1.0, 1.0, 1.0)] + list(self.row_colors[1:]))
+
     def test_mask_reorganization(self):
 
         kws = self.default_kws.copy()


### PR DESCRIPTION
Includes the proposed changes from #441 for supporting dataframe row_colors and col_colors in cluster map and using the column names as labels in the resulting plot. The current implementation allows supplying colors as dataframes, in which case columns as used as labels, or as a (named) series, in which case the name of the series is used as label (if the name is not None). 

The current implementation also matches the index of row_colors and col_colors to the data index/columns, to ensure that the order of the colors is coherent with the data. This may break current behaviour, but I personally feel that it is a welcome addition, as it ensures that your colors correspond properly with your data (this has bitten me before) and makes good use of the index/column annotation to do so. I do not currently check for missing entries, and the torgb code breaks on NaNs at the moment. My initial solution to NaNs with be to replace them with the background color (white?) effectively omitting them from the annotation.

I have not written any extra unit tests yet, but the existing tests all pass. If there is legitimate interest in the feature, I am happy to add the extra unit tests.

A basic example:

```{python}
import pandas as pd
import numpy as np
import seaborn as sis

np.random.seed(0)

# Generate data.
data = pd.DataFrame(np.random.randn(10, 10),
                    index=['F{}'.format(i) for i in range(10)],
                    columns=['S{}'.format(i) for i in range(10)])

# Generate colors.
col_colors = pd.DataFrame({'Annotation 1': (['red'] * 5) + ['blue'] * 5},
                          index=data.columns)

row_colors = pd.DataFrame({'Annotation 2': (['green'] * 5) + (['black'] * 5)},
                          index=data.index)

# Draw example.
sns.clustermap(data, col_colors=col_colors, row_colors=row_colors)
```

![unknown](https://cloud.githubusercontent.com/assets/307739/13443547/bf5c7f78-e001-11e5-96b9-ca2f144a40d1.png)

A shuffled example (where colors are shuffled):

```{python}
np.random.seed(0)

# Generate colors
col_colors = pd.DataFrame({'Annotation 1': (['red'] * 5) + ['blue'] * 5},
                          index=data.columns)

row_colors = pd.DataFrame({'Annotation 2': (['green'] * 5) + (['black'] * 5)},
                          index=data.index)

# Shuffle col_colors.
samples = list(data.columns)
np.random.shuffle(samples)
col_colors = col_colors.ix[samples]

# Shuffle row_colors
features = list(data.index)
np.random.shuffle(features)
row_colors = row_colors.ix[features]

# Shuffled example, without proper matching.
sns.clustermap(data, col_colors=col_colors.T.values, row_colors=row_colors.T.values)

# Shuffled example, now matched by index/column.
sns.clustermap(data, col_colors=col_colors, row_colors=row_colors)
```

![unknown-1](https://cloud.githubusercontent.com/assets/307739/13443561/d9302b16-e001-11e5-9288-0b3f86e292aa.png)
![unknown-2](https://cloud.githubusercontent.com/assets/307739/13443567/dde502a8-e001-11e5-978b-31378bbc0b0e.png)

And using the network example:

```{python}
import pandas as pd
import seaborn as sns
sns.set(font="monospace")

# Load the brain networks example dataset
df = sns.load_dataset("brain_networks", header=[0, 1, 2], index_col=0)

# Select a subset of the networks
used_networks = [1, 5, 6, 7, 8, 11, 12, 13, 16, 17]
used_columns = (df.columns.get_level_values("network")
                          .astype(int)
                          .isin(used_networks))
df = df.loc[:, used_columns]

# Create a custom palette to identify the networks
network_pal = sns.cubehelix_palette(len(used_networks),
                                    light=.9, dark=.1, reverse=True,
                                    start=1, rot=-2)
network_lut = dict(zip(map(str, used_networks), network_pal))

# Convert the palette to vectors that will be drawn on the side of the matrix
networks = df.columns.get_level_values("network")
network_colors = pd.Series(networks).map(network_lut)

# Create a custom colormap for the heatmap values
cmap = sns.diverging_palette(h_neg=210, h_pos=350, s=90, l=30, as_cmap=True)

# Convert colors to dataframe.
colors_df = pd.DataFrame({'colors': network_colors})
colors_df.index = df.columns

# Draw the full plot
sns.clustermap(df.corr(), row_colors= colors_df, linewidths=.5,
               col_colors= colors_df, figsize=(13, 13), cmap=cmap)
```
![unknown-4](https://cloud.githubusercontent.com/assets/307739/13443608/0f4ce3d8-e002-11e5-9b59-2d3229fbf117.png)

Supplying as (named) Series:

```{python}
# Draw the full plot
sns.clustermap(df.corr(), row_colors=colors_df['colors'], linewidths=.5,
               col_colors=colors_df['colors'], figsize=(13, 13), cmap=cmap)
```
![unknown-5](https://cloud.githubusercontent.com/assets/307739/13443626/282c26fc-e002-11e5-853b-c6e11a0c916e.png)