### PR TITLE
Don't set seaborn style on import

### DIFF
--- a/doc/installing.rst
+++ b/doc/installing.rst
@@ -60,24 +60,6 @@ matplotlibs will work fine.
 
 Seaborn is tested on the most recent versions offered through ``conda``.
 
-
-Importing seaborn
-~~~~~~~~~~~~~~~~~
-
-Seaborn will apply its default style parameters to the global matplotlib style
-dictionary when you import it. This will change the look of all plots,
-including those created by using matplotlib functions directly. To avoid this
-behavior and use the default matplotlib aesthetics (along with any
-customization in your ``matplotlibrc``), you can import the ``seaborn.apionly``
-namespace.
-
-Seaborn has several other pre-packaged styles along with high-level :ref:`tools
-<aesthetics_tutorial>` for managing them, so you should not limit yourself to the
-default aesthetics.
-
-By convention, ``seaborn`` is abbreviated to ``sns`` on import.
-
-
 Testing
 ~~~~~~~
 
@@ -105,14 +87,8 @@ report.
 Known issues
 ~~~~~~~~~~~~
 
-There is a `bug <https://github.com/matplotlib/matplotlib/issues/2654>`_ in the
-matplotlib OSX backend that causes unavoidable problems with some of the
-seaborn functions (particularly those that draw multi-panel figures). If you
-encounter this, you will want to try a `different backend
-<http://matplotlib.org/api/matplotlib_configuration_api.html>`_. In particular, this bug affects any multi-panel figure that internally calls the matplotlib ``tight_layout`` function.
-
 An unfortunate consequence of how the matplotlib marker styles work is that
 line-art markers (e.g. ``"+"``) or markers with ``facecolor`` set to ``"none"``
 will be invisible when the default seaborn style is in effect. This can be
 changed by using a different ``markeredgewidth`` (aliased to ``mew``) either in
-the function call or globally in the `rcParams`.
+the function call or globally in the ``rcParams``.

--- a/doc/releases/v0.8.0.txt
+++ b/doc/releases/v0.8.0.txt
@@ -2,6 +2,8 @@
 v0.8.0 (Unreleased)
 -------------------
 
+- The default style is no longer applied when seaborn is imported. It is now necessary to explicitly call :func:`set` or one or more of :func:`set_style`, :func:`set_context`, and :func:`set_palette`. Correspondingly, the ``seaborn.apionly`` module has been deprecated.
+
 - Changed the behavior of :func:`heatmap` (and by extension :func:`clustermap`) when plotting divergent dataesets (i.e. when the ``center`` parameter is used). Instead of extending the lower and upper limits of the colormap to be symettrical around the ``center`` value, the colormap is modified so that its middle color corresponds to ``center``. This means that the full range of the colormap will not be used (unless the data or specified ``vmin`` and ``vmax`` are symettric), but the upper and lower limits of the colorbar will correspond to the range of the data. See the Github pull request `(#1184) <https://github.com/mwaskom/seaborn/pull/1184>`_ for examples of the behavior.
 
 - Removed automatic detection of diverging data in :func:`heatmap` (and by extension :func:`clustermap`). If you want the colormap to be treated as diverging (see above), it is now necessary to specify the ``center`` value. When no colormap is specified, specifying ``center`` will still change the default to be one that is more appropriate for displaying diverging data.

--- a/doc/tutorial/aesthetics.ipynb
+++ b/doc/tutorial/aesthetics.ipynb
@@ -47,6 +47,7 @@
     "import numpy as np\n",
     "import matplotlib as mpl\n",
     "import matplotlib.pyplot as plt\n",
+    "import seaborn as sns\n",
     "np.random.seed(sum(map(ord, \"aesthetics\")))"
    ]
   },
