### PR TITLE
Heatmap annotate values with other dataframe

### DIFF
--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -172,7 +172,10 @@ class _HeatMapper(object):
         if annot_data is None:
             self.annot_data = plot_data
         else:
-            self.annot_data = annot_data.ix[::-1].values
+            if isinstance(annot_data, pd.DataFrame):
+                self.annot_data = annot_data.ix[::-1].values
+            else:
+                self.annot_data = annot_data[::-1]
 
         self.fmt = fmt
         self.annot_kws = {} if annot_kws is None else annot_kws

--- a/seaborn/tests/test_matrix.py
+++ b/seaborn/tests/test_matrix.py
@@ -39,7 +39,7 @@ class TestHeatmap(PlotTestCase):
 
     default_kws = dict(vmin=None, vmax=None, cmap=None, center=None,
                        robust=False, annot=False, fmt=".2f", annot_kws=None,
-                       cbar=True, cbar_kws=None, mask=None, annot_data=None)
+                       cbar=True, cbar_kws=None, mask=None)
 
     def test_ndarray_input(self):
 
@@ -256,8 +256,8 @@ class TestHeatmap(PlotTestCase):
     def test_heatmap_annotation_other_data(self):
         annot_data = self.df_norm + 10
 
-        ax = mat.heatmap(self.df_norm, annot=True, fmt=".1f",
-                         annot_kws={"fontsize": 14}, annot_data=annot_data)
+        ax = mat.heatmap(self.df_norm, annot=annot_data, fmt=".1f",
+                         annot_kws={"fontsize": 14})
 
         for val, text in zip(annot_data.values[::-1].flat, ax.texts):
             nt.assert_equal(text.get_text(), "{:.1f}".format(val))

--- a/seaborn/tests/test_matrix.py
+++ b/seaborn/tests/test_matrix.py
@@ -39,7 +39,7 @@ class TestHeatmap(PlotTestCase):
 
     default_kws = dict(vmin=None, vmax=None, cmap=None, center=None,
                        robust=False, annot=False, fmt=".2f", annot_kws=None,
-                       cbar=True, cbar_kws=None, mask=None)
+                       cbar=True, cbar_kws=None, mask=None, annot_data=None)
 
     def test_ndarray_input(self):
 
@@ -252,6 +252,16 @@ class TestHeatmap(PlotTestCase):
         nt.assert_equal(len(mesh.get_facecolors()), self.df_norm.values.size)
 
         plt.close("all")
+
+    def test_heatmap_annotation_other_data(self):
+        annot_data = self.df_norm + 10
+
+        ax = mat.heatmap(self.df_norm, annot=True, fmt=".1f",
+                         annot_kws={"fontsize": 14}, annot_data=annot_data)
+
+        for val, text in zip(annot_data.values[::-1].flat, ax.texts):
+            nt.assert_equal(text.get_text(), "{:.1f}".format(val))
+            nt.assert_equal(text.get_fontsize(), 14)
 
     def test_heatmap_cbar(self):
 


### PR DESCRIPTION
The `annot=True` flag in `sns.heatmap()` is very helpful:

```python
import seaborn as sns
import numpy as np
np.random.seed(314)

values = np.random.randint(low=0, high=1e6, size=20).reshape(4, 5)
values[2, 3] += 1000000
sns.heatmap(values, annot=True)
```

![image](https://cloud.githubusercontent.com/assets/806256/13782554/dbe45ec6-ea84-11e5-921b-987da67ce5fa.png)

But sometimes I want to plot the percentages as the heatmap, but annotate with the original values. This is especially when some of the percentages are very low but I'd still like the raw value to tell them apart.

```python
percentages = 100*values/values.sum()
sns.heatmap(percentages, annot=True, annot_data=values, vmin=0, vmax=100)
```
![image](https://cloud.githubusercontent.com/assets/806256/13782605/04c6fa60-ea85-11e5-82c9-b6adc390b5e9.png)

This PR adds the keyword argument `annot_data=None` and allows the user to pass a dataframe/numpy array to use as the annotation. It doesn't check for whether the `annot_data` and `data` are the same size but it probably should.

[Here](http://nbviewer.jupyter.org/gist/olgabot/c9d87392ac4f1b44564b) is an nbviewer notebook with the code above.