### PR TITLE
Fix missing labels in clustermap col_colors when row_colors not given

### DIFF
--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -758,6 +758,7 @@ class ClusterGrid(Grid):
         self.dendrogram_col = None
 
     def _preprocess_colors(self, data, colors, axis):
+        """Preprocess {row/col}_colors to extract labels and convert colors."""
         labels = None
 
         if colors is not None:
@@ -773,7 +774,7 @@ class ClusterGrid(Grid):
 
                 # Extract color values and labels from frame/series
                 if isinstance(colors, pd.DataFrame):
-                    labels = colors.columns
+                    labels = list(colors.columns)
                     colors = colors.T.values
                 else:
                     labels = [colors.name]
@@ -1017,7 +1018,7 @@ class ClusterGrid(Grid):
                 self.col_colors, xind, axis=1)
 
             # Get col_color labels
-            if self.row_color_labels is not None:
+            if self.col_color_labels is not None:
                 col_color_labels = self.col_color_labels
             else:
                 col_color_labels = False
@@ -1115,10 +1116,14 @@ def clustermap(data, pivot_kws=None, method='average', metric='euclidean',
     {row,col}_linkage : numpy.array, optional
         Precomputed linkage matrix for the rows or columns. See
         scipy.cluster.hierarchy.linkage for specific formats.
-    {row,col}_colors : list-like, optional
+    {row,col}_colors : list-like or pandas DataFrame/Series, optional
         List of colors to label for either the rows or columns. Useful to
         evaluate whether samples within a group are clustered together. Can
-        use nested lists for multiple color levels of labeling.
+        use nested lists or DataFrame for multiple color levels of labeling.
+        If given as a DataFrame or Series, labels for the colors are extracted
+        from the DataFrames column names or from the name of the Series.
+        DataFrame/Series colors are also matched to the data by their
+        index, ensuring colors are drawn in the correct order.
     mask : boolean array or DataFrame, optional
         If passed, data will not be shown in cells where ``mask`` is True.
         Cells with missing values are automatically masked. Only used for

--- a/seaborn/tests/test_matrix.py
+++ b/seaborn/tests/test_matrix.py
@@ -854,20 +854,26 @@ class TestClustermap(PlotTestCase):
 
     def test_row_col_colors_df(self):
         kws = self.default_kws.copy()
-        kws['row_colors'] = pd.DataFrame({'row_annot': list(self.row_colors)},
-                                         index=self.df_norm.index)
-        kws['col_colors'] = pd.DataFrame({'col_annot': list(self.col_colors)},
-                                         index=self.df_norm.columns)
+        kws['row_colors'] = pd.DataFrame({'row_1': list(self.row_colors),
+                                          'row_2': list(self.row_colors)},
+                                         index=self.df_norm.index,
+                                         columns=['row_1', 'row_2'])
+        kws['col_colors'] = pd.DataFrame({'col_1': list(self.col_colors),
+                                          'col_2': list(self.col_colors)},
+                                         index=self.df_norm.columns,
+                                         columns=['col_1', 'col_2'])
 
         cm = mat.clustermap(self.df_norm, **kws)
 
         row_labels = [l.get_text() for l in
                       cm.ax_row_colors.get_xticklabels()]
-        nt.assert_equal(row_labels, ['row_annot'])
+        nt.assert_equal(cm.row_color_labels, ['row_1', 'row_2'])
+        nt.assert_equal(row_labels, cm.row_color_labels)
 
         col_labels = [l.get_text() for l in
                       cm.ax_col_colors.get_yticklabels()]
-        nt.assert_equal(col_labels, ['col_annot'])
+        nt.assert_equal(cm.col_color_labels, ['col_1', 'col_2'])
+        nt.assert_equal(col_labels[::-1], cm.col_color_labels)
 
     def test_row_col_colors_df_shuffled(self):
         # Tests if colors are properly matched, even if given in wrong order
@@ -909,6 +915,36 @@ class TestClustermap(PlotTestCase):
         nt.assert_equal(list(cm.row_colors)[0],
                         [(1.0, 1.0, 1.0)] + list(self.row_colors[1:]))
 
+    def test_row_col_colors_df_one_axis(self):
+        # Test case with only row annotation.
+        kws1 = self.default_kws.copy()
+        kws1['row_colors'] = pd.DataFrame({'row_1': list(self.row_colors),
+                                           'row_2': list(self.row_colors)},
+                                          index=self.df_norm.index,
+                                          columns=['row_1', 'row_2'])
+
+        cm1 = mat.clustermap(self.df_norm, **kws1)
+
+        row_labels = [l.get_text() for l in
+                      cm1.ax_row_colors.get_xticklabels()]
+        nt.assert_equal(cm1.row_color_labels, ['row_1', 'row_2'])
+        nt.assert_equal(row_labels, cm1.row_color_labels)
+
+        # Test case with onl col annotation.
+        kws2 = self.default_kws.copy()
+        kws2['col_colors'] = pd.DataFrame({'col_1': list(self.col_colors),
+                                           'col_2': list(self.col_colors)},
+                                          index=self.df_norm.columns,
+                                          columns=['col_1', 'col_2'])
+
+        cm2 = mat.clustermap(self.df_norm, **kws2)
+
+        col_labels = [l.get_text() for l in
+                      cm2.ax_col_colors.get_yticklabels()]
+        nt.assert_equal(cm2.col_color_labels, ['col_1', 'col_2'])
+        nt.assert_equal(col_labels[::-1], cm2.col_color_labels)
+
+
     def test_row_col_colors_series(self):
         kws = self.default_kws.copy()
         kws['row_colors'] = pd.Series(list(self.row_colors), name='row_annot',
@@ -920,11 +956,13 @@ class TestClustermap(PlotTestCase):
 
         row_labels = [l.get_text() for l in
                       cm.ax_row_colors.get_xticklabels()]
-        nt.assert_equal(row_labels, ['row_annot'])
+        nt.assert_equal(cm.row_color_labels, ['row_annot'])
+        nt.assert_equal(row_labels, cm.row_color_labels)
 
         col_labels = [l.get_text() for l in
                       cm.ax_col_colors.get_yticklabels()]
-        nt.assert_equal(col_labels, ['col_annot'])
+        nt.assert_equal(cm.col_color_labels, ['col_annot'])
+        nt.assert_equal(col_labels, cm.col_color_labels)
 
     def test_row_col_colors_series_shuffled(self):
         # Tests if colors are properly matched, even if given in wrong order

--- a/seaborn/tests/test_matrix.py
+++ b/seaborn/tests/test_matrix.py
@@ -944,7 +944,6 @@ class TestClustermap(PlotTestCase):
         nt.assert_equal(cm2.col_color_labels, ['col_1', 'col_2'])
         nt.assert_equal(col_labels[::-1], cm2.col_color_labels)
 
-
     def test_row_col_colors_series(self):
         kws = self.default_kws.copy()
         kws['row_colors'] = pd.Series(list(self.row_colors), name='row_annot',


### PR DESCRIPTION
Small adjustments to #877. I discovered a small typo in checking for col_label_colors, which resulted in column color labels not being drawn if no row_label_colors were given. I also changed preprocess_colors to ensure that labels are now a simple list instead of a pandas Index object. Finally, I added some documentation of clustermap to reflect the addition of the Series/Dataframe functionality.

Sorry for the late changes, I didn't expect the pull request to be accepted that quickly after the first revision!