### PR TITLE
Support for different fmt strings in heatmap

### DIFF
--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -245,7 +245,10 @@ class _HeatMapper(object):
             if m is not np.ma.masked:
                 l = relative_luminance(color)
                 text_color = ".15" if l > .408 else "w"
-                annotation = ("{:" + self.fmt + "}").format(val)
+                if self.fmt is not None:
+                    annotation = ("{:" + self.fmt + "}").format(val)
+                else:
+                    annotation = val
                 text_kwargs = dict(color=text_color, ha="center", va="center")
                 text_kwargs.update(self.annot_kws)
                 ax.text(x, y, annotation, **text_kwargs)


### PR DESCRIPTION

## Rationale ##
Sometimes one may wish to annotate a heatmap with a different string formatting codes per column.
Here is a simple example I personally had:

| ID | Some Value | Some Percentage |
|----|------------|-----------------|
|  0 |        340 |          .76312 |
|  1 |        933 |          .43351 |
|  2 |        127 |          .72982 |

I'd like a heatmap with colors normalized per column, and then annotated based on the type of data.
I think the easiest way to do this is to just let the user pass in their dataset with the annotations formatted just the way they want it with the `annot` keyword.
Then the user explicitly passes in `None` for the `fmt` keyword.

In this simple example I'd like to format the `Some Value` column with `{:0f}` and the `Some Percentage` column with `{:.2%}`.
With my pull request I can do this:
```
>>> import pandas as pd
>>> import seaborn as sns

>>> df = pd.DataFrame({'Some Value': [340, 933, 127], 'Some Percentage': [.76312, .43351, .72982]})
>>> norm_df = df / df.max()  # normalize DataFrame by column
>>> annot_df = df.copy()
>>> annot_df['Some Value'] = annot_df['Some Value'].apply(lambda x: '{:.0f}'.format(x))
>>> annot_df['Some Percentage'] = annot_df['Some Percentage'].apply(lambda x: '{:.2%}'.format(x))
>>> sns.heatmap(norm_df, annot=annot_df, fmt=None)

```
![column_annot_fmt](https://cloud.githubusercontent.com/assets/11843940/17342094/36f4676a-58bd-11e6-917b-a62969020adb.png)

This is just my solution. It's fairly simple and of course still preserves previous functionality.
Both of these still work fine, for example:
```
>>> sb.heatmap(norm_df,annot=True)
>>> sb.heatmap(norm_df,annot=True, fmt='f')
```
![default_params](https://cloud.githubusercontent.com/assets/11843940/17342125/506d48ce-58bd-11e6-92f5-e84575889a47.png)
![universal_param](https://cloud.githubusercontent.com/assets/11843940/17342139/64dc4922-58bd-11e6-8fce-e2ad7fcb60c0.png)


Maybe this is a bit of an edge case, but I think it's an easy way to let the user do some more custom formatting with their plots.
I think it would be much harder to have to manually change each annotation text through matplotlib after the fact.
Running `make test` after this change passes.

