### PR TITLE
Replace str with to_utf8 methods

### DIFF
--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -64,7 +64,7 @@ class Grid(object):
             if self.hue_names is None:
                 label_order = np.sort(list(legend_data.keys()))
             else:
-                label_order = list(map(str, self.hue_names))
+                label_order = list(map(utils.to_utf8, self.hue_names))
 
         blank_handle = mpl.patches.Patch(alpha=0, linewidth=0)
         handles = [legend_data.get(l, blank_handle) for l in label_order]
@@ -711,7 +711,7 @@ class FacetGrid(Grid):
 
             # Insert a label in the keyword arguments for the legend
             if self._hue_var is not None:
-                kwargs["label"] = str(self.hue_names[hue_k])
+                kwargs["label"] = utils.to_utf8(self.hue_names[hue_k])
 
             # Get the actual data we are going to plot with
             plot_data = data_ijk[list(args)]

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -1515,7 +1515,7 @@ class _CategoricalStatPlotter(_CategoricalPlotter):
         # Rename the value label to reflect the estimation
         if self.value_label is not None:
             self.value_label = u"{}({})".format(estimator.__name__,
-                                               self.value_label)
+                                                self.value_label)
 
     def draw_confints(self, ax, at_group, confint, colors,
                       errwidth=None, capsize=None, **kws):

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -1514,7 +1514,7 @@ class _CategoricalStatPlotter(_CategoricalPlotter):
 
         # Rename the value label to reflect the estimation
         if self.value_label is not None:
-            self.value_label = "{}({})".format(estimator.__name__,
+            self.value_label = u"{}({})".format(estimator.__name__,
                                                self.value_label)
 
     def draw_confints(self, ax, at_group, confint, colors,
@@ -3500,7 +3500,7 @@ def factorplot(x=None, y=None, hue=None, data=None, row=None, col=None,
             g.set_axis_labels(y_var="count")
 
     if legend and (hue is not None) and (hue not in [x, row, col]):
-        hue_order = list(map(str, hue_order))
+        hue_order = list(map(utils.to_utf8, hue_order))
         g.add_legend(title=hue, label_order=hue_order)
 
     return g

--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -12,7 +12,7 @@ from scipy.cluster import hierarchy
 
 from .axisgrid import Grid
 from .palettes import cubehelix_palette
-from .utils import despine, axis_ticklabels_overlap, relative_luminance
+from .utils import despine, axis_ticklabels_overlap, relative_luminance, to_utf8
 
 
 __all__ = ["heatmap", "clustermap"]
@@ -21,7 +21,7 @@ __all__ = ["heatmap", "clustermap"]
 def _index_to_label(index):
     """Convert a pandas index or multiindex to an axis label."""
     if isinstance(index, pd.MultiIndex):
-        return "-".join(map(str, index.names))
+        return "-".join(map(to_utf8, index.names))
     else:
         return index.name
 
@@ -29,7 +29,7 @@ def _index_to_label(index):
 def _index_to_ticklabels(index):
     """Convert a pandas index or multiindex into ticklabels."""
     if isinstance(index, pd.MultiIndex):
-        return ["-".join(map(str, i)) for i in index.values]
+        return ["-".join(map(to_utf8, i)) for i in index.values]
     else:
         return index.values
 

--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -12,7 +12,8 @@ from scipy.cluster import hierarchy
 
 from .axisgrid import Grid
 from .palettes import cubehelix_palette
-from .utils import despine, axis_ticklabels_overlap, relative_luminance, to_utf8
+from .utils import (despine, axis_ticklabels_overlap, relative_luminance,
+                    to_utf8)
 
 
 __all__ = ["heatmap", "clustermap"]


### PR DESCRIPTION
Replaced str function calls with utils.to_utf8 to avoid unicode errors when labels had unicode in them. Tested with python 2.7.
