### PR TITLE
Fixed documentation issue on load_dataset

### DIFF
--- a/seaborn/utils.py
+++ b/seaborn/utils.py
@@ -409,7 +409,7 @@ def load_dataset(name, cache=True, data_home=None, **kws):
     cache : boolean, optional
         If True, then cache data locally and use the cache on subsequent calls
     data_home : string, optional
-        The directory in which to cache data. By default, uses ~/seaborn_data/
+        The directory in which to cache data. By default, uses ~/seaborn-data/
     kws : dict, optional
         Passed to pandas.read_csv
 


### PR DESCRIPTION
I edited a comment on load_dataset() in seaborn/utils.py, correcting the default path. A very small pull request, but the incorrect default data path caused me some confusion while I was trying to debug an issue with retrieving the iris data set behind a firewall.