### PR TITLE
Clean up top-level seaborn namespace

### DIFF
--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -9,10 +9,11 @@ import pandas as pd
 import matplotlib as mpl
 import matplotlib.pyplot as plt
 
-from six import string_types
-
 from . import utils
 from .palettes import color_palette
+
+
+__all__ = ["FacetGrid", "PairGrid", "JointGrid"]
 
 
 class Grid(object):

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -21,6 +21,10 @@ from .palettes import color_palette, husl_palette, light_palette
 from .axisgrid import FacetGrid, _facet_docs
 
 
+__all__ = ["boxplot", "violinplot", "stripplot", "swarmplot", "lvplot",
+           "pointplot", "barplot", "countplot", "factorplot"]
+
+
 class _CategoricalPlotter(object):
 
     width = .8

--- a/seaborn/distributions.py
+++ b/seaborn/distributions.py
@@ -20,6 +20,9 @@ from .palettes import color_palette, blend_palette
 from .axisgrid import JointGrid
 
 
+__all__ = ["distplot", "kdeplot", "rugplot", "jointplot"]
+
+
 def _freedman_diaconis_bins(a):
     """Calculate number of hist bins using Freedman-Diaconis rule."""
     # From http://stats.stackexchange.com/questions/798/

--- a/seaborn/linearmodels.py
+++ b/seaborn/linearmodels.py
@@ -28,6 +28,11 @@ from .axisgrid import FacetGrid, PairGrid, _facet_docs
 from .distributions import kdeplot
 
 
+__all__ = ["lmplot", "regplot", "residplot",
+           "coefplot", "interactplot",
+           "pairplot"]
+
+
 class _LinearPlotter(object):
     """Base class for plotting relational data in tidy format.
 

--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -13,7 +13,9 @@ from scipy.cluster import hierarchy
 from .axisgrid import Grid
 from .palettes import cubehelix_palette
 from .utils import despine, axis_ticklabels_overlap, relative_luminance
-from .external.six.moves import range
+
+
+__all__ = ["heatmap", "clustermap"]
 
 
 def _index_to_label(index):

--- a/seaborn/miscplot.py
+++ b/seaborn/miscplot.py
@@ -4,6 +4,9 @@ import matplotlib as mpl
 import matplotlib.pyplot as plt
 
 
+__call__ = ["palplot", "puppyplot"]
+
+
 def palplot(pal, size=1):
     """Plot the values in a color palette as a horizontal array.
 

--- a/seaborn/palettes.py
+++ b/seaborn/palettes.py
@@ -13,6 +13,13 @@ from .utils import desaturate, set_hls_values, get_color_cycle
 from .xkcd_rgb import xkcd_rgb
 from .crayons import crayons
 
+
+__all__ = ["color_palette", "hls_palette", "husl_palette", "mpl_palette",
+           "dark_palette", "light_palette", "diverging_palette",
+           "blend_palette", "xkcd_palette", "crayon_palette",
+           "cubehelix_palette", "set_color_codes"]
+
+
 SEABORN_PALETTES = dict(
     deep=["#4C72B0", "#55A868", "#C44E52",
           "#8172B2", "#CCB974", "#64B5CD"],

--- a/seaborn/rcmod.py
+++ b/seaborn/rcmod.py
@@ -7,7 +7,14 @@ import matplotlib as mpl
 
 from . import palettes, _orig_rc_params
 
+
 mpl_ge_150 = LooseVersion(mpl.__version__) >= '1.5.0'
+
+
+__all__ = ["set", "reset_defaults", "reset_orig",
+           "axes_style", "set_style", "plotting_context", "set_context",
+           "set_palette"]
+
 
 _style_keys = (
 

--- a/seaborn/tests/test_palettes.py
+++ b/seaborn/tests/test_palettes.py
@@ -6,7 +6,8 @@ import matplotlib as mpl
 import nose.tools as nt
 import numpy.testing as npt
 
-from .. import palettes, utils, rcmod, husl
+from .. import palettes, utils, rcmod
+from ..external import husl
 from ..xkcd_rgb import xkcd_rgb
 from ..crayons import crayons
 

--- a/seaborn/timeseries.py
+++ b/seaborn/timeseries.py
@@ -8,10 +8,12 @@ import matplotlib.pyplot as plt
 
 from .external.six import string_types
 
-
 from . import utils
 from . import algorithms as algo
 from .palettes import color_palette
+
+
+__all__ = ["tsplot"]
 
 
 def tsplot(data, time=None, unit=None, condition=None, value=None,

--- a/seaborn/utils.py
+++ b/seaborn/utils.py
@@ -17,6 +17,10 @@ mpl_ge_150 = LooseVersion(mpl.__version__) >= "1.5.0"
 from .external.six.moves.urllib.request import urlopen, urlretrieve
 
 
+__all__ = ["desaturate", "saturate", "set_hls_values",
+           "despine", "get_dataset_names", "load_dataset"]
+
+
 def ci_to_errsize(cis, heights):
     """Convert intervals to error arguments relative to plot heights.
 

--- a/seaborn/widgets.py
+++ b/seaborn/widgets.py
@@ -23,6 +23,11 @@ from .palettes import (color_palette, dark_palette, light_palette,
                        diverging_palette, cubehelix_palette)
 
 
+__all__ = ["choose_colorbrewer_palette", "choose_cubehelix_palette",
+           "choose_dark_palette", "choose_light_palette",
+           "choose_diverging_palette"]
+
+
 def _init_mutable_colormap():
     """Create a matplotlib colormap that will be updated by the widgets."""
     greys = color_palette("Greys", 256)


### PR DESCRIPTION
Add explicit `__all__` declarations in seaborn modules to avoid importing 

With this change, `python -c 'import seaborn; print(len(dir(seaborn)))` shows 85 objects in contrast to 143 before the change.

It's possible that this could break some code if people are using objects in the top level namespace that aren't really part of the public API (in terms of what is documented and used in examples), but those functions still exist they just need to be explicitly imported.

Closes #904