### PR TITLE
ENH for heatmap: adds invert_yaxis to flip the y axis

### DIFF
--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -296,7 +296,7 @@ def heatmap(data, vmin=None, vmax=None, cmap=None, center=None, robust=False,
             linewidths=0, linecolor="white",
             cbar=True, cbar_kws=None, cbar_ax=None,
             square=False, ax=None, xticklabels=True, yticklabels=True,
-            mask=None,
+            mask=None, invert_y=False,
             **kwargs):
     """Plot rectangular data as a color-encoded matrix.
 
@@ -367,6 +367,10 @@ def heatmap(data, vmin=None, vmax=None, cmap=None, center=None, robust=False,
     mask : boolean array or DataFrame, optional
         If passed, data will not be shown in cells where ``mask`` is True.
         Cells with missing values are automatically masked.
+    invert_y : boolearn, optional
+        If True, flip the ordering of values on the y-axis. For typical
+        visualizations, this results in lower values on the bottom of the
+        y-axis (default: False).
     kwargs : other keyword arguments
         All other keyword arguments are passed to ``ax.pcolormesh``.
 
@@ -493,6 +497,8 @@ def heatmap(data, vmin=None, vmax=None, cmap=None, center=None, robust=False,
         ax = plt.gca()
     if square:
         ax.set_aspect("equal")
+    if invert_y:
+        ax.invert_yaxis()
     plotter.plot(ax, cbar_ax, kwargs)
     return ax
 

--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -296,7 +296,7 @@ def heatmap(data, vmin=None, vmax=None, cmap=None, center=None, robust=False,
             linewidths=0, linecolor="white",
             cbar=True, cbar_kws=None, cbar_ax=None,
             square=False, ax=None, xticklabels=True, yticklabels=True,
-            mask=None, invert_y=False,
+            mask=None, invert_yaxis=False,
             **kwargs):
     """Plot rectangular data as a color-encoded matrix.
 
@@ -367,7 +367,7 @@ def heatmap(data, vmin=None, vmax=None, cmap=None, center=None, robust=False,
     mask : boolean array or DataFrame, optional
         If passed, data will not be shown in cells where ``mask`` is True.
         Cells with missing values are automatically masked.
-    invert_y : boolearn, optional
+    invert_yaxis : boolearn, optional
         If True, flip the ordering of values on the y-axis. For typical
         visualizations, this results in lower values on the bottom of the
         y-axis (default: False).
@@ -497,7 +497,7 @@ def heatmap(data, vmin=None, vmax=None, cmap=None, center=None, robust=False,
         ax = plt.gca()
     if square:
         ax.set_aspect("equal")
-    if invert_y:
+    if invert_yaxis:
         ax.invert_yaxis()
     plotter.plot(ax, cbar_ax, kwargs)
     return ax


### PR DESCRIPTION
Often times in my statistical visualizations with `sns.heatmap`, it'd be nice to have invert the y-axis. This is possible through `ax.invert_yaxis` as found in [this StackOverflow answer] but it'd be nice to have a new default option -- I'd rather not have to search for this.

A basic test (really a use case):

<img width="479" alt="screen shot 2016-08-31 at 9 51 03 am" src="https://cloud.githubusercontent.com/assets/1320475/18133499/7a765854-6f60-11e6-9307-510e6e80ed83.png">

[this StackOverflow answer]:http://stackoverflow.com/a/34444939