### PR TITLE
Ignore warnings when importing widgets

### DIFF
--- a/seaborn/widgets.py
+++ b/seaborn/widgets.py
@@ -7,15 +7,18 @@ from matplotlib.colors import LinearSegmentedColormap
 try:
     from ipywidgets import interact, FloatSlider, IntSlider
 except ImportError:
-    try:
-        from IPython.html.widgets import interact, FloatSlider, IntSlider
-    except ImportError:
+    import warnings
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore") # ignore ShimWarning raised by IPython, see #892
         try:
-            from IPython.html.widgets import (interact,
-                                              FloatSliderWidget as FloatSlider,
-                                              IntSliderWidget as IntSlider)
+            from IPython.html.widgets import interact, FloatSlider, IntSlider
         except ImportError:
-            pass
+            try:
+                from IPython.html.widgets import (interact,
+                                                  FloatSliderWidget as FloatSlider,
+                                                  IntSliderWidget as IntSlider)
+            except ImportError:
+                pass
 
 
 from .miscplot import palplot


### PR DESCRIPTION
Ignore the `ShimWarning` raised by IPython when importing widgets from IPython instead of ipywidgets. This warning only confuses the user - "I didn't import `IPython.html`!" - and the dev already knows that he's using a deprecated API.

Fixes #892, #874.