### PR TITLE
Add option for probability mass function to distplot()

### DIFF
--- a/doc/tutorial/distributions.ipynb
+++ b/doc/tutorial/distributions.ipynb
@@ -80,7 +80,23 @@
    "outputs": [],
    "source": [
     "x = np.random.normal(size=100)\n",
-    "sns.distplot(x);"
+    "sns.distplot(x)"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "The integral of the probability density function is 1 (roughly speaking the sum of width * height for all bars). If you want the histogram heights to sum up to one, then plot the probability mass function using the `norm_hist='mass'` keyword."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sns.distplot(x, norm_hist='mass', kde=False)"
    ]
   },
   {

--- a/seaborn/distributions.py
+++ b/seaborn/distributions.py
@@ -71,9 +71,11 @@ def distplot(a, bins=None, hist=True, kde=True, rug=False, fit=None,
         Color to plot everything but the fitted curve in.
     vertical : bool, optional
         If True, oberved values are on y-axis.
-    norm_hist : bool, optional
+    norm_hist : bool, or str, optional
         If True, the histogram height shows a density rather than a count.
         This is implied if a KDE or fitted density is plotted.
+        If 'mass', the histogram height shows a mass and the height of
+        all bars will sum up to 1.
     axlabel : string, False, or None, optional
         Name for the support axis label. If None, will try to get it
         from a.namel if False, do not set a label.
@@ -175,7 +177,8 @@ def distplot(a, bins=None, hist=True, kde=True, rug=False, fit=None,
         a = a.squeeze()
 
     # Decide if the hist is normed
-    norm_hist = norm_hist or kde or (fit is not None)
+    if norm_hist != 'mass':
+        norm_hist = norm_hist or kde or (fit is not None)
 
     # Handle dictionary defaults
     if hist_kws is None:
@@ -211,7 +214,10 @@ def distplot(a, bins=None, hist=True, kde=True, rug=False, fit=None,
         if bins is None:
             bins = min(_freedman_diaconis_bins(a), 50)
         hist_kws.setdefault("alpha", 0.4)
-        hist_kws.setdefault("normed", norm_hist)
+        if norm_hist == 'mass':
+            hist_kws.setdefault("weights", np.ones_like(a) / len(a))
+        else:
+            hist_kws.setdefault("normed", norm_hist)
         orientation = "horizontal" if vertical else "vertical"
         hist_color = hist_kws.pop("color", color)
         ax.hist(a, bins, orientation=orientation,


### PR DESCRIPTION
[On](https://stackoverflow.com/questions/5498008/pylab-histdata-normed-1-normalization-seems-to-work-incorrect) [popular](https://stackoverflow.com/questions/3866520/plotting-histograms-whose-bar-heights-sum-to-1-in-matplotlib) [demand](https://stackoverflow.com/questions/22241240/how-to-normalize-a-histogram-in-python) a lot of people want to plot the probability mass function instead of the probability density function, i.e. the height of the histogram bars should sum up 1 instead of the integral (height * width) sum up to 1.

This patch adds the option `sns.distplot(norm_hist='mass')` to achieve this.