### PR TITLE
`sns.swarmplot` that scales better

### DIFF
--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -1202,8 +1202,6 @@ class _SwarmPlotter(_CategoricalScatterPlotter):
         """Return a list of all swarm points that could overlap with target.
 
         Assumes that swarm is a sorted list of all points below xy_i.
-
-        Returns a sorted list of neigbors
         """
         _, y_i = xy_i
         neighbors = []
@@ -1213,13 +1211,7 @@ class _SwarmPlotter(_CategoricalScatterPlotter):
                 neighbors.append(xy_j)
             else:
                 break
-
-        neighbors = np.array(neighbors)
-        if len(neighbors) == 0:
-            return neighbors
-
-        neighbors = neighbors[np.argsort(neighbors[:, 0])]
-        return neighbors
+        return np.array(list(reversed(neighbors)))
 
     def position_candidates(self, xy_i, neighbors, d):
         """Return a list of (x, y) coordinates that might be valid."""
@@ -1239,26 +1231,18 @@ class _SwarmPlotter(_CategoricalScatterPlotter):
         return np.array(candidates)
 
     def first_non_overlapping_candidate(self, candidates, neighbors, d):
-        """
-        Remove candidates from the list if they overlap with the swarm.
-        Assumes neighbors is sorted ascending by x coordinate
-        """
+        """Remove candidates from the list if they overlap with the swarm."""
 
         # IF we have no neighbours, all candidates are good.
         if len(neighbors) == 0:
             return candidates[0]
 
         d_square = d ** 2
-        neighbors_x = neighbors[:, 0]
 
         for xy_i in candidates:
             x_i, y_i = xy_i
 
-            # Find all neighbors that are within one diameter from the target
-            # exploit the sorted structure of neighbors array for efficiency
-            left = np.searchsorted(neighbors_x, x_i-d, side='left')
-            right = np.searchsorted(neighbors_x, x_i+d, side='right')
-            close_neighbors = neighbors[left:right]
+            close_neighbors = neighbors[np.abs(neighbors[:, 0] - x_i) < d]
 
             dx = close_neighbors[:, 0] - x_i
             dy = close_neighbors[:, 1] - y_i

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -1237,15 +1237,16 @@ class _SwarmPlotter(_CategoricalScatterPlotter):
         if len(neighbors) == 0:
             return candidates[0]
 
+        neighbors_x = neighbors[:, 0]
+        neighbors_y = neighbors[:, 1]
+
         d_square = d ** 2
 
         for xy_i in candidates:
             x_i, y_i = xy_i
 
-            close_neighbors = neighbors[np.abs(neighbors[:, 0] - x_i) < d]
-
-            dx = close_neighbors[:, 0] - x_i
-            dy = close_neighbors[:, 1] - y_i
+            dx = neighbors_x - x_i
+            dy = neighbors_y - y_i
 
             sq_distances = np.power(dx, 2.0) + np.power(dy, 2.0)
 

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -1202,6 +1202,8 @@ class _SwarmPlotter(_CategoricalScatterPlotter):
         """Return a list of all swarm points that could overlap with target.
 
         Assumes that swarm is a sorted list of all points below xy_i.
+
+        Returns a sorted list of neigbors
         """
         _, y_i = xy_i
         neighbors = []
@@ -1211,7 +1213,13 @@ class _SwarmPlotter(_CategoricalScatterPlotter):
                 neighbors.append(xy_j)
             else:
                 break
-        return np.array(list(reversed(neighbors)))
+
+        neighbors = np.array(neighbors)
+        if len(neighbors) == 0:
+            return neighbors
+
+        neighbors = neighbors[np.argsort(neighbors[:, 0])]
+        return neighbors
 
     def position_candidates(self, xy_i, neighbors, d):
         """Return a list of (x, y) coordinates that might be valid."""
@@ -1231,18 +1239,26 @@ class _SwarmPlotter(_CategoricalScatterPlotter):
         return np.array(candidates)
 
     def first_non_overlapping_candidate(self, candidates, neighbors, d):
