### PR TITLE
allow custom string annotations for matrix

### DIFF
--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -240,7 +240,10 @@ class _HeatMapper(object):
             if m is not np.ma.masked:
                 l = relative_luminance(color)
                 text_color = ".15" if l > .408 else "w"
-                annotation = ("{:" + self.fmt + "}").format(val)
+                if isinstance(val, str):
+                    annotation = val
+                else:
+                    annotation = ("{:" + self.fmt + "}").format(val)
                 text_kwargs = dict(color=text_color, ha="center", va="center")
                 text_kwargs.update(self.annot_kws)
                 ax.text(x, y, annotation, **text_kwargs)


### PR DESCRIPTION
This allows to pass `np.array(dtype=np.str)` as annotations for matrix 
Without this fix there is an error "unknown format code 'g' for object of type numpy.str_"