### PR TITLE
Rotate all axis labels when setting ticklabels

### DIFF
--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -882,7 +882,7 @@ class FacetGrid(Grid):
 
     def set_xticklabels(self, labels=None, step=None, **kwargs):
         """Set x axis tick labels on the bottom row of the grid."""
-        for ax in self._bottom_axes:
+        for ax in self.axes.flat:
             if labels is None:
                 labels = [l.get_text() for l in ax.get_xticklabels()]
                 if step is not None:
@@ -890,14 +890,16 @@ class FacetGrid(Grid):
                     labels = labels[::step]
                     ax.set_xticks(xticks)
             ax.set_xticklabels(labels, **kwargs)
+        self.fig.tight_layout()
         return self
 
     def set_yticklabels(self, labels=None, **kwargs):
         """Set y axis tick labels on the left column of the grid."""
-        for ax in self._left_axes:
+        for ax in self.axes.flat:
             if labels is None:
                 labels = [l.get_text() for l in ax.get_yticklabels()]
             ax.set_yticklabels(labels, **kwargs)
+        self.fig.tight_layout()
         return self
 
     def set_titles(self, template=None, row_template=None,  col_template=None,


### PR DESCRIPTION
This would change `g.set_xticklabels` and `g.set_yticklabels` to not only apply to bottom and left axes.

I recently came across [this SO post](https://stackoverflow.com/questions/41434126/rotate-x-axis-ticks-for-all-facetgrid-plots), where the `g.set_xticklabels` only rotates the bottom x-axis labels when there are x-axis labels on multiple rows in the plot. I would also expect that all visible x-axis labels are rotated when using `g.set_xticklabels`, what is your opinion on this?

The suggested fix in this PR always applies `g.set_xticklabels` to all labels instead of only the bottom labels. I did not see any immediate drawbacks to applying this to hidden labels, but if you do, I can add a condition to only apply it to visible xticklabels. I also included the same suggested fix for the y-labels.


## xticklabels

```python
tips = sns.load_dataset('tips')
g = sns.FacetGrid(tips, col='day', col_wrap=2, sharex=False)
g.map(sns.barplot, 'sex', 'tip')
g = g.set_xticklabels(rotation=45)
```
### Current behavior

![image](https://user-images.githubusercontent.com/4560057/32085339-5d593a92-ba9c-11e7-9b99-c57ca29b7061.png)

### Suggested new behavior

![image](https://user-images.githubusercontent.com/4560057/32085347-680f2172-ba9c-11e7-9709-86215537359f.png)

## yticklabels

```python
tips = sns.load_dataset('tips')
g = sns.FacetGrid(tips, col='day', col_wrap=2, sharey=False)
g.map(sns.barplot, 'tip', 'sex')
g = g.set_yticklabels(rotation=45)
```

### Current behavior

![image](https://user-images.githubusercontent.com/4560057/32085361-7c43ca3a-ba9c-11e7-9726-5d0a3884536a.png)

### Suggested new behavior

![image](https://user-images.githubusercontent.com/4560057/32085368-83dddd1c-ba9c-11e7-8d65-7e2ad4a825a2.png)
