### PR TITLE
Optimize pruning of candidates in SwarmPlotter

### DIFF
--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -1233,6 +1233,7 @@ class _SwarmPlotter(_CategoricalScatterPlotter):
             for xy_j in neighbors:
                 if self.overlap(xy_i, xy_j, d):
                     good_candidate = False
+                    break
             if good_candidate:
                 good_candidates.append(xy_i)
         return np.array(good_candidates)


### PR DESCRIPTION
Exit the for-loop when the first overlap with a neighbor is found.