### PR TITLE
Added checks for input types for distributions.jointplot

### DIFF
--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -4,6 +4,8 @@ from distutils.version import LooseVersion
 import warnings
 from textwrap import dedent
 
+from six import string_types
+
 import numpy as np
 import pandas as pd
 import matplotlib as mpl
@@ -1649,10 +1651,17 @@ class JointGrid(object):
 
         # Possibly extract the variables from a DataFrame
         if data is not None:
-            if x in data:
-                x = data[x]
-            if y in data:
-                y = data[y]
+            msg = "'{}' is not a valid column name of 'data'"
+            if isinstance(x, string_types):
+                if x in data:
+                    x = data[x]
+                else:
+                    raise KeyError(msg.format(x))
+            if isinstance(y, string_types):
+                if y in data:
+                    y = data[y]
+                else:
+                    raise KeyError(msg.format(y))
 
         # Possibly drop NA
         if dropna:

--- a/seaborn/distributions.py
+++ b/seaborn/distributions.py
@@ -800,15 +800,6 @@ def jointplot(x, y, data=None, kind="scatter", stat_func=stats.pearsonr,
         ...                   s=40, edgecolor="w", linewidth=1)
 
     """
-    # Verify that 'x' and 'y' are valid column names if 'data' is passed
-    if data is not None:
-        if not isinstance(data, pd.DataFrame):
-            msg = "If passed, 'data' has to be of type {}"
-            raise TypeError(msg.format(type(pd.DataFrame())))
-        for column in (x, y):
-            if column not in data.columns:
-                msg = "'{}' is not a valid column name of 'data'"
-                raise KeyError(msg.format(column))
 
     # Set up empty default kwarg dicts
     if joint_kws is None:

--- a/seaborn/distributions.py
+++ b/seaborn/distributions.py
@@ -800,6 +800,16 @@ def jointplot(x, y, data=None, kind="scatter", stat_func=stats.pearsonr,
         ...                   s=40, edgecolor="w", linewidth=1)
 
     """
+    # Verify that 'x' and 'y' are valid column names if 'data' is passed
+    if data is not None:
+        if not isinstance(data, pd.DataFrame):
+            msg = "If passed, 'data' has to be of type {}"
+            raise TypeError(msg.format(type(pd.DataFrame())))
+        for column in (x, y):
+            if column not in data.columns:
+                msg = "'{}' is not a valid column name of 'data'"
+                raise KeyError(msg.format(column))
+
     # Set up empty default kwarg dicts
     if joint_kws is None:
         joint_kws = {}

--- a/seaborn/tests/test_distributions.py
+++ b/seaborn/tests/test_distributions.py
@@ -134,8 +134,6 @@ class TestJointPlot(PlotTestCase):
 
     def test_input(self):
 
-        with nt.assert_raises(TypeError):
-            dist.jointplot("x", "y", self.rs)
         with nt.assert_raises(KeyError):
             dist.jointplot("not_a_column", "y", self.data)
             dist.jointplot("x", "not_a_column", self.data)

--- a/seaborn/tests/test_distributions.py
+++ b/seaborn/tests/test_distributions.py
@@ -132,6 +132,14 @@ class TestJointPlot(PlotTestCase):
     y = rs.randn(100)
     data = pd.DataFrame(dict(x=x, y=y))
 
+    def test_input(self):
+        
+        with nt.assert_raises(TypeError):
+            dist.jointplot("x", "y", self.rs)
+        with nt.assert_raises(KeyError):
+            dist.jointplot("not_a_column", "y", self.data)
+            dist.jointplot("x", "not_a_column", self.data)
+
     def test_scatter(self):
 
         g = dist.jointplot("x", "y", self.data)

--- a/seaborn/tests/test_distributions.py
+++ b/seaborn/tests/test_distributions.py
@@ -133,7 +133,7 @@ class TestJointPlot(PlotTestCase):
     data = pd.DataFrame(dict(x=x, y=y))
 
     def test_input(self):
-        
+
         with nt.assert_raises(TypeError):
             dist.jointplot("x", "y", self.rs)
         with nt.assert_raises(KeyError):


### PR DESCRIPTION
Added a couple of checks for `distributions.jointplot`:
* Check if `data` is a `pandas.DataFrame` (if passed)
* Check if `x` and `y` are valid column names in `data`

Added a test unit as well