### PR TITLE
Clustermap: collapse dendrograms, side_colors and colorbar if not given, make ratios configurable.

### DIFF
--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -850,11 +850,11 @@ class ClusterGrid(Grid):
         """
 
         if axis == 0:
-            side_colors = self.row_colors
-            side_cluster = self.row_cluster
-        else:
             side_colors = self.col_colors
             side_cluster = self.col_colors
+        else:
+            side_colors = self.row_colors
+            side_cluster = self.row_cluster
 
         # Get resizing proportion of this figure for the dendrogram and
         # colorbar, so only the heatmap gets bigger but the dendrogram stays

--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -751,7 +751,8 @@ def dendrogram(data, linkage=None, axis=1, label=True, metric='euclidean',
 
 class ClusterGrid(Grid):
     def __init__(self, data, pivot_kws=None, z_score=None, standard_scale=None,
-                 figsize=None, row_colors=None, col_colors=None, mask=None):
+                 figsize=None, row_colors=None, col_colors=None,
+                 col_color_ratio=None, row_color_ratio=None, mask=None):
         """Grid object for organizing clustered heatmap input on to axes"""
 
         if isinstance(data, pd.DataFrame):
@@ -776,10 +777,12 @@ class ClusterGrid(Grid):
 
         width_ratios = self.dim_ratios(self.row_colors,
                                        figsize=figsize,
+                                       side_colors_ratio=row_color_ratio,
                                        axis=1)
 
         height_ratios = self.dim_ratios(self.col_colors,
                                         figsize=figsize,
+                                        side_colors_ratio=col_color_ratio,
                                         axis=0)
         nrows = 3 if self.col_colors is None else 4
         ncols = 3 if self.row_colors is None else 4
@@ -933,9 +936,13 @@ class ClusterGrid(Grid):
         else:
             return standardized.T
 
-    def dim_ratios(self, side_colors, axis, figsize, side_colors_ratio=0.05):
+    def dim_ratios(self, side_colors, axis, figsize, side_colors_ratio=None):
         """Get the proportions of the figure taken up by each axes
         """
+
+        if side_colors_ratio is None:
+            side_colors_ratio = 0.05
+
         figdim = figsize[axis]
         # Get resizing proportion of this figure for the dendrogram and
         # colorbar, so only the heatmap gets bigger but the dendrogram stays
@@ -1145,7 +1152,9 @@ def clustermap(data, pivot_kws=None, method='average', metric='euclidean',
                z_score=None, standard_scale=None, figsize=None, cbar_kws=None,
                row_cluster=True, col_cluster=True,
                row_linkage=None, col_linkage=None,
-               row_colors=None, col_colors=None, mask=None, **kwargs):
+               row_colors=None, col_colors=None,
+               col_color_ratio=None, row_color_ratio=None,
+               mask=None, **kwargs):
     """Plot a matrix dataset as a hierarchically-clustered heatmap.
 
     Parameters
