### PR TITLE
added check for empty array in distplot before ax creation

### DIFF
--- a/seaborn/distributions.py
+++ b/seaborn/distributions.py
@@ -157,6 +157,13 @@ def distplot(a, bins=None, hist=True, kde=True, rug=False, fit=None,
         ...                             "alpha": 1, "color": "g"})
 
     """
+    # Make a a 1-d array
+    a = np.asarray(a).squeeze()
+
+    # Check if array is empty
+    if a.shape[0] < 1:
+        raise ValueError('Empty array')
+
     if ax is None:
         ax = plt.gca()
 
@@ -166,9 +173,6 @@ def distplot(a, bins=None, hist=True, kde=True, rug=False, fit=None,
         axlabel = a.name
         if axlabel is not None:
             label_ax = True
-
-    # Make a a 1-d array
-    a = np.asarray(a).squeeze()
 
     # Decide if the hist is normed
     norm_hist = norm_hist or kde or (fit is not None)


### PR DESCRIPTION
Moved `distplot` array creation above `ax` instantiation and raises a `ValueError` if array is empty. 