### PR TITLE
Logscale kde

### DIFF
--- a/seaborn/distributions.py
+++ b/seaborn/distributions.py
@@ -255,12 +255,17 @@ def distplot(a, bins=None, hist=True, kde=True, rug=False, fit=None,
 
 
 def _univariate_kdeplot(data, shade, vertical, kernel, bw, gridsize, cut,
-                        clip, legend, ax, cumulative=False, **kwargs):
+                        clip, legend, ax, logspace=False, cumulative=False,
+                        **kwargs):
     """Plot a univariate kernel density estimate on one of the axes."""
 
     # Sort out the clipping
     if clip is None:
         clip = (-np.inf, np.inf)
+
+    if logspace:
+        # Do the KDE-ing and plotting on the log of the data, then transform back
+        data = np.log(data)
 
     # Calculate the KDE
     if _has_statsmodels:
@@ -279,6 +284,10 @@ def _univariate_kdeplot(data, shade, vertical, kernel, bw, gridsize, cut,
                               "only implemented in statsmodels."
                               "Please install statsmodels.")
         x, y = _scipy_univariate_kde(data, bw, gridsize, cut, clip)
+
+    if logspace:
+        # y is the KDE estimate at the corresponding x, but we logged the data, so un-log the x's
+        x = np.exp(x)
 
     # Make sure the density is nonnegative
     y = np.amax(np.c_[np.zeros_like(y), y], axis=1)
@@ -346,6 +355,7 @@ def _scipy_univariate_kde(data, bw, gridsize, cut, clip):
     if isinstance(bw, string_types):
         bw = "scotts" if bw == "scott" else bw
         bw = getattr(kde, "%s_factor" % bw)() * np.std(data)
+
     grid = _kde_support(data, bw, gridsize, cut, clip)
     y = kde(grid)
     return grid, y
@@ -353,7 +363,7 @@ def _scipy_univariate_kde(data, bw, gridsize, cut, clip):
 
 def _bivariate_kdeplot(x, y, filled, fill_lowest,
                        kernel, bw, gridsize, cut, clip,
-                       axlabel, ax, **kwargs):
+                       axlabel, ax, logspace=False, **kwargs):
     """Plot a joint KDE estimate as a bivariate contour plot."""
     # Determine the clipping
     if clip is None:
@@ -361,11 +371,21 @@ def _bivariate_kdeplot(x, y, filled, fill_lowest,
     elif np.ndim(clip) == 1:
         clip = [clip, clip]
 
+    # If in logspace, log the data
+    if logspace:
+        x = np.log(x)
+        y = np.log(y)
+
     # Calculate the KDE
     if _has_statsmodels:
         xx, yy, z = _statsmodels_bivariate_kde(x, y, bw, gridsize, cut, clip)
     else:
         xx, yy, z = _scipy_bivariate_kde(x, y, bw, gridsize, cut, clip)
+
+    # If in logspace, xx, yy are logged, so transform back
+    if logspace:
+        xx = np.exp(xx)
+        yy = np.exp(yy)
 
     # Plot the contours
     n_levels = kwargs.pop("n_levels", 10)
@@ -441,7 +461,7 @@ def _scipy_bivariate_kde(x, y, bw, gridsize, cut, clip):
 
 def kdeplot(data, data2=None, shade=False, vertical=False, kernel="gau",
             bw="scott", gridsize=100, cut=3, clip=None, legend=True,
-            cumulative=False, shade_lowest=True, ax=None, **kwargs):
+            cumulative=False, logspace=False, shade_lowest=True, ax=None, **kwargs):
     """Fit and plot a univariate or bivariate kernel density estimate.
 
     Parameters
@@ -472,6 +492,8 @@ def kdeplot(data, data2=None, shade=False, vertical=False, kernel="gau",
         If True, add a legend or label the axes when possible.
     cumulative : bool, optional
         If True, draw the cumulative distribution estimated by the kde.
+    logspace : bool, optional
+        If True, compute and plot the KDE on the log of the data.
     shade_lowest : bool, optional
         If True, shade the lowest contour of a bivariate KDE plot. Not
         relevant when drawing a univariate plot or when ``shade=False``.
@@ -597,11 +619,19 @@ def kdeplot(data, data2=None, shade=False, vertical=False, kernel="gau",
     if bivariate:
         ax = _bivariate_kdeplot(x, y, shade, shade_lowest,
                                 kernel, bw, gridsize, cut, clip, legend,
-                                ax, **kwargs)
+                                ax, logspace=logspace, **kwargs)
+        if logspace:
+            ax.set_xscale("log")
+            ax.set_yscale("log")
     else:
         ax = _univariate_kdeplot(data, shade, vertical, kernel, bw,
-                                 gridsize, cut, clip, legend, ax,
+                                 gridsize, cut, clip, legend, ax, logspace=logspace,
                                  cumulative=cumulative, **kwargs)
+        if logspace:
+            if vertical:
+                ax.set_yscale("log")
+            else:
+                ax.set_xscale("log")
 
     return ax
 


### PR DESCRIPTION
I have found it nice to sometimes plot p(log(x)) from samples of x, automatically log-ing the x-axis.  This branch adds a `logspace=` optional argument to the KDE density plots which does exactly this.  