### PR TITLE
Don't depend on ticks for heatmap annotations

### DIFF
--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -233,7 +233,8 @@ class _HeatMapper(object):
     def _annotate_heatmap(self, ax, mesh):
         """Add textual labels with the value in each cell."""
         mesh.update_scalarmappable()
-        xpos, ypos = np.meshgrid(ax.get_xticks(), ax.get_yticks())
+        height, width = self.annot_data.shape
+        xpos, ypos = np.meshgrid(np.arange(width) + .5, np.arange(height) + .5)
         for x, y, m, color, val in zip(xpos.flat, ypos.flat,
                                        mesh.get_array(), mesh.get_facecolors(),
                                        self.annot_data.flat):

--- a/seaborn/tests/test_matrix.py
+++ b/seaborn/tests/test_matrix.py
@@ -284,6 +284,12 @@ class TestHeatmap(PlotTestCase):
             nt.assert_equal(text.get_text(), "{:.1f}".format(val))
             nt.assert_equal(text.get_fontsize(), 14)
 
+    def test_heatmap_annotation_with_limited_ticklabels(self):
+        ax = mat.heatmap(self.df_norm, fmt=".2f", annot=True,
+                         xticklabels=False, yticklabels=False)
+        for val, text in zip(self.x_norm.flat, ax.texts):
+            nt.assert_equal(text.get_text(), "{:.2f}".format(val))
+
     def test_heatmap_cbar(self):
 
         f = plt.figure()


### PR DESCRIPTION
Will now show annotations on all cells regardless of what value
x/yticklabels take. Fixes #837.