### PR TITLE
Additional enhancements to basic plots

### DIFF
--- a/doc/releases/v0.9.0.txt
+++ b/doc/releases/v0.9.0.txt
@@ -28,7 +28,7 @@ v0.9.0 (Unreleased)
 
 - Added the ``subplot_kws`` parameter to :class:`PairGrid` for more flexibility.
 
-- Enhanced :func:`color_palette` to accept a parameterized specification of a cubehelix palette in in a string, prefixed with ``"ch:"`` (e.g. ``"ch:-.1,.2,light=.7"``). This will be accepted by any seaborn function with a ``palette=`` parameter.
+- Enhanced :func:`color_palette` to accept a parameterized specification of a cubehelix palette in in a string, prefixed with ``"ch:"`` (e.g. ``"ch:-.1,.2,l=.7"``). None that keyword arguments can be spelled out or referenced using only their first letter, except reversing the palette is accomplished by appending ``"_r"`` as with other matplotlib colormaps. This specification will be accepted by any seaborn function with a ``palette=`` parameter.
 
 - Changed the default diagonal plots in :func:`pairplot` to use `func`:kdeplot` when a ``"hue"`` dimension is used.
 

--- a/seaborn/basic.py
+++ b/seaborn/basic.py
@@ -234,9 +234,8 @@ class _BasicPlotter(object):
         # at the extremes of the colormap against the background?
 
         # Identify the colormap to use
-        if palette is None:
-            cmap = mpl.cm.get_cmap(plt.rcParams["image.cmap"])
-        elif isinstance(palette, mpl.colors.Colormap):
+        palette = "ch:" if palette is None else palette
+        if isinstance(palette, mpl.colors.Colormap):
             cmap = palette
         elif str(palette).startswith("ch:"):
             args, kwargs = _parse_cubehelix_args(palette)

--- a/seaborn/basic.py
+++ b/seaborn/basic.py
@@ -423,7 +423,7 @@ class _BasicPlotter(object):
                 try:
                     limits = min(sizes.keys()), max(sizes.keys())
                 except TypeError:
-                    pass
+                    limits = None
 
             else:
 
@@ -454,7 +454,8 @@ class _BasicPlotter(object):
 
                 scl = norm(numbers)
                 widths = np.asarray(min_width + scl * (max_width - min_width))
-                widths[scl.mask] = 0
+                if scl.mask.any():
+                    widths[scl.mask] = 0
                 sizes = dict(zip(levels, widths))
                 # sizes = {l: min_width + norm(n) * (max_width - min_width)
                 #          for l, n in zip(levels, numbers)}
@@ -525,7 +526,7 @@ class _BasicPlotter(object):
                 float_data = data.astype(np.float)
                 values = np.unique(float_data.dropna())
                 if np.array_equal(values, np.array([0., 1.])):
-                        return "categorical"
+                    return "categorical"
                 return "numeric"
             except (ValueError, TypeError):
                 return "categorical"

--- a/seaborn/basic.py
+++ b/seaborn/basic.py
@@ -1236,7 +1236,7 @@ def scatterplot(x=None, y=None, hue=None, style=None, size=None, data=None,
     p = _ScatterPlotter(
         x=x, y=y, hue=hue, style=style, size=size, data=data,
         palette=palette, hue_order=hue_order, hue_limits=hue_limits,
-        sizes=sizes, size_order=size_order,
+        sizes=sizes, size_order=size_order, size_limits=size_limits,
         markers=markers, style_order=style_order,
         x_bins=x_bins, y_bins=y_bins,
         estimator=estimator, ci=ci, n_boot=n_boot,

--- a/seaborn/basic.py
+++ b/seaborn/basic.py
@@ -259,14 +259,20 @@ class _BasicPlotter(object):
         if not norm.scaled():
             norm(np.asarray(data.dropna()))
 
-        palette = {l: cmap(norm(l)) for l in levels}
+        # TODO this should also use color_lookup, but that needs the
+        # class attributes that get set after using this function...
+        palette = dict(zip(levels, cmap(norm(levels))))
+        # palette = {l: cmap(norm([l, 1]))[0] for l in levels}
 
         return levels, palette, cmap, norm
 
     def color_lookup(self, key):
         """Return the color corresponding to the hue level."""
         if self.hue_type == "numeric":
-            return self.cmap(self.hue_norm(key))
+            normed = self.hue_norm(key)
+            if np.ma.is_masked(normed):
+                normed = np.nan
+            return self.cmap(normed)
         elif self.hue_type == "categorical":
             return self.palette[key]
 
@@ -1159,14 +1165,15 @@ lineplot.__doc__ = dedent("""\
         ...                   hue="coherence", style="choice",
         ...                   data=dots)
 
-    Change the data limits over which the colormap is normalized:
+    Use a different normalization for the colormap:
 
     .. plot::
         :context: close-figs
 
+        >>> from matplotlib.colors import LogNorm
         >>> ax = sns.lineplot(x="time", y="firing_rate",
         ...                   hue="coherence", style="choice",
-        ...                   hue_norm=(0, 100), data=dots)
+        ...                   hue_norm=LogNorm(), data=dots)
 
     Use a different color palette:
 
@@ -1175,7 +1182,7 @@ lineplot.__doc__ = dedent("""\
 
         >>> ax = sns.lineplot(x="time", y="firing_rate",
         ...                   hue="coherence", style="choice",
-        ...                   palette="viridis_r", data=dots)
+        ...                   palette="ch:2.5,.25", data=dots)
 
     Use specific color values, treating the hue variable as categorical:
 
@@ -1203,7 +1210,7 @@ lineplot.__doc__ = dedent("""\
 
         >>> ax = sns.lineplot(x="time", y="firing_rate",
         ...                   size="coherence", hue="choice",
-        ...                   sizes=(.2, 1), data=dots)
+        ...                   sizes=(.25, 2.5), data=dots)
 
     Plot from a wide-form DataFrame:
 

--- a/seaborn/basic.py
+++ b/seaborn/basic.py
@@ -522,7 +522,10 @@ class _BasicPlotter(object):
             return "categorical"
         else:
             try:
-                data.astype(np.float)
+                float_data = data.astype(np.float)
+                values = np.unique(float_data.dropna())
+                if np.array_equal(values, np.array([0., 1.])):
+                        return "categorical"
                 return "numeric"
             except (ValueError, TypeError):
                 return "categorical"

--- a/seaborn/basic.py
+++ b/seaborn/basic.py
@@ -465,10 +465,21 @@ class _BasicPlotter(object):
             )
 
         paths = {}
+        filled_markers = []
         for k, m in markers.items():
             if not isinstance(m, mpl.markers.MarkerStyle):
                 m = mpl.markers.MarkerStyle(m)
             paths[k] = m.get_path().transformed(m.get_transform())
+            filled_markers.append(m.is_filled())
+
+        # Mixture of filled and unfilled markers will show line art markers
+        # in the edge color, which defaults to white. This can be handled,
+        # but there would be additional complexity with specifying the
+        # weight of the line art markers without overwhelming the filled
+        # ones with the edges. So for now, we will disallow mixtures.
+        if not all(filled_markers) and any(filled_markers):
+            err = "Filled and line art markers cannot be mixed"
+            raise ValueError(err)
 
         self.style_levels = levels
         self.dashes = dashes

--- a/seaborn/palettes.py
+++ b/seaborn/palettes.py
@@ -969,7 +969,7 @@ def cubehelix_palette(n_colors=6, start=0, rot=.4, gamma=1.0, hue=0.8,
         if reverse:
             x_256 = x_256[::-1]
         pal_256 = cmap(x_256)
-        cmap = mpl.colors.ListedColormap(pal_256)
+        cmap = mpl.colors.ListedColormap(pal_256, "seaborn_cubehelix")
         return cmap
     else:
         return _ColorPalette(pal)

--- a/seaborn/palettes.py
+++ b/seaborn/palettes.py
@@ -842,6 +842,10 @@ def cubehelix_palette(n_colors=6, start=0, rot=.4, gamma=1.0, hue=0.8,
     user more control over the look of the palette and has a different set of
     defaults.
 
+    In addition to using this function, it is also possible to generate a
+    cubehelix palette generally in seaborn using a string-shorthand; see the
+    example below.
+
     Parameters
     ----------
     n_colors : int
@@ -934,6 +938,13 @@ def cubehelix_palette(n_colors=6, start=0, rot=.4, gamma=1.0, hue=0.8,
         >>> cmap = sns.cubehelix_palette(dark=0, light=1, as_cmap=True)
         >>> ax = sns.heatmap(x, cmap=cmap)
 
+    Use through the :func:`color_palette` interface:
+
+    .. plot::
+        :context: close-figs
+
+        >>> sns.palplot(sns.color_palette("ch:2,r=.2,l=.6"))
+
     """
     def get_color_function(p0, p1):
         # Copied from matplotlib because it lives in private module
@@ -977,11 +988,18 @@ def cubehelix_palette(n_colors=6, start=0, rot=.4, gamma=1.0, hue=0.8,
 
 def _parse_cubehelix_args(argstr):
     """Turn stringified cubehelix params into args/kwargs."""
+
     if argstr.startswith("ch:"):
         argstr = argstr[3:]
 
+    if argstr.endswith("_r"):
+        reverse = True
+        argstr = argstr[:-2]
+    else:
+        reverse = False
+
     if not argstr:
-        return [], {}
+        return [], {"reverse": reverse}
 
     all_args = argstr.split(",")
 
@@ -989,6 +1007,16 @@ def _parse_cubehelix_args(argstr):
 
     kwargs = [a.split("=") for a in all_args if "=" in a]
     kwargs = {k.strip(" "): float(v.strip(" ")) for k, v in kwargs}
+
+    kwarg_map = dict(
+        s="start", r="rot", g="gamma",
+        h="hue", l="light", d="dark",  # noqa: E741
+    )
+
+    kwargs = {kwarg_map.get(k, k): v for k, v in kwargs.items()}
+
+    if reverse:
+        kwargs["reverse"] = True
 
     return args, kwargs
 

--- a/seaborn/tests/test_basic.py
+++ b/seaborn/tests/test_basic.py
@@ -976,6 +976,22 @@ class TestLinePlotter(TestBasicPlotter):
         with pytest.raises(ValueError):
             p.add_legend_data(ax)
 
+        ax.clear()
+        p = basic._LinePlotter(x=x, y=y, hue=z,
+                               hue_norm=mpl.colors.LogNorm(),
+                               legend="brief")
+        p.add_legend_data(ax)
+        handles, labels = ax.get_legend_handles_labels()
+        assert float(labels[2]) / float(labels[1]) == 10
+
+        ax.clear()
+        p = basic._LinePlotter(x=x, y=y, size=z,
+                               size_norm=mpl.colors.LogNorm(),
+                               legend="brief")
+        p.add_legend_data(ax)
+        handles, labels = ax.get_legend_handles_labels()
+        assert float(labels[2]) / float(labels[1]) == 10
+
     def test_plot(self, long_df, repeated_df):
 
         f, ax = plt.subplots()
@@ -1143,6 +1159,9 @@ class TestLinePlotter(TestBasicPlotter):
                             wide_df, long_df, missing_df):
 
         f, ax = plt.subplots()
+
+        basic.lineplot([], [])
+        ax.clear()
 
         basic.lineplot(data=flat_array)
         ax.clear()
@@ -1415,6 +1434,9 @@ class TestScatterPlotter(TestBasicPlotter):
                                wide_df, long_df, missing_df):
 
         f, ax = plt.subplots()
+
+        basic.scatterplot([], [])
+        ax.clear()
 
         basic.scatterplot(data=flat_array)
         ax.clear()

--- a/seaborn/tests/test_basic.py
+++ b/seaborn/tests/test_basic.py
@@ -472,9 +472,18 @@ class TestBasicPlotter(object):
         assert p.hue_limits == (p.plot_data.hue.min(), p.plot_data.hue.max())
 
         # Test specified hue limits
-        hue_limits = 1, 4
-        p.parse_hue(p.plot_data.hue, None, None, hue_limits)
-        assert p.hue_limits == hue_limits
+        hue_norm = 1, 4
+        p.parse_hue(p.plot_data.hue, None, None, hue_norm)
+        assert p.hue_limits == hue_norm
+        assert isinstance(p.hue_norm, mpl.colors.Normalize)
+        assert p.hue_norm.vmin == hue_norm[0]
+        assert p.hue_norm.vmax == hue_norm[1]
+
+        # Test Normalize object
+        hue_norm = mpl.colors.PowerNorm(2, vmin=1, vmax=10)
+        p.parse_hue(p.plot_data.hue, None, None, hue_norm)
+        assert p.hue_limits == (hue_norm.vmin, hue_norm.vmax)
+        assert p.hue_norm is hue_norm
 
         # Test default colormap values
         hmin, hmax = p.plot_data.hue.min(), p.plot_data.hue.max()
@@ -483,9 +492,9 @@ class TestBasicPlotter(object):
         assert p.palette[hmax] == pytest.approx(p.cmap(1.0))
 
         # Test specified colormap values
-        hue_limits = hmin - 1, hmax - 1
-        p.parse_hue(p.plot_data.hue, None, None, hue_limits)
-        norm_min = (hmin - hue_limits[0]) / (hue_limits[1] - hue_limits[0])
+        hue_norm = hmin - 1, hmax - 1
+        p.parse_hue(p.plot_data.hue, None, None, hue_norm)
+        norm_min = (hmin - hue_norm[0]) / (hue_norm[1] - hue_norm[0])
         assert p.palette[hmin] == pytest.approx(p.cmap(norm_min))
         assert p.palette[hmax] == pytest.approx(p.cmap(1.0))
 

--- a/seaborn/tests/test_basic.py
+++ b/seaborn/tests/test_basic.py
@@ -57,6 +57,7 @@ class TestBasicPlotter(object):
             y=rs.randn(n),
             a=np.take(list("abc"), rs.randint(0, 3, n)),
             b=np.take(list("mnop"), rs.randint(0, 4, n)),
+            c=np.take(list([0, 1]), rs.randint(0, 2, n)),
             s=np.take([2, 4, 8], rs.randint(0, 3, n)),
         ))
 
@@ -443,6 +444,11 @@ class TestBasicPlotter(object):
         expected_colors = color_palette("husl", n_colors=len(levels))
         expected_palette = dict(zip(levels, expected_colors))
         assert p.palette == expected_palette
+
+        # Test binary data
+        p = basic._LinePlotter(x="x", y="y", hue="c", data=long_df)
+        assert p.hue_levels == [0, 1]
+        assert p.hue_type is "categorical"
 
     def test_parse_hue_numeric(self, long_df):
 

--- a/seaborn/tests/test_basic.py
+++ b/seaborn/tests/test_basic.py
@@ -623,6 +623,11 @@ class TestBasicPlotter(object):
         with pytest.raises(ValueError):
             p.parse_style(p.plot_data["style"], markers, dashes, None)
 
+        # Test mixture of filled and unfilled markers
+        markers, dashes = ["o", "x", "s"], None
+        with pytest.raises(ValueError):
+            p.parse_style(p.plot_data["style"], markers, dashes, None)
+
     def test_subset_data_quantities(self, long_df):
 
         p = basic._LinePlotter(x="x", y="y", data=long_df)

--- a/seaborn/tests/test_basic.py
+++ b/seaborn/tests/test_basic.py
@@ -456,7 +456,7 @@ class TestBasicPlotter(object):
         hue_levels = list(np.sort(long_df.s.unique()))
         assert p.hue_levels == hue_levels
         assert p.hue_type is "numeric"
-        assert p.cmap is mpl.cm.get_cmap(mpl.rcParams["image.cmap"])
+        assert p.cmap.name == "seaborn_cubehelix"
 
         # Test named colormap
         palette = "Purples"

--- a/seaborn/tests/test_palettes.py
+++ b/seaborn/tests/test_palettes.py
@@ -275,14 +275,23 @@ class TestColorPalettes(object):
 
     def test_cubehelix_code(self):
 
-        pal1 = palettes.color_palette("ch:", 8)
-        pal2 = palettes.color_palette(palettes.cubehelix_palette(8))
+        color_palette = palettes.color_palette
+        cubehelix_palette = palettes.cubehelix_palette
+
+        pal1 = color_palette("ch:", 8)
+        pal2 = color_palette(cubehelix_palette(8))
         assert pal1 == pal2
 
-        pal1 = palettes.color_palette("ch:.5, -.25,hue = .5,light=.75", 8)
-        pal2 = palettes.color_palette(
-            palettes.cubehelix_palette(8, .5, -.25, hue=.5, light=.75)
-        )
+        pal1 = color_palette("ch:.5, -.25,hue = .5,light=.75", 8)
+        pal2 = color_palette(cubehelix_palette(8, .5, -.25, hue=.5, light=.75))
+        assert pal1 == pal2
+
+        pal1 = color_palette("ch:h=1,r=.5", 9)
+        pal2 = color_palette(cubehelix_palette(9, hue=1, rot=.5))
+        assert pal1 == pal2
+
+        pal1 = color_palette("ch:_r", 6)
+        pal2 = color_palette(cubehelix_palette(6, reverse=True))
         assert pal1 == pal2
 
     def test_xkcd_palette(self):


### PR DESCRIPTION
These enhancements clean up some open issues in `scatterplot`/`lineplot`:

- Renamed `{hue,size}_limits` to `{hue,size}_norm` and allowed them to accept and use a matplotlib `Normalize` object. There is some support for using the LogTicker to generate brief legend ticks (but see https://github.com/matplotlib/matplotlib/issues/11518); other kinds of normalization are not associated with other ticks, but are less likely to be used.
- Binary data (i.e. data with only 0s or 1s) is treated as categorical by default instead of getting the ends of the default numeric colormap and weird legend "ticks"
- Raise on getting a mixture of  filled and unfilled markers, otherwise the unfilled markers will be drawn with the edgecolor (white by default, causing them to appear invisible).
- Changed the default numeric hue colormap to the default cubehelix palette for more contrast against the background.

Additionally, this PR includes a commit that makes the `"ch:"` string specification of cubehelix more convenient by allowing single-letter shorthands for keyword arguments.

Closes #1470, closes #1441