### PR TITLE
type check for pairplot

### DIFF
--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -2004,10 +2004,10 @@ def pairplot(data, hue=None, hue_order=None, palette=None,
         ...                  diag_kws=dict(shade=True))
 
     """
-    if not isinstance(data,pd.DataFrame):
+    if not isinstance(data, pd.DataFrame):
         raise TypeError(
             "'data' must be pandas DataFrame object, not: {typefound}".format(
-            	typefound=type(data)))
+                typefound=type(data)))
 
     if plot_kws is None:
         plot_kws = {}

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -2004,6 +2004,11 @@ def pairplot(data, hue=None, hue_order=None, palette=None,
         ...                  diag_kws=dict(shade=True))
 
     """
+    if not isinstance(data,pd.DataFrame):
+        raise TypeError(
+            "'data' must be pandas DataFrame object, not: {typefound}".format(
+            	typefound=type(data)))
+
     if plot_kws is None:
         plot_kws = {}
     if diag_kws is None:


### PR DESCRIPTION
added a check for the `data` argument in the pairplot function . Raises a `TypeError` if it is not a `DataFrame` . 

Fixes issue #1067 