-        """Remove candidates from the list if they overlap with the swarm."""
+        """
+        Remove candidates from the list if they overlap with the swarm.
+        Assumes neighbors is sorted ascending by x coordinate
+        """
 
         # IF we have no neighbours, all candidates are good.
         if len(neighbors) == 0:
             return candidates[0]
 
         d_square = d ** 2
+        neighbors_x = neighbors[:, 0]
 
         for xy_i in candidates:
             x_i, y_i = xy_i
 
-            close_neighbors = neighbors[np.abs(neighbors[:, 0] - x_i) < d]
+            # Find all neighbors that are within one diameter from the target
+            # exploit the sorted structure of neighbors array for efficiency
+            left = np.searchsorted(neighbors_x, x_i-d, side='left')
+            right = np.searchsorted(neighbors_x, x_i+d, side='right')
+            close_neighbors = neighbors[left:right]
 
             dx = close_neighbors[:, 0] - x_i
             dy = close_neighbors[:, 1] - y_i

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -1252,14 +1252,17 @@ class _SwarmPlotter(_CategoricalScatterPlotter):
 
             # good candidate does not overlap any of neighbors
             # which means that squared distance between candidate
-            # and any of the neighbours has to be at least square of the diameter
+            # and any of the neighbours has to be at least
+            # square of the diameter
             good_candidate = np.all(sq_distances >= d_square)
 
             if good_candidate:
                 return xy_i
 
-        # If `position_candidates` works well this should never happen
-        raise Exception('No non-overlapping candidates found. This should not happen.')
+        # If `position_candidates` works well
+        # this should never happen
+        raise Exception('No non-overlapping candidates found. '
+                        'This should not happen.')
 
     def beeswarm(self, orig_xy, d):
         """Adjust x position of points to avoid overlaps."""
@@ -1286,7 +1289,8 @@ class _SwarmPlotter(_CategoricalScatterPlotter):
             candidates = candidates[np.argsort(offsets)]
 
             # Find the first candidate that doesn't overlap any neighbours
-            new_xy_i = self.first_non_overlapping_candidate(candidates, neighbors, d)
+            new_xy_i = self.first_non_overlapping_candidate(candidates,
+                                                            neighbors, d)
 
             # Place it into the swarm
             swarm.append(new_xy_i)

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -1237,16 +1237,15 @@ class _SwarmPlotter(_CategoricalScatterPlotter):
         if len(neighbors) == 0:
             return candidates[0]
 
-        neighbors_x = neighbors[:, 0]
-        neighbors_y = neighbors[:, 1]
-
         d_square = d ** 2
 
         for xy_i in candidates:
             x_i, y_i = xy_i
 
-            dx = neighbors_x - x_i
-            dy = neighbors_y - y_i
+            close_neighbors = neighbors[np.abs(neighbors[:, 0] - x_i) < d]
+
+            dx = close_neighbors[:, 0] - x_i
+            dy = close_neighbors[:, 1] - y_i
 
             sq_distances = np.power(dx, 2.0) + np.power(dy, 2.0)
 

--- a/seaborn/tests/test_categorical.py
+++ b/seaborn/tests/test_categorical.py
@@ -1636,17 +1636,11 @@ class TestSwarmPlotter(CategoricalFixture):
                        order=None, hue_order=None, split=False,
                        orient=None, color=None, palette=None)
 
-    def test_overlap(self):
-
-        p = cat._SwarmPlotter(**self.default_kws)
-        nt.assert_false(p.overlap((0, 0), (1, 1), np.sqrt(1.999)))
-        nt.assert_true(p.overlap((0, 0), (1, 1), np.sqrt(2.001)))
-
     def test_could_overlap(self):
 
         p = cat._SwarmPlotter(**self.default_kws)
         neighbors = p.could_overlap((1, 1), [(0, 0), (1, .5), (.5, .5)], 1)
-        nt.assert_equal(neighbors, [(1, .5), (.5, .5)])
+        npt.assert_array_equal(neighbors, [(1, .5), (.5, .5)])
 
     def test_position_candidates(self):
 
@@ -1663,7 +1657,7 @@ class TestSwarmPlotter(CategoricalFixture):
 
         p = cat._SwarmPlotter(**self.default_kws)
         candidates = [(.5, 1), (1, 1), (1.5, 1)]
