### PR TITLE
Making the error message for jet more informative

### DIFF
--- a/seaborn/palettes.py
+++ b/seaborn/palettes.py
@@ -168,7 +168,9 @@ def color_palette(palette=None, n_colors=None, desat=None):
         elif palette == "husl":
             palette = husl_palette(n_colors)
         elif palette.lower() == "jet":
-            raise ValueError("No.")
+            raise ValueError("The jet color map is not supported by seaborn, "
+                "since it is a bad color map due to its problematic"
+                " luminance profile and various other reasons.")
         elif palette in SEABORN_PALETTES:
             palette = SEABORN_PALETTES[palette]
         else:


### PR DESCRIPTION
Just stumbled upon discussions regarding the rather brief error message when a user attempts to use 'jet' as a color map. To make the `ValueError` more informative, and to provide some basic information to people who are not (yet) aware of jet's issues, I modified the error message.