### PR TITLE
Avoid turning off axes autoscaling in kdeplot

### DIFF
--- a/seaborn/distributions.py
+++ b/seaborn/distributions.py
@@ -329,9 +329,9 @@ def _univariate_kdeplot(data, shade, vertical, kernel, bw, gridsize, cut,
     # Set the density axis minimum to 0
     xmargin, ymargin = ax.margins()
     if vertical:
-        ax.set_xlim(0, max(ax.get_xlim()[1], (1 + xmargin) * x.max()))
+        ax.set_xlim(0, auto=None)
     else:
-        ax.set_ylim(0, max(ax.get_ylim()[1], (1 + ymargin) * y.max()))
+        ax.set_ylim(0, auto=None)
 
     # Draw the legend here
     handles, labels = ax.get_legend_handles_labels()


### PR DESCRIPTION
This related to #1272 .

The reason the maximum axes limits were not being updated correctly is that `set_ylim` and `set_xlim` [turn off axes autoscaling by default](https://github.com/matplotlib/matplotlib/blob/master/lib/matplotlib/axes/_base.py#L2857-L2859). So the axes would be scaled to the first data set that was plotted with `sns.kdeplot`, but then remain at that level for all following plots into the same axes. By passing `auto=None`, the axes' current autoscaling setting is kept intact and there is no need to specify the max value.

 I initially didn't realize you already fixed this since I was running 0.8.0, but the approach in this PR might avoid future issues related to turning off the axes autoscaling, so I am posting it here in case you prefer it.