### PR TITLE
Update color palettes to 10 colors

### DIFF
--- a/doc/releases/v0.9.0.txt
+++ b/doc/releases/v0.9.0.txt
@@ -12,7 +12,7 @@ v0.9.0 (Unreleased)
 
 - Updated the seaborn palettes ("deep", "muted", "colorblind", etc.) to correspond with the new 10-color matplotlib default. The legacy palettes are now available at "deep6", "muted6", "colorblind6", etc. Additionally, a few individual colors were tweaked for better consistency, aesthetics, and accessibility.
 
-- Calling :func:`set_palette` with a named qualitative palettes (i.e. one of the seaborn palettes, the colorbrewer qualitative palettes, or the matplotlib matplotlib tableau-derived palettes) and no specified number of colors will use all of the colors in the palette. Note that this behavior is different from what :func:`color_palette` has and continues to do, which is to default to 6 colors for named palettes.
+- Calling :func:`color_palette` (or :func:`set_palette`) with a named qualitative palettes (i.e. one of the seaborn palettes, the colorbrewer qualitative palettes, or the matplotlib matplotlib tableau-derived palettes) and no specified number of colors will return all of the colors in the palette. This means that for some palettes, the returned list will have a different length than it did in previous versions.
 
 - Fixed :func:`jointplot`/:class:`JointGrid` and :func:`regplot` so that they now accept list inputs.
 

--- a/doc/releases/v0.9.0.txt
+++ b/doc/releases/v0.9.0.txt
@@ -10,6 +10,10 @@ v0.9.0 (Unreleased)
 
 - Deprecated the statistical annotation component of :class:`JointGrid`. The method is still available but will be removed in a future version.
 
+- Updated the seaborn palettes ("deep", "muted", "colorblind", etc.) to correspond with the new 10-color matplotlib default. The legacy palettes are now available at "deep6", "muted6", "colorblind6", etc. Additionally, a few individual colors were tweaked for better consistency, aesthetics, and accessibility.
+
+- Calling :func:`set_palette` with a named qualitative palettes (i.e. one of the seaborn palettes, the colorbrewer qualitative palettes, or the matplotlib matplotlib tableau-derived palettes) and no specified number of colors will use all of the colors in the palette. Note that this behavior is different from what :func:`color_palette` has and continues to do, which is to default to 6 colors for named palettes.
+
 - Fixed :func:`jointplot`/:class:`JointGrid` and :func:`regplot` so that they now accept list inputs.
 
 - Fixed a bug in :class:`FacetGrid` when using a single row/column level or using ``col_wrap=1``.

--- a/doc/tutorial/color_palettes.ipynb
+++ b/doc/tutorial/color_palettes.ipynb
@@ -55,7 +55,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.set(rc={\"figure.figsize\": (6, 6)})\n",
+    "sns.set()\n",
     "np.random.seed(sum(map(ord, \"palettes\")))"
    ]
   },
