### PR TITLE
PDF backend not compatible with using get_renderer

### DIFF
--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -311,7 +311,11 @@ class _HeatMapper(object):
         ytl = ax.set_yticklabels(yticklabels, rotation="vertical")
 
         # Possibly rotate them if they overlap
-        ax.figure.draw(ax.figure.canvas.get_renderer())
+        if mpl.get_backend().upper() == "PDF":
+            # https://github.com/mwaskom/seaborn/issues/1262
+            plt.draw()
+        else:
+            ax.figure.draw(ax.figure.canvas.get_renderer())
         if axis_ticklabels_overlap(xtl):
             plt.setp(xtl, rotation="vertical")
         if axis_ticklabels_overlap(ytl):
@@ -696,7 +700,11 @@ class _DendrogramPlotter(object):
         ytl = ax.set_yticklabels(self.yticklabels, rotation='vertical')
 
         # Force a draw of the plot to avoid matplotlib window error
-        ax.figure.draw(ax.figure.canvas.get_renderer())
+        if mpl.get_backend().upper() == "pdf":
+            # https://github.com/mwaskom/seaborn/issues/1262
+            plt.draw()
+        else:
+            ax.figure.draw(ax.figure.canvas.get_renderer())
         if len(ytl) > 0 and axis_ticklabels_overlap(ytl):
             plt.setp(ytl, rotation="horizontal")
         if len(xtl) > 0 and axis_ticklabels_overlap(xtl):

--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -700,7 +700,7 @@ class _DendrogramPlotter(object):
         ytl = ax.set_yticklabels(self.yticklabels, rotation='vertical')
 
         # Force a draw of the plot to avoid matplotlib window error
-        if mpl.get_backend().upper() == "pdf":
+        if mpl.get_backend().upper() == "PDF":
             # https://github.com/mwaskom/seaborn/issues/1262
             plt.draw()
         else:


### PR DESCRIPTION
I introduced a check on the backend, so that PDF backend can still be used.

See https://github.com/mwaskom/seaborn/issues/1262