### PR TITLE
Update docstring parameters from split to dodge for swarmplot and str…

### DIFF
--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -2633,7 +2633,7 @@ stripplot.__doc__ = dedent("""\
         it is easier to see the distribution. You can specify the amount
         of jitter (half the width of the uniform random variable support),
         or just use ``True`` for a good default.
-    split : bool, optional
+    dodge : bool, optional
         When using ``hue`` nesting, setting this to ``True`` will separate
         the strips for different hue levels along the categorical axis.
         Otherwise, the points for each level will be plotted on top of
@@ -2837,7 +2837,7 @@ swarmplot.__doc__ = dedent("""\
     {input_params}
     {categorical_data}
     {order_vars}
-    split : bool, optional
+    dodge : bool, optional
         When using ``hue`` nesting, setting this to ``True`` will separate
         the strips for different hue levels along the categorical axis.
         Otherwise, the points for each level will be plotted in one swarm.


### PR DESCRIPTION
Fixes https://github.com/mwaskom/seaborn/issues/1278 (closes https://github.com/mwaskom/seaborn/pull/1279 , which fixes it partially, only for stripplot) by renaming the split->dodge in doctring for swarmplot and stripplot.