### PR TITLE
Remove special-cased stacked diagonal histograms in PairGrid

### DIFF
--- a/doc/releases/v0.9.0.txt
+++ b/doc/releases/v0.9.0.txt
@@ -16,6 +16,8 @@ v0.9.0 (Unreleased)
 
 - Added the ``subplot_kws`` parameter to :class:`PairGrid` for more flexibility.
 
+- Changed the default diagonal plots in :func:`pairplot` to use :func:`kdeplot` and changed the default off-diagonal plots to use :func:`scatterplot`.
+
 - Removed a special case in :class:`PairGrid` that defaulted to drawing stacked histograms on the diagonal axes.
 
 - Fixed functions that set axis limits so that they preserve auto-scaling state on matplotlib 2.0.

--- a/doc/releases/v0.9.0.txt
+++ b/doc/releases/v0.9.0.txt
@@ -16,6 +16,8 @@ v0.9.0 (Unreleased)
 
 - Added the ``subplot_kws`` parameter to :class:`PairGrid` for more flexibility.
 
+- Removed a special case in :class:`PairGrid` that defaulted to drawing stacked histograms on the diagonal axes.
+
 - Fixed functions that set axis limits so that they preserve auto-scaling state on matplotlib 2.0.
 
 - Avoided an error when using matplotlib backends that cannot render a canvas (e.g. PDF).

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -1351,42 +1351,22 @@ class PairGrid(Grid):
             ax = self.diag_axes[i]
             hue_grouped = self.data[var].groupby(self.hue_vals)
 
-            # Special-case plt.hist with stacked bars
-            if func is plt.hist:
-                plt.sca(ax)
+            plt.sca(ax)
 
-                vals = []
-                for label in self.hue_names:
-                    # Attempt to get data for this level, allowing for empty
-                    try:
-                        vals.append(np.asarray(hue_grouped.get_group(label)))
-                    except KeyError:
-                        vals.append(np.array([]))
+            for k, label_k in enumerate(self.hue_names):
 
-                color = self.palette if fixed_color is None else fixed_color
+                # Attempt to get data for this level, allowing for empty
+                try:
+                    data_k = hue_grouped.get_group(label_k)
+                except KeyError:
+                    data_k = np.array([])
 
-                if "histtype" in kwargs:
-                    func(vals, color=color, **kwargs)
+                if fixed_color is None:
+                    color = self.palette[k]
                 else:
-                    func(vals, color=color, histtype="barstacked", **kwargs)
+                    color = fixed_color
 
-            else:
-                plt.sca(ax)
-
-                for k, label_k in enumerate(self.hue_names):
-
-                    # Attempt to get data for this level, allowing for empty
-                    try:
-                        data_k = hue_grouped.get_group(label_k)
-                    except KeyError:
-                        data_k = np.array([])
-
-                    if fixed_color is None:
-                        color = self.palette[k]
-                    else:
-                        color = fixed_color
-
-                    func(data_k, label=label_k, color=color, **kwargs)
+                func(data_k, label=label_k, color=color, **kwargs)
 
             self._clean_axis(ax)
 

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -1273,7 +1273,8 @@ class PairGrid(Grid):
         ----------
         func : callable plotting function
             Must take x, y arrays as positional arguments and draw onto the
-            "currently active" matplotlib Axes.
+            "currently active" matplotlib Axes. Also needs to accept kwargs
+            called ``color`` and  ``label``.
 
         """
         kw_color = kwargs.pop("color", None)
@@ -1315,10 +1316,9 @@ class PairGrid(Grid):
         Parameters
         ----------
         func : callable plotting function
-            Must take an x array as a positional arguments and draw onto the
-            "currently active" matplotlib Axes. There is a special case when
-            using a ``hue`` variable and ``plt.hist``; the histogram will be
-            plotted with stacked bars.
+            Must take an x array as a positional argument and draw onto the
+            "currently active" matplotlib Axes. Also needs to accept kwargs
+            called ``color`` and  ``label``.
 
         """
         # Add special diagonal axes for the univariate plot
@@ -1372,7 +1372,8 @@ class PairGrid(Grid):
         ----------
         func : callable plotting function
             Must take x, y arrays as positional arguments and draw onto the
-            "currently active" matplotlib Axes.
+            "currently active" matplotlib Axes. Also needs to accept kwargs
+            called ``color`` and  ``label``.
 
         """
         kw_color = kwargs.pop("color", None)
@@ -1417,7 +1418,8 @@ class PairGrid(Grid):
         ----------
         func : callable plotting function
             Must take x, y arrays as positional arguments and draw onto the
-            "currently active" matplotlib Axes.
+            "currently active" matplotlib Axes. Also needs to accept kwargs
+            called ``color`` and  ``label``.
 
         """
         kw_color = kwargs.pop("color", None)
