### PR TITLE
Fix scale bug in _scipy_univariate_kde

### DIFF
--- a/seaborn/distributions.py
+++ b/seaborn/distributions.py
@@ -345,7 +345,7 @@ def _scipy_univariate_kde(data, bw, gridsize, cut, clip):
             warnings.warn(msg, UserWarning)
     if isinstance(bw, string_types):
         bw = "scotts" if bw == "scott" else bw
-        bw = getattr(kde, "%s_factor" % bw)()
+        bw = getattr(kde, "%s_factor" % bw)()*np.std(data)
     grid = _kde_support(data, bw, gridsize, cut, clip)
     y = kde(grid)
     return grid, y


### PR DESCRIPTION
There is a missing scale factor in `bw` in `_scipy_univariate_kde`.  This patch fixes it.  The bug becomes evident when the scale of the data to which the KDE is applied is much smaller than 1.  I have attached two `kdeplot`s from before and after the fix.  The data were created as `data = 0.01*randn(1000)`; you can see that the scale is properly tracked post-fix.
[pre-fix.pdf](https://github.com/mwaskom/seaborn/files/254088/pre-fix.pdf)
[post-fix.pdf](https://github.com/mwaskom/seaborn/files/254089/post-fix.pdf)

