### PR TITLE
Fix legend_out with GUI backend

### DIFF
--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -93,7 +93,7 @@ class Grid(object):
             figlegend._legend_title_box._text.set_font_properties(prop)
 
             # Draw the plot to set the bounding boxes correctly
-            plt.draw()
+            self.fig.draw(self.fig.canvas.get_renderer())
 
             # Calculate and set the new width of the figure so the legend fits
             legend_width = figlegend.get_window_extent().width / self.fig.dpi
@@ -101,7 +101,7 @@ class Grid(object):
             self.fig.set_figwidth(figure_width + legend_width)
 
             # Draw the plot again to get the new transformations
-            plt.draw()
+            self.fig.draw(self.fig.canvas.get_renderer())
 
             # Now calculate how much space we need on the right side
             legend_width = figlegend.get_window_extent().width / self.fig.dpi


### PR DESCRIPTION
There was a bug that FacetGrid.add_legend() with legend_out=True did not
work when the backend was "GUI"-based ones such as Qt5Agg and
NbAgg (checked with matplotlib 2.0.2).  Note that it was working
correctly with Agg backend.  This is likely because pyplot.draw calls
canvas.draw_idle() which may not force re-draw [1].

[1] https://github.com/matplotlib/matplotlib/blob/v2.0.2/lib/matplotlib/pyplot.py#L691


You can check the bug with the following script.

```python
def plot_with_backend(backend):
    import matplotlib as mpl
    mpl.use(backend)
    import seaborn as sns

    tips = sns.load_dataset('tips')
    g = sns.lmplot('total_bill', 'tip', tips, hue='smoker', fit_reg=False)
    g.savefig(backend + '.png')

# plot_with_backend(Agg')  # works fine w/o this PR
plot_with_backend('Qt5Agg')
```

Before this patch, it produces:
![image](https://user-images.githubusercontent.com/29282/28054150-b46e2046-65c8-11e7-9a91-b2971ae7e852.png)

After this patch, it produces:
![image](https://user-images.githubusercontent.com/29282/28054176-cb768094-65c8-11e7-802f-3a982e282a65.png)
