### PR TITLE
Fix #929: FacetGrid with unused categories

### DIFF
--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -271,7 +271,7 @@ class FacetGrid(Grid):
                 err = "Cannot use `row` and `col_wrap` together."
                 raise ValueError(err)
             ncol = col_wrap
-            nrow = int(np.ceil(len(data[col].unique()) / col_wrap))
+            nrow = int(np.ceil(len(col_names) / col_wrap))
         self._ncol = ncol
         self._nrow = nrow
 

--- a/seaborn/tests/test_axisgrid.py
+++ b/seaborn/tests/test_axisgrid.py
@@ -718,7 +718,7 @@ class TestFacetGrid(PlotTestCase):
         df = self.df.copy()
         df['a'] = df['a'].astype('category')
 
-        g = ag.FacetGrid(df.query("a != 'a'"), col="a", col_wrap=1)
+        g = ag.FacetGrid(df[df['a'] == 'a'], col="a", col_wrap=1)
 
         nt.assert_equal(g.axes.shape, (len(df['a'].cat.categories),))
 

--- a/seaborn/tests/test_axisgrid.py
+++ b/seaborn/tests/test_axisgrid.py
@@ -24,6 +24,7 @@ from ..utils import categorical_order
 rs = np.random.RandomState(0)
 
 old_matplotlib = LooseVersion(mpl.__version__) < "1.4"
+pandas_has_categoricals = LooseVersion(pd.__version__) >= "0.15"
 
 
 class TestFacetGrid(PlotTestCase):
@@ -713,6 +714,7 @@ class TestFacetGrid(PlotTestCase):
         g = ag.FacetGrid(df, row="b")
         g = g.map(plt.plot, "x")
 
+    @skipif(not pandas_has_categoricals)
     def test_categorical_column_missing_categories(self):
 
         df = self.df.copy()

--- a/seaborn/tests/test_axisgrid.py
+++ b/seaborn/tests/test_axisgrid.py
@@ -713,6 +713,15 @@ class TestFacetGrid(PlotTestCase):
         g = ag.FacetGrid(df, row="b")
         g = g.map(plt.plot, "x")
 
+    def test_categorical_column_missing_categories(self):
+
+        df = self.df.copy()
+        df['a'] = df['a'].astype('category')
+
+        g = ag.FacetGrid(df.query("a != 'a'"), col="a", col_wrap=1)
+
+        nt.assert_equal(g.axes.shape, (len(df['a'].cat.categories),))
+
 
 class TestPairGrid(PlotTestCase):
 


### PR DESCRIPTION
Calculates correct number of subplots to draw when unused categories are present

The test confirms the fix solves the ValueError.

It also asserts that the number of axes drawn by FacetGrid should be equal to the number of categories in `.cat.categories`, not the number of unique values that are present in the series.