### PR TITLE
Allow interface to cubehelix through color_palette

### DIFF
--- a/doc/releases/v0.9.0.txt
+++ b/doc/releases/v0.9.0.txt
@@ -18,6 +18,8 @@ v0.9.0 (Unreleased)
 
 - Added the ``subplot_kws`` parameter to :class:`PairGrid` for more flexibility.
 
+- Enhanced :func:`color_palette` to accept a parameterized specification of a cubehelix palette in in a string, prefixed with ``"ch:"`` (e.g. ``"ch:-.1,.2,light=.7"``). This will be accepted by any seaborn function with a ``palette=`` parameter.
+
 - Changed the default diagonal plots in :func:`pairplot` to use :func:`kdeplot` and changed the default off-diagonal plots to use :func:`scatterplot`.
 
 - Removed a special case in :class:`PairGrid` that defaulted to drawing stacked histograms on the diagonal axes.

--- a/seaborn/basic.py
+++ b/seaborn/basic.py
@@ -14,7 +14,7 @@ from . import utils
 from .utils import (categorical_order, get_color_cycle, ci_to_errsize, sort_df,
                     remove_na)
 from .algorithms import bootstrap
-from .palettes import color_palette
+from .palettes import color_palette, cubehelix_palette, _parse_cubehelix_args
 
 
 __all__ = ["lineplot", "scatterplot"]
@@ -22,7 +22,6 @@ __all__ = ["lineplot", "scatterplot"]
 
 class _BasicPlotter(object):
 
-    # We could use "line art glyphs" (e.g. "P") on mpl 2
     if LooseVersion(mpl.__version__) >= "2.0":
         default_markers = ["o", "X", "s", "P", "D", "^", "v", "p"]
     else:
@@ -239,6 +238,9 @@ class _BasicPlotter(object):
             cmap = mpl.cm.get_cmap(plt.rcParams["image.cmap"])
         elif isinstance(palette, mpl.colors.Colormap):
             cmap = palette
+        elif str(palette).startswith("ch:"):
+            args, kwargs = _parse_cubehelix_args(palette)
+            cmap = cubehelix_palette(0, *args, as_cmap=True, **kwargs)
         else:
             try:
                 cmap = mpl.cm.get_cmap(palette)

--- a/seaborn/palettes.py
+++ b/seaborn/palettes.py
@@ -62,13 +62,14 @@ def color_palette(palette=None, n_colors=None, desat=None):
         deep, muted, bright, pastel, dark, colorblind
 
     Other options:
-        hls, husl, any named matplotlib palette, list of colors
+        name of matplotlib cmap, 'ch:<cubehelix arguments>', 'hls', 'husl',
+        or a list of colors in any format matplotlib accepts
 
     Calling this function with ``palette=None`` will return the current
     matplotlib color cycle.
 
     Matplotlib palettes can be specified as reversed palettes by appending
-    "_r" to the name or as dark palettes by appending "_d" to the name.
+    "_r" to the name or as "dark" palettes by appending "_d" to the name.
     (These options are mutually exclusive, but the resulting list of colors
     can also be reversed).
 
@@ -105,39 +106,51 @@ def color_palette(palette=None, n_colors=None, desat=None):
     Examples
     --------
 
-    Show one of the "seaborn palettes", which have the same basic order of hues
-    as the default matplotlib color cycle but more attractive colors.
+    Calling with no arguments returns the current default color cycle:
 
     .. plot::
         :context: close-figs
 
         >>> import seaborn as sns; sns.set()
+        >>> sns.palplot(sns.color_palette())
+
+    Show one of the other "seaborn palettes", which have the same basic order
+    of hues as the default matplotlib color cycle but more attractive colors:
+
+    .. plot::
+        :context: close-figs
+
         >>> sns.palplot(sns.color_palette("muted"))
 
-    Use discrete values from one of the built-in matplotlib colormaps.
+    Use discrete values from one of the built-in matplotlib colormaps:
 
     .. plot::
         :context: close-figs
 
         >>> sns.palplot(sns.color_palette("RdBu", n_colors=7))
 
