### PR TITLE
Add optional colorbar for bivariate KDE plots

### DIFF
--- a/doc/releases/v0.8.0.txt
+++ b/doc/releases/v0.8.0.txt
@@ -4,6 +4,8 @@ v0.8.0 (Unreleased)
 
 - Added the ``dodge`` argument to :func:`boxplot`, :func:`violinplot`, and :func:`barplot` to allow use of ``hue`` without changing the position or width of the plot elements, as when the ``hue`` varible is not nested within the main categorical variable.
 
+- Added the ability to draw a colorbar for a bivariate :func:`kdeplot` with the ``cbar`` parameter (and related ``cbar_ax`` and ``cbar_kws`` parameters).
+
 - Allow side-specific offsets in :func:`despine`.
 
 - Put a cap on the number of bins used in :func:`jointplot` for ``type=="hex"`` to avoid hanging when the reference rule prescribes too many.

--- a/seaborn/distributions.py
+++ b/seaborn/distributions.py
@@ -353,7 +353,7 @@ def _scipy_univariate_kde(data, bw, gridsize, cut, clip):
 
 def _bivariate_kdeplot(x, y, filled, fill_lowest,
                        kernel, bw, gridsize, cut, clip,
-                       axlabel, ax, **kwargs):
+                       axlabel, cbar, cbar_ax, cbar_kws, ax, **kwargs):
     """Plot a joint KDE estimate as a bivariate contour plot."""
     # Determine the clipping
     if clip is None:
@@ -384,6 +384,10 @@ def _bivariate_kdeplot(x, y, filled, fill_lowest,
     if filled and not fill_lowest:
         cset.collections[0].set_alpha(0)
     kwargs["n_levels"] = n_levels
+
+    if cbar:
+        cbar_kws = {} if cbar_kws is None else cbar_kws
+        ax.figure.colorbar(cset, cbar_ax, ax, **cbar_kws)
 
     # Label the axes
     if hasattr(x, "name") and axlabel:
@@ -441,7 +445,8 @@ def _scipy_bivariate_kde(x, y, bw, gridsize, cut, clip):
 
 def kdeplot(data, data2=None, shade=False, vertical=False, kernel="gau",
             bw="scott", gridsize=100, cut=3, clip=None, legend=True,
-            cumulative=False, shade_lowest=True, ax=None, **kwargs):
+            cumulative=False, shade_lowest=True, cbar=False, cbar_ax=None,
+            cbar_kws=None, ax=None, **kwargs):
     """Fit and plot a univariate or bivariate kernel density estimate.
 
     Parameters
@@ -557,6 +562,13 @@ def kdeplot(data, data2=None, shade=False, vertical=False, kernel="gau",
 
         >>> ax = sns.kdeplot(x, cut=0)
 
+    Add a colorbar for the contours:
+
+    .. plot::
+        :context: close-figs
+
+        >>> ax = sns.kdeplot(x, y, cbar=True)
+
     Plot two shaded bivariate densities:
 
     .. plot::
@@ -597,7 +609,7 @@ def kdeplot(data, data2=None, shade=False, vertical=False, kernel="gau",
     if bivariate:
         ax = _bivariate_kdeplot(x, y, shade, shade_lowest,
                                 kernel, bw, gridsize, cut, clip, legend,
-                                ax, **kwargs)
+                                cbar, cbar_ax, cbar_kws, ax, **kwargs)
     else:
         ax = _univariate_kdeplot(data, shade, vertical, kernel, bw,
                                  gridsize, cut, clip, legend, ax,

--- a/seaborn/tests/test_distributions.py
+++ b/seaborn/tests/test_distributions.py
@@ -3,6 +3,7 @@ import pandas as pd
 import matplotlib as mpl
 import matplotlib.pyplot as plt
 
+from distutils.version import LooseVersion
 import nose.tools as nt
 import numpy.testing as npt
 from numpy.testing.decorators import skipif
@@ -16,6 +17,9 @@ try:
     _no_statsmodels = False
 except ImportError:
     _no_statsmodels = True
+
+
+_old_matplotlib = LooseVersion(mpl.__version__) < "1.5"
 
 
 class TestKDE(PlotTestCase):
@@ -110,6 +114,7 @@ class TestKDE(PlotTestCase):
         nt.assert_equal(ax_series.collections[0].get_paths(),
                         ax_values.collections[0].get_paths())
 
+    @skipif(_old_matplotlib)
     def test_bivariate_kde_colorbar(self):
 
         f, ax = plt.subplots()

--- a/seaborn/tests/test_distributions.py
+++ b/seaborn/tests/test_distributions.py
@@ -110,6 +110,15 @@ class TestKDE(PlotTestCase):
         nt.assert_equal(ax_series.collections[0].get_paths(),
                         ax_values.collections[0].get_paths())
 
+    def test_bivariate_kde_colorbar(self):
+
+        f, ax = plt.subplots()
+        dist.kdeplot(self.x, self.y,
+                     cbar=True, cbar_kws=dict(label="density"),
+                     ax=ax)
+        nt.assert_equal(len(f.axes), 2)
+        nt.assert_equal(f.axes[1].get_ylabel(), "density")
+
 
 class TestJointPlot(PlotTestCase):
 


### PR DESCRIPTION
I think this is of somewhat dubious informational value but many people seem quite keen on it (#312) and it's reasonably compatible with the API for `heatmap` (though I still dislike how many arguments to `kdeplot` depend on the form of the input).