### PR TITLE
Clustermap: Automatic conversion of row/column annotation data to colors

### DIFF
--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -1,8 +1,12 @@
 """Functions to visualize matrices of data."""
 import itertools
+from collections import OrderedDict
 
 import matplotlib as mpl
 from matplotlib.collections import LineCollection
+from matplotlib.cm import ScalarMappable
+from matplotlib.colors import LinearSegmentedColormap, Normalize, rgb2hex
+from matplotlib import patches as mpatches
 import matplotlib.pyplot as plt
 from matplotlib import gridspec
 import numpy as np
@@ -87,6 +91,85 @@ def _matrix_mask(data, mask):
     mask = mask | pd.isnull(data)
 
     return mask
+
+
+def _color_annotation(df, colors, bg_color='#ffffff'):
+    """Converts a data frame of annotations to colors."""
+
+    colored_cols = OrderedDict()
+    color_maps = OrderedDict()
+
+    for (col_name, values), color in zip(df.items(), colors):
+        colored, color_map = _color_column(values, color, bg_color)
+        colored_cols[col_name] = colored
+        color_maps[col_name] = color_map
+
+    return pd.DataFrame(colored_cols), color_maps
+
+
+def _color_column(series, color, bg_color):
+    """Converts an annotation column to colors."""
+    if series.dtype == bool:
+        # Boolean case.
+        return _color_bool_column(series, color, bg_color)
+    elif series.dtype.kind in 'biufc':
+        # Numeric case.
+        return _color_numeric_column(series, color, bg_color)
+    elif series.dtype.kind == 'O':
+        # Strings and categorical case..
+        return _color_cat_column(series, color, bg_color)
+    else:
+        raise ValueError('Unsupported dtype: {}'.format(series.dtype))
+
+
+def _color_bool_column(series, color, bg_color):
+    """Converts a boolean annotation column to colors."""
+    return _color_numeric_column(series.astype(int), color, bg_color)
+
+
+def _color_numeric_column(series, color, bg_color, n=200):
+    """Converts a numeric annotation column to colors."""
+
+    cmap = LinearSegmentedColormap.from_list(
+        name='custom_cmap', colors=[bg_color, color], N=n)
+    norm = Normalize(vmin=series.min(), vmax=series.max())
+    mappable = ScalarMappable(norm=norm, cmap=cmap)
+
+    rgba_colors = mappable.to_rgba(series.values)
+    hex_colors = (rgb2hex(rgba) for rgba in rgba_colors)
+
+    mapped = pd.Series(hex_colors, index=series.index, name=series.name)
+
+    return mapped, color
+
+
+def _color_cat_column(series, colors, bg_color):
+    """Converts a categorical annotation column to colors."""
+
+    if series.dtype.name == 'category' and series.cat.ordered:
+        str_values = series.cat.categories
+    else:
+        str_values = set(series.dropna())
+
+    if isinstance(colors, list):
+        colors = [_rgb_to_hex(c, normalized=True) for c in colors]
+        color_map = dict(zip(str_values, colors))
+        mapped = series.map(color_map).fillna(bg_color)
+    else:
+        numeric_values = np.linspace(0, 1, len(str_values) + 1)[1:]
+        numeric_map = dict(zip(str_values, numeric_values))
+
+        mapped = _color_numeric_column(series.map(numeric_map),
+                                       colors, bg_color=bg_color)
+        color_map = dict(zip(series, mapped.values))
+
+    return mapped, color_map
+
+
+def _rgb_to_hex(rgb, normalized=True):
+    if normalized:
+        rgb = tuple(map(lambda x: int(x * 255), rgb))
+    return '#%02x%02x%02x' % rgb
 
 
 class _HeatMapper(object):


### PR DESCRIPTION
In this pull-request I would like to propose an initial approach to automatically convert any given annotation to row/col_colors that can be used in plotting. This would allow us to avoid manually converting annotations to colors before plotting a clustermap (which many people are probably frequently doing).

The current implementation is just a loose example of the code that I have currently been using to convert annotations in a dataframe format to row/col_colors for clustermap. Ideally this type of conversion would be used internally by clustermap to be transparent for the future.

Example with different types of annotation:

```{python}
import pandas as pd
import numpy as np
import seaborn as sns

from seaborn.matrix import _color_annotation

sns.set_style('white')

np.random.seed(0)

# Generate data.
data = pd.DataFrame(np.random.randn(10, 10),
                    index=['F{}'.format(i) for i in range(10)],
                    columns=['S{}'.format(i) for i in range(10)])

# Generate annotation.
col_ann = pd.DataFrame({'Col 1': (['a'] * 5) + (['b'] * 5),
                        'Col 2': np.random.rand(10),
                        'Col 3': [True, False, True, True, False] * 2},
                       index=data.columns)
# col_ann.ix[1, 'Col 1'] = np.nan

# Color annotation and draw clustermap.
colors = [sns.color_palette(), sns.color_palette('Set1')[0], sns.color_palette('Set1')[1]]
col_colors, color_maps = _color_annotation(col_ann, colors=colors)

sns.clustermap(data, col_colors=col_colors)
```

![unknown-2](https://cloud.githubusercontent.com/assets/307739/14157193/429ee0cc-f6ca-11e5-8ede-3ce10940f211.png)

Example of how legends might be added:

```{python}
from matplotlib import patches as mpatches

def draw_legend(color_map, ax, name, **kwargs):
    """Helper for drawing custom legends."""
    
    patches = [mpatches.Patch(color=color, label=label)
               for label, color in color_map.items()]
    legend = ax.legend(handles=patches, frameon=True,
                       title=name, **kwargs)
    
    return legend

# Generate annotation.
col_ann = pd.DataFrame({'Col 1': (['a'] * 5) + (['b'] * 5)}, index=data.columns)

# Color annotation and plot clustermap.
col_colors, color_maps = _color_annotation(col_ann, colors=[sns.color_palette()])
g = sns.clustermap(data, col_colors=col_colors)

for i, (name, color_map) in enumerate(color_maps.items()):
    leg = draw_legend(color_map, ax=g.ax_heatmap, name=name,
                      loc=1, bbox_to_anchor=(1.2, 1 - (0.13 * i)))
```

![unknown-1](https://cloud.githubusercontent.com/assets/307739/14157152/15ab7648-f6ca-11e5-93fa-b1716012b32c.png)

I would be interested to hear if there is any interest in integrating this kind of functionality of seaborn. Critique on the current implementation is also welcome.

As it stands, I think we would still have to overcome the following issues:
- Decide how to best pass colors if this is to be used in clustermap. Currently I use a (nested) list of color palettes, with nesting mainly being used to support categorical/string columns which require multiple colors.
- Determine if row/col_colors are already plottable colors or are data that need to be converted. Any idea on how to reliably determine this?
- Decide on how to handle numeric values. Currently I am linearly interpolating colors from min/max between a foreground color and a background color. Maybe it would be desirable to allow for more flexibility in the conversion. Alternatively, we could leave more complex cases up the to user to convert themselves.
- Determine how/where to plot legends. Maybe constraint solving libraries such as cassowary would be an interesting/suitable approach for solving the where issue. This might also allow us to place the colorbar in a better place to address that issue in #891. I have zero experience with cassowary however.