@@ -1260,7 +1269,7 @@ def clustermap(data, pivot_kws=None, method='average', metric='euclidean',
     .. plot::
         :context: close-figs
 
-        >>> g = sns.clustermap(iris, col_cluster=False)
+        >>> g = sns.clustermap(flights, z_score=0)
 
     Add colored labels:
 
@@ -1279,7 +1288,6 @@ def clustermap(data, pivot_kws=None, method='average', metric='euclidean',
         >>> g = sns.clustermap(iris, standard_scale=1)
 
     Normalize the data within the rows:
-
     .. plot::
         :context: close-figs
 
@@ -1290,7 +1298,8 @@ def clustermap(data, pivot_kws=None, method='average', metric='euclidean',
     plotter = ClusterGrid(data, pivot_kws=pivot_kws, figsize=figsize,
                           row_colors=row_colors, col_colors=col_colors,
                           z_score=z_score, standard_scale=standard_scale,
-                          mask=mask)
+                          col_color_ratio=col_color_ratio,
+                          row_color_ratio=row_color_ratio, mask=mask)
 
     return plotter.plot(metric=metric, method=method,
                         colorbar_kws=cbar_kws,

--- a/seaborn/tests/test_matrix.py
+++ b/seaborn/tests/test_matrix.py
@@ -664,11 +664,11 @@ class TestClustermap(PlotTestCase):
     df_norm_leaves = np.asarray(df_norm.columns[x_norm_leaves])
 
     default_kws = dict(pivot_kws=None, z_score=None, standard_scale=None,
-                       figsize=None, row_colors=None, col_colors=None)
+                       figsize=None, row_colors=None, col_colors=None,
+                       row_cluster=True, col_cluster=True)
 
     default_plot_kws = dict(metric='euclidean', method='average',
                             colorbar_kws=None,
-                            row_cluster=True, col_cluster=True,
                             row_linkage=None, col_linkage=None)
 
     row_colors = color_palette('Set2', df_norm.shape[0])
@@ -859,15 +859,17 @@ class TestClustermap(PlotTestCase):
         kws['col_cluster'] = False
 
         cm = mat.clustermap(self.df_norm, **kws)
-        nt.assert_equal(len(cm.ax_row_dendrogram.lines), 0)
-        nt.assert_equal(len(cm.ax_col_dendrogram.lines), 0)
-
-        nt.assert_equal(len(cm.ax_row_dendrogram.get_xticks()), 0)
-        nt.assert_equal(len(cm.ax_row_dendrogram.get_yticks()), 0)
-        nt.assert_equal(len(cm.ax_col_dendrogram.get_xticks()), 0)
-        nt.assert_equal(len(cm.ax_col_dendrogram.get_yticks()), 0)
+        nt.assert_equal(cm.ax_row_dendrogram, None)
+        nt.assert_equal(cm.ax_col_dendrogram, None)
 
         pdt.assert_frame_equal(cm.data2d, self.df_norm)
+
+    def test_colorbar_false(self):
+        kws = self.default_kws.copy()
+        kws['colorbar'] = False
+
+        cm = mat.clustermap(self.df_norm, **kws)
+        nt.assert_equal(cm.cax, None)
 
     def test_row_col_colors(self):
         kws = self.default_kws.copy()
@@ -887,13 +889,9 @@ class TestClustermap(PlotTestCase):
         kws['col_colors'] = self.col_colors
 
         cm = mat.clustermap(self.df_norm, **kws)
-        nt.assert_equal(len(cm.ax_row_dendrogram.lines), 0)
-        nt.assert_equal(len(cm.ax_col_dendrogram.lines), 0)
+        nt.assert_equal(cm.ax_row_dendrogram, None)
+        nt.assert_equal(cm.ax_col_dendrogram, None)
 
-        nt.assert_equal(len(cm.ax_row_dendrogram.get_xticks()), 0)
-        nt.assert_equal(len(cm.ax_row_dendrogram.get_yticks()), 0)
-        nt.assert_equal(len(cm.ax_col_dendrogram.get_xticks()), 0)
-        nt.assert_equal(len(cm.ax_col_dendrogram.get_yticks()), 0)
         nt.assert_equal(len(cm.ax_row_colors.collections), 1)
         nt.assert_equal(len(cm.ax_col_colors.collections), 1)
 


### PR DESCRIPTION
This pull request addresses some issues that were originally discussed in #437. More specifically, I have introduced the following changes:
- Added col_color_ratio and row_color_ratio arguments that allow the user to specific a ratio for the side_colors when building the axes for clustermap. This allows users to adjust the size of the colors if needed (to prevent overlapping labels, or colors that are too compressed to view). I think it is best that this can be overridden by the user, as I don't see a sensible default that will always work (for example, choosing the same height as the rows will not work in heatmaps with many rows/columns, as is generally the case for gene expression matrices etc.)
- Refactored the setting up of axes into a single function _setup_axes. The function accounts for the presence of row/column clustering and row/column colors when setting up the axes, avoiding adding axes of no clustering is performed or no colors are provided.  
- Made the colorbar optional, which as a bonus allows for dropping whitespace if dendrograms are omitted. 

I am not quite happy with the colorbar, as it results in some considerable whitespace when dendrograms are omitted. We could choose to drop the colorbar down to where the row dendrogram would be if no dendrograms are needed, which would avoid at least the vertical whitespace. I don't however see a cleaner option without moving the colorbar to the right, which then runs into issues with the labels of the heatmap.

Some examples are shown below.

Full plot:

![unknown](https://cloud.githubusercontent.com/assets/307739/13899941/9819b4ce-edfa-11e5-9f6a-a30089f34d1b.png)

No col_cluster:

![unknown-1](https://cloud.githubusercontent.com/assets/307739/13899942/9f14db32-edfa-11e5-8a7d-d37df92d1c13.png)

No col/row_cluster:

![unknown-2](https://cloud.githubusercontent.com/assets/307739/13899945/a5477ac8-edfa-11e5-92a0-19f91825b128.png)

No clustering + no colorbar:

![unknown-3](https://cloud.githubusercontent.com/assets/307739/13899951/af748d1a-edfa-11e5-96b6-020ce3e31f56.png)
