### PR TITLE
Replace np.ceil() with a faster operation

### DIFF
--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -274,7 +274,7 @@ class FacetGrid(Grid):
                 err = "Cannot use `row` and `col_wrap` together."
                 raise ValueError(err)
             ncol = col_wrap
-            nrow = int(np.ceil(len(col_names) / col_wrap))
+            nrow = (len(col_names) + col_wrap - 1) // col_wrap
         self._ncol = ncol
         self._nrow = nrow
 


### PR DESCRIPTION
This is approx. 88 times faster on my machine.
Plus no need to explicitly convert to `int` because `len(col_names)` and `col_wrap` are guaranteed to be integers. 

```
$ python -m timeit -s "import numpy as np" "int(np.ceil(100 / 3))"
1000000 loops, best of 3: 0.949 usec per loop
$ python -m timeit -s "import numpy as np" "(10 + 3 - 1) // 3"
10000000 loops, best of 3: 0.0108 usec per loop
```
