### PR TITLE
Don't fail on PerfectSeparationError in regplot logistic regression

### DIFF
--- a/seaborn/linearmodels.py
+++ b/seaborn/linearmodels.py
@@ -252,7 +252,8 @@ class _RegressionPlotter(_LinearPlotter):
             try:
                 yhat = model(_y, _x, **kwargs).fit().predict(grid)
             except glm.PerfectSeparationError:
-                yhat = np.ones(len(grid)) * np.nan
+                yhat = np.empty(len(grid))
+                yhat.fill(np.nan)
             return yhat
 
         yhat = reg_func(X, y)

--- a/seaborn/linearmodels.py
+++ b/seaborn/linearmodels.py
@@ -247,12 +247,14 @@ class _RegressionPlotter(_LinearPlotter):
         X, y = np.c_[np.ones(len(self.x)), self.x], self.y
         grid = np.c_[np.ones(len(grid)), grid]
         import statsmodels.genmod.generalized_linear_model as glm
+
         def reg_func(_x, _y):
             try:
                 yhat = model(_y, _x, **kwargs).fit().predict(grid)
             except glm.PerfectSeparationError:
                 yhat = np.ones(len(grid)) * np.nan
             return yhat
+
         yhat = reg_func(X, y)
         if self.ci is None:
             return yhat, None

--- a/seaborn/linearmodels.py
+++ b/seaborn/linearmodels.py
@@ -246,7 +246,13 @@ class _RegressionPlotter(_LinearPlotter):
         """More general regression function using statsmodels objects."""
         X, y = np.c_[np.ones(len(self.x)), self.x], self.y
         grid = np.c_[np.ones(len(grid)), grid]
-        reg_func = lambda _x, _y: model(_y, _x, **kwargs).fit().predict(grid)
+        import statsmodels.genmod.generalized_linear_model as glm
+        def reg_func(_x, _y):
+            try:
+                yhat = model(_y, _x, **kwargs).fit().predict(grid)
+            except glm.PerfectSeparationError:
+                yhat = np.ones(len(grid)) * np.nan
+            return yhat
         yhat = reg_func(X, y)
         if self.ci is None:
             return yhat, None

--- a/seaborn/tests/test_linearmodels.py
+++ b/seaborn/tests/test_linearmodels.py
@@ -350,6 +350,15 @@ class TestRegressionPlotter(PlotTestCase):
         npt.assert_array_less(0, yhat)
 
     @skipif(_no_statsmodels)
+    def test_logistic_perfect_separation(self):
+
+        y = self.df.x > self.df.x.mean()
+        p = lm._RegressionPlotter("x", y, data=self.df,
+                                  logistic=True, n_boot=10)
+        _, yhat, _ = p.fit_regression(x_range=(-3, 3))
+        nt.assert_true(np.isnan(yhat).all())
+
+    @skipif(_no_statsmodels)
     def test_robust_regression(self):
 
         p_ols = lm._RegressionPlotter("x", "y", data=self.df,


### PR DESCRIPTION
Instead, return an array of nans as yhat which will propogate through to no regression plot (when the data have a perfect separation) or no error bands (when at least one bootstrap sample has a perfect separation).

Arguably the nans should be pruned from at least the bootstraps, but this seems like a good way to indicate "something isn't quite right with the confidence intervals".