### PR TITLE
End caps on barplot confidence intervals #606 update

### DIFF
--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -1502,39 +1502,49 @@ class _CategoricalStatPlotter(_CategoricalPlotter):
                       ax, at_group,
                       confint,
                       colors,
-                      conf_lw=1,
-                      capsize=0,
+                      conf_lw=None,
+                      capsize=None,
                       **kws):
 
-        kws.setdefault("lw", mpl.rcParams["lines.linewidth"] * conf_lw)
-        kws.pop('lw')
+        if conf_lw:
+            kws.setdefault("lw", mpl.rcParams["lines.linewidth"] * conf_lw)
+            kws.pop("lw")
+        else:
+            kws.setdefault("lw", mpl.rcParams["lines.linewidth"] * 1.8)
 
-        for at, (ci_low, ci_high), color in zip(at_group,
-                                                confint,
-                                                colors):
-            if self.orient == "v":
-                ax.plot([at, at], [ci_low, ci_high], color=color,
-                        lw=conf_lw, **kws)
-                ax.plot([at - capsize / 2, at + capsize / 2],
-                        [ci_low, ci_low], color=color, lw=conf_lw, **kws)
-                ax.plot([at - capsize / 2, at + capsize / 2],
-                        [ci_high, ci_high], color=color, lw=conf_lw, **kws)
-            else:
-                ax.plot([ci_low, ci_high], [at, at], color=color,
-                        lw=conf_lw, **kws)
-                ax.plot([ci_low, ci_low],
-                        [at - capsize /2, at + capsize /2],
-                        color=color, lw=conf_lw, **kws)
-                ax.plot([ci_high, ci_high],
-                        [at - capsize /2, at + capsize /2],
-                        color=color, lw=conf_lw, **kws)
+        if capsize:
+            for at, (ci_low, ci_high), color in zip(at_group,
+                                                    confint,
+                                                    colors):
+                if self.orient == "v":
+                    ax.plot([at, at], [ci_low, ci_high], color=color, **kws)
+                    ax.plot([at - capsize / 2, at + capsize / 2],
+                            [ci_low, ci_low], color=color, **kws)
+                    ax.plot([at - capsize / 2, at + capsize / 2],
+                            [ci_high, ci_high], color=color, **kws)
+                else:
+                    ax.plot([ci_low, ci_high], [at, at], color=color, **kws)
+                    ax.plot([ci_low, ci_low],
+                            [at - capsize /2, at + capsize /2],
+                            color=color, **kws)
+                    ax.plot([ci_high, ci_high],
+                            [at - capsize /2, at + capsize /2],
+                            color=color, **kws)
+        else:
+            for at, (ci_low, ci_high), color in zip(at_group,
+                                                        confint,
+                                                        colors):
+                if self.orient == "v":
+                    ax.plot([at, at], [ci_low, ci_high], color=color, **kws)
+                else:
+                    ax.plot([ci_low, ci_high], [at, at], color=color, **kws)
 
 class _BarPlotter(_CategoricalStatPlotter):
     """Show point estimates and confidence intervals with bars."""
     def __init__(self, x, y, hue, data, order, hue_order,
                  estimator, ci, n_boot, units,
-                 orient, color, palette, saturation, errcolor, conf_lw,
-                 capsize):
+                 orient, color, palette, saturation, errcolor, conf_lw=None,
+                 capsize=None):
         """Initialize the plotter."""
         self.establish_variables(x, y, hue, data, orient,
                                  order, hue_order, units)
@@ -1587,6 +1597,7 @@ class _BarPlotter(_CategoricalStatPlotter):
                                        self.conf_lw,
                                        self.capsize)
 
+
     def plot(self, ax, bar_kws):
         """Make the plot."""
         self.draw_bars(ax, bar_kws)
