### PR TITLE
Stylish class, equivalent to mpl.rc_context

### DIFF
--- a/seaborn/rcmod.py
+++ b/seaborn/rcmod.py
@@ -13,7 +13,7 @@ mpl_ge_150 = LooseVersion(mpl.__version__) >= '1.5.0'
 
 __all__ = ["set", "reset_defaults", "reset_orig",
            "axes_style", "set_style", "plotting_context", "set_context",
-           "set_palette"]
+           "set_palette", "Stylish"]
 
 
 _style_keys = (
@@ -111,6 +111,10 @@ def set(context="notebook", style="darkgrid", palette="deep",
     if rc is not None:
         mpl.rcParams.update(rc)
 
+class Stylish(mpl.rc_context):
+    def __init__(self, **kwargs):
+        mpl.rc_context.__init__(self)
+        set(**kwargs)
 
 def reset_defaults():
     """Restore all RC params to default settings."""


### PR DESCRIPTION
See [this question](http://stackoverflow.com/questions/31191063/using-with-sns-set-in-seaborn-plots/37365095) on SO.

(probably worth merging with a more serious name - or maybe just transforming ``set`` itself in a context manager?)