-        neighbors = [(0, 1)]
+        neighbors = np.array([(0, 1)])
 
         first = p.first_non_overlapping_candidate(candidates, neighbors, 1)
         npt.assert_array_equal(first, (1, 1))

--- a/seaborn/tests/test_categorical.py
+++ b/seaborn/tests/test_categorical.py
@@ -1640,7 +1640,7 @@ class TestSwarmPlotter(CategoricalFixture):
 
         p = cat._SwarmPlotter(**self.default_kws)
         neighbors = p.could_overlap((1, 1), [(0, 0), (1, .5), (.5, .5)], 1)
-        npt.assert_array_equal(neighbors, [(1, .5), (.5, .5)])
+        npt.assert_array_equal(neighbors, [(.5, .5), (1, .5)])
 
     def test_position_candidates(self):
 

--- a/seaborn/tests/test_categorical.py
+++ b/seaborn/tests/test_categorical.py
@@ -1656,16 +1656,17 @@ class TestSwarmPlotter(CategoricalFixture):
         candidates = p.position_candidates(xy_i, neighbors, 1)
         dx1 = 1.05
         dx2 = np.sqrt(1 - .5 ** 2) * 1.05
-        nt.assert_equal(candidates,
-                        [(0, 1), (-dx1, 1), (dx1, 1), (dx2, 1), (-dx2, 1)])
+        npt.assert_array_equal(candidates,
+                               [(0, 1), (-dx1, 1), (dx1, 1), (dx2, 1), (-dx2, 1)])
 
-    def test_prune_candidates(self):
+    def test_find_first_non_overlapping_candidate(self):
 
         p = cat._SwarmPlotter(**self.default_kws)
-        candidates = [(.5, 1), (1, 1)]
+        candidates = [(.5, 1), (1, 1), (1.5, 1)]
         neighbors = [(0, 1)]
-        candidates = p.prune_candidates(candidates, neighbors, 1)
-        npt.assert_array_equal(candidates, np.array([(1, 1)]))
+
+        first = p.first_non_overlapping_candidate(candidates, neighbors, 1)
+        npt.assert_array_equal(first, (1, 1))
 
     def test_beeswarm(self):
 

--- a/seaborn/tests/test_categorical.py
+++ b/seaborn/tests/test_categorical.py
@@ -1651,7 +1651,8 @@ class TestSwarmPlotter(CategoricalFixture):
         dx1 = 1.05
         dx2 = np.sqrt(1 - .5 ** 2) * 1.05
         npt.assert_array_equal(candidates,
-                               [(0, 1), (-dx1, 1), (dx1, 1), (dx2, 1), (-dx2, 1)])
+                               [(0, 1), (-dx1, 1), (dx1, 1),
+                                (dx2, 1), (-dx2, 1)])
 
     def test_find_first_non_overlapping_candidate(self):
 

--- a/seaborn/tests/test_categorical.py
+++ b/seaborn/tests/test_categorical.py
@@ -1640,7 +1640,7 @@ class TestSwarmPlotter(CategoricalFixture):
 
         p = cat._SwarmPlotter(**self.default_kws)
         neighbors = p.could_overlap((1, 1), [(0, 0), (1, .5), (.5, .5)], 1)
-        npt.assert_array_equal(neighbors, [(.5, .5), (1, .5)])
+        npt.assert_array_equal(neighbors, [(1, .5), (.5, .5)])
 
     def test_position_candidates(self):
 


### PR DESCRIPTION
This PR changes the way swarmplot checks for point overlaps.

