### PR TITLE
Distplot emptycheck issue1227

### DIFF
--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -2004,10 +2004,10 @@ def pairplot(data, hue=None, hue_order=None, palette=None,
         ...                  diag_kws=dict(shade=True))
 
     """
-    if not isinstance(data,pd.DataFrame):
+    if not isinstance(data, pd.DataFrame):
         raise TypeError(
             "'data' must be pandas DataFrame object, not: {typefound}".format(
-            	typefound=type(data)))
+                typefound=type(data)))
 
     if plot_kws is None:
         plot_kws = {}

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -2004,6 +2004,11 @@ def pairplot(data, hue=None, hue_order=None, palette=None,
         ...                  diag_kws=dict(shade=True))
 
     """
+    if not isinstance(data,pd.DataFrame):
+        raise TypeError(
+            "'data' must be pandas DataFrame object, not: {typefound}".format(
+            	typefound=type(data)))
+
     if plot_kws is None:
         plot_kws = {}
     if diag_kws is None:

--- a/seaborn/distributions.py
+++ b/seaborn/distributions.py
@@ -170,6 +170,10 @@ def distplot(a, bins=None, hist=True, kde=True, rug=False, fit=None,
     # Make a a 1-d array
     a = np.asarray(a).squeeze()
 
+    #check if array is empty
+    if a.shape[0] < 1:
+        raise ValueError('Empty array')
+
     # Decide if the hist is normed
     norm_hist = norm_hist or kde or (fit is not None)
 

--- a/seaborn/distributions.py
+++ b/seaborn/distributions.py
@@ -157,6 +157,13 @@ def distplot(a, bins=None, hist=True, kde=True, rug=False, fit=None,
         ...                             "alpha": 1, "color": "g"})
 
     """
+    # Make a a 1-d array
+    a = np.asarray(a).squeeze()
+
+    # Check if array is empty
+    if a.shape[0] < 1:
+        raise ValueError('Empty array')
+
     if ax is None:
         ax = plt.gca()
 
@@ -166,13 +173,6 @@ def distplot(a, bins=None, hist=True, kde=True, rug=False, fit=None,
         axlabel = a.name
         if axlabel is not None:
             label_ax = True
-
-    # Make a a 1-d array
-    a = np.asarray(a).squeeze()
-
-    #check if array is empty
-    if a.shape[0] < 1:
-        raise ValueError('Empty array')
 
     # Decide if the hist is normed
     norm_hist = norm_hist or kde or (fit is not None)


### PR DESCRIPTION
added a check to make sure array-like argument of `distplot` is not empty, raises `ValueError` if it is. I moved the array creation and check before  the `ax`  gets created so it errors before instantiating an axis. 

Fixes #1136 . 