### PR TITLE
made usage of string module in one example compatible to Python3

### DIFF
--- a/examples/many_pairwise_correlations.py
+++ b/examples/many_pairwise_correlations.py
@@ -4,7 +4,7 @@ Plotting a diagonal correlation matrix
 
 _thumb: .3, .6
 """
-from string import letters
+from string import ascii_letters
 import numpy as np
 import pandas as pd
 import seaborn as sns
@@ -15,7 +15,7 @@ sns.set(style="white")
 # Generate a large random dataset
 rs = np.random.RandomState(33)
 d = pd.DataFrame(data=rs.normal(size=(100, 26)),
-                 columns=list(letters[:26]))
+                 columns=list(ascii_letters[:26]))
 
 # Compute the correlation matrix
 corr = d.corr()


### PR DESCRIPTION
In Py3k, `string` does not contain `letters` any more, only `ascii_letters`. It is also available in Python 2.7 with the same content as `letters`.