### PR TITLE
First approach to relational plot legends

### DIFF
--- a/seaborn/basic.py
+++ b/seaborn/basic.py
@@ -550,10 +550,10 @@ class _BasicPlotter(object):
             err = "`legend` must be 'brief', 'full', or False"
             raise ValueError(err)
 
-        keys = []
         legend_kwargs = {}
-        legend_data = {}
-        titles = []
+        keys = []
+
+        title_kws = dict(color="w", s=0, linewidth=0, marker="", dashes="")
 
         def update(var_name, val_name, **kws):
 
@@ -564,7 +564,6 @@ class _BasicPlotter(object):
                 keys.append(key)
 
                 legend_kwargs[key] = dict(**kws)
-                titles.append(None)
 
         # -- Add a legend for hue semantics
 
@@ -578,10 +577,11 @@ class _BasicPlotter(object):
         else:
             hue_levels = self.hue_levels
 
+        # Add the hue semantic subtitle
         if self.hue_label is not None:
-            titles.append(self.hue_label)
-            keys.append(None)
+            update((self.hue_label, "title"), self.hue_label, **title_kws)
 
+        # Add the hue semantic labels
         for level in hue_levels:
             if level is not None:
                 color = self.color_lookup(level)
@@ -599,10 +599,11 @@ class _BasicPlotter(object):
         else:
             size_levels = self.size_levels
 
+        # Add the size semantic subtitle
         if self.size_label is not None:
-            titles.append(self.size_label)
-            keys.append(None)
+            update((self.size_label, "title"), self.size_label, **title_kws)
 
+        # Add the size semantic labels
         for level in size_levels:
             if level is not None:
                 size = self.size_lookup(level)
@@ -610,10 +611,11 @@ class _BasicPlotter(object):
 
         # -- Add a legend for style semantics
 
+        # Add the style semantic title
         if self.style_label is not None:
-            titles.append(self.style_label)
-            keys.append(None)
+            update((self.style_label, "title"), self.style_label, **title_kws)
 