@@ -1600,7 +1611,7 @@ class _PointPlotter(_CategoricalStatPlotter):
     def __init__(self, x, y, hue, data, order, hue_order,
                  estimator, ci, n_boot, units,
                  markers, linestyles, dodge, join, scale,
-                 orient, color, palette, conf_lw, capsize):
+                 orient, color, palette, conf_lw=None, capsize=None):
         """Initialize the plotter."""
         self.establish_variables(x, y, hue, data, orient,
                                  order, hue_order, units)
@@ -1668,8 +1679,7 @@ class _PointPlotter(_CategoricalStatPlotter):
 
             # Draw the confidence intervals
             self.draw_confints(ax, pointpos, self.confint, self.colors,
-                               self.conf_lw, self.capsize, lw=lw)
-
+                               self.conf_lw, self.capsize)
             # Draw the estimate points
             marker = self.markers[0]
             if self.orient == "h":
@@ -1710,7 +1720,7 @@ class _PointPlotter(_CategoricalStatPlotter):
                     errcolors = [self.colors[j]] * len(offpos)
                     self.draw_confints(ax, offpos, confint, errcolors,
                                        self.conf_lw, self.capsize,
-                                       zorder=z, lw=lw)
+                                       zorder=z)
 
                 # Draw the estimate points
                 marker = self.markers[j]
@@ -2880,7 +2890,7 @@ swarmplot.__doc__ = dedent("""\
 def barplot(x=None, y=None, hue=None, data=None, order=None, hue_order=None,
             estimator=np.mean, ci=95, n_boot=1000, units=None,
             orient=None, color=None, palette=None, saturation=.75,
-            errcolor=".26", conf_lw=1.8, capsize=0, ax=None, **kwargs):
+            errcolor=".26", conf_lw=None, capsize=None, ax=None, **kwargs):
 
     # Handle some deprecated arguments
     if "hline" in kwargs:
@@ -3040,8 +3050,8 @@ barplot.__doc__ = dedent("""\
 def pointplot(x=None, y=None, hue=None, data=None, order=None, hue_order=None,
               estimator=np.mean, ci=95, n_boot=1000, units=None,
               markers="o", linestyles="-", dodge=False, join=True, scale=1,
-              orient=None, color=None, palette=None, ax=None, conf_lw=1.8,
-              capsize=0, **kwargs):
+              orient=None, color=None, palette=None, ax=None, conf_lw=None,
+              capsize=None, **kwargs):
 
     # Handle some deprecated arguments
     if "hline" in kwargs:
@@ -3244,7 +3254,7 @@ def countplot(x=None, y=None, hue=None, data=None, order=None, hue_order=None,
     plotter = _BarPlotter(x, y, hue, data, order, hue_order,
                           estimator, ci, n_boot, units,
                           orient, color, palette, saturation,
-                          errcolor, conf_lw=1, capsize=0)
+                          errcolor)
 
     plotter.value_label = "count"
 

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -1511,30 +1511,25 @@ class _CategoricalStatPlotter(_CategoricalPlotter):
         else:
             kws.setdefault("lw", 1.8)
 
-        if capsize is not None:
-            for at, (ci_low, ci_high), color in zip(at_group,
-                                                    confint,
-                                                    colors):
-                if self.orient == "v":
-                    ax.plot([at, at], [ci_low, ci_high], color=color, **kws)
+        for at, (ci_low, ci_high), color in zip(at_group,
+                                                confint,
+                                                colors):
+            if self.orient == "v":
+                ax.plot([at, at], [ci_low, ci_high], color=color, **kws)
+                if capsize is not None:
                     ax.plot([at - capsize / 2, at + capsize / 2],
                             [ci_low, ci_low], color=color, **kws)
                     ax.plot([at - capsize / 2, at + capsize / 2],
                             [ci_high, ci_high], color=color, **kws)