-    Make a "dark" matplotlib sequential palette variant. (This can be good
-    when coloring multiple lines or points that correspond to an ordered
-    variable, where you don't want the lightest lines to be invisible).
+    Make a customized cubehelix color palette:
 
     .. plot::
         :context: close-figs
 
-        >>> sns.palplot(sns.color_palette("Blues_d"))
+        >>> sns.palplot(sns.color_palette("ch:2.5,-.2,dark=.3"))
 
-    Use a categorical matplotlib palette, add some desaturation. (This can be
-    good when making plots with large patches, which look best with dimmer
-    colors).
+    Use a categorical matplotlib palette and add some desaturation:
 
     .. plot::
         :context: close-figs
 
         >>> sns.palplot(sns.color_palette("Set1", n_colors=8, desat=.5))
+
+    Make a "dark" matplotlib sequential palette variant. (This can be good
+    when coloring multiple lines or points that correspond to an ordered
+    variable, where you don't want the lightest lines to be invisible):
+
+    .. plot::
+        :context: close-figs
+
+        >>> sns.palplot(sns.color_palette("Blues_d"))
 
     Use as a context manager:
 
@@ -179,9 +192,9 @@ def color_palette(palette=None, n_colors=None, desat=None):
             # Paternalism
             raise ValueError("No.")
 
-        elif palette.startswith("cube:"):
+        elif palette.startswith("ch:"):
             # Cubehelix palette with params specified in string
-            args, kwargs = _parse_cube_args(palette)
+            args, kwargs = _parse_cubehelix_args(palette)
             palette = cubehelix_palette(n_colors, *args, **kwargs)
 
         else:
@@ -940,10 +953,10 @@ def cubehelix_palette(n_colors=6, start=0, rot=.4, gamma=1.0, hue=0.8,
         return _ColorPalette(pal)
 
 
-def _parse_cube_args(argstr):
+def _parse_cubehelix_args(argstr):
     """Turn stringified cubehelix params into args/kwargs."""
-    if argstr.startswith("cube:"):
-        argstr = argstr[5:]
+    if argstr.startswith("ch:"):
+        argstr = argstr[3:]
 
     if not argstr:
         return [], {}

--- a/seaborn/palettes.py
+++ b/seaborn/palettes.py
@@ -194,7 +194,7 @@ def color_palette(palette=None, n_colors=None, desat=None):
     return palette
 
 
-def hls_palette(n_colors=6, h=.01, l=.6, s=.65):
+def hls_palette(n_colors=6, h=.01, l=.6, s=.65):  # noqa
     """Get a set of evenly spaced colors in HLS hue space.
 
     h, l, and s should be between 0 and 1
@@ -262,7 +262,7 @@ def hls_palette(n_colors=6, h=.01, l=.6, s=.65):
     return _ColorPalette(palette)
 
 
-def husl_palette(n_colors=6, h=.01, s=.9, l=.65):
+def husl_palette(n_colors=6, h=.01, s=.9, l=.65):  # noqa
     """Get a set of evenly spaced colors in HUSL hue space.
 
     h, s, and l should be between 0 and 1
@@ -327,7 +327,7 @@ def husl_palette(n_colors=6, h=.01, s=.9, l=.65):
     hues %= 1
     hues *= 359
     s *= 99
-    l *= 99
+    l *= 99  # noqa
     palette = [husl.husl_to_rgb(h_i, s, l) for h_i in hues]
     return _ColorPalette(palette)
 
@@ -585,7 +585,7 @@ def light_palette(color, n_colors=6, reverse=False, as_cmap=False,
 
     """
     color = _color_to_rgb(color, input)
-    light = set_hls_values(color, l=.95)
+    light = set_hls_values(color, l=.95)  # noqa
     colors = [color, light] if reverse else [light, color]
     return blend_palette(colors, n_colors, as_cmap)
 
@@ -617,8 +617,8 @@ def _flat_palette(color, n_colors=6, reverse=False, as_cmap=False,
     return blend_palette(colors, n_colors, as_cmap)
 
 
-def diverging_palette(h_neg, h_pos, s=75, l=50, sep=10, n=6, center="light",
-                      as_cmap=False):
+def diverging_palette(h_neg, h_pos, s=75, l=50, sep=10, n=6,  # noqa
+                      center="light", as_cmap=False):
     """Make a diverging palette between two HUSL colors.
 
     If you are using the IPython notebook, you can also choose this palette

--- a/seaborn/palettes.py
+++ b/seaborn/palettes.py
@@ -950,10 +950,10 @@ def _parse_cube_args(argstr):
 
     all_args = argstr.split(",")
 
-    args = [float(a) for a in all_args if "=" not in a]
+    args = [float(a.strip(" ")) for a in all_args if "=" not in a]
 
     kwargs = [a.split("=") for a in all_args if "=" in a]
-    kwargs = {k: float(v) for k, v in kwargs}
+    kwargs = {k.strip(" "): float(v.strip(" ")) for k, v in kwargs}
 
     return args, kwargs
 

--- a/seaborn/palettes.py
+++ b/seaborn/palettes.py
@@ -900,7 +900,28 @@ def cubehelix_palette(n_colors=6, start=0, rot=.4, gamma=1.0, hue=0.8,
         >>> ax = sns.heatmap(x, cmap=cmap)
 
     """
-    cdict = mpl._cm.cubehelix(gamma, start, rot, hue)
+    def get_color_function(p0, p1):
+        # Copied from matplotlib because it lives in private module
+        def color(x):
+            # Apply gamma factor to emphasise low or high intensity values
+            xg = x ** gamma
+
+            # Calculate amplitude and angle of deviation from the black
+            # to white diagonal in the plane of constant
+            # perceived intensity.
+            a = hue * xg * (1 - xg) / 2
+
+            phi = 2 * np.pi * (start / 3 + rot * x)
+
+            return xg + a * (p0 * np.cos(phi) + p1 * np.sin(phi))
+        return color
+
+    cdict = {
+            "red": get_color_function(-0.14861, 1.78277),
+            "green": get_color_function(-0.29227, -0.90649),
+            "blue": get_color_function(1.97294, 0.0),
+    }
+
     cmap = mpl.colors.LinearSegmentedColormap("cubehelix", cdict)
 
     x = np.linspace(light, dark, n_colors)

--- a/seaborn/tests/test_basic.py
+++ b/seaborn/tests/test_basic.py
@@ -462,6 +462,11 @@ class TestBasicPlotter(object):
         p.parse_hue(p.plot_data.hue, palette, None, None)
         assert p.cmap is palette
 
+        # Test cubehelix shorthand
+        palette = "ch:2,0,light=.2"
+        p.parse_hue(p.plot_data.hue, palette, None, None)
+        assert isinstance(p.cmap, mpl.colors.ListedColormap)
+
         # Test default hue limits
         p.parse_hue(p.plot_data.hue, None, None, None)
         assert p.hue_limits == (p.plot_data.hue.min(), p.plot_data.hue.max())

--- a/seaborn/tests/test_palettes.py
+++ b/seaborn/tests/test_palettes.py
@@ -260,7 +260,7 @@ class TestColorPalettes(object):
         pal2 = palettes.color_palette(palettes.cubehelix_palette(8))
         assert pal1 == pal2
 
-        pal1 = palettes.color_palette("cube:.5,-.25,hue=.5,light=.75", 8)
+        pal1 = palettes.color_palette("cube:.5, -.25,hue = .5,light=.75", 8)
         pal2 = palettes.color_palette(
             palettes.cubehelix_palette(8, .5, -.25, hue=.5, light=.75)
         )

--- a/seaborn/tests/test_palettes.py
+++ b/seaborn/tests/test_palettes.py
@@ -124,8 +124,8 @@ class TestColorPalettes(object):
         pal2 = pal2[3:] + pal2[:3]
         npt.assert_array_almost_equal(pal1, pal2)
 
-        pal_dark = palettes.hls_palette(5, l=.2)
-        pal_bright = palettes.hls_palette(5, l=.8)
+        pal_dark = palettes.hls_palette(5, l=.2)  # noqa
+        pal_bright = palettes.hls_palette(5, l=.8)  # noqa
         npt.assert_array_less(list(map(sum, pal_dark)),
                               list(map(sum, pal_bright)))
 
@@ -141,8 +141,8 @@ class TestColorPalettes(object):
         pal2 = pal2[3:] + pal2[:3]
         npt.assert_array_almost_equal(pal1, pal2)
 
-        pal_dark = palettes.husl_palette(5, l=.2)
-        pal_bright = palettes.husl_palette(5, l=.8)
+        pal_dark = palettes.husl_palette(5, l=.2)  # noqa
+        pal_bright = palettes.husl_palette(5, l=.8)  # noqa
         npt.assert_array_less(list(map(sum, pal_dark)),
                               list(map(sum, pal_bright)))
 

--- a/seaborn/tests/test_palettes.py
+++ b/seaborn/tests/test_palettes.py
@@ -256,11 +256,11 @@ class TestColorPalettes(object):
 
     def test_cubehelix_code(self):
 
-        pal1 = palettes.color_palette("cube:", 8)
+        pal1 = palettes.color_palette("ch:", 8)
         pal2 = palettes.color_palette(palettes.cubehelix_palette(8))
         assert pal1 == pal2
 
-        pal1 = palettes.color_palette("cube:.5, -.25,hue = .5,light=.75", 8)
+        pal1 = palettes.color_palette("ch:.5, -.25,hue = .5,light=.75", 8)
         pal2 = palettes.color_palette(
             palettes.cubehelix_palette(8, .5, -.25, hue=.5, light=.75)
         )

--- a/seaborn/tests/test_palettes.py
+++ b/seaborn/tests/test_palettes.py
@@ -254,6 +254,18 @@ class TestColorPalettes(object):
         pal_reverse = cmap_rev(x[::-1]).tolist()
         nt.assert_list_equal(pal_forward, pal_reverse)
 
+    def test_cubehelix_code(self):
+
+        pal1 = palettes.color_palette("cube:", 8)
+        pal2 = palettes.color_palette(palettes.cubehelix_palette(8))
+        assert pal1 == pal2
+
+        pal1 = palettes.color_palette("cube:.5,-.25,hue=.5,light=.75", 8)
+        pal2 = palettes.color_palette(
+            palettes.cubehelix_palette(8, .5, -.25, hue=.5, light=.75)
+        )
+        assert pal1 == pal2
+
     def test_xkcd_palette(self):
 
         names = list(xkcd_rgb.keys())[10:15]


### PR DESCRIPTION
e.g.

```python
sns.palplot(sns.color_palette("cube:.1,-.2,hue=1,dark=.3"))
```
![image](https://user-images.githubusercontent.com/315810/41802529-666220da-764f-11e8-9e8c-1de24d220024.png)

This means it can be used in any seaborn function with a `palette` kwarg:

```python
sns.boxplot(x="subject", y="signal",
            palette="cube:.1,-.2,hue=1,dark=.3",
            data=fmri)
```

Needs:
- [ ] Documentation (including release notes)
- [x] Decision about best prefix
- [x] Special handling of colormap case in basic plots