### PR TITLE
Use one-step linkage calculation with both scipy and fastcluster

### DIFF
--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -567,10 +567,8 @@ class _DendrogramPlotter(object):
         if np.product(self.shape) >= 10000:
             UserWarning('This will be slow... (gentle suggestion: '
                         '"pip install fastcluster")')
-
-        pairwise_dists = distance.pdist(self.array, metric=self.metric)
-        linkage = hierarchy.linkage(pairwise_dists, method=self.method)
-        del pairwise_dists
+        linkage = hierarchy.linkage(self.array, method=self.method,
+                                    metric=self.metric)
         return linkage
 
     def _calculate_linkage_fastcluster(self):
@@ -586,9 +584,8 @@ class _DendrogramPlotter(object):
                                               method=self.method,
                                               metric=self.metric)
         else:
-            pairwise_dists = distance.pdist(self.array, metric=self.metric)
-            linkage = fastcluster.linkage(pairwise_dists, method=self.method)
-            del pairwise_dists
+            linkage = fastcluster.linkage(self.array, method=self.method,
+                                          metric=self.metric)
             return linkage
 
     @property


### PR DESCRIPTION
Trying to solve https://github.com/mwaskom/seaborn/issues/909, do linkage calculation in one step rather than two because of a weird compatibility issue with `scipy` 0.17 (https://github.com/scipy/scipy/issues/6180)
