### PR TITLE
Fix incorrect indent level in tsplot

### DIFF
--- a/seaborn/timeseries.py
+++ b/seaborn/timeseries.py
@@ -327,11 +327,11 @@ def tsplot(data, time=None, unit=None, condition=None, value=None,
         label = cond if legend else "_nolegend_"
         ax.plot(x, central_data, color=color, label=label, **kwargs)
 
-    # Pad the sides of the plot only when not interpolating
-    ax.set_xlim(x.min(), x.max())
-    x_diff = x[1] - x[0]
-    if not interpolate:
-        ax.set_xlim(x.min() - x_diff, x.max() + x_diff)
+        # Pad the sides of the plot only when not interpolating
+        ax.set_xlim(x.min(), x.max())
+        x_diff = x[1] - x[0]
+        if not interpolate:
+            ax.set_xlim(x.min() - x_diff, x.max() + x_diff)
 
     # Add the plot labels
     if xlabel is not None:


### PR DESCRIPTION
The variable `x` is only set when multiple traces are plotted via `data.groupby(...)`; this causes the later call to `ax.set_extent()` to fail, because it relies on that `x`. I intermittently and inconsistently ran into a bug here when analyzing a dataset, and this fix worked fine. An alternative would be to be sure to set `x` outside of the groupby loop, if for some reason it isn't entered.