### PR TITLE
fixing husl int bug

### DIFF
--- a/seaborn/external/husl.py
+++ b/seaborn/external/husl.py
@@ -170,7 +170,7 @@ def rgb_prepare(triple):
         # instead of Python 2 which is rounded to 5.0 which caused
         # a couple off by one errors in the tests. Tests now all pass
         # in Python 2 and Python 3
-        ret.append(round(ch * 255 + 0.001, 0))
+        ret.append(int(round(ch * 255 + 0.001, 0)))
 
     return ret
 


### PR DESCRIPTION
this fixes a bug that popped up when I was trying to use the `husl` module. Basically it's converting numbers to a scale of 255 and then calling `np.round`, but they're left as floats. This means that when they are converted to something like hex with `%02x`, it was returning an error because it required an int, not a float. This PR just explicitly turns RGB values into `int` after calling `np.round`.