-                else:
-                    ax.plot([ci_low, ci_high], [at, at], color=color, **kws)
+            else:
+                ax.plot([ci_low, ci_high], [at, at], color=color, **kws)
+                if capsize is not None:
                     ax.plot([ci_low, ci_low],
                             [at - capsize / 2, at + capsize / 2],
                             color=color, **kws)
                     ax.plot([ci_high, ci_high],
                             [at - capsize / 2, at + capsize / 2],
                             color=color, **kws)
-        else:
-            for at, (ci_low, ci_high), color in zip(at_group, confint, colors):
-                if self.orient == "v":
-                    ax.plot([at, at], [ci_low, ci_high], color=color, **kws)
-                else:
-                    ax.plot([ci_low, ci_high], [at, at], color=color, **kws)
 
 
 class _BarPlotter(_CategoricalStatPlotter):

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -1506,12 +1506,12 @@ class _CategoricalStatPlotter(_CategoricalPlotter):
                       capsize=None,
                       **kws):
 
-        if conf_lw:
+        if conf_lw is not None:
             kws.setdefault("lw", mpl.rcParams["lines.linewidth"] * conf_lw)
         else:
             kws.setdefault("lw", mpl.rcParams["lines.linewidth"] * 1.8)
 
-        if capsize:
+        if capsize is not None:
             for at, (ci_low, ci_high), color in zip(at_group,
                                                     confint,
                                                     colors):

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -1502,12 +1502,12 @@ class _CategoricalStatPlotter(_CategoricalPlotter):
                       ax, at_group,
                       confint,
                       colors,
-                      conf_lw=None,
+                      errwidth=None,
                       capsize=None,
                       **kws):
 
-        if conf_lw is not None:
-            kws.setdefault("lw", mpl.rcParams["lines.linewidth"] * conf_lw)
+        if errwidth is not None:
+            kws.setdefault("lw", mpl.rcParams["lines.linewidth"] * errwidth)
         else:
             kws.setdefault("lw", mpl.rcParams["lines.linewidth"] * 1.8)
 
@@ -1542,7 +1542,7 @@ class _BarPlotter(_CategoricalStatPlotter):
 
     def __init__(self, x, y, hue, data, order, hue_order,
                  estimator, ci, n_boot, units,
-                 orient, color, palette, saturation, errcolor, conf_lw=None,
+                 orient, color, palette, saturation, errcolor, errwidth=None,
                  capsize=None):
         """Initialize the plotter."""
         self.establish_variables(x, y, hue, data, orient,
@@ -1551,7 +1551,7 @@ class _BarPlotter(_CategoricalStatPlotter):
         self.estimate_statistic(estimator, ci, n_boot)
 
         self.errcolor = errcolor
-        self.conf_lw = conf_lw
+        self.errwidth = errwidth
         self.capsize = capsize
 
     def draw_bars(self, ax, kws):
@@ -1572,7 +1572,7 @@ class _BarPlotter(_CategoricalStatPlotter):
                                barpos,
                                self.confint,
                                errcolors,
-                               self.conf_lw,
+                               self.errwidth,
                                self.capsize)
 
         else:
@@ -1593,7 +1593,7 @@ class _BarPlotter(_CategoricalStatPlotter):
                                        offpos,
                                        confint,
                                        errcolors,
-                                       self.conf_lw,
+                                       self.errwidth,
                                        self.capsize)
 
     def plot(self, ax, bar_kws):
@@ -1609,7 +1609,7 @@ class _PointPlotter(_CategoricalStatPlotter):
     def __init__(self, x, y, hue, data, order, hue_order,
                  estimator, ci, n_boot, units,
                  markers, linestyles, dodge, join, scale,
-                 orient, color, palette, conf_lw=None, capsize=None):
+                 orient, color, palette, errwidth=None, capsize=None):
         """Initialize the plotter."""
         self.establish_variables(x, y, hue, data, orient,
                                  order, hue_order, units)
@@ -1642,7 +1642,7 @@ class _PointPlotter(_CategoricalStatPlotter):
         self.dodge = dodge
         self.join = join
         self.scale = scale