@@ -93,7 +94,7 @@
    "cell_type": "raw",
    "metadata": {},
    "source": [
-    "To switch to seaborn defaults, simply import the package."
+    "To switch to seaborn defaults, simply call the :func:`set` function."
    ]
   },
   {
@@ -104,7 +105,7 @@
    },
    "outputs": [],
    "source": [
-    "import seaborn as sns\n",
+    "sns.set()\n",
     "sinplot()"
    ]
   },
@@ -112,7 +113,7 @@
    "cell_type": "raw",
    "metadata": {},
    "source": [
-    "The seaborn defaults break from the MATLAB inspired aesthetic of matplotlib to plot in more muted colors over a light gray background with white grid lines. We find that the grid aids in the use of figures for conveying quantitative information – in almost all cases, figures should be preferred to tables. The white-on-gray grid that is used by default avoids being obtrusive. The grid is particularly useful in giving structure to figures with multiple facets, which is central to some of the more complex tools in the library.\n",
+    "(Note that in versions of seaborn prior to 0.8, :func:`set` was called on import. On later versions, it must be explicitly invoked).\n",
     "\n",
     "Seaborn splits matplotlib parameters into two independent groups. The first group sets the aesthetic style of the plot, and the second scales various elements of the figure so that it can be easily incorporated into different contexts.\n",
     "\n",
@@ -460,7 +461,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.11"
+   "version": "2.7.12"
   }
  },
  "nbformat": 4,

--- a/seaborn/__init__.py
+++ b/seaborn/__init__.py
@@ -18,7 +18,4 @@ from .xkcd_rgb import xkcd_rgb
 from .crayons import crayons
 from . import cm
 
-# Set default aesthetics
-set()
-
 __version__ = "0.8.dev"

--- a/seaborn/apionly.py
+++ b/seaborn/apionly.py
@@ -1,7 +1,7 @@
 import warnings
 msg = (
-"The seaborn.apionly module is deprecated, as seaborn no longer sets a default "
-"style on import. It will be removed in a future version."
+    "As seaborn no longer sets a default style on import, the seaborn.apionly "
+    "module is deprecated. It will be removed in a future version."
 )
 warnings.warn(msg, UserWarning)
 

--- a/seaborn/apionly.py
+++ b/seaborn/apionly.py
@@ -1,2 +1,9 @@
+import warnings
+msg = (
+"The seaborn.apionly module is deprecated, as seaborn no longer sets a default "
+"style on import. It will be removed in a future version."
+)
+warnings.warn(msg, UserWarning)
+
 from seaborn import *
 reset_orig()

--- a/seaborn/rcmod.py
+++ b/seaborn/rcmod.py
@@ -186,9 +186,9 @@ def axes_style(style=None, rc=None):
             "xtick.color": dark_gray,
             "ytick.color": dark_gray,
             "axes.axisbelow": True,
-            "image.cmap": "Greys",
+            "image.cmap": "rocket",
             "font.family": ["sans-serif"],
-            "font.sans-serif": ["Arial", "Liberation Sans",
+            "font.sans-serif": ["DejaVu Sans", "Arial", "Liberation Sans",
                                 "Bitstream Vera Sans", "sans-serif"],
             "grid.linestyle": "-",
             "lines.solid_capstyle": "round",
@@ -348,7 +348,7 @@ def plotting_context(context=None, font_scale=1, rc=None):
         # Set up dictionary of default parameters
         base_context = {
 
-            "figure.figsize": np.array([8, 5.5]),
+            "figure.figsize": np.array([6.4, 4.8]),
             "font.size": 12,
             "axes.labelsize": 11,
             "axes.titlesize": 12,


### PR DESCRIPTION
In recognition of the substantial improvements in the matplotlib style defaults in 2.0, importing seaborn will no longer change the rcParams. It is now necessary to explicitly invoke ``sns.set()`` to get the default gray grid style. Correspondingly, the ``seaborn.apionly`` module has been deprecated.

Additionally, this PR updates a couple of style defaults for better compatibility with matplotlib 2.0+.