### PR TITLE
Show standard deviation of observations in error bars

### DIFF
--- a/doc/releases/v0.8.0.txt
+++ b/doc/releases/v0.8.0.txt
@@ -6,6 +6,8 @@ v0.8.0 (Unreleased)
 
 - Added the ability to draw a colorbar for a bivariate :func:`kdeplot` with the ``cbar`` parameter (and related ``cbar_ax`` and ``cbar_kws`` parameters).
 
+- Added the ability to use error bars to show standard deviations rather than bootstrip confidence intervals in most statistical functions.
+
 - Allow side-specific offsets in :func:`despine`.
 
 - Put a cap on the number of bins used in :func:`jointplot` for ``type=="hex"`` to avoid hanging when the reference rule prescribes too many.

--- a/doc/releases/v0.8.0.txt
+++ b/doc/releases/v0.8.0.txt
@@ -6,7 +6,7 @@ v0.8.0 (Unreleased)
 
 - Added the ability to draw a colorbar for a bivariate :func:`kdeplot` with the ``cbar`` parameter (and related ``cbar_ax`` and ``cbar_kws`` parameters).
 
-- Added the ability to use error bars to show standard deviations rather than bootstrip confidence intervals in most statistical functions.
+- Added the ability to use error bars to show standard deviations rather than bootstrap confidence intervals in most statistical functions.
 
 - Allow side-specific offsets in :func:`despine`.
 

--- a/doc/releases/v0.8.0.txt
+++ b/doc/releases/v0.8.0.txt
@@ -6,7 +6,7 @@ v0.8.0 (Unreleased)
 
 - Added the ability to draw a colorbar for a bivariate :func:`kdeplot` with the ``cbar`` parameter (and related ``cbar_ax`` and ``cbar_kws`` parameters).
 
-- Added the ability to use error bars to show standard deviations rather than bootstrap confidence intervals in most statistical functions.
+- Added the ability to use error bars to show standard deviations rather than bootstrap confidence intervals in most statistical functions by putting `ci="sd"`.
 
 - Allow side-specific offsets in :func:`despine`.
 

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -1478,10 +1478,18 @@ class _CategoricalStatPlotter(_CategoricalPlotter):
                         confint.append([np.nan, np.nan])
                         continue
 
-                    boots = bootstrap(stat_data, func=estimator,
-                                      n_boot=n_boot,
-                                      units=unit_data)
-                    confint.append(utils.ci(boots, ci))
+                    if ci == "std":
+
+                        estimate = estimator(stat_data)
+                        sd = np.std(stat_data)
+                        confint.append((estimate - sd, estimate + sd))
+
+                    else:
+
+                        boots = bootstrap(stat_data, func=estimator,
+                                          n_boot=n_boot,
+                                          units=unit_data)
+                        confint.append(utils.ci(boots, ci))
 
             # Option 2: we are grouping by a hue layer
             # ----------------------------------------
@@ -1520,10 +1528,18 @@ class _CategoricalStatPlotter(_CategoricalPlotter):
                             confint[i].append([np.nan, np.nan])
                             continue
 
-                        boots = bootstrap(stat_data, func=estimator,
-                                          n_boot=n_boot,
-                                          units=unit_data)
-                        confint[i].append(utils.ci(boots, ci))
+                        if ci == "std":
+
+                            estimate = estimator(stat_data)
+                            sd = np.std(stat_data)
+                            confint[i].append((estimate - sd, estimate + sd))
+
+                        else:
+
+                            boots = bootstrap(stat_data, func=estimator,
+                                              n_boot=n_boot,
+                                              units=unit_data)
+                            confint[i].append(utils.ci(boots, ci))
 
         # Save the resulting values for plotting
         self.statistic = np.array(statistic)