-        self.conf_lw = conf_lw
+        self.errwidth = errwidth
         self.capsize = capsize
 
     @property
@@ -1677,7 +1677,7 @@ class _PointPlotter(_CategoricalStatPlotter):
 
             # Draw the confidence intervals
             self.draw_confints(ax, pointpos, self.confint, self.colors,
-                               self.conf_lw, self.capsize)
+                               self.errwidth, self.capsize)
             # Draw the estimate points
             marker = self.markers[0]
             if self.orient == "h":
@@ -1717,7 +1717,7 @@ class _PointPlotter(_CategoricalStatPlotter):
                     confint = self.confint[:, j]
                     errcolors = [self.colors[j]] * len(offpos)
                     self.draw_confints(ax, offpos, confint, errcolors,
-                                       self.conf_lw, self.capsize,
+                                       self.errwidth, self.capsize,
                                        zorder=z)
 
                 # Draw the estimate points
@@ -2074,8 +2074,8 @@ _categorical_docs = dict(
              primary line. If 0.0 (default), no caps will be drawn.
              Typical values are between 0.03 and 0.1.\
          """),
-    conf_lw=dedent("""\
-         conf_lw : float, optional
+    errwidth=dedent("""\
+         errwidth : float, optional
              Thickness of lines draw for the confidence interval (and caps).
              Default is 1.8.\
          """),
@@ -2888,7 +2888,7 @@ swarmplot.__doc__ = dedent("""\
 def barplot(x=None, y=None, hue=None, data=None, order=None, hue_order=None,
             estimator=np.mean, ci=95, n_boot=1000, units=None,
             orient=None, color=None, palette=None, saturation=.75,
-            errcolor=".26", conf_lw=None, capsize=None, ax=None, **kwargs):
+            errcolor=".26", errwidth=None, capsize=None, ax=None, **kwargs):
 
     # Handle some deprecated arguments
     if "hline" in kwargs:
@@ -2907,7 +2907,7 @@ def barplot(x=None, y=None, hue=None, data=None, order=None, hue_order=None,
     plotter = _BarPlotter(x, y, hue, data, order, hue_order,
                           estimator, ci, n_boot, units,
                           orient, color, palette, saturation,
-                          errcolor, conf_lw, capsize)
+                          errcolor, errwidth, capsize)
 
     if ax is None:
         ax = plt.gca()
@@ -2951,7 +2951,7 @@ barplot.__doc__ = dedent("""\
     errcolor : matplotlib color
         Color for the lines that represent the confidence interval.
     {ax_in}
-    {conf_lw}
+    {errwidth}
     {capsize}
     kwargs : key, value mappings
         Other keyword arguments are passed through to ``plt.bar`` at draw
@@ -3048,7 +3048,7 @@ barplot.__doc__ = dedent("""\
 def pointplot(x=None, y=None, hue=None, data=None, order=None, hue_order=None,
               estimator=np.mean, ci=95, n_boot=1000, units=None,
               markers="o", linestyles="-", dodge=False, join=True, scale=1,
-              orient=None, color=None, palette=None, ax=None, conf_lw=None,
+              orient=None, color=None, palette=None, ax=None, errwidth=None,
               capsize=None, **kwargs):
 
     # Handle some deprecated arguments
@@ -3068,7 +3068,7 @@ def pointplot(x=None, y=None, hue=None, data=None, order=None, hue_order=None,
     plotter = _PointPlotter(x, y, hue, data, order, hue_order,
                             estimator, ci, n_boot, units,
                             markers, linestyles, dodge, join, scale,
-                            orient, color, palette, conf_lw, capsize)
+                            orient, color, palette, errwidth, capsize)
 
     if ax is None:
         ax = plt.gca()

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -1524,22 +1524,22 @@ class _CategoricalStatPlotter(_CategoricalPlotter):
                 else:
                     ax.plot([ci_low, ci_high], [at, at], color=color, **kws)
                     ax.plot([ci_low, ci_low],
-                            [at - capsize /2, at + capsize /2],
+                            [at - capsize / 2, at + capsize / 2],
                             color=color, **kws)
                     ax.plot([ci_high, ci_high],
-                            [at - capsize /2, at + capsize /2],
+                            [at - capsize / 2, at + capsize / 2],
                             color=color, **kws)
         else:
-            for at, (ci_low, ci_high), color in zip(at_group,
-                                                        confint,
-                                                        colors):
+            for at, (ci_low, ci_high), color in zip(at_group, confint, colors):
                 if self.orient == "v":
                     ax.plot([at, at], [ci_low, ci_high], color=color, **kws)
                 else:
                     ax.plot([ci_low, ci_high], [at, at], color=color, **kws)
 
+
 class _BarPlotter(_CategoricalStatPlotter):
     """Show point estimates and confidence intervals with bars."""
+
     def __init__(self, x, y, hue, data, order, hue_order,
                  estimator, ci, n_boot, units,
                  orient, color, palette, saturation, errcolor, conf_lw=None,
@@ -1595,7 +1595,6 @@ class _BarPlotter(_CategoricalStatPlotter):
                                        errcolors,
                                        self.conf_lw,
                                        self.capsize)
-
 
     def plot(self, ax, bar_kws):
         """Make the plot."""
@@ -2071,11 +2070,11 @@ _categorical_docs = dict(
     """),
     capsize=dedent("""\
          capsize : float, optional
-             Length of caps on confidence interval (drawn perpendicular to primary
-             line. If 0.0 (default), no caps will be drawn. Typical values are
-             between 0.03 and 0.1.\
+             Length of caps on confidence interval (drawn perpendicular to
+             primary line. If 0.0 (default), no caps will be drawn.
+             Typical values are between 0.03 and 0.1.\
          """),
-    conf_lw = dedent("""\
+    conf_lw=dedent("""\
          conf_lw : float, optional
              Thickness of lines draw for the confidence interval (and caps).
              Default is 1.8.\

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -2071,7 +2071,7 @@ _categorical_docs = dict(
     capsize=dedent("""\
          capsize : float, optional
              Length of caps on confidence interval (drawn perpendicular to
-             primary line. If 0.0 (default), no caps will be drawn.
+             primary line). If unspecified, no caps will be drawn.
              Typical values are between 0.03 and 0.1.\
          """),
     errwidth=dedent("""\

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -2076,8 +2076,7 @@ _categorical_docs = dict(
          """),
     errwidth=dedent("""\
          errwidth : float, optional
-             Thickness of lines draw for the confidence interval (and caps).
-             Default is 1.8.\
+             Thickness of lines drawn for the confidence interval (and caps).\
          """),
     width=dedent("""\
     width : float, optional

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -1507,9 +1507,9 @@ class _CategoricalStatPlotter(_CategoricalPlotter):
                       **kws):
 
         if errwidth is not None:
-            kws.setdefault("lw", mpl.rcParams["lines.linewidth"] * errwidth)
+            kws.setdefault("lw", errwidth)
         else:
-            kws.setdefault("lw", mpl.rcParams["lines.linewidth"] * 1.8)
+            kws.setdefault("lw", 1.8)
 
         if capsize is not None:
             for at, (ci_low, ci_high), color in zip(at_group,

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -1508,7 +1508,6 @@ class _CategoricalStatPlotter(_CategoricalPlotter):
 
         if conf_lw:
             kws.setdefault("lw", mpl.rcParams["lines.linewidth"] * conf_lw)
-            kws.pop("lw")
         else:
             kws.setdefault("lw", mpl.rcParams["lines.linewidth"] * 1.8)
 

--- a/seaborn/tests/test_categorical.py
+++ b/seaborn/tests/test_categorical.py
@@ -1749,7 +1749,7 @@ class TestBarPlotter(CategoricalFixture):
                        estimator=np.mean, ci=95, n_boot=100, units=None,
                        order=None, hue_order=None,
                        orient=None, color=None, palette=None,
-                       saturation=.75, errcolor=".26")
+                       saturation=.75, errcolor=".26", conf_lw=1.8, capsize=0)
 
     def test_nested_width(self):
 
@@ -1974,7 +1974,7 @@ class TestPointPlotter(CategoricalFixture):
                        order=None, hue_order=None,
                        markers="o", linestyles="-", dodge=0,
                        join=True, scale=1,
-                       orient=None, color=None, palette=None)
+                       orient=None, color=None, palette=None, conf_lw=1, capsize=0)
 
     def test_different_defualt_colors(self):
 

--- a/seaborn/tests/test_categorical.py
+++ b/seaborn/tests/test_categorical.py
@@ -1749,7 +1749,7 @@ class TestBarPlotter(CategoricalFixture):
                        estimator=np.mean, ci=95, n_boot=100, units=None,
                        order=None, hue_order=None,
                        orient=None, color=None, palette=None,
-                       saturation=.75, errcolor=".26", conf_lw=1.8, capsize=0)
+                       saturation=.75, errcolor=".26")
 
     def test_nested_width(self):
 
@@ -1974,7 +1974,7 @@ class TestPointPlotter(CategoricalFixture):
                        order=None, hue_order=None,
                        markers="o", linestyles="-", dodge=0,
                        join=True, scale=1,
-                       orient=None, color=None, palette=None, conf_lw=1, capsize=0)
+                       orient=None, color=None, palette=None)
 
     def test_different_defualt_colors(self):
 

--- a/seaborn/tests/test_categorical.py
+++ b/seaborn/tests/test_categorical.py
@@ -684,9 +684,9 @@ class TestCategoricalStatPlotter(CategoricalFixture):
 
         plt.close("all")
 
-        # Test conf_lw is set appropriately
+        # Test errwidth is set appropriately
         f, ax = plt.subplots()
-        p.draw_confints(ax, at_group, confints, colors, conf_lw=2)
+        p.draw_confints(ax, at_group, confints, colors, errwidth=2)
         capline = ax.lines[len(ax.lines)-1]
         nt.assert_equal(capline._linewidth, 2)
         nt.assert_equal(len(ax.lines), 2)

--- a/seaborn/tests/test_categorical.py
+++ b/seaborn/tests/test_categorical.py
@@ -2001,6 +2001,7 @@ class TestBarPlotter(CategoricalFixture):
         nt.assert_equal(ax.get_ylabel(), "g")
         plt.close("all")
 
+
 class TestPointPlotter(CategoricalFixture):
 
     default_kws = dict(x=None, y=None, hue=None, data=None,


### PR DESCRIPTION
I think this fixes the end cap addition to barplot and scatterplot confidence intervals. Let me know what you think. It should pass all the automated tests. Let me know if there is anything wrong. I've attached some images, along with the python script I used to generate them. This should show you what the different parameters look like for different capsize and conf_lw. Major thanks to jat255 who did the initial work on this. This is my very first contribution to an open source project that is not my own. Let me know if there is anything else that needs to be done as far as style and/or code cleanup.

```python
import seaborn as sns

##LINEPLOTS

g=None
sns.set(style="whitegrid")
df = sns.load_dataset("exercise")
g = sns.factorplot(x="time", y="pulse", hue="kind", col="diet", data=df,
                   palette="YlGnBu_d", size=6, aspect=.75)
g.despine(left=True)
g.savefig("test1.png")

g=None
sns.set(style="whitegrid")
df = sns.load_dataset("exercise")
g = sns.factorplot(x="time", y="pulse", hue="kind", col="diet", data=df,
                   palette="YlGnBu_d", size=6, aspect=.75, conf_lw=1, capsize=0.3)
g.despine(left=True)
g.savefig("test2.png")

g=None
sns.set(style="whitegrid")
df = sns.load_dataset("exercise")
g = sns.factorplot(x="time", y="pulse", hue="kind", col="diet", data=df,
                   palette="YlGnBu_d", size=6, aspect=.75, conf_lw=4, capsize=0.3)
g.despine(left=True)
g.savefig("test2b.png")

g=None
sns.set(style="whitegrid")
df = sns.load_dataset("exercise")
g = sns.factorplot(x="time", y="pulse", hue="kind", col="diet", data=df,
                   palette="YlGnBu_d", size=6, aspect=.75, conf_lw=1, capsize=0.1)
g.despine(left=True)
g.savefig("test3.png")

g=None
sns.set(style="whitegrid")
df = sns.load_dataset("exercise")
g = sns.factorplot(x="time", y="pulse", hue="kind", col="diet", data=df,
                   palette="YlGnBu_d", size=6, aspect=.75, conf_lw=2, capsize=0.3)
g.despine(left=True)
g.savefig("test4.png")

##BarPlots

g=None
sns.set(style="whitegrid")
titanic = sns.load_dataset("titanic")
g = sns.factorplot(x="class", y="survived", hue="sex", data=titanic,
                   size=6, kind="bar", palette="muted")
g.despine(left=True)
g.set_ylabels("survival probability")
g.savefig("test5.png")

g=None
sns.set(style="whitegrid")
titanic = sns.load_dataset("titanic")
g = sns.factorplot(x="class", y="survived", hue="sex", data=titanic,
                   size=6, kind="bar", palette="muted", conf_lw=1, capsize=0.3)
g.despine(left=True)
g.set_ylabels("survival probability")
g.savefig("test6.png")

g=None
sns.set(style="whitegrid")
titanic = sns.load_dataset("titanic")
g = sns.factorplot(x="class", y="survived", hue="sex", data=titanic,
                   size=6, kind="bar", palette="muted", conf_lw=1, capsize=0.1)
g.despine(left=True)
g.set_ylabels("survival probability")
g.savefig("test7.png")

g=None
sns.set(style="whitegrid")
titanic = sns.load_dataset("titanic")
g = sns.factorplot(x="class", y="survived", hue="sex", data=titanic,
                   size=6, kind="bar", palette="muted", conf_lw=2, capsize=0.3)
g.despine(left=True)
g.set_ylabels("survival probability")
g.savefig("test8.png")
```









`












![test1](https://cloud.githubusercontent.com/assets/1033706/14166575/45fb4e8a-f6da-11e5-9721-a8386090ef68.png)
![test2](https://cloud.githubusercontent.com/assets/1033706/14166576/45fc33ea-f6da-11e5-81f9-0cb5c3220495.png)
![test2b](https://cloud.githubusercontent.com/assets/1033706/14166578/45ffec92-f6da-11e5-927d-0299589f5286.png)
![test3](https://cloud.githubusercontent.com/assets/1033706/14166577/45ffec9c-f6da-11e5-84ae-bc7e0a9c1371.png)
![test4](https://cloud.githubusercontent.com/assets/1033706/14166580/4600eca0-f6da-11e5-8638-0aeb20007ad8.png)
![test5](https://cloud.githubusercontent.com/assets/1033706/14166579/4600e3fe-f6da-11e5-8cc3-f5d251a85697.png)
![test6](https://cloud.githubusercontent.com/assets/1033706/14166581/4603d17c-f6da-11e5-9ec1-f866a8376a66.png)
![test7](https://cloud.githubusercontent.com/assets/1033706/14166582/46055cfe-f6da-11e5-8275-8e3d1d494c1b.png)
![test8](https://cloud.githubusercontent.com/assets/1033706/14166583/46094d46-f6da-11e5-9af9-41a8e50e80e3.png)