+        # Add the style semantic labels
         for level in self.style_levels:
             if level is not None:
                 update(self.style_label, level,
@@ -625,16 +627,13 @@ class _BasicPlotter(object):
         legend_data = {}
         legend_order = []
 
-        for title, key in zip(titles, keys):
-            if title is not None:
-                func([], [], label=title, visible=False)
-                continue
+        for key in keys:
 
             _, label = key
             kws = legend_kwargs[key]
             kws.setdefault("color", ".2")
             use_kws = {}
-            for attr in self._legend_attributes:
+            for attr in self._legend_attributes + ["visible"]:
                 if attr in kws:
                     use_kws[attr] = kws[attr]
             artist = func([], [], label=label, **use_kws)
@@ -645,8 +644,6 @@ class _BasicPlotter(object):
 
         self.legend_data = legend_data
         self.legend_order = legend_order
-
-        return titles
 
 
 class _LinePlotter(_BasicPlotter):
@@ -830,13 +827,10 @@ class _LinePlotter(_BasicPlotter):
         # Finalize the axes details
         self.label_axes(ax)
         if self.legend:
-            titles = self.add_legend_data(ax)
+            self.add_legend_data(ax)
             handles, _ = ax.get_legend_handles_labels()
             if handles:
-                legend = ax.legend()
-                texts = legend.get_texts()[-len(titles):]
-                for title, text in zip(titles, texts):
-                    text.set_horizontal_alignment("right")
+                ax.legend()
 
 
 class _ScatterPlotter(_BasicPlotter):

--- a/seaborn/tests/test_basic.py
+++ b/seaborn/tests/test_basic.py
@@ -916,8 +916,8 @@ class TestLinePlotter(TestBasicPlotter):
         p.add_legend_data(ax)
         handles, labels = ax.get_legend_handles_labels()
         colors = [h.get_color() for h in handles]
-        assert labels == p.hue_levels
-        assert colors == [p.palette[l] for l in labels]
+        assert labels == ["a"] + p.hue_levels
+        assert colors == ["w"] + [p.palette[l] for l in p.hue_levels]
 
         # --
 
@@ -928,9 +928,9 @@ class TestLinePlotter(TestBasicPlotter):
         handles, labels = ax.get_legend_handles_labels()
         colors = [h.get_color() for h in handles]
         markers = [h.get_marker() for h in handles]
-        assert labels == p.hue_levels == p.style_levels
-        assert colors == [p.palette[l] for l in labels]
-        assert markers == [p.markers[l] for l in labels]
+        assert labels == ["a"] + p.hue_levels == ["a"] + p.style_levels
+        assert colors == ["w"] + [p.palette[l] for l in p.hue_levels]
+        assert markers == [""] + [p.markers[l] for l in p.style_levels]
 
         # --
 
@@ -941,11 +941,11 @@ class TestLinePlotter(TestBasicPlotter):
         handles, labels = ax.get_legend_handles_labels()
         colors = [h.get_color() for h in handles]
         markers = [h.get_marker() for h in handles]
-        expected_colors = ([p.palette[l] for l in p.hue_levels]
-                           + [".2" for _ in p.style_levels])
-        expected_markers = (["None" for _ in p.hue_levels]
-                            + [p.markers[l] for l in p.style_levels])
-        assert labels == p.hue_levels + p.style_levels
+        expected_colors = (["w"] + [p.palette[l] for l in p.hue_levels]
+                           + ["w"] + [".2" for _ in p.style_levels])
+        expected_markers = ([""] + ["None" for _ in p.hue_levels]
+                            + [""] + [p.markers[l] for l in p.style_levels])
+        assert labels == ["a"] + p.hue_levels + ["b"] + p.style_levels
         assert colors == expected_colors
         assert markers == expected_markers
 
@@ -958,9 +958,9 @@ class TestLinePlotter(TestBasicPlotter):
         handles, labels = ax.get_legend_handles_labels()
         colors = [h.get_color() for h in handles]
         widths = [h.get_linewidth() for h in handles]
-        assert labels == p.hue_levels == p.size_levels
-        assert colors == [p.palette[l] for l in labels]
-        assert widths == [p.sizes[l] for l in labels]
+        assert labels == ["a"] + p.hue_levels == ["a"] + p.size_levels
+        assert colors == ["w"] + [p.palette[l] for l in p.hue_levels]
+        assert widths == [0] + [p.sizes[l] for l in p.size_levels]
 
         # --
 
@@ -1250,7 +1250,10 @@ class TestScatterPlotter(TestBasicPlotter):
     def test_legend_data(self, long_df):
 
         m = mpl.markers.MarkerStyle("o")
-        default_marker = m.get_path().transformed(m.get_transform())
+        default_mark = m.get_path().transformed(m.get_transform())
+
+        m = mpl.markers.MarkerStyle("")
+        null_mark = m.get_path().transformed(m.get_transform())
 
         f, ax = plt.subplots()
 
@@ -1267,8 +1270,9 @@ class TestScatterPlotter(TestBasicPlotter):
         p.add_legend_data(ax)
         handles, labels = ax.get_legend_handles_labels()
         colors = [h.get_facecolors()[0] for h in handles]
-        assert labels == p.hue_levels
-        assert self.colors_equal(colors, [p.palette[l] for l in labels])
+        expected_colors = ["w"] + [p.palette[l] for l in p.hue_levels]
+        assert labels == ["a"] + p.hue_levels
+        assert self.colors_equal(colors, expected_colors)
 
         # --
 
@@ -1278,10 +1282,12 @@ class TestScatterPlotter(TestBasicPlotter):
         p.add_legend_data(ax)
         handles, labels = ax.get_legend_handles_labels()
         colors = [h.get_facecolors()[0] for h in handles]
+        expected_colors = ["w"] + [p.palette[l] for l in p.hue_levels]
         paths = [h.get_paths()[0] for h in handles]
-        assert labels == p.hue_levels == p.style_levels
-        assert self.colors_equal(colors, [p.palette[l] for l in labels])
-        assert self.paths_equal(paths, [p.paths[l] for l in labels])
+        expected_paths = [null_mark] + [p.paths[l] for l in p.style_levels]
+        assert labels == ["a"] + p.hue_levels == ["a"] + p.style_levels
+        assert self.colors_equal(colors, expected_colors)
+        assert self.paths_equal(paths, expected_paths)
 
         # --
 
@@ -1292,11 +1298,11 @@ class TestScatterPlotter(TestBasicPlotter):
         handles, labels = ax.get_legend_handles_labels()
         colors = [h.get_facecolors()[0] for h in handles]
         paths = [h.get_paths()[0] for h in handles]
-        expected_colors = ([p.palette[l] for l in p.hue_levels]
-                           + [".2" for _ in p.style_levels])
-        expected_paths = ([default_marker for _ in p.hue_levels]
-                          + [p.paths[l] for l in p.style_levels])
-        assert labels == p.hue_levels + p.style_levels
+        expected_colors = (["w"] + [p.palette[l] for l in p.hue_levels]
+                           + ["w"] + [".2" for _ in p.style_levels])
+        expected_paths = ([null_mark] + [default_mark for _ in p.hue_levels]
+                          + [null_mark] + [p.paths[l] for l in p.style_levels])
+        assert labels == ["a"] + p.hue_levels + ["b"] + p.style_levels
         assert self.colors_equal(colors, expected_colors)
         assert self.paths_equal(paths, expected_paths)
 
@@ -1308,10 +1314,12 @@ class TestScatterPlotter(TestBasicPlotter):
         p.add_legend_data(ax)
         handles, labels = ax.get_legend_handles_labels()
         colors = [h.get_facecolors()[0] for h in handles]
+        expected_colors = ["w"] + [p.palette[l] for l in p.hue_levels]
         sizes = [h.get_sizes()[0] for h in handles]
-        assert labels == p.hue_levels == p.size_levels
-        assert self.colors_equal(colors, [p.palette[l] for l in labels])
-        assert sizes == [p.sizes[l] for l in labels]
+        expected_sizes = [0] + [p.sizes[l] for l in p.size_levels]
+        assert labels == ["a"] + p.hue_levels == ["a"] + p.size_levels
+        assert self.colors_equal(colors, expected_colors)
+        assert sizes == expected_sizes
 
         # --
 
@@ -1610,11 +1618,12 @@ class TestRelPlotter(TestBasicPlotter):
 
         g = basic.relplot(x="x", y="y", hue="a", data=long_df)
         texts = [t.get_text() for t in g._legend.texts]
-        assert np.array_equal(texts, long_df["a"].unique())
+        expected_texts = np.append(["a"], long_df["a"].unique())
+        assert np.array_equal(texts, expected_texts)
 
         g = basic.relplot(x="x", y="y", hue="s", size="s", data=long_df)
         texts = [t.get_text() for t in g._legend.texts]
-        assert np.array_equal(texts, np.sort(texts))
+        assert np.array_equal(texts[1:], np.sort(texts[1:]))
 
         g = basic.relplot(x="x", y="y", hue="a", legend=False, data=long_df)
         assert g._legend is None


### PR DESCRIPTION
This PR adds invisible artists to the axes that can be used as subtitles in a legend for a plot with multiple semantics:

![image](https://user-images.githubusercontent.com/315810/42346556-0ce305a2-8071-11e8-9d77-445c802d8cc1.png)

The downside is that the subtitles are stuck in the right column with other labels. See planned enhancements in #1440, but I'm also interested in other, better long-term solutions. (First-class support for sectioned legends in matplotlib would be ideal).

Closes #1440