### PR TITLE
fix IndexError in ClusterGrid when x/yticklabels is set to False

### DIFF
--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -1115,8 +1115,14 @@ class ClusterGrid(Grid):
                 cbar_kws=colorbar_kws, mask=self.mask,
                 xticklabels=xtl, yticklabels=ytl, **kws)
 
-        xtl_rot = self.ax_heatmap.get_xticklabels()[0].get_rotation()
-        ytl_rot = self.ax_heatmap.get_yticklabels()[0].get_rotation()
+        try:
+            xtl_rot = self.ax_heatmap.get_xticklabels()[0].get_rotation()
+        except IndexError:
+            xtl_rot = 0
+        try:
+            ytl_rot = self.ax_heatmap.get_yticklabels()[0].get_rotation()
+        except IndexError:
+            ytl_rot = 0
 
         self.ax_heatmap.yaxis.set_ticks_position('right')
         self.ax_heatmap.yaxis.set_label_position('right')


### PR DESCRIPTION
If you try to create a clustermap with x or yticklabels set to False, you get an IndexError:

    >>> import seaborn as sns; sns.set(color_codes=True)
    >>> iris = sns.load_dataset("iris")
    >>> species = iris.pop("species")
    >>> g = sns.clustermap(iris, yticklabels=False)

```
/home/me/Virtualenvs/py35/lib/python3.5/site-packages/seaborn/matrix.py in clustermap(data, pivot_kws, method, metric, z_score, standard_scale, figsize, cbar_kws, row_cluster, col_cluster, row_linkage, col_linkage, row_colors, col_colors, mask, **kwargs)
   1299                         row_cluster=row_cluster, col_cluster=col_cluster,
   1300                         row_linkage=row_linkage, col_linkage=col_linkage,
-> 1301                         **kwargs)

/home/me/Virtualenvs/py35/lib/python3.5/site-packages/seaborn/matrix.py in plot(self, metric, method, colorbar_kws, row_cluster, col_cluster, row_linkage, col_linkage, **kws)
   1140 
   1141         self.plot_colors(xind, yind, **kws)
-> 1142         self.plot_matrix(colorbar_kws, xind, yind, **kws)
   1143         return self
   1144 

/home/me/Virtualenvs/py35/lib/python3.5/site-packages/seaborn/matrix.py in plot_matrix(self, colorbar_kws, xind, yind, **kws)
   1117 
   1118         xtl_rot = self.ax_heatmap.get_xticklabels()[0].get_rotation()
-> 1119         ytl_rot = self.ax_heatmap.get_yticklabels()[0].get_rotation()
   1120 
   1121         self.ax_heatmap.yaxis.set_ticks_position('right')

IndexError: list index out of range

```

This pull request is a simple fix to that problem, if not very elegant.