### PR TITLE
Fix doc building for sphinx >= 1.6

### DIFF
--- a/doc/sphinxext/ipython_directive.py
+++ b/doc/sphinxext/ipython_directive.py
@@ -124,7 +124,7 @@ except ImportError:
 import sphinx
 from docutils.parsers.rst import directives
 from docutils import nodes
-from sphinx.util.compat import Directive
+from docutils.parsers.rst import Directive
 
 # Our own
 from traitlets.config import Config


### PR DESCRIPTION
I get the following error when building the documentation:

```
$ make html 
sphinx-build -b html -d _build/doctrees   . _build/html
Running Sphinx v1.7.4

Extension error:
Could not import extension ipython_directive (exception: cannot import name 'Directive')
make: *** [html] Error 2
```

According to the release notes of [Sphinx 1.6](http://www.sphinx-doc.org/en/master/changes.html#id35):

> sphinx.util.compat.Directive class is now deprecated. Please
> use instead docutils.parsers.rst.Directive

Please not that in order to successfully build, I also [downgraded matplotlib](https://github.com/matplotlib/matplotlib/pull/10881) for now with

```
pip uninstall matplotlib
pip install -Iv https://github.com/matplotlib/matplotlib/archive/v2.2.1.tar.gz
```