### PR TITLE
Fixed broken link in doc/installing.rst

### DIFF
--- a/doc/installing.rst
+++ b/doc/installing.rst
@@ -33,7 +33,7 @@ Mandatory dependencies
 
 -  `scipy <http://www.scipy.org/>`__
 
--  `matplotlib <matplotlib.sourceforge.net>`__
+-  `matplotlib <http://matplotlib.org>`__
 
 -  `pandas <http://pandas.pydata.org/>`__
 


### PR DESCRIPTION
I've also replaced the sourceforge link (that only redirects to matplotlib.org) with it's redirect target. It's a small but annoying issue :)