The way it currently works:
1. Swarmplot tries placing each of the swarm points one-by one.
2. Each time finding all the points the newly-placed point could be overlapping (i.e. points that are within one diameter from the point [NB: I suspect code uses "diameter" when it actually means "radius" but it doesn't matter here]).
3. Then it proposes new locations for points to be to the left/right of these points.
4. The algorithm then loops through all of these proposed points and check if they overlap with any of the previously found neighbours. If they do, these points are removed (leaving only non-overlapping points).
5. The algorithm then selects the middle-most point of the remaining points and places the new point there. Repeating everything.

Since overlap checking was the bottleneck, 
I changed the algorithm parts [4-5]  to pre-sort the candidate points by how close to the mid-point they are before checking for overlaps. In this scenario we need to only find one point that is good and thus can terminate early (a6ffdee)
I also moved some of the computations to numpy layer (4c4a29d). 
Tried out additional optimisations (other commits) but they did more bad than good so they were reverted.

To test the performance, I used the following script:

```python
import pandas as pd
import numpy as np
import click
import seaborn as sns
from matplotlib import pyplot as plt
import timeit

print(sns.__version__)

N = 1000
KS = ['a', 'b', 'c']


def generate_plot(n, close=True):
    values = np.random.randn(n)
    facets = np.random.choice(KS, size=n)

    data = pd.DataFrame({'x': facets, 'y': values})

    sns.swarmplot(x='x', y='y', data=data)
    if close:
        plt.close()


@click.command()
@click.option('-n', type=int, default=N)
@click.option('--show-plot', is_flag=True)
def main(n, show_plot):
    np.random.seed(2317)
    print('N = {}'.format(n))
    if show_plot:
        generate_plot(n, close=False)
        plt.show()
    else:
        n_loop = 10
        times = timeit.repeat('generate_plot(n)',
                               setup='from __main__ import generate_plot; n = {!r}'.format(n),
                               number=n_loop,
                               repeat=3)

        import pint
        ureg = pint.UnitRegistry()

        for time in sorted(times):
            time /= n_loop
            print('{:.2f~} per iter ({!r} s)'.format((time * ureg.seconds).to_compact(), time))


if __name__ == '__main__':
    main()
```

Before (993c6a2) and after images of the generated swarm with N=1000 (`python swarm_example.py -n 1000 --show-plot`).

Before:

![swarm-before](https://cloud.githubusercontent.com/assets/108413/23520163/a438c5a4-ff71-11e6-8f98-9b93d24de10f.png)

After:

![swarm-after](https://cloud.githubusercontent.com/assets/108413/23520170/a96612b6-ff71-11e6-82fa-13f6aa569011.png)

(there should be no difference in how they look)

On the other hand, here are the stats for runtimes.
It is clear that the performance scales better now (yellow line vs red line):

![image](https://cloud.githubusercontent.com/assets/108413/23520025/14d00e22-ff71-11e6-84bb-95acc738d5fb.png)


| Commit	| N |	Best	| Best (s) |
| --------- | --- | -----------| -------- |
| 993c6a2 | 10 | 77.05 ms | 0.077048394 |
| 993c6a2 | 100 | 103.49 ms | 0.103489597 |
| 993c6a2 | 1000 | 1.17 s | 1.173759292 |
| 993c6a2 | 2000 | 7.89 s | 7.894506943 |
| a6ffdeef7 | 10 | 77.98 ms | 0.077982094 |
| a6ffdeef7 | 100 | 108.26 ms | 0.108259719 |
| a6ffdeef7 | 1000 | 713.11 ms | 0.713108945 |
| a6ffdeef7 | 2000 | 3.35 s | 3.349439375 |
| 4c4a29da | 10 | 77.75 ms | 0.077749728 |
| 4c4a29da | 100 | 110.44 ms | 0.110443773 |
| 4c4a29da | 1000 | 641.97 ms | 0.641972809 |
| 4c4a29da | 2000 | 1.84 s | 1.835392294 |
| ed06906 | 10 | 81.05 ms | 0.08104773 |
| ed06906 | 100 | 109.21 ms | 0.109209078 |
| ed06906 | 1000 | 770.27 ms | 0.770273886 |
| ed06906 | 2000 | 2.27 s | 2.27069 |
| 684725e43186 | 10 | 80.99 ms | 0.080990762 |
| 684725e43186 | 100 | 113.14 ms | 0.113138432 |
| 684725e43186 | 1000 | 785.46 ms | 0.785456822 |
| 684725e43186 | 2000 | 2.23 s | 2.228930535 |
| 41afc3fa952e2 | 10 | 79.99 ms | 0.079991932 |
| 41afc3fa952e2 | 100 | 110.46 ms  | 0.110459668 |
| 41afc3fa952e2 | 1000 | 650.15 ms | 0.650152328 |
| 41afc3fa952e2 | 2000 | 1.80 s | 1.795588099