@@ -107,12 +107,57 @@
    "cell_type": "raw",
    "metadata": {},
    "source": [
-    "There are six variations of the default theme, called ``deep``, ``muted``, ``pastel``, ``bright``, ``dark``, and ``colorblind``.\n",
+    "There are six variations of the default theme, called ``deep``, ``muted``, ``pastel``, ``bright``, ``dark``, and ``colorblind``."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# TODO hide input here when merged with doc updating branch\n",
+    "f = plt.figure(figsize=(6, 6))\n",
     "\n",
+    "ax_locs = dict(\n",
+    "    deep=(.4, .4),\n",
+    "    bright=(.8, .8),\n",
+    "    muted=(.49, .71),\n",
+    "    dark=(.8, .2),\n",
+    "    pastel=(.2, .8),\n",
+    "    colorblind=(.71, .49),\n",
+    ")\n",
+    "\n",
+    "s = .35\n",
+    "\n",
+    "for pal, (x, y) in ax_locs.items():\n",
+    "    ax = f.add_axes([x - s / 2, y - s / 2, s, s])\n",
+    "    ax.pie(np.ones(10),\n",
+    "           colors=sns.color_palette(pal, 10),\n",
+    "           counterclock=False, startangle=180,\n",
+    "           wedgeprops=dict(linewidth=1, edgecolor=\"w\"))\n",
+    "    f.text(x, y, pal, ha=\"center\", va=\"center\", size=14,\n",
+    "           bbox=dict(facecolor=\"white\", alpha=0.85, boxstyle=\"round,pad=0.2\"))\n",
+    "\n",
+    "f.text(.1, .05, \"Saturation\", size=18, ha=\"left\", va=\"center\",\n",
+    "       bbox=dict(facecolor=\"white\", edgecolor=\"w\"))\n",
+    "f.text(.05, .1, \"Luminance\", size=18, ha=\"center\", va=\"bottom\", rotation=90,\n",
+    "       bbox=dict(facecolor=\"white\", edgecolor=\"w\"))\n",
+    "\n",
+    "ax = f.add_axes([0, 0, 1, 1])\n",
+    "ax.set_axis_off()\n",
+    "ax.arrow(.15, .05, .4, 0, width=.002, head_width=.015, color=\"k\")\n",
+    "ax.arrow(.05, .15, 0, .4, width=.002, head_width=.015, color=\"k\");"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
     "Using circular color systems\n",
     "~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n",
     "\n",
-    "When you have more than six categories to distinguish, the easiest thing is to draw evenly-spaced colors in a circular color space (such that the hue changes which keeping the brightness and saturation constant). This is what most seaborn functions default to when they need to use more colors than are currently set in the default color cycle.\n",
+    "When you have an arbitrary number of categories to distinguish without emphasizing any one, the easiest approach is to draw evenly-spaced colors in a circular color space (one where the hue changes while keeping the brightness and saturation constant). This is what most seaborn functions default to when they need to use more colors than are currently set in the default color cycle.\n",
     "\n",
     "The most common way to do this uses the ``hls`` color space, which is a simple transformation of RGB values."
    ]
