### PR TITLE
Fix for list inputs to JointGrid

### DIFF
--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -1682,12 +1682,6 @@ class JointGrid(object):
                 err = "Could not interpret input '{}'".format(var)
                 raise ValueError(err)
 
-        # Possibly drop NA
-        if dropna:
-            not_na = pd.notnull(x) & pd.notnull(y)
-            x = x[not_na]
-            y = y[not_na]
-
         # Find the names of the variables
         if hasattr(x, "name"):
             xlabel = x.name
@@ -1696,9 +1690,18 @@ class JointGrid(object):
             ylabel = y.name
             ax_joint.set_ylabel(ylabel)
 
-        # Convert the x and y data to arrays for plotting
-        self.x = np.asarray(x)
-        self.y = np.asarray(y)
+        # Convert the x and y data to arrays for indexing and plotting
+        x_array = np.asarray(x)
+        y_array = np.asarray(y)
+
+        # Possibly drop NA
+        if dropna:
+            not_na = pd.notnull(x_array) & pd.notnull(y_array)
+            x_array = x_array[not_na]
+            y_array = y_array[not_na]
+
+        self.x = x_array
+        self.y = y_array
 
         if xlim is not None:
             ax_joint.set_xlim(xlim)

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -2670,9 +2670,11 @@ stripplot.__doc__ = dedent("""\
     .. plot::
         :context: close-figs
 
+        >>> import matplotlib.pyplot as plt
         >>> import seaborn as sns
         >>> sns.set_style("whitegrid")
         >>> tips = sns.load_dataset("tips")
+        >>> test_figure = plt.figure()
         >>> ax = sns.stripplot(x=tips["total_bill"])
 
     Group the strips by a categorical variable:
@@ -2680,6 +2682,7 @@ stripplot.__doc__ = dedent("""\
     .. plot::
         :context: close-figs
 
+        >>> test_figure = plt.figure()
         >>> ax = sns.stripplot(x="day", y="total_bill", data=tips)
 
     Add jitter to bring out the distribution of values:
@@ -2687,6 +2690,7 @@ stripplot.__doc__ = dedent("""\
     .. plot::
         :context: close-figs
 
+        >>> test_figure = plt.figure()
         >>> ax = sns.stripplot(x="day", y="total_bill", data=tips, jitter=True)
 
     Use a smaller amount of jitter:
@@ -2694,6 +2698,7 @@ stripplot.__doc__ = dedent("""\
     .. plot::
         :context: close-figs
 
+        >>> test_figure = plt.figure()
         >>> ax = sns.stripplot(x="day", y="total_bill", data=tips, jitter=0.05)
 
     Draw horizontal strips:
@@ -2701,6 +2706,7 @@ stripplot.__doc__ = dedent("""\
     .. plot::
         :context: close-figs
 
+        >>> test_figure = plt.figure()
         >>> ax = sns.stripplot(x="total_bill", y="day", data=tips,
         ...                    jitter=True)
 
@@ -2709,6 +2715,7 @@ stripplot.__doc__ = dedent("""\
     .. plot::
         :context: close-figs
 
+        >>> test_figure = plt.figure()
         >>> ax = sns.stripplot(x="total_bill", y="day", data=tips,
         ...                    jitter=True, linewidth=1)
 
@@ -2717,6 +2724,7 @@ stripplot.__doc__ = dedent("""\
     .. plot::
         :context: close-figs
 
+        >>> test_figure = plt.figure()
         >>> ax = sns.stripplot(x="sex", y="total_bill", hue="day",
         ...                    data=tips, jitter=True)
 
@@ -2726,6 +2734,7 @@ stripplot.__doc__ = dedent("""\
     .. plot::
         :context: close-figs
 
+        >>> test_figure = plt.figure()
         >>> ax = sns.stripplot(x="day", y="total_bill", hue="smoker",
         ...                    data=tips, jitter=True,
         ...                    palette="Set2", dodge=True)
@@ -2735,6 +2744,7 @@ stripplot.__doc__ = dedent("""\
     .. plot::
         :context: close-figs
 
+        >>> test_figure = plt.figure()
         >>> ax = sns.stripplot(x="time", y="tip", data=tips,
         ...                    order=["Dinner", "Lunch"])
 
@@ -2743,6 +2753,7 @@ stripplot.__doc__ = dedent("""\
     .. plot::
         :context: close-figs
 
+        >>> test_figure = plt.figure()
         >>> ax =  sns.stripplot("day", "total_bill", "smoker", data=tips,
         ...                    palette="Set2", size=20, marker="D",
         ...                    edgecolor="gray", alpha=.25)
@@ -2752,6 +2763,7 @@ stripplot.__doc__ = dedent("""\
     .. plot::
         :context: close-figs
 
+        >>> test_figure = plt.figure()
         >>> ax = sns.boxplot(x="tip", y="day", data=tips, whis=np.inf)
         >>> ax = sns.stripplot(x="tip", y="day", data=tips,
         ...                    jitter=True, color=".3")
@@ -2761,6 +2773,7 @@ stripplot.__doc__ = dedent("""\
     .. plot::
         :context: close-figs
 
+        >>> test_figure = plt.figure()
         >>> ax = sns.violinplot(x="day", y="total_bill", data=tips,
         ...                     inner=None, color=".8")
         >>> ax = sns.stripplot(x="day", y="total_bill", data=tips, jitter=True)
@@ -2773,6 +2786,7 @@ stripplot.__doc__ = dedent("""\
     .. plot::
         :context: close-figs
 
+        >>> test_figure = plt.figure()
         >>> g = sns.factorplot(x="sex", y="total_bill",
         ...                    hue="smoker", col="time",
         ...                    data=tips, kind="strip",
@@ -3224,9 +3238,11 @@ pointplot.__doc__ = dedent("""\
     .. plot::
         :context: close-figs
 
+        >>> import matplotlib.pyplot as plt
         >>> import seaborn as sns
         >>> sns.set_style("darkgrid")
         >>> tips = sns.load_dataset("tips")
+        >>> test_figure = plt.figure()
         >>> ax = sns.pointplot(x="time", y="total_bill", data=tips)
 
     Draw a set of vertical points with nested grouping by a two variables:
@@ -3234,6 +3250,7 @@ pointplot.__doc__ = dedent("""\
     .. plot::
         :context: close-figs
 
+        >>> test_figure = plt.figure()
         >>> ax = sns.pointplot(x="time", y="total_bill", hue="smoker",
         ...                    data=tips)
 
@@ -3242,6 +3259,7 @@ pointplot.__doc__ = dedent("""\
     .. plot::
         :context: close-figs
 
+        >>> test_figure = plt.figure()
         >>> ax = sns.pointplot(x="time", y="total_bill", hue="smoker",
         ...                    data=tips, dodge=True)
 
@@ -3250,6 +3268,7 @@ pointplot.__doc__ = dedent("""\
     .. plot::
         :context: close-figs
 
+        >>> test_figure = plt.figure()
         >>> ax = sns.pointplot(x="time", y="total_bill", hue="smoker",
         ...                    data=tips,
         ...                    markers=["o", "x"],
@@ -3260,6 +3279,7 @@ pointplot.__doc__ = dedent("""\
     .. plot::
         :context: close-figs
 
+        >>> test_figure = plt.figure()
         >>> ax = sns.pointplot(x="tip", y="day", data=tips)
 
     Don't draw a line connecting each point:
@@ -3267,6 +3287,7 @@ pointplot.__doc__ = dedent("""\
     .. plot::
         :context: close-figs
 
+        >>> test_figure = plt.figure()
         >>> ax = sns.pointplot(x="tip", y="day", data=tips, join=False)
 
     Use a different color for a single-layer plot:
@@ -3274,6 +3295,7 @@ pointplot.__doc__ = dedent("""\
     .. plot::
         :context: close-figs
 
+        >>> test_figure = plt.figure()
         >>> ax = sns.pointplot("time", y="total_bill", data=tips,
         ...                    color="#bb3f3f")
 
@@ -3282,6 +3304,7 @@ pointplot.__doc__ = dedent("""\
     .. plot::
         :context: close-figs
 
+        >>> test_figure = plt.figure()
         >>> ax = sns.pointplot(x="time", y="total_bill", hue="smoker",
         ...                    data=tips, palette="Set2")
 
@@ -3290,6 +3313,7 @@ pointplot.__doc__ = dedent("""\
     .. plot::
         :context: close-figs
 
+        >>> test_figure = plt.figure()
         >>> ax = sns.pointplot(x="time", y="tip", data=tips,
         ...                    order=["Dinner", "Lunch"])
 
@@ -3298,6 +3322,7 @@ pointplot.__doc__ = dedent("""\
     .. plot::
         :context: close-figs
 
+        >>> test_figure = plt.figure()
         >>> from numpy import median
         >>> ax = sns.pointplot(x="day", y="tip", data=tips, estimator=median)
 
@@ -3306,6 +3331,7 @@ pointplot.__doc__ = dedent("""\
     .. plot::
         :context: close-figs
 
+        >>> test_figure = plt.figure()
         >>> ax = sns.pointplot(x="day", y="tip", data=tips, ci=68)
 
     Show standard deviation of observations instead of a confidence interval:
@@ -3313,6 +3339,7 @@ pointplot.__doc__ = dedent("""\
     .. plot::
         :context: close-figs
 
+        >>> test_figure = plt.figure()
         >>> ax = sns.pointplot(x="day", y="tip", data=tips, ci="sd")
 
     Add "caps" to the error bars:
@@ -3320,6 +3347,7 @@ pointplot.__doc__ = dedent("""\
     .. plot::
         :context: close-figs
 
+        >>> test_figure = plt.figure()
         >>> ax = sns.pointplot(x="day", y="tip", data=tips, capsize=.2)
 
     Use :func:`factorplot` to combine a :func:`barplot` and a
@@ -3330,6 +3358,7 @@ pointplot.__doc__ = dedent("""\
     .. plot::
         :context: close-figs
 
+        >>> test_figure = plt.figure()
         >>> g = sns.factorplot(x="sex", y="total_bill",
         ...                    hue="smoker", col="time",
         ...                    data=tips, kind="point",

--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -914,8 +914,8 @@ class ClusterGrid(Grid):
 
         >>> import numpy as np
         >>> d = np.arange(5, 8, 0.5)
-        >>> ClusterGrid.standard_scale(d)
-        array([ 0. ,  0.2,  0.4,  0.6,  0.8,  1. ])
+        >>> ClusterGrid.standard_scale(d).tolist()
+        [0.0, 0.2, 0.4, 0.6, 0.8, 1.0]
         """
         # Normalize these values to range from 0 to 1
         if axis == 1:


### PR DESCRIPTION
This fix should address issue #1352. In particular, the x and y parameters are converted to arrays earlier, preventing an indexing bug in the case that they are lists. 