### PR TITLE
Fix palette test

### DIFF
--- a/doc/installing.rst
+++ b/doc/installing.rst
@@ -33,7 +33,7 @@ Mandatory dependencies
 
 -  `scipy <http://www.scipy.org/>`__
 
--  `matplotlib <matplotlib.sourceforge.net>`__
+-  `matplotlib <http://matplotlib.org>`__
 
 -  `pandas <http://pandas.pydata.org/>`__
 

--- a/seaborn/tests/test_palettes.py
+++ b/seaborn/tests/test_palettes.py
@@ -163,7 +163,7 @@ class TestColorPalettes(object):
 
         pal_forward = palettes.mpl_palette("BuPu", 6)
         pal_reverse = palettes.mpl_palette("BuPu_r", 6)
-        nt.assert_equal(pal_forward, pal_reverse[::-1])
+        npt.assert_array_almost_equal(pal_forward, pal_reverse[::-1])
 
     def test_rgb_from_hls(self):
 


### PR DESCRIPTION
I suspect Travis failures involve some change in colormap generation in matplotlib 2.0.

Also closes #1101 