### PR TITLE
Fix header interference in doc linking, fixes #610

### DIFF
--- a/doc/_static/style.css
+++ b/doc/_static/style.css
@@ -18,12 +18,9 @@ code {
     color: #2c3e50 !important;
 }
 
-.headerlink:before {
-
-  display: block;
-  context: " ";
-  height: 200px; /*same height as header*/
-  margin-top: -200px; /*same height as header*/
-  visibility: hidden;
-
+.function dt {
+    padding-top: 150px;
+    margin-top: -150px;
+    -webkit-background-clip: content-box;
+    background-clip: content-box;
 }


### PR DESCRIPTION
Title says all, simply some CSS that fixes the anchor link to doc pages