### PR TITLE
Add warning in FacetGrid when drawing categorical plots

### DIFF
--- a/doc/releases/v0.8.1.txt
+++ b/doc/releases/v0.8.1.txt
@@ -2,6 +2,8 @@
 v0.8.1 (Unreleased)
 -------------------
 
+- Added a warning in :class:`FacetGrid` when passing a categorical plot function without specifying ``order`` (or ``hue_order`` when ``hue`` is used), which is likely to produce a plot that is incorrect.
+
 - Fixed a problem where the :class:`FacetGrid` or :class:`PairGrid` legend remained inside the figure when using ``legend_out=True`` on an interactive backend.
 
 - Fixed an bug in :func:`clustermap` when using ``yticklabels=False``.

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -500,7 +500,7 @@ class FacetGrid(Grid):
             :context: close-figs
 
             >>> g = sns.FacetGrid(tips, col="day", size=4, aspect=.5)
-            >>> g = g.map(sns.boxplot, "time", "total_bill")
+            >>> g = g.map(plt.hist, "total_bill", bins=bins)
 
         Specify the order for plot elements:
 
@@ -549,9 +549,8 @@ class FacetGrid(Grid):
             :context: close-figs
 
             >>> attend = sns.load_dataset("attention")
-            >>> g = sns.FacetGrid(attend, col="subject", col_wrap=5,
-            ...                   size=1.5, ylim=(0, 10))
-            >>> g = g.map(sns.pointplot, "solutions", "score", scale=.7)
+            >>> g = sns.FacetGrid(attend, col="subject", col_wrap=5, size=1.5)
+            >>> g = g.map(plt.plot, "solutions", "score", marker=".")
 
         Define a custom bivariate function to map onto the grid:
 

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -695,6 +695,19 @@ class FacetGrid(Grid):
         # If color was a keyword argument, grab it here
         kw_color = kwargs.pop("color", None)
 
+        # Check for categorical plots without order information
+        if func.__module__ == "seaborn.categorical":
+            if "order" not in kwargs:
+                warning = ("Using the {} function without specifying "
+                           "`order` is likely to produce an incorrect "
+                           "plot.".format(func.__name__))
+                warnings.warn(warning)
+            if len(args) == 3 and "hue_order" not in kwargs:
+                warning = ("Using the {} function without specifying "
+                           "`hue_order` is likely to produce an incorrect "
+                           "plot.".format(func.__name__))
+                warnings.warn(warning)
+
         # Iterate over the data subsets
         for (row_i, col_j, hue_k), data_ijk in self.facet_data():
 

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -322,7 +322,10 @@ class _CategoricalPlotter(object):
         def is_categorical(s):
             try:
                 # Correct way, but doesnt exist in older Pandas
-                return pd.core.common.is_categorical_dtype(s)
+                try:
+                    return pd.api.types.is_categorical_dtype(s)
+                except AttributeError:
+                    return pd.core.common.is_categorical_dtype(s)
             except AttributeError:
                 # Also works, but feels hackier
                 return str(s.dtype) == "categorical"

--- a/seaborn/tests/test_axisgrid.py
+++ b/seaborn/tests/test_axisgrid.py
@@ -475,7 +475,7 @@ class TestFacetGrid(PlotTestCase):
 
         x, y = np.arange(10), np.arange(10)
         df = pd.DataFrame(np.c_[x, y], columns=["x", "y"])
-        g = ag.FacetGrid(df).map(pointplot, "x", "y")
+        g = ag.FacetGrid(df).map(pointplot, "x", "y", order=x)
         g.set_xticklabels(step=2)
         got_x = [int(l.get_text()) for l in g.axes[0, 0].get_xticklabels()]
         npt.assert_array_equal(x[::2], got_x)
@@ -726,6 +726,14 @@ class TestFacetGrid(PlotTestCase):
         g = ag.FacetGrid(df[df['a'] == 'a'], col="a", col_wrap=1)
 
         nt.assert_equal(g.axes.shape, (len(df['a'].cat.categories),))
+
+    def test_categorical_warning(self):
+
+        g = ag.FacetGrid(self.df, col="b")
+        with warnings.catch_warnings():
+            warnings.resetwarnings()
+            warnings.simplefilter("always")
+            npt.assert_warns(UserWarning, g.map, pointplot, "b", "x")
 
 
 class TestPairGrid(PlotTestCase):


### PR DESCRIPTION
It is risky to pass a categorical plotting function into `FacetGrid.map()` without providing order information. If category levels are not consistently present across all facets, the plot order and/or labeling is likely to be incorrect. `sns.factorplot` exists in part to handle this bookkeeping for people, but I still see lots of questions about unexpected behavior when using `sns.FacetGrid` directly. This change tries to predict when users are doing something risky and fire a warning to inform them.