@@ -191,7 +236,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.palplot(sns.color_palette(\"Set2\", 10))"
+    "sns.palplot(sns.color_palette(\"Set2\"))"
    ]
   },
   {

--- a/seaborn/palettes.py
+++ b/seaborn/palettes.py
@@ -47,6 +47,18 @@ SEABORN_PALETTES = dict(
     )
 
 
+MPL_QUAL_PALS = {
+    "tab10": 10, "tab20": 20, "tab20b": 20, "tab20c": 20,
+    "Set1": 9, "Set2": 8, "Set3": 12,
+    "Accent": 8, "Paired": 12,
+    "Pastel1": 9, "Pastel2": 8, "Dark2": 8,
+}
+
+
+QUAL_PALETTE_SIZES = MPL_QUAL_PALS.copy()
+QUAL_PALETTE_SIZES.update({k: len(v) for k, v in SEABORN_PALETTES.items()})
+
+
 class _ColorPalette(list):
     """Set the color palette in a with statement, otherwise be a list."""
     def __enter__(self):
@@ -118,7 +130,8 @@ def color_palette(palette=None, n_colors=None, desat=None):
     Examples
     --------
 
-    Calling with no arguments returns the current default color cycle:
+    Calling with no arguments returns all colors from the current default
+    color cycle:
 
     .. plot::
         :context: close-figs
@@ -127,7 +140,8 @@ def color_palette(palette=None, n_colors=None, desat=None):
         >>> sns.palplot(sns.color_palette())
 
     Show one of the other "seaborn palettes", which have the same basic order
-    of hues as the default matplotlib color cycle but more attractive colors:
+    of hues as the default matplotlib color cycle but more attractive colors.
+    Calling with the name of a palette will return 6 colors by default:
 
     .. plot::
         :context: close-figs
@@ -431,11 +445,6 @@ def mpl_palette(name, n_colors=6):
         >>> sns.palplot(sns.mpl_palette("GnBu_d"))
 
     """
-    mpl_qual_pals = {"Accent": 8, "Dark2": 8, "Paired": 12,
-                     "Pastel1": 9, "Pastel2": 8,
-                     "Set1": 9, "Set2": 8, "Set3": 12,
-                     "tab10": 10, "tab20": 20, "tab20b": 20, "tab20c": 20}
-
     if name.endswith("_d"):
         pal = ["#333333"]
         pal.extend(color_palette(name.replace("_d", "_r"), 2))
@@ -444,8 +453,8 @@ def mpl_palette(name, n_colors=6):
         cmap = mpl.cm.get_cmap(name)
         if cmap is None:
             raise ValueError("{} is not a valid colormap".format(name))
-    if name in mpl_qual_pals:
-        bins = np.linspace(0, 1, mpl_qual_pals[name])[:n_colors]
+    if name in MPL_QUAL_PALS:
+        bins = np.linspace(0, 1, MPL_QUAL_PALS[name])[:n_colors]
     else:
         bins = np.linspace(0, 1, n_colors + 2)[1:-1]
     palette = list(map(tuple, cmap(bins)[:, :3]))

--- a/seaborn/palettes.py
+++ b/seaborn/palettes.py
@@ -200,18 +200,19 @@ def color_palette(palette=None, n_colors=None, desat=None):
     else:
 
         if n_colors is None:
-            n_colors = 6
+            # Use all colors in a qualitative palette or 6 of another kind
+            n_colors = QUAL_PALETTE_SIZES.get(palette, 6)
 
         if palette in SEABORN_PALETTES:
             # Named "seaborn variant" of old matplotlib default palette
             palette = SEABORN_PALETTES[palette]
 
         elif palette == "hls":
-            # Evenly spaced colors in cylindrical RGB
+            # Evenly spaced colors in cylindrical RGB space
             palette = hls_palette(n_colors)
 
         elif palette == "husl":
-            # Evenly spaced colors in cylindrical Lab
+            # Evenly spaced colors in cylindrical Lab space
             palette = husl_palette(n_colors)
 
         elif palette.lower() == "jet":

--- a/seaborn/palettes.py
+++ b/seaborn/palettes.py
@@ -32,7 +32,7 @@ SEABORN_PALETTES = dict(
             "#DEBB9B", "#FAB0E4", "#CFCFCF", "#FFFEA3", "#B9F2F0"],
     pastel6=["#A1C9F4", "#8DE5A1", "#FF9F9B",
              "#D0BBFF", "#FFFEA3", "#B9F2F0"],
-    bright=["#023EFF", "#FF6000", "#1AC938", "#E8000B", "#8B2BE2",
+    bright=["#023EFF", "#FF7C00", "#1AC938", "#E8000B", "#8B2BE2",
             "#9F4800", "#F14CC1", "#A3A3A3", "#FFC400", "#00D7FF"],
     bright6=["#023EFF", "#1AC938", "#E8000B",
              "#8B2BE2", "#FFC400", "#00D7FF"],

--- a/seaborn/palettes.py
+++ b/seaborn/palettes.py
@@ -20,18 +20,30 @@ __all__ = ["color_palette", "hls_palette", "husl_palette", "mpl_palette",
 
 
 SEABORN_PALETTES = dict(
-    deep=["#4C72B0", "#55A868", "#C44E52",
-          "#8172B2", "#CCB974", "#64B5CD"],
-    muted=["#4878CF", "#6ACC65", "#D65F5F",
-           "#B47CC7", "#C4AD66", "#77BEDB"],
-    pastel=["#92C6FF", "#97F0AA", "#FF9F9A",
-            "#D0BBFF", "#FFFEA3", "#B0E0E6"],
-    bright=["#003FFF", "#03ED3A", "#E8000B",
-            "#8A2BE2", "#FFC400", "#00D7FF"],
-    dark=["#001C7F", "#017517", "#8C0900",
-          "#7600A1", "#B8860B", "#006374"],
-    colorblind=["#0072B2", "#009E73", "#D55E00",
-                "#CC79A7", "#F0E442", "#56B4E9"]
+    deep=["#4C72B0", "#DD8452", "#55A868", "#C44E52", "#8172B3",
+          "#937860", "#DA8BC3", "#8C8C8C", "#CCB974", "#64B5CD"],
+    deep6=["#4C72B0", "#55A868", "#C44E52",
+           "#8172B3", "#CCB974", "#64B5CD"],
+    muted=["#4878D0", "#EE854A", "#6ACC64", "#D65F5F", "#956CB4",
+           "#8C613C", "#DC7EC0", "#797979", "#D5BB67", "#82C6E2"],
+    muted6=["#4878D0", "#6ACC64", "#D65F5F",
+            "#956CB4", "#D5BB67", "#82C6E2"],
+    pastel=["#A1C9F4", "#FFB482", "#8DE5A1", "#FF9F9B", "#D0BBFF",
+            "#DEBB9B", "#FAB0E4", "#CFCFCF", "#FFFEA3", "#B9F2F0"],
+    pastel6=["#A1C9F4", "#8DE5A1", "#FF9F9B",
+             "#D0BBFF", "#FFFEA3", "#B9F2F0"],
+    bright=["#023EFF", "#FF6000", "#1AC938", "#E8000B", "#8B2BE2",
+            "#9F4800", "#F14CC1", "#A3A3A3", "#FFC400", "#00D7FF"],
+    bright6=["#023EFF", "#1AC938", "#E8000B",
+             "#8B2BE2", "#FFC400", "#00D7FF"],
+    dark=["#001C7F", "#B1400D", "#12711C", "#8C0800", "#591E71",
+          "#592F0D", "#A23582", "#3C3C3C", "#B8850A", "#006374"],
+    dark6=["#001C7F", "#12711C", "#8C0800",
+           "#591E71", "#B8850A", "#006374"],
+    colorblind=["#0173B2", "#DE8F05", "#029E73", "#D55E00", "#CC78BC",
+                "#CA9161", "#FBAFE4", "#949494", "#ECE133", "#56B4E9"],
+    colorblind6=["#0173B2", "#029E73", "#D55E00",
+                 "#CC78BC", "#ECE133", "#56B4E9"]
     )
 
 
@@ -1015,7 +1027,9 @@ def set_color_codes(palette="deep"):
     if palette == "reset":
         colors = [(0., 0., 1.), (0., .5, 0.), (1., 0., 0.), (.75, .75, 0.),
                   (.75, .75, 0.), (0., .75, .75), (0., 0., 0.)]
-    else:
+    elif palette in SEABORN_PALETTES:
+        if not palette.endswith("6"):
+            palette = palette + "6"
         colors = SEABORN_PALETTES[palette] + [(.1, .1, .1)]
     for code, color in zip("bgrmyck", colors):
         rgb = mpl.colors.colorConverter.to_rgb(color)

--- a/seaborn/rcmod.py
+++ b/seaborn/rcmod.py
@@ -2,6 +2,7 @@
 from distutils.version import LooseVersion
 import functools
 import matplotlib as mpl
+from .external.six import string_types
 from . import palettes, _orig_rc_params
 
 
@@ -497,6 +498,8 @@ def set_palette(palette, n_colors=None, desat=None, color_codes=False):
     set_style : set the default parameters for figure style
 
     """
+    if n_colors is None and isinstance(palette, string_types):
+        n_colors = palettes.QUAL_PALETTE_SIZES.get(palette, None)
     colors = palettes.color_palette(palette, n_colors, desat)
     if mpl_ge_150:
         from cycler import cycler

--- a/seaborn/rcmod.py
+++ b/seaborn/rcmod.py
@@ -2,7 +2,6 @@
 from distutils.version import LooseVersion
 import functools
 import matplotlib as mpl
-from .external.six import string_types
 from . import palettes, _orig_rc_params
 
 
@@ -471,7 +470,7 @@ def set_palette(palette, n_colors=None, desat=None, color_codes=False):
 
     Parameters
     ----------
-    palette : hls | husl | matplotlib colormap | seaborn color palette
+    palette : seaborn color paltte | matplotlib colormap | hls | husl
         Palette definition. Should be something that :func:`color_palette`
         can process.
     n_colors : int
@@ -498,8 +497,6 @@ def set_palette(palette, n_colors=None, desat=None, color_codes=False):
     set_style : set the default parameters for figure style
 
     """
-    if n_colors is None and isinstance(palette, string_types):
-        n_colors = palettes.QUAL_PALETTE_SIZES.get(palette, None)
     colors = palettes.color_palette(palette, n_colors, desat)
     if mpl_ge_150:
         from cycler import cycler

--- a/seaborn/tests/test_axisgrid.py
+++ b/seaborn/tests/test_axisgrid.py
@@ -7,6 +7,7 @@ import matplotlib as mpl
 import matplotlib.pyplot as plt
 from distutils.version import LooseVersion
 
+import pytest
 import nose.tools as nt
 import numpy.testing as npt
 from numpy.testing.decorators import skipif
@@ -35,7 +36,7 @@ class TestFacetGrid(object):
                            a=np.repeat(list("abc"), 20),
                            b=np.tile(list("mn"), 30),
                            c=np.tile(list("tuv"), 20),
-                           d=np.tile(list("abcdefghij"), 6)))
+                           d=np.tile(list("abcdefghijkl"), 5)))
 
     def test_self_data(self):
 
@@ -92,29 +93,31 @@ class TestFacetGrid(object):
 
     def test_col_wrap(self):
 
+        n = len(self.df.d.unique())
+
         g = ag.FacetGrid(self.df, col="d")
-        nt.assert_equal(g.axes.shape, (1, 10))
-        nt.assert_is(g.facet_axis(0, 8), g.axes[0, 8])
+        assert g.axes.shape == (1, n)
+        assert g.facet_axis(0, 8) is g.axes[0, 8]
 
         g_wrap = ag.FacetGrid(self.df, col="d", col_wrap=4)
-        nt.assert_equal(g_wrap.axes.shape, (10,))
-        nt.assert_is(g_wrap.facet_axis(0, 8), g_wrap.axes[8])
-        nt.assert_equal(g_wrap._ncol, 4)
-        nt.assert_equal(g_wrap._nrow, 3)
+        assert g_wrap.axes.shape == (n,)
+        assert g_wrap.facet_axis(0, 8) is g_wrap.axes[8]
+        assert g_wrap._ncol == 4
+        assert g_wrap._nrow == (n / 4)
 
-        with nt.assert_raises(ValueError):
+        with pytest.raises(ValueError):
             g = ag.FacetGrid(self.df, row="b", col="d", col_wrap=4)
 
         df = self.df.copy()
         df.loc[df.d == "j"] = np.nan
         g_missing = ag.FacetGrid(df, col="d")
-        nt.assert_equal(g_missing.axes.shape, (1, 9))
+        assert g_missing.axes.shape == (1, n - 1)
 
         g_missing_wrap = ag.FacetGrid(df, col="d", col_wrap=4)
-        nt.assert_equal(g_missing_wrap.axes.shape, (9,))
+        assert g_missing_wrap.axes.shape == (n - 1,)
 
         g = ag.FacetGrid(self.df, col="d", col_wrap=1)
-        assert len(list(g.facet_data())) == len(self.df.d.unique())
+        assert len(list(g.facet_data())) == n
 
     def test_normal_axes(self):
 
@@ -306,7 +309,6 @@ class TestFacetGrid(object):
     @skipif(old_matplotlib)
     def test_gridspec_kws_col_wrap(self):
         ratios = [3, 1, 2, 1, 1]
-        sizes = [0.46, 0.15, 0.31]
 
         gskws = dict(width_ratios=ratios)
         with warnings.catch_warnings():
@@ -318,7 +320,6 @@ class TestFacetGrid(object):
     @skipif(not old_matplotlib)
     def test_gridsic_kws_old_mpl(self):
         ratios = [3, 1, 2]
-        sizes = [0.46, 0.15, 0.31]
 
         gskws = dict(width_ratios=ratios, height_ratios=ratios)
         with warnings.catch_warnings():
@@ -385,7 +386,10 @@ class TestFacetGrid(object):
     def test_map_dataframe(self):
 
         g = ag.FacetGrid(self.df, row="a", col="b", hue="c")
-        plot = lambda x, y, data=None, **kws: plt.plot(data[x], data[y], **kws)
+
+        def plot(x, y, data=None, **kws):
+            plt.plot(data[x], data[y], **kws)
+
         g.map_dataframe(plot, "x", "y", linestyle="--")
 
         lines = g.axes[0, 0].lines
@@ -547,23 +551,23 @@ class TestFacetGrid(object):
         rcmod.set()
 
         g = ag.FacetGrid(self.df, hue="c")
-        nt.assert_equal(g._colors, color_palette(n_colors=3))
+        assert g._colors == color_palette(n_colors=len(self.df.c.unique()))
 
         g = ag.FacetGrid(self.df, hue="d")
-        nt.assert_equal(g._colors, color_palette("husl", 10))
+        assert g._colors == color_palette("husl", len(self.df.d.unique()))
 
         g = ag.FacetGrid(self.df, hue="c", palette="Set2")
-        nt.assert_equal(g._colors, color_palette("Set2", 3))
+        assert g._colors == color_palette("Set2", len(self.df.c.unique()))
 
         dict_pal = dict(t="red", u="green", v="blue")
         list_pal = color_palette(["red", "green", "blue"], 3)
         g = ag.FacetGrid(self.df, hue="c", palette=dict_pal)
-        nt.assert_equal(g._colors, list_pal)
+        assert g._colors == list_pal
 
         list_pal = color_palette(["green", "blue", "red"], 3)
         g = ag.FacetGrid(self.df, hue="c", hue_order=list("uvt"),
                          palette=dict_pal)
-        nt.assert_equal(g._colors, list_pal)
+        assert g._colors == list_pal
 
     def test_hue_kws(self):
 
@@ -741,11 +745,11 @@ class TestFacetGrid(object):
 class TestPairGrid(object):
 
     rs = np.random.RandomState(sum(map(ord, "PairGrid")))
-    df = pd.DataFrame(dict(x=rs.normal(size=80),
-                           y=rs.randint(0, 4, size=(80)),
-                           z=rs.gamma(3, size=80),
-                           a=np.repeat(list("abcd"), 20),
-                           b=np.repeat(list("abcdefgh"), 10)))
+    df = pd.DataFrame(dict(x=rs.normal(size=60),
+                           y=rs.randint(0, 4, size=(60)),
+                           z=rs.gamma(3, size=60),
+                           a=np.repeat(list("abc"), 20),
+                           b=np.repeat(list("abcdefghijkl"), 5)))
 
     def test_self_data(self):
 
@@ -858,7 +862,7 @@ class TestPairGrid(object):
             for j, ax in enumerate(axes_i):
                 x_in = self.df[vars[j]]
                 y_in = self.df[vars[i]]
-                for k, k_level in enumerate("abcd"):
+                for k, k_level in enumerate(self.df.a.unique()):
                     x_in_k = x_in[self.df.a == k_level]
                     y_in_k = y_in[self.df.a == k_level]
                     x_out, y_out = ax.collections[k].get_offsets().T
@@ -935,7 +939,7 @@ class TestPairGrid(object):
         g3.map_diag(plt.hist)
 
         for ax in g3.diag_axes:
-            nt.assert_equal(len(ax.patches), 40)
+            nt.assert_equal(len(ax.patches), 30)
 
         g4 = ag.PairGrid(self.df, hue="a")
         g4.map_diag(plt.hist, histtype='step')
@@ -1011,23 +1015,23 @@ class TestPairGrid(object):
         rcmod.set()
 
         g = ag.PairGrid(self.df, hue="a")
-        nt.assert_equal(g.palette, color_palette(n_colors=4))
+        assert g.palette == color_palette(n_colors=len(self.df.a.unique()))
 
         g = ag.PairGrid(self.df, hue="b")
-        nt.assert_equal(g.palette, color_palette("husl", 8))
+        assert g.palette == color_palette("husl", len(self.df.b.unique()))
 
         g = ag.PairGrid(self.df, hue="a", palette="Set2")
-        nt.assert_equal(g.palette, color_palette("Set2", 4))
+        assert g.palette == color_palette("Set2", len(self.df.a.unique()))
 
-        dict_pal = dict(a="red", b="green", c="blue", d="purple")
-        list_pal = color_palette(["red", "green", "blue", "purple"], 4)
+        dict_pal = dict(a="red", b="green", c="blue")
+        list_pal = color_palette(["red", "green", "blue"])
         g = ag.PairGrid(self.df, hue="a", palette=dict_pal)
-        nt.assert_equal(g.palette, list_pal)
+        assert g.palette == list_pal
 
-        list_pal = color_palette(["purple", "blue", "red", "green"], 4)
-        g = ag.PairGrid(self.df, hue="a", hue_order=list("dcab"),
+        list_pal = color_palette(["blue", "red", "green"])
+        g = ag.PairGrid(self.df, hue="a", hue_order=list("cab"),
                         palette=dict_pal)
-        nt.assert_equal(g.palette, list_pal)
+        assert g.palette == list_pal
 
     def test_hue_kws(self):
 
@@ -1156,7 +1160,7 @@ class TestPairGrid(object):
             for j, ax in enumerate(axes_i):
                 x_in = self.df[vars[j]]
                 y_in = self.df[vars[i]]
-                for k, k_level in enumerate("abcd"):
+                for k, k_level in enumerate(self.df.a.unique()):
                     x_in_k = x_in[self.df.a == k_level]
                     y_in_k = y_in[self.df.a == k_level]
                     x_out, y_out = ax.collections[k].get_offsets().T
@@ -1261,12 +1265,12 @@ class TestPairGrid(object):
     def test_pairplot_markers(self):
 
         vars = ["x", "y", "z"]
-        markers = ["o", "x", "s", "d"]
+        markers = ["o", "x", "s"]
         g = ag.pairplot(self.df, hue="a", vars=vars, markers=markers)
-        nt.assert_equal(g.hue_kws["marker"], markers)
+        assert g.hue_kws["marker"] == markers
         plt.close("all")
 
-        with nt.assert_raises(ValueError):
+        with pytest.raises(ValueError):
             g = ag.pairplot(self.df, hue="a", vars=vars, markers=markers[:-2])
 
 

--- a/seaborn/tests/test_palettes.py
+++ b/seaborn/tests/test_palettes.py
@@ -47,6 +47,23 @@ class TestColorPalettes(object):
         # Reset default
         rcmod.set()
 
+    def test_palette_size(self):
+
+        pal = palettes.color_palette("deep")
+        assert len(pal) == palettes.QUAL_PALETTE_SIZES["deep"]
+
+        pal = palettes.color_palette("pastel6")
+        assert len(pal) == palettes.QUAL_PALETTE_SIZES["pastel6"]
+
+        pal = palettes.color_palette("Set3")
+        assert len(pal) == palettes.QUAL_PALETTE_SIZES["Set3"]
+
+        pal = palettes.color_palette("husl")
+        assert len(pal) == 6
+
+        pal = palettes.color_palette("Greens")
+        assert len(pal) == 6
+
     def test_seaborn_palettes(self):
 
         pals = "deep", "muted", "pastel", "bright", "dark", "colorblind"

--- a/seaborn/tests/test_palettes.py
+++ b/seaborn/tests/test_palettes.py
@@ -51,8 +51,10 @@ class TestColorPalettes(object):
 
         pals = "deep", "muted", "pastel", "bright", "dark", "colorblind"
         for name in pals:
-            pal_out = palettes.color_palette(name)
-            nt.assert_equal(len(pal_out), 6)
+            full = palettes.color_palette(name, 10).as_hex()
+            short = palettes.color_palette(name + "6", 6).as_hex()
+            b, _, g, r, m, _, _, _, y, c = full
+            assert [b, g, r, m, y, c] == list(short)
 
     def test_hls_palette(self):
 
@@ -113,8 +115,8 @@ class TestColorPalettes(object):
 
     def test_palette_cycles(self):
 
-        deep = palettes.color_palette("deep")
-        double_deep = palettes.color_palette("deep", 12)
+        deep = palettes.color_palette("deep6")
+        double_deep = palettes.color_palette("deep6", 12)
         nt.assert_equal(double_deep, deep + deep)
 
     def test_hls_values(self):
@@ -285,7 +287,7 @@ class TestColorPalettes(object):
     def test_color_codes(self):
 
         palettes.set_color_codes("deep")
-        colors = palettes.color_palette("deep") + [".1"]
+        colors = palettes.color_palette("deep6") + [".1"]
         for code, color in zip("bgrmyck", colors):
             rgb_want = mpl.colors.colorConverter.to_rgb(color)
             rgb_got = mpl.colors.colorConverter.to_rgb(code)

--- a/seaborn/tests/test_palettes.py
+++ b/seaborn/tests/test_palettes.py
@@ -18,9 +18,9 @@ class TestColorPalettes(object):
 
     def test_current_palette(self):
 
-        pal = palettes.color_palette(["red", "blue", "green"], 3)
-        rcmod.set_palette(pal, 3)
-        nt.assert_equal(pal, utils.get_color_cycle())
+        pal = palettes.color_palette(["red", "blue", "green"])
+        rcmod.set_palette(pal)
+        assert pal == utils.get_color_cycle()
         rcmod.set()
 
     def test_palette_context(self):

--- a/seaborn/tests/test_rcmod.py
+++ b/seaborn/tests/test_rcmod.py
@@ -6,7 +6,7 @@ import matplotlib.pyplot as plt
 import nose.tools as nt
 import numpy.testing as npt
 
-from .. import rcmod
+from .. import rcmod, palettes, utils
 
 
 class RCParamTester(object):
@@ -173,6 +173,23 @@ class TestPlottingContext(RCParamTester):
             self.assert_rc_params(context_params)
         func()
         self.assert_rc_params(orig_params)
+
+
+class TestPalette(object):
+
+    def test_set_palette(self):
+
+        rcmod.set_palette("deep")
+        assert utils.get_color_cycle() == palettes.color_palette("deep", 10)
+
+        rcmod.set_palette("pastel6")
+        assert utils.get_color_cycle() == palettes.color_palette("pastel6", 6)
+
+        rcmod.set_palette("dark", 4)
+        assert utils.get_color_cycle() == palettes.color_palette("dark", 4)
+
+        rcmod.set_palette("Set2")
+        assert utils.get_color_cycle() == palettes.color_palette("Set2", 8)
 
 
 class TestFonts(object):

--- a/seaborn/tests/test_rcmod.py
+++ b/seaborn/tests/test_rcmod.py
@@ -230,8 +230,7 @@ class TestFonts(object):
             raise nose.SkipTest
 
         rcmod.set()
-        rcmod.set_style(rc={"font.sans-serif":
-                            ["Verdana"]})
+        rcmod.set_style(rc={"font.sans-serif": ["Verdana"]})
 
         _, ax = plt.subplots()
         ax.set_xlabel("foo")
@@ -256,7 +255,7 @@ def has_verdana():
     import matplotlib.font_manager as mplfm
     try:
         verdana_font = mplfm.findfont('Verdana', fallback_to_default=False)
-    except:
+    except:  # noqa
         # if https://github.com/matplotlib/matplotlib/pull/3435
         # gets accepted
         return False
@@ -264,7 +263,7 @@ def has_verdana():
     try:
         unlikely_font = mplfm.findfont("very_unlikely_to_exist1234",
                                        fallback_to_default=False)
-    except:
+    except:  # noqa
         # if matched verdana but not unlikely, Verdana must exist
         return True
     # otherwise -- if they match, must be the same default


### PR DESCRIPTION
This PR changes the named seaborn color palettes (i.e. "deep", "muted", "pastel", "bright", "dark", and "colorblind"). It expands them to 10 colors that correspond to the 10 colors in the new matplotlib default palette ("tab10").

The old palettes can be used by appending "6" to the name (e.g. "muted6").

There's also a new image in the tutorial docs showing off all the color palettes with some information about how they're related:

![palettes](https://user-images.githubusercontent.com/315810/41814522-20db0940-771d-11e8-8480-41778e045b2e.png)

(If of interest, I've also generated this image while simulating [various forms of color deficiency](https://gist.github.com/mwaskom/b35f6ebc2d4b340b4f64a4e28e778486).)

Additionally, a few colors in the non-default seaborn palettes have been tweaked for better aesthetics/consistency/colorblind accessibility.

The other change here is that calling `sns.color_palette` (or `sns.set_palette`) with a named qualitative palette that seaborn knows about will now set *all* colors for that palette by default. In other words, `sns.color_palette("Blues")` will return a 6 color palette but `sns.color_palette("Set2")` will return an 8 color palette.

~~I think it would be nice if `color_palette` also behaved this way, but it seems more likely that having that function return a list with a different length than previously expected would cause code to break. (These changes are alreadhy "breaking" in the sense that plots will look different, but I view that as a smaller cost than having code fail to run).~~

I determined that there is enough precedence for `color_palette` returning a flexible number of colors when none is specified that it ultimately makes more sense to have that logic live there.