@@ -1463,7 +1465,8 @@ class PairGrid(Grid):
         ----------
         func : callable plotting function
             Must take x, y arrays as positional arguments and draw onto the
-            "currently active" matplotlib Axes.
+            "currently active" matplotlib Axes. Also needs to accept kwargs
+            called ``color`` and  ``label``.
 
         """
 

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -1348,7 +1348,7 @@ class PairGrid(Grid):
 
                 # Attempt to get data for this level, allowing for empty
                 try:
-                    data_k = hue_grouped.get_group(label_k)
+                    data_k = np.asarray(hue_grouped.get_group(label_k))
                 except KeyError:
                     data_k = np.array([])
 

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -13,6 +13,7 @@ import matplotlib.pyplot as plt
 from . import utils
 from .palettes import color_palette, blend_palette
 from .external.six import string_types
+from .basic import scatterplot
 from .distributions import distplot, kdeplot,  _freedman_diaconis_bins
 
 
@@ -1862,7 +1863,7 @@ class JointGrid(object):
 
 def pairplot(data, hue=None, hue_order=None, palette=None,
              vars=None, x_vars=None, y_vars=None,
-             kind="scatter", diag_kind="hist", markers=None,
+             kind="scatter", diag_kind="kde", markers=None,
              size=2.5, aspect=1, dropna=True,
              plot_kws=None, diag_kws=None, grid_kws=None):
     """Plot pairwise relationships in a dataset.
@@ -2044,10 +2045,12 @@ def pairplot(data, hue=None, hue_order=None, palette=None,
         grid.hue_kws = {"marker": markers}
 
     # Maybe plot on the diagonal
+    diag_kws = diag_kws.copy()
     if grid.square_grid:
         if diag_kind == "hist":
             grid.map_diag(plt.hist, **diag_kws)
         elif diag_kind == "kde":
+            diag_kws.setdefault("shade", True)
             diag_kws["legend"] = False
             grid.map_diag(kdeplot, **diag_kws)
 
@@ -2058,8 +2061,7 @@ def pairplot(data, hue=None, hue_order=None, palette=None,
         plotter = grid.map
 
     if kind == "scatter":
-        plot_kws.setdefault("edgecolor", "white")
-        plotter(plt.scatter, **plot_kws)
+        plotter(scatterplot, **plot_kws)
     elif kind == "reg":
         from .regression import regplot  # Avoid circular import
         plotter(regplot, **plot_kws)

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -86,12 +86,7 @@ class Grid(object):
             figlegend = self.fig.legend(handles, label_order, "center right",
                                         **kwargs)
             self._legend = figlegend
-            figlegend.set_title(title)
-
-            # Set the title size a roundabout way to maintain
-            # compatability with matplotlib 1.1
-            prop = mpl.font_manager.FontProperties(size=title_size)
-            figlegend._legend_title_box._text.set_font_properties(prop)
+            figlegend.set_title(title, prop={"size": title_size})
 
             # Draw the plot to set the bounding boxes correctly
             if hasattr(self.fig.canvas, "get_renderer"):
@@ -120,12 +115,7 @@ class Grid(object):
             # Draw a legend in the first axis
             ax = self.axes.flat[0]
             leg = ax.legend(handles, label_order, loc="best", **kwargs)
-            leg.set_title(title)
-
-            # Set the title size a roundabout way to maintain
-            # compatability with matplotlib 1.1
-            prop = mpl.font_manager.FontProperties(size=title_size)
-            leg._legend_title_box._text.set_font_properties(prop)
+            leg.set_title(title, prop={"size": title_size})
 
         return self
 

--- a/seaborn/tests/test_axisgrid.py
+++ b/seaborn/tests/test_axisgrid.py
@@ -1170,7 +1170,8 @@ class TestPairGrid(object):
         g = ag.pairplot(self.df)
 
         for ax in g.diag_axes:
-            nt.assert_equal(len(ax.patches), 10)
+            assert len(ax.lines) == 1
+            assert len(ax.collections) == 1
 
         for i, j in zip(*np.triu_indices_from(g.axes, 1)):
             ax = g.axes[i, j]
@@ -1196,7 +1197,7 @@ class TestPairGrid(object):
     def test_pairplot_reg(self):
 
         vars = ["x", "y", "z"]
-        g = ag.pairplot(self.df, kind="reg")
+        g = ag.pairplot(self.df, diag_kind="hist", kind="reg")
 
         for ax in g.diag_axes:
             nt.assert_equal(len(ax.patches), 10)


### PR DESCRIPTION
Also changes the `pairplot` defaults:

```python
sns.pairplot(iris, hue="species")
```
![image](https://user-images.githubusercontent.com/315810/41746079-1c1fe292-7577-11e8-8733-49ee8e82ac46.png)
