### PR TITLE
Add snap_axis parameter to kde plot

### DIFF
--- a/seaborn/distributions.py
+++ b/seaborn/distributions.py
@@ -261,7 +261,7 @@ def distplot(a, bins=None, hist=True, kde=True, rug=False, fit=None,
 
 
 def _univariate_kdeplot(data, shade, vertical, kernel, bw, gridsize, cut,
-                        clip, legend, ax, cumulative=False, **kwargs):
+                        clip, legend, snap_axis, ax, cumulative=False, **kwargs):
     """Plot a univariate kernel density estimate on one of the axes."""
 
     # Sort out the clipping
@@ -327,11 +327,12 @@ def _univariate_kdeplot(data, shade, vertical, kernel, bw, gridsize, cut,
             ax.fill_between(x, 0, y, **shade_kws)
 
     # Set the density axis minimum to 0
-    xmargin, ymargin = ax.margins()
-    if vertical:
-        ax.set_xlim(0, max(ax.get_xlim()[1], (1 + xmargin) * x.max()))
-    else:
-        ax.set_ylim(0, max(ax.get_ylim()[1], (1 + ymargin) * y.max()))
+    if snap_axis:
+        xmargin, ymargin = ax.margins()
+        if vertical:
+            ax.set_xlim(0, max(ax.get_xlim()[1], (1 + xmargin) * x.max()))
+        else:
+            ax.set_ylim(0, max(ax.get_ylim()[1], (1 + ymargin) * y.max()))
 
     # Draw the legend here
     handles, labels = ax.get_legend_handles_labels()
@@ -466,8 +467,8 @@ def _scipy_bivariate_kde(x, y, bw, gridsize, cut, clip):
 
 def kdeplot(data, data2=None, shade=False, vertical=False, kernel="gau",
             bw="scott", gridsize=100, cut=3, clip=None, legend=True,
-            cumulative=False, shade_lowest=True, cbar=False, cbar_ax=None,
-            cbar_kws=None, ax=None, **kwargs):
+            cumulative=False, shade_lowest=True, snap_axis=True, cbar=False,
+            cbar_ax=None, cbar_kws=None, ax=None, **kwargs):
     """Fit and plot a univariate or bivariate kernel density estimate.
 
     Parameters
@@ -503,6 +504,9 @@ def kdeplot(data, data2=None, shade=False, vertical=False, kernel="gau",
         relevant when drawing a univariate plot or when ``shade=False``.
         Setting this to ``False`` can be useful when you want multiple
         densities on the same Axes.
+    snap_axis : bool, optional
+        If True and drawing a univariate KDE, adjust the value axis to zero to
+        prevent whitespace between the KDE line and the axis spine.
     cbar : bool, optional
         If True and drawing a bivariate KDE plot, add a colorbar.
     cbar_ax : matplotlib axes, optional
@@ -657,7 +661,7 @@ def kdeplot(data, data2=None, shade=False, vertical=False, kernel="gau",
                                 cbar, cbar_ax, cbar_kws, ax, **kwargs)
     else:
         ax = _univariate_kdeplot(data, shade, vertical, kernel, bw,
-                                 gridsize, cut, clip, legend, ax,
+                                 gridsize, cut, clip, legend, snap_axis, ax,
                                  cumulative=cumulative, **kwargs)
 
     return ax


### PR DESCRIPTION
Currently, when using `sns.kdeplot`, the minimum limit on the value axis is "snapped" to zero. This is great when using the kde plot alone, but might be undesirable when combining it with other plot types, e.g. `sns.rugplot`, since there will be overlapping plot elements.

In addition, when using `sns.kdeplot` in a `FacetGrid` with a defined `ylim`, the impression becomes that the `ylim` parameter is not working as expected, since the y-min is readjusted to zero by `sns.kdeplot`.

The motivation with this PR is to make it explicit that kdeplot modifies the value axis min, and to provide a parameter to turn off this behavior to make kdeplots work as expected with the FacetGrid axes limit parameters.

## Examples

```python
# Create sample data for overlapping rug / kdeplot
import numpy as np
import pandas as pd
import seaborn as sns

np.random.seed(4)
dists = {}
dists['lognormal'] = np.random.lognormal(size=100)
dists['chisquare'] = np.random.chisquare(5, size=100)
dists['uniform'] = np.random.uniform(0, 12, size=100)
df = pd.DataFrame.from_dict(dists).melt()
```

### Current behavior

```python
g = sns.FacetGrid(df, hue='variable', aspect=1.8, ylim=(-0.03, 0.5))
g = g.map(sns.kdeplot,'value')
g = g.map(sns.rugplot,'value')
```
![image](https://user-images.githubusercontent.com/4560057/32147180-7e0408b6-bcb9-11e7-934b-5a1b7e2b9f5f.png)

### Suggested behavior

The proposed parameter `snap_axis` could be set to `False` to respect the y-limits specified in the call to FacetGrid. This option might also increase awareness that `sns.kdeplot` is automatically adjusting the y-min.

```python
g = sns.FacetGrid(df, hue='variable', aspect=1.8, ylim=(-0.03, 0.5))
g = g.map(sns.kdeplot,'value', snap_axis=False)
g = g.map(sns.rugplot,'value')
```
![image](https://user-images.githubusercontent.com/4560057/32147183-85dfb684-bcb9-11e7-8eb1-22594435b38f.png)

## Notes

Note that the same results could currently be achieved by changing the y-limits manually between the calls to `FacetGrid.map`.

```python
g = sns.FacetGrid(df, hue='variable', aspect=1.8)
g = g.map(sns.kdeplot,'value')
g.ax.set_ylim(-0.03, None, auto=None)
g = g.map(sns.rugplot,'value')
```
However, it could still be a good idea to be explicit about that `sns.kdeplot`  snaps y-min to zero, and adding the `snap_axis` parameter would also make the suggested behavior possible with `sns.distplot` in a `FacetGrid`:

```python
g = sns.FacetGrid(df, hue='variable', aspect=1.8, ylim=(-0.03, 0.5))
g.map(sns.distplot, 'value', rug=True, hist=False, kde_kws={'snap_axis':False})
```

*On a side note, let me know if you prefer that I open an issue to discuss a topic before submitting a PR*