### PR TITLE
Avoid comparison of numpy arrays to [] for equality.

### DIFF
--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -141,7 +141,7 @@ class _HeatMapper(object):
         # Get the positions and used label for the ticks
         nx, ny = data.T.shape
 
-        if xticklabels == []:
+        if len(xticklabels) == 0:
             self.xticks = []
             self.xticklabels = []
         else:
@@ -149,7 +149,7 @@ class _HeatMapper(object):
             self.xticks = np.arange(xstart, xend, xstep) + .5
             self.xticklabels = xticklabels[xstart:xend:xstep]
 
-        if yticklabels == []:
+        if len(yticklabels) == 0:
             self.yticks = []
             self.yticklabels = []
         else:

--- a/seaborn/tests/test_matrix.py
+++ b/seaborn/tests/test_matrix.py
@@ -1,6 +1,5 @@
 import contextlib
 import itertools
-import pkg_resources
 import tempfile
 import warnings
 
@@ -1072,17 +1071,7 @@ class TestClustermap(PlotTestCase):
                     'error', 'elementwise.*comparison', FutureWarning)
                 warnings.filterwarnings(
                     'error', 'elementwise.*comparison', DeprecationWarning)
-                npv = pkg_resources.parse_version(np.__version__)
-                npv_warning = pkg_resources.parse_version('1.9.0')
-                #npv_change = pkg_resources.parse_version('?.?.?')
-                if npv < npv_warning:
-                    yield
-                #elif npv < npv_change:
-                else:
-                    with nt.assert_raises(Warning):
-                        yield
-                #else:
-                #    yield
+                yield
         df = pd.DataFrame(
             [
                 ['f', 'f', 1.0], ['f', 'b', 0.2], ['f', 'c', 0.3],


### PR DESCRIPTION
Avoids current warning

```    
seaborn/matrix.py:144: FutureWarning: elementwise comparison failed; returning scalar instead, but in the future will perform elementwise comparison
```

and presumably avoids future failure in seaborn.clustermap.  Reproducer is included as an automatic test.  (The warning appears to have changed between FutureWarning and DeprecationWarning across versions of numpy, so the automatic test to confirm the warning and its absence covers both.)

From Feras Saad.