### PR TITLE
fix AttributeError that occurs when using with ci='sd' and err_style='ci_bars'

### DIFF
--- a/seaborn/timeseries.py
+++ b/seaborn/timeseries.py
@@ -383,7 +383,8 @@ def _plot_ci_band(ax, x, ci, color, err_kws, **kwargs):
 
 def _plot_ci_bars(ax, x, central_data, ci, color, err_kws, **kwargs):
     """Plot error bars at each data point."""
-    for x_i, y_i, (low, high) in zip(x, central_data, ci.T):
+    ci_low, ci_high = ci
+    for x_i, y_i, low, high in zip(x, central_data, ci_low.T, ci_high.T):
         ax.plot([x_i, x_i], [low, high], color=color,
                 solid_capstyle="round", **err_kws)
 


### PR DESCRIPTION
`sns.tsplot(data=all_data_frames, condition=..., unit=..., time=...,value=..., err_style="ci_bars", ci='sd')` will throw an AttributeError in seaborn version 0.8.1. This is caused by the _plot_ci_bars function which assumes that ci has a transpose.
With err_style="ci_bars"  this is not the case as ci is a tuple.

This pull request fixes said problem.