### PR TITLE
set_figwidth in add_legend should forward its change

### DIFF
--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -98,7 +98,7 @@ class Grid(object):
             # Calculate and set the new width of the figure so the legend fits
             legend_width = figlegend.get_window_extent().width / self.fig.dpi
             figure_width = self.fig.get_figwidth()
-            self.fig.set_figwidth(figure_width + legend_width)
+            self.fig.set_figwidth(figure_width + legend_width, forward=True)
 
             # Draw the plot again to get the new transformations
             self.fig.draw(self.fig.canvas.get_renderer())


### PR DESCRIPTION
Using `add_legend`, the legend overlaps with the axes. This should be prevented by enlarging the figure width via `self.fig.set_figwidth`. However, this will only take effect if the figure is actually saved, else, one would need to call `set_figwidth(..., forward=True)`.

Example code:

```
import matplotlib.pyplot as plt
import numpy as np
import pandas as pd
import seaborn as sns

df = pd.DataFrame(np.random.rand(20,2), columns=['x', 'y'])
df["class"] = np.random.choice(["Class A","Class B"], size=20)

fg = sns.FacetGrid(data=df, hue='class')
fg.map(plt.scatter, 'x', 'y').add_legend()

plt.show()
```

produces 

![forwardfalse](https://user-images.githubusercontent.com/23121882/32865906-7a4b8500-ca65-11e7-9038-340429d591ef.png)

If instead `forward=True` is set in Line 101 the output would be

![forwardtrue](https://user-images.githubusercontent.com/23121882/32865936-9b12bb6e-ca65-11e7-8b8c-c9899e7d4db0.png)

as expected. This concerns only cases where the figure is not being saved beforehands, so it will not affect the inline images in notebooks or saved images. However the issue is present when showing the figure or e.g. using the `%matplotlib notebook` backend.