@@ -2066,10 +2082,11 @@ _categorical_docs = dict(
     stat_api_params=dedent("""\
     estimator : callable that maps vector -> scalar, optional
         Statistical function to estimate within each categorical bin.
-    ci : float or None, optional
-        Size of confidence intervals to draw around estimated values. If
-        ``None``, no bootstrapping will be performed, and error bars will
-        not be drawn.
+    ci : float or "std" or None, optional
+        Size of confidence intervals to draw around estimated values.  If
+        "std", skip bootstrapping and draw the standard deviation of the
+        observerations. If ``None``, no bootstrapping will be performed, and
+        error bars will not be drawn.
     n_boot : int, optional
         Number of bootstrap iterations to use when computing confidence
         intervals.

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -1478,7 +1478,7 @@ class _CategoricalStatPlotter(_CategoricalPlotter):
                         confint.append([np.nan, np.nan])
                         continue
 
-                    if ci == "std":
+                    if ci == "sd":
 
                         estimate = estimator(stat_data)
                         sd = np.std(stat_data)
@@ -1528,7 +1528,7 @@ class _CategoricalStatPlotter(_CategoricalPlotter):
                             confint[i].append([np.nan, np.nan])
                             continue
 
-                        if ci == "std":
+                        if ci == "sd":
 
                             estimate = estimator(stat_data)
                             sd = np.std(stat_data)
@@ -2082,9 +2082,9 @@ _categorical_docs = dict(
     stat_api_params=dedent("""\
     estimator : callable that maps vector -> scalar, optional
         Statistical function to estimate within each categorical bin.
-    ci : float or "std" or None, optional
+    ci : float or "sd" or None, optional
         Size of confidence intervals to draw around estimated values.  If
-        "std", skip bootstrapping and draw the standard deviation of the
+        "sd", skip bootstrapping and draw the standard deviation of the
         observerations. If ``None``, no bootstrapping will be performed, and
         error bars will not be drawn.
     n_boot : int, optional
@@ -3124,7 +3124,7 @@ barplot.__doc__ = dedent("""\
     .. plot::
         :context: close-figs
 
-        >>> ax = sns.barplot(x="day", y="tip", data=tips, ci="std")
+        >>> ax = sns.barplot(x="day", y="tip", data=tips, ci="sd")
 
     Add "caps" to the error bars:
 
@@ -3370,7 +3370,7 @@ pointplot.__doc__ = dedent("""\
     .. plot::
         :context: close-figs
 
-        >>> ax = sns.pointplot(x="day", y="tip", data=tips, ci="std")
+        >>> ax = sns.pointplot(x="day", y="tip", data=tips, ci="sd")
 
     Add "caps" to the error bars:
 

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -3119,6 +3119,13 @@ barplot.__doc__ = dedent("""\
 
         >>> ax = sns.barplot(x="day", y="tip", data=tips, ci=68)
 
+    Show standard deviation of observations instead of a confidence interval:
+
+    .. plot::
+        :context: close-figs
+
+        >>> ax = sns.barplot(x="day", y="tip", data=tips, ci="std")
+
     Add "caps" to the error bars:
 
     .. plot::
@@ -3357,6 +3364,13 @@ pointplot.__doc__ = dedent("""\
         :context: close-figs
 
         >>> ax = sns.pointplot(x="day", y="tip", data=tips, ci=68)
+
+    Show standard deviation of observations instead of a confidence interval:
+
+    .. plot::
+        :context: close-figs
+
+        >>> ax = sns.pointplot(x="day", y="tip", data=tips, ci="std")
 
     Add "caps" to the error bars:
 

--- a/seaborn/linearmodels.py
+++ b/seaborn/linearmodels.py
@@ -166,9 +166,9 @@ class _RegressionPlotter(_LinearPlotter):
                 cis.append(None)
             else:
                 units = None
-                if self.x_ci == "std":
-                    std = np.std(_y)
-                    _ci = est - std, est + std
+                if self.x_ci == "sd":
+                    sd = np.std(_y)
+                    _ci = est - sd, est + sd
                 else:
                     if self.units is not None:
                         units = self.units[x == val]
@@ -442,10 +442,10 @@ _regression_docs = dict(
         ``x_estimator`` is ``numpy.mean``.\
     """),
     x_ci=dedent("""\
-    x_ci : "ci", "std", int in [0, 100] or None, optional
+    x_ci : "ci", "sd", int in [0, 100] or None, optional
         Size of the confidence interval used when plotting a central tendency
         for discrete values of ``x``. If ``"ci"``, defer to the value of the
-        ``ci`` parameter. If ``"std"``, skip bootstrappig and show the standard
+        ``ci`` parameter. If ``"sd"``, skip bootstrappig and show the standard
         deviation of the observations in each bin.\
     """),
     scatter=dedent("""\

--- a/seaborn/linearmodels.py
+++ b/seaborn/linearmodels.py
@@ -166,11 +166,15 @@ class _RegressionPlotter(_LinearPlotter):
                 cis.append(None)
             else:
                 units = None
-                if self.units is not None:
-                    units = self.units[x == val]
-                boots = algo.bootstrap(_y, func=self.x_estimator,
-                                       n_boot=self.n_boot, units=units)
-                _ci = utils.ci(boots, self.x_ci)
+                if self.x_ci == "std":
+                    std = np.std(_y)
+                    _ci = est - std, est + std
+                else:
+                    if self.units is not None:
+                        units = self.units[x == val]
+                    boots = algo.bootstrap(_y, func=self.x_estimator,
+                                           n_boot=self.n_boot, units=units)
+                    _ci = utils.ci(boots, self.x_ci)
                 cis.append(_ci)
 
         return vals, points, cis
@@ -424,7 +428,7 @@ _regression_docs = dict(
     x_estimator : callable that maps vector -> scalar, optional
         Apply this function to each unique value of ``x`` and plot the
         resulting estimate. This is useful when ``x`` is a discrete variable.
-        If ``x_ci`` is not ``None``, this estimate will be bootstrapped and a
+        If ``x_ci`` is given, this estimate will be bootstrapped and a
         confidence interval will be drawn.\
     """),
     x_bins=dedent("""\
@@ -438,10 +442,11 @@ _regression_docs = dict(
         ``x_estimator`` is ``numpy.mean``.\
     """),
     x_ci=dedent("""\
-    x_ci : "ci", int in [0, 100] or None, optional
+    x_ci : "ci", "std", int in [0, 100] or None, optional
         Size of the confidence interval used when plotting a central tendency
-        for discrete values of ``x``. If "ci", defer to the value of the``ci``
-        parameter.\
+        for discrete values of ``x``. If ``"ci"``, defer to the value of the
+        ``ci`` parameter. If ``"std"``, skip bootstrappig and show the standard
+        deviation of the observations in each bin.\
     """),
     scatter=dedent("""\
     scatter : bool, optional

--- a/seaborn/tests/test_categorical.py
+++ b/seaborn/tests/test_categorical.py
@@ -17,6 +17,7 @@ from .. import palettes
 
 
 pandas_has_categoricals = LooseVersion(pd.__version__) >= "0.15"
+mpl_barplot_change = LooseVersion("2.0.1")
 
 
 class CategoricalFixture(PlotTestCase):
@@ -1826,7 +1827,7 @@ class TestBarPlotter(CategoricalFixture):
         for bar, pos, stat in zip(ax.patches, positions, p.statistic):
             nt.assert_equal(bar.get_x(), pos)
             nt.assert_equal(bar.get_width(), p.width)
-            if LooseVersion(mpl.__version__) >= "2.0.2":
+            if mpl.__version__ >= mpl_barplot_change:
                 nt.assert_equal(bar.get_y(), 0)
                 nt.assert_equal(bar.get_height(), stat)
             else:
@@ -1852,7 +1853,7 @@ class TestBarPlotter(CategoricalFixture):
         for bar, pos, stat in zip(ax.patches, positions, p.statistic):
             nt.assert_equal(bar.get_y(), pos)
             nt.assert_equal(bar.get_height(), p.width)
-            if LooseVersion(mpl.__version__) >= "2.0.2":
+            if mpl.__version__ >= mpl_barplot_change:
                 nt.assert_equal(bar.get_x(), 0)
                 nt.assert_equal(bar.get_width(), stat)
             else:
@@ -1883,7 +1884,7 @@ class TestBarPlotter(CategoricalFixture):
             nt.assert_almost_equal(bar.get_width(), p.nested_width)
 
         for bar, stat in zip(ax.patches, p.statistic.T.flat):
-            if LooseVersion(mpl.__version__) >= "2.0.2":
+            if LooseVersion(mpl.__version__) >= mpl_barplot_change:
                 nt.assert_almost_equal(bar.get_y(), 0)
                 nt.assert_almost_equal(bar.get_height(), stat)
             else:
@@ -1914,7 +1915,7 @@ class TestBarPlotter(CategoricalFixture):
             nt.assert_almost_equal(bar.get_height(), p.nested_width)
 
         for bar, stat in zip(ax.patches, p.statistic.T.flat):
-            if LooseVersion(mpl.__version__) >= "2.0.2":
+            if LooseVersion(mpl.__version__) >= mpl_barplot_change:
                 nt.assert_almost_equal(bar.get_x(), 0)
                 nt.assert_almost_equal(bar.get_width(), stat)
             else:

--- a/seaborn/tests/test_categorical.py
+++ b/seaborn/tests/test_categorical.py
@@ -602,7 +602,7 @@ class TestCategoricalStatPlotter(CategoricalFixture):
         npt.assert_array_equal(p.confint[2],
                                np.zeros((3, 2)) * np.nan)
 
-    def test_std_error_bars(self):
+    def test_sd_error_bars(self):
 
         p = cat._CategoricalStatPlotter()
 
@@ -610,7 +610,7 @@ class TestCategoricalStatPlotter(CategoricalFixture):
         y = pd.Series(np.random.RandomState(0).randn(300))
 
         p.establish_variables(g, y)
-        p.estimate_statistic(np.mean, "std", None)
+        p.estimate_statistic(np.mean, "sd", None)
 
         nt.assert_equal(p.statistic.shape, (3,))
         nt.assert_equal(p.confint.shape, (3, 2))
@@ -624,7 +624,7 @@ class TestCategoricalStatPlotter(CategoricalFixture):
             ci_want = mean - half_ci, mean + half_ci
             npt.assert_array_almost_equal(ci_want, ci, 2)
 
-    def test_nested_std_error_bars(self):
+    def test_nested_sd_error_bars(self):
 
         p = cat._CategoricalStatPlotter()
 
@@ -633,7 +633,7 @@ class TestCategoricalStatPlotter(CategoricalFixture):
         y = pd.Series(np.random.RandomState(0).randn(300))
 
         p.establish_variables(g, y, h)
-        p.estimate_statistic(np.mean, "std", None)
+        p.estimate_statistic(np.mean, "sd", None)
 
         nt.assert_equal(p.statistic.shape, (3, 2))
         nt.assert_equal(p.confint.shape, (3, 2, 2))

--- a/seaborn/tests/test_linearmodels.py
+++ b/seaborn/tests/test_linearmodels.py
@@ -158,6 +158,10 @@ class TestRegressionPlotter(PlotTestCase):
         nt.assert_equal(p.ci, 95)
         nt.assert_equal(p.x_ci, 68)
 
+        p = lm._RegressionPlotter("x", "y", data=self.df, ci=95, x_ci="std")
+        nt.assert_equal(p.ci, 95)
+        nt.assert_equal(p.x_ci, "std")
+
     @skipif(_no_statsmodels)
     def test_fast_regression(self):
 

--- a/seaborn/tests/test_linearmodels.py
+++ b/seaborn/tests/test_linearmodels.py
@@ -158,9 +158,9 @@ class TestRegressionPlotter(PlotTestCase):
         nt.assert_equal(p.ci, 95)
         nt.assert_equal(p.x_ci, 68)
 
-        p = lm._RegressionPlotter("x", "y", data=self.df, ci=95, x_ci="std")
+        p = lm._RegressionPlotter("x", "y", data=self.df, ci=95, x_ci="sd")
         nt.assert_equal(p.ci, 95)
-        nt.assert_equal(p.x_ci, "std")
+        nt.assert_equal(p.x_ci, "sd")
 
     @skipif(_no_statsmodels)
     def test_fast_regression(self):

--- a/seaborn/timeseries.py
+++ b/seaborn/timeseries.py
@@ -281,8 +281,11 @@ def tsplot(data, time=None, unit=None, condition=None, value=None,
         x = df_c.columns.values.astype(np.float)
 
         # Bootstrap the data for confidence intervals
-        if ci == "std":
-            cis = [np.std(df_c.values, axis=0)]
+        if "std" in ci:
+            est = estimator(df_c.values, axis=0)
+            std = np.std(df_c.values, axis=0)
+            cis = [(est - std, est + std)]
+            boot_data = df_c.values
         else:
             boot_data = algo.bootstrap(df_c.values, n_boot=n_boot,
                                        axis=0, func=estimator)

--- a/seaborn/timeseries.py
+++ b/seaborn/timeseries.py
@@ -61,9 +61,9 @@ def tsplot(data, time=None, unit=None, condition=None, value=None,
         Names of ways to plot uncertainty across units from set of
         {ci_band, ci_bars, boot_traces, boot_kde, unit_traces, unit_points}.
         Can use one or more than one method.
-    ci : float or list of floats in [0, 100] or "std" or None
+    ci : float or list of floats in [0, 100] or "sd" or None
         Confidence interval size(s). If a list, it will stack the error plots
-        for each confidence interval. If ``"std"``, show standard deviation of
+        for each confidence interval. If ``"sd"``, show standard deviation of
         the observations instead of boostrapped confidence intervals. Only
         relevant for error styles with "ci" in the name.
     interpolate : boolean
@@ -149,7 +149,7 @@ def tsplot(data, time=None, unit=None, condition=None, value=None,
     .. plot::
         :context: close-figs
 
-        >>> ax = sns.tsplot(data=data, ci="std")
+        >>> ax = sns.tsplot(data=data, ci="sd")
 
     Use a different estimator:
 
@@ -288,10 +288,10 @@ def tsplot(data, time=None, unit=None, condition=None, value=None,
         x = df_c.columns.values.astype(np.float)
 
         # Bootstrap the data for confidence intervals
-        if "std" in ci:
+        if "sd" in ci:
             est = estimator(df_c.values, axis=0)
-            std = np.std(df_c.values, axis=0)
-            cis = [(est - std, est + std)]
+            sd = np.std(df_c.values, axis=0)
+            cis = [(est - sd, est + sd)]
             boot_data = df_c.values
         else:
             boot_data = algo.bootstrap(df_c.values, n_boot=n_boot,

--- a/seaborn/timeseries.py
+++ b/seaborn/timeseries.py
@@ -61,10 +61,11 @@ def tsplot(data, time=None, unit=None, condition=None, value=None,
         Names of ways to plot uncertainty across units from set of
         {ci_band, ci_bars, boot_traces, boot_kde, unit_traces, unit_points}.
         Can use one or more than one method.
-    ci : float or list of floats in [0, 100]
-        Confidence interval size(s). If a list, it will stack the error
-        plots for each confidence interval. Only relevant for error styles
-        with "ci" in the name.
+    ci : float or list of floats in [0, 100] or "std" or None
+        Confidence interval size(s). If a list, it will stack the error plots
+        for each confidence interval. If ``"std"``, show standard deviation of
+        the observations instead of boostrapped confidence intervals. Only
+        relevant for error styles with "ci" in the name.
     interpolate : boolean
         Whether to do a linear interpolation between each timepoint when
         plotting. The value of this parameter also determines the marker
@@ -280,9 +281,12 @@ def tsplot(data, time=None, unit=None, condition=None, value=None,
         x = df_c.columns.values.astype(np.float)
 
         # Bootstrap the data for confidence intervals
-        boot_data = algo.bootstrap(df_c.values, n_boot=n_boot,
-                                   axis=0, func=estimator)
-        cis = [utils.ci(boot_data, v, axis=0) for v in ci]
+        if ci == "std":
+            cis = [np.std(df_c.values, axis=0)]
+        else:
+            boot_data = algo.bootstrap(df_c.values, n_boot=n_boot,
+                                       axis=0, func=estimator)
+            cis = [utils.ci(boot_data, v, axis=0) for v in ci]
         central_data = estimator(df_c.values, axis=0)
 
         # Get the color for this condition

--- a/seaborn/timeseries.py
+++ b/seaborn/timeseries.py
@@ -144,6 +144,13 @@ def tsplot(data, time=None, unit=None, condition=None, value=None,
 
         >>> ax = sns.tsplot(data=data, ci=[68, 95], color="m")
 
+    Show the standard deviation of the observations:
+
+    .. plot::
+        :context: close-figs
+
+        >>> ax = sns.tsplot(data=data, ci="std")
+
     Use a different estimator:
 
     .. plot::


### PR DESCRIPTION
It's now possible to do `ci="sd"` in functions that draw error bars and the error bars will show the standard deviation of observations instead of boostrapped confidence intervals.

A little semantically confused, but better than adding new keyword arguments.