### PR TITLE
Rename factorplot to catplot and change the default plot kind to strip

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -30,7 +30,7 @@ Categorical plots
     swarmplot
     boxplot
     violinplot
-    lvplot
+    boxenplot
     pointplot
     barplot
     countplot

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -25,7 +25,7 @@ Categorical plots
 .. autosummary::
     :toctree: generated/
 
-    factorplot
+    catplot
     stripplot
     swarmplot
     boxplot

--- a/doc/introduction.ipynb
+++ b/doc/introduction.ipynb
@@ -235,7 +235,7 @@
     "Specialized categorical plots\n",
     "-----------------------------\n",
     "\n",
-    "Standard scatter and line plots visualize relationships between numerical variables, but many data analyses involve categorical variables. There are several specialized plot types in seaborn that are optimized for visualizing this kind of data. They can be accessed through :func:`factorplot`. Similar to :func:`relplot`, the idea of :func:`factorplot` is that it exposes a common dataset-oriented API that generalizes over different representations of the relationship between one numeric variable and one (or more) categorical variables.\n",
+    "Standard scatter and line plots visualize relationships between numerical variables, but many data analyses involve categorical variables. There are several specialized plot types in seaborn that are optimized for visualizing this kind of data. They can be accessed through :func:`catplot`. Similar to :func:`relplot`, the idea of :func:`catplot` is that it exposes a common dataset-oriented API that generalizes over different representations of the relationship between one numeric variable and one (or more) categorical variables.\n",
     "\n",
     "These representations offer different levels of granularity in their presentation of the underlying data. At the finest level, you may wish to see every observation by drawing a scatter plot that adjusts the positions of the points along the categorical axis so that they don't overlap:"
    ]
@@ -246,8 +246,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.factorplot(x=\"day\", y=\"total_bill\", hue=\"smoker\",\n",
-    "               kind=\"swarm\", data=tips);"
+    "sns.catplot(x=\"day\", y=\"total_bill\", hue=\"smoker\",\n",
+    "            kind=\"swarm\", data=tips);"
    ]
   },
   {
@@ -263,8 +263,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.factorplot(x=\"day\", y=\"total_bill\", hue=\"smoker\",\n",
-    "               kind=\"violin\", split=True, data=tips);"
+    "sns.catplot(x=\"day\", y=\"total_bill\", hue=\"smoker\",\n",
+    "            kind=\"violin\", split=True, data=tips);"
    ]
   },
   {
@@ -280,8 +280,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.factorplot(x=\"day\", y=\"total_bill\", hue=\"smoker\",\n",
-    "               kind=\"bar\", data=tips);"
+    "sns.catplot(x=\"day\", y=\"total_bill\", hue=\"smoker\",\n",
+    "            kind=\"bar\", data=tips);"
    ]
   },
   {
@@ -438,9 +438,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "g = sns.factorplot(x=\"total_bill\", y=\"day\", hue=\"time\",\n",
-    "                   height=3.5, aspect=1.5,\n",
-    "                   kind=\"box\", legend=False, data=tips);\n",
+    "g = sns.catplot(x=\"total_bill\", y=\"day\", hue=\"time\",\n",
+    "                height=3.5, aspect=1.5,\n",
+    "                kind=\"box\", legend=False, data=tips);\n",
     "g.add_legend(title=\"Meal\")\n",
     "g.set_axis_labels(\"Total bill ($)\", \"\")\n",
     "g.set(xlim=(0, 60), yticklabels=[\"Thursday\", \"Friday\", \"Saturday\", \"Sunday\"])\n",

--- a/doc/releases/v0.3.0.txt
+++ b/doc/releases/v0.3.0.txt
@@ -2,14 +2,14 @@
 v0.3.0 (March 2014)
 -------------------
 
-This is a major release from 0.2 with a number of enhancements to the plotting capabilities and styles. Highlights include :class:`FacetGrid`, :func:`factorplot`, :func:`jointplot`, and an overhaul to :ref:`style management <aesthetics_tutorial>`. There is also lots of new documentation, including an :ref:`example gallery <example_gallery>` and reorganized :ref:`tutorial <tutorial>`.
+This is a major release from 0.2 with a number of enhancements to the plotting capabilities and styles. Highlights include :class:`FacetGrid`, ``factorplot``, :func:`jointplot`, and an overhaul to :ref:`style management <aesthetics_tutorial>`. There is also lots of new documentation, including an :ref:`example gallery <example_gallery>` and reorganized :ref:`tutorial <tutorial>`.
 
 New plotting functions
 ~~~~~~~~~~~~~~~~~~~~~~
 
 - The :class:`FacetGrid` class adds a new form of functionality to seaborn, providing a way to abstractly structure a grid of plots corresponding to subsets of a dataset. It can be used with a wide variety of plotting functions (including most of the matplotlib and seaborn APIs. See the :ref:`tutorial <facet_grid>` for more information.
 
-- Version 0.3 introduces the :func:`factorplot` function, which is similar in spirit to :func:`lmplot` but intended for use when the main independent variable is categorical instead of quantitative. :func:`factorplot` can draw a plot in either a point or bar representation using the corresponding Axes-level functions :func:`pointplot` and :func:`barplot` (which are also new). Additionally, the :func:`factorplot` function can be used to draw box plots on a faceted grid. For examples of how to use these functions, you can refer to the tutorial.
+- Version 0.3 introduces the ``factorplot`` function, which is similar in spirit to :func:`lmplot` but intended for use when the main independent variable is categorical instead of quantitative. ``factorplot`` can draw a plot in either a point or bar representation using the corresponding Axes-level functions :func:`pointplot` and :func:`barplot` (which are also new). Additionally, the ``factorplot`` function can be used to draw box plots on a faceted grid. For examples of how to use these functions, you can refer to the tutorial.
 
 - Another new function is :func:`jointplot`, which is built using the new :class:`JointGrid` object. :func:`jointplot` generalizes the behavior of :func:`regplot` in previous versions of seaborn (:func:`regplot` has changed somewhat in 0.3; see below for details) by drawing a bivariate plot of the relationship between two variables with their marginal distributions drawn on the side of the plot. With :func:`jointplot`, you can draw a scatterplot or regression plot as before, but you can now also draw bivariate kernel densities or hexbin plots with appropriate univariate graphs for the marginal distributions. Additionally, it's easy to use :class:`JointGrid` directly to build up more complex plots when the default methods offered by :func:`jointplot` are not suitable for your visualization problem. The tutorial for :class:`JointGrid` has more examples of how this object can be useful.
 

--- a/doc/releases/v0.3.1.txt
+++ b/doc/releases/v0.3.1.txt
@@ -7,7 +7,7 @@ This is a minor release from 0.3 with fixes for several bugs.
 Plotting functions
 ~~~~~~~~~~~~~~~~~~
 
-- The size of the points in :func:`pointplot` and :func:`factorplot` are now scaled with the linewidth for better aesthetics across different plotting contexts.
+- The size of the points in :func:`pointplot` and ``factorplot`` are now scaled with the linewidth for better aesthetics across different plotting contexts.
 
 - The :func:`pointplot` glyphs for different levels of the hue variable are drawn at different z-orders so that they appear uniform.
 

--- a/doc/releases/v0.4.0.txt
+++ b/doc/releases/v0.4.0.txt
@@ -15,7 +15,7 @@ Plotting functions
 
 - When using :class:`FacetGrid` with a ``hue`` variable, the legend is no longer drawn by default when you call :meth:`FacetGrid.map`. Instead, you have to call :meth:`FacetGrid.add_legend` manually. This should make it easier to layer multiple plots onto the grid without having duplicated legends.
 
-- Made some changes to :func:`factorplot` so that it behaves better when not all levels of the ``x`` variable are represented in each facet.
+- Made some changes to ``factorplot`` so that it behaves better when not all levels of the ``x`` variable are represented in each facet.
 
 - Added the ``logx`` option to :func:`regplot` for fitting the regression in log space.
 

--- a/doc/releases/v0.6.0.txt
+++ b/doc/releases/v0.6.0.txt
@@ -16,7 +16,7 @@ In version 0.6, the "categorical" plots have been unified with a common API. Thi
 
 The categorical functions now each accept the same formats of input data and can be invoked in the same way. They can plot using long- or wide-form data, and can be drawn vertically or horizontally. When long-form data is used, the orientation of the plots is inferred from the types of the input data. Additionally, all functions natively take a ``hue`` variable to add a second layer of categorization.
 
-With the (in some cases new) API, these functions can all be drawn correctly by :class:`FacetGrid`. However, :func:`factorplot` can also now create faceted verisons of any of these kinds of plots, so in most cases it will be unnecessary to use :class:`FacetGrid` directly. By default, :func:`factorplot` draws a point plot, but this is controlled by the ``kind`` parameter.
+With the (in some cases new) API, these functions can all be drawn correctly by :class:`FacetGrid`. However, ``factorplot`` can also now create faceted verisons of any of these kinds of plots, so in most cases it will be unnecessary to use :class:`FacetGrid` directly. By default, ``factorplot`` draws a point plot, but this is controlled by the ``kind`` parameter.
 
 Here are details on what has changed in the process of unifying these APIs:
 

--- a/doc/releases/v0.7.1.txt
+++ b/doc/releases/v0.7.1.txt
@@ -5,7 +5,7 @@ v0.7.1 (June 2016)
 .. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.54844.svg
    :target: https://doi.org/10.5281/zenodo.54844
 
-- Added the ability to put "caps" on the error bars that are drawn by :func:`barplot` or :func:`pointplot` (and, by extension, :func:`factorplot`). Additionally, the line width of the error bars can now be controlled. These changes involve the new parameters ``capsize`` and ``errwidth``. See the `github pull request (#898) <https://github.com/mwaskom/seaborn/pull/898>`_ for examples of usage.
+- Added the ability to put "caps" on the error bars that are drawn by :func:`barplot` or :func:`pointplot` (and, by extension, ``factorplot``). Additionally, the line width of the error bars can now be controlled. These changes involve the new parameters ``capsize`` and ``errwidth``. See the `github pull request (#898) <https://github.com/mwaskom/seaborn/pull/898>`_ for examples of usage.
 
 - Improved the row and column colors display in :func:`clustermap`. It is now possible to pass Pandas objects for these elements and, when possible, the semantic information in the Pandas objects will be used to add labels to the plot. When Pandas objects are used, the color data is matched against the main heatmap based on the index, not on position. This is more accurate, but it may lead to different results if current code assumed positional matching.
 

--- a/doc/releases/v0.9.0.txt
+++ b/doc/releases/v0.9.0.txt
@@ -12,7 +12,7 @@ v0.9.0 (Unreleased)
 
 - Updated the seaborn palettes ("deep", "muted", "colorblind", etc.) to correspond with the new 10-color matplotlib default. The legacy palettes are now available at "deep6", "muted6", "colorblind6", etc. Additionally, a few individual colors were tweaked for better consistency, aesthetics, and accessibility.
 
-- Renamed the ``size`` parameter to ``height`` in multiplot grid objects (:class:`FacetGrid`, :class:`PairGrid`, and :class:`JointGrid`) along with functions that use them (:func:`factorplot`, :func:`lmplot`, :func:`pairplot`, and :func:`jointplot`) to avoid conflicts with the ``size`` parameter that is used in ``scatterplot`` and ``lineplot`` (necessary to make :func:`relplot` work) and also makes the meaning of the parameter a bit more clear.
+- Renamed the ``size`` parameter to ``height`` in multiplot grid objects (:class:`FacetGrid`, :class:`PairGrid`, and :class:`JointGrid`) along with functions that use them (``factorplot``, :func:`lmplot`, :func:`pairplot`, and :func:`jointplot`) to avoid conflicts with the ``size`` parameter that is used in ``scatterplot`` and ``lineplot`` (necessary to make :func:`relplot` work) and also makes the meaning of the parameter a bit more clear.
 
 - Calling :func:`color_palette` (or :func:`set_palette`) with a named qualitative palettes (i.e. one of the seaborn palettes, the colorbrewer qualitative palettes, or the matplotlib matplotlib tableau-derived palettes) and no specified number of colors will return all of the colors in the palette. This means that for some palettes, the returned list will have a different length than it did in previous versions.
 

--- a/doc/releases/v0.9.0.txt
+++ b/doc/releases/v0.9.0.txt
@@ -6,6 +6,10 @@ v0.9.0 (Unreleased)
 
 - Added the :func:`lineplot` function for representing relationships between``x`` and ``y`` variables with lines, potentially after conditioning on up to three other variables and semantically mapping those conditions with the color, size, or style of the lines. This function replaces :func:`tsplot`, but with an API that is more consistent with other modern seaborn functions and has both more flexibility (more dimensions of semantic mapping, better handling of dates) and less flexibility (fewer options for visual representing uncertainty). There is considerable new API documentation and a few gallery examples.
 
+- TODO change from factorplot to catplot
+
+- TODO default jitter in stripplot
+
 - Final removal of the previously-deprecated ``coefplot`` and ``interactplot`` functions.
 
 - Deprecated the statistical annotation component of :class:`JointGrid`. The method is still available but will be removed in a future version.

--- a/doc/releases/v0.9.0.txt
+++ b/doc/releases/v0.9.0.txt
@@ -8,6 +8,8 @@ v0.9.0 (Unreleased)
 
 - TODO change from factorplot to catplot
 
+- TODO change from lvplot to boxenplot
+
 - TODO default jitter in stripplot
 
 - Final removal of the previously-deprecated ``coefplot`` and ``interactplot`` functions.

--- a/doc/tutorial/axis_grids.ipynb
+++ b/doc/tutorial/axis_grids.ipynb
@@ -29,7 +29,7 @@
     "\n",
     "To use these features, your data has to be in a Pandas DataFrame and it must take the form of what Hadley Whickam calls `\"tidy\" data <https://vita.had.co.nz/papers/tidy-data.pdf>`_. In brief, that means your dataframe should be structured such that each column is a variable and each row is an observation.\n",
     "\n",
-    "For advanced use, you can use the objects discussed in this part of the tutorial directly, which will provide maximum flexibility. Some seaborn functions (such as :func:`lmplot`, :func:`factorplot`, and :func:`pairplot`) also use them behind the scenes. Unlike other seaborn functions that are \"Axes-level\" and draw onto specific (possibly already-existing) matplotlib ``Axes`` without otherwise manipulating the figure, these higher-level functions create a figure when called and are generally more strict about how it gets set up. In some cases, arguments either to those functions or to the constructor of the class they rely on will provide a different interface attributes like the figure size, as in the case of :func:`lmplot` where you can set the height and aspect ratio for each facet rather than the overall size of the figure. Any function that uses one of these objects will always return it after plotting, though, and most of these objects have convenience methods for changing how the plot is drawn, often in a more abstract and easy way."
+    "For advanced use, you can use the objects discussed in this part of the tutorial directly, which will provide maximum flexibility. Some seaborn functions (such as :func:`lmplot`, :func:`catplot`, and :func:`pairplot`) also use them behind the scenes. Unlike other seaborn functions that are \"Axes-level\" and draw onto specific (possibly already-existing) matplotlib ``Axes`` without otherwise manipulating the figure, these higher-level functions create a figure when called and are generally more strict about how it gets set up. In some cases, arguments either to those functions or to the constructor of the class they rely on will provide a different interface attributes like the figure size, as in the case of :func:`lmplot` where you can set the height and aspect ratio for each facet rather than the overall size of the figure. Any function that uses one of these objects will always return it after plotting, though, and most of these objects have convenience methods for changing how the plot is drawn, often in a more abstract and easy way."
    ]
   },
   {
@@ -79,7 +79,7 @@
     "\n",
     "The class is used by initializing a :class:`FacetGrid` object with a dataframe and the names of the variables that will form the row, column, or hue dimensions of the grid. These variables should be categorical or discrete, and then the data at each level of the variable will be used for a facet along that axis. For example, say we wanted to examine differences between lunch and dinner in the ``tips`` dataset.\n",
     "\n",
-    "Additionally, both :func:`lmplot` and :func:`factorplot` use this object internally, and they return the object when they are finished so that it can be used for further tweaking."
+    "Additionally, each of :func:`relplot`, :func:`catplot`, and :func:`lmplot` use this object internally, and they return the object when they are finished so that it can be used for further tweaking."
    ]
   },
   {

--- a/doc/tutorial/categorical.ipynb
+++ b/doc/tutorial/categorical.ipynb
@@ -29,7 +29,7 @@
     "\n",
     "It's useful to divide seaborn's categorical plots into three groups: those that show each observation at each level of the categorical variable, those that show an abstract representation of each *distribution* of observations, and those that apply a statistical estimation to show a measure of central tendency and confidence interval. The first includes the functions :func:`swarmplot` and :func:`stripplot`, the second includes :func:`boxplot`, :func:`violinplot` and :func:`lvplot`, and the third includes :func:`barplot` and :func:`pointplot`. These functions all share a basic API for how they accept data, although each has specific parameters that control the particulars of the visualization that is applied to that data.\n",
     "\n",
-    "Much like the relationship between :func:`regplot` and :func:`lmplot`, in seaborn there are both relatively low-level and relatively high-level approaches for making categorical plots. The functions named above are all low-level in that they plot onto a specific matplotlib axes. There is also the higher-level :func:`factorplot`, which combines these functions with a :class:`FacetGrid` to apply a categorical plot across a grid of figure panels.\n",
+    "Much like the relationship between :func:`regplot` and :func:`lmplot`, in seaborn there are both relatively low-level and relatively high-level approaches for making categorical plots. The functions named above are all low-level in that they plot onto a specific matplotlib axes. There is also the higher-level :func:`catplot`, which combines these functions with a :class:`FacetGrid` to apply a categorical plot across a grid of figure panels.\n",
     "\n",
     "It is easiest and best to invoke these functions with a DataFrame that is in `\"tidy\" <https://vita.had.co.nz/papers/tidy-data.pdf>`_ format, although the lower-level functions also accept wide-form DataFrames or simple vectors of observations. See below for examples."
    ]
@@ -69,17 +69,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "titanic = sns.load_dataset(\"titanic\")\n",
-    "tips = sns.load_dataset(\"tips\")\n",
-    "iris = sns.load_dataset(\"iris\")"
-   ]
-  },
-  {
    "cell_type": "raw",
    "metadata": {},
    "source": [
@@ -95,7 +84,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.factorplot(x=\"day\", y=\"total_bill\", kind=\"strip\", data=tips);"
+    "tips = sns.load_dataset(\"tips\")\n",
+    "sns.catplot(x=\"day\", y=\"total_bill\",  data=tips);"
    ]
   },
   {
@@ -111,8 +101,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.factorplot(x=\"day\", y=\"total_bill\",\n",
-    "               kind=\"strip\", jitter=True, data=tips);"
+    "sns.catplot(x=\"day\", y=\"total_bill\",\n",
+    "            kind=\"strip\", jitter=True, data=tips);"
    ]
   },
   {
@@ -128,7 +118,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.factorplot(x=\"day\", y=\"total_bill\", kind=\"swarm\", data=tips);"
+    "sns.catplot(x=\"day\", y=\"total_bill\", kind=\"swarm\", data=tips);"
    ]
   },
   {
@@ -144,7 +134,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.factorplot(x=\"day\", y=\"total_bill\", hue=\"sex\", kind=\"swarm\", data=tips);"
+    "sns.catplot(x=\"day\", y=\"total_bill\", hue=\"sex\", kind=\"swarm\", data=tips);"
    ]
   },
   {
@@ -160,7 +150,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.factorplot(x=\"size\", y=\"total_bill\", kind=\"swarm\", data=tips);"
+    "sns.catplot(x=\"size\", y=\"total_bill\", kind=\"swarm\", data=tips);"
    ]
   },
   {
@@ -176,7 +166,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.factorplot(x=\"total_bill\", y=\"day\", hue=\"time\", kind=\"swarm\", data=tips);"
+    "sns.catplot(x=\"total_bill\", y=\"day\", hue=\"time\", kind=\"swarm\", data=tips);"
    ]
   },
   {
@@ -200,7 +190,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.factorplot(x=\"day\", y=\"total_bill\", hue=\"time\", kind=\"box\", data=tips);"
+    "sns.catplot(x=\"day\", y=\"total_bill\", hue=\"time\", kind=\"box\", data=tips);"
    ]
   },
   {
@@ -217,8 +207,8 @@
    "outputs": [],
    "source": [
     "tips[\"weekend\"] = tips[\"day\"].isin([\"Sat\", \"Sun\"])\n",
-    "sns.factorplot(x=\"day\", y=\"total_bill\", hue=\"weekend\",\n",
-    "               kind=\"box\", dodge=False, data=tips);"
+    "sns.catplot(x=\"day\", y=\"total_bill\", hue=\"weekend\",\n",
+    "            kind=\"box\", dodge=False, data=tips);"
    ]
   },
   {
@@ -237,8 +227,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.factorplot(x=\"total_bill\", y=\"day\", hue=\"time\",\n",
-    "               kind=\"violin\", data=tips);"
+    "sns.catplot(x=\"total_bill\", y=\"day\", hue=\"time\",\n",
+    "            kind=\"violin\", data=tips);"
    ]
   },
   {
@@ -254,9 +244,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.factorplot(x=\"total_bill\", y=\"day\", hue=\"time\",\n",
-    "               kind=\"violin\", bw=.1, scale=\"count\", scale_hue=False,\n",
-    "               data=tips);"
+    "sns.catplot(x=\"total_bill\", y=\"day\", hue=\"time\",\n",
+    "            kind=\"violin\", bw=.1, scale=\"count\", scale_hue=False,\n",
+    "            data=tips);"
    ]
   },
   {
@@ -272,8 +262,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.factorplot(x=\"day\", y=\"total_bill\", hue=\"sex\",\n",
-    "               kind=\"violin\", split=True, data=tips);"
+    "sns.catplot(x=\"day\", y=\"total_bill\", hue=\"sex\",\n",
+    "            kind=\"violin\", split=True, data=tips);"
    ]
   },
   {
@@ -289,9 +279,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.factorplot(x=\"day\", y=\"total_bill\", hue=\"sex\",\n",
-    "               kind=\"violin\", inner=\"stick\", split=True,\n",
-    "               palette=\"pastel\", data=tips);"
+    "sns.catplot(x=\"day\", y=\"total_bill\", hue=\"sex\",\n",
+    "            kind=\"violin\", inner=\"stick\", split=True,\n",
+    "            palette=\"pastel\", data=tips);"
    ]
   },
   {
@@ -307,7 +297,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "g = sns.factorplot(x=\"day\", y=\"total_bill\", kind=\"violin\", inner=None, data=tips)\n",
+    "g = sns.catplot(x=\"day\", y=\"total_bill\", kind=\"violin\", inner=None, data=tips)\n",
     "sns.swarmplot(x=\"day\", y=\"total_bill\", color=\"k\", size=3, data=tips, ax=g.ax);"
    ]
   },
@@ -332,7 +322,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.factorplot(x=\"sex\", y=\"survived\", hue=\"class\", kind=\"bar\", data=titanic);"
+    "titanic = sns.load_dataset(\"titanic\")\n",
+    "sns.catplot(x=\"sex\", y=\"survived\", hue=\"class\", kind=\"bar\", data=titanic);"
    ]
   },
   {
@@ -348,7 +339,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.factorplot(x=\"deck\", kind=\"count\", data=titanic);"
+    "sns.catplot(x=\"deck\", kind=\"count\", data=titanic);"
    ]
   },
   {
@@ -364,9 +355,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.factorplot(y=\"deck\", hue=\"class\", kind=\"count\",\n",
-    "               palette=\"pastel\", edgecolor=\".6\",\n",
-    "               data=titanic);"
+    "sns.catplot(y=\"deck\", hue=\"class\", kind=\"count\",\n",
+    "            palette=\"pastel\", edgecolor=\".6\",\n",
+    "            data=titanic);"
    ]
   },
   {
@@ -385,7 +376,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.factorplot(x=\"sex\", y=\"survived\", hue=\"class\", kind=\"point\", data=titanic);"
+    "sns.catplot(x=\"sex\", y=\"survived\", hue=\"class\", kind=\"point\", data=titanic);"
    ]
   },
   {
@@ -401,10 +392,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.factorplot(x=\"class\", y=\"survived\", hue=\"sex\",\n",
-    "               palette={\"male\": \"g\", \"female\": \"m\"},\n",
-    "               markers=[\"^\", \"o\"], linestyles=[\"-\", \"--\"],\n",
-    "               kind=\"point\", data=titanic);"
+    "sns.catplot(x=\"class\", y=\"survived\", hue=\"sex\",\n",
+    "            palette={\"male\": \"g\", \"female\": \"m\"},\n",
+    "            markers=[\"^\", \"o\"], linestyles=[\"-\", \"--\"],\n",
+    "            kind=\"point\", data=titanic);"
    ]
   },
   {
@@ -423,14 +414,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.factorplot(data=iris, orient=\"h\", kind=\"box\");"
+    "iris = sns.load_dataset(\"iris\")\n",
+    "sns.catplot(data=iris, orient=\"h\", kind=\"box\");"
    ]
   },
   {
    "cell_type": "raw",
    "metadata": {},
    "source": [
-    "Additionally, these functions accept vectors of Pandas or numpy objects rather than variables in a ``DataFrame``:"
+    "Additionally, the axes-level functions accept vectors of Pandas or numpy objects rather than variables in a ``DataFrame``:"
    ]
   },
   {
@@ -466,7 +458,7 @@
     "Drawing multi-panel categorical plots\n",
     "-------------------------------------\n",
     "\n",
-    "As we mentioned above, there are two ways to draw categorical plots in seaborn. Similar to the duality in the regression plots, you can either use the functions introduced above, or the higher-level function :func:`factorplot`, which combines these functions with a :func:`FacetGrid` to add the ability to examine additional categories through the larger structure of the figure. By default, :func:`factorplot` produces a :func:`pointplot`:"
+    "As we mentioned above, there are two ways to draw categorical plots in seaborn. Similar to the duality in the regression plots, you can either use the functions introduced above, or the higher-level function :func:`catplot`, which combines these functions with a :func:`FacetGrid` to add the ability to examine additional categories through the larger structure of the figure. By default, :func:`catplot` produces a :func:`pointplot`:"
    ]
   },
   {
@@ -475,7 +467,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.factorplot(x=\"day\", y=\"total_bill\", hue=\"smoker\", kind=\"point\", data=tips);"
+    "sns.catplot(x=\"day\", y=\"total_bill\", hue=\"smoker\", kind=\"point\", data=tips);"
    ]
   },
   {
@@ -491,14 +483,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.factorplot(x=\"day\", y=\"total_bill\", hue=\"smoker\", kind=\"bar\", data=tips);"
+    "sns.catplot(x=\"day\", y=\"total_bill\", hue=\"smoker\", kind=\"bar\", data=tips);"
    ]
   },
   {
    "cell_type": "raw",
    "metadata": {},
    "source": [
-    "The main advantage of using a :func:`factorplot` is that it is very easy to \"facet\" the plot and investigate the role of other categorical variables:"
+    "The main advantage of using a :func:`catplot` is that it is very easy to \"facet\" the plot and investigate the role of other categorical variables:"
    ]
   },
   {
@@ -507,8 +499,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.factorplot(x=\"day\", y=\"total_bill\", hue=\"smoker\",\n",
-    "               col=\"time\", kind=\"swarm\", data=tips);"
+    "sns.catplot(x=\"day\", y=\"total_bill\", hue=\"smoker\",\n",
+    "            col=\"time\", kind=\"swarm\", data=tips);"
    ]
   },
   {
@@ -524,8 +516,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.factorplot(x=\"time\", y=\"total_bill\", hue=\"smoker\", col=\"day\",\n",
-    "               height=4, aspect=.5, kind=\"box\", data=tips);"
+    "sns.catplot(x=\"time\", y=\"total_bill\", hue=\"smoker\", col=\"day\",\n",
+    "            height=4, aspect=.5, kind=\"box\", data=tips);"
    ]
   },
   {

--- a/doc/tutorial/categorical.ipynb
+++ b/doc/tutorial/categorical.ipynb
@@ -35,7 +35,7 @@
     "\n",
     "- :func:`boxplot` (with ``kind=\"box\"``)\n",
     "- :func:`violinplot` (with ``kind=\"violin\"``)\n",
-    "- :func:`lvplot` (with ``kind=\"lv\"``)\n",
+    "- :func:`boxenplot` (with ``kind=\"boxen\"``)\n",
     "\n",
     "Categorical estimate plots:\n",
     "\n",
@@ -247,6 +247,24 @@
     "tips[\"weekend\"] = tips[\"day\"].isin([\"Sat\", \"Sun\"])\n",
     "sns.catplot(x=\"day\", y=\"total_bill\", hue=\"weekend\",\n",
     "            kind=\"box\", dodge=False, data=tips);"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "A related function, :func:`boxenplot`, draws a plot that is similar to a box plot but optimized for showing more information about the shape of the distribution. It is best suited for larger datasets:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "diamonds = sns.load_dataset(\"diamonds\")\n",
+    "sns.catplot(x=\"color\", y=\"price\", kind=\"boxen\",\n",
+    "            data=diamonds.sort_values(\"color\"));"
    ]
   },
   {

--- a/doc/tutorial/categorical.ipynb
+++ b/doc/tutorial/categorical.ipynb
@@ -18,20 +18,34 @@
     "\n",
     ".. raw:: html\n",
     "\n",
-    "   <div class=col-md-9>\n"
-   ]
-  },
-  {
-   "cell_type": "raw",
-   "metadata": {},
-   "source": [
-    "We :ref:`previously <regression_tutorial>` learned how to use scatterplots and regression model fits to visualize the relationship between two variables and how it changes across levels of additional categorical variables. However, what if one of the main variables you are interested in is categorical? In this case, the scatterplot and regression model approach won't work. There are several options, however, for visualizing such a relationship, which we will discuss in this tutorial.\n",
+    "   <div class=col-md-9>\n",
+    "   \n",
+    "In the :ref:`relational plot tutorial <relational_tutorial>` we saw how to use visual different representations to show the relationship between multiple variables in a dataset. In the examples, we focused on cases where the main relationship was between two numerical variables. If one of the main variables is \"categorical\" (divided into discrete groups) it may be helpful to use a more specialized approach to visualization.\n",
     "\n",
-    "It's useful to divide seaborn's categorical plots into three groups: those that show each observation at each level of the categorical variable, those that show an abstract representation of each *distribution* of observations, and those that apply a statistical estimation to show a measure of central tendency and confidence interval. The first includes the functions :func:`swarmplot` and :func:`stripplot`, the second includes :func:`boxplot`, :func:`violinplot` and :func:`lvplot`, and the third includes :func:`barplot` and :func:`pointplot`. These functions all share a basic API for how they accept data, although each has specific parameters that control the particulars of the visualization that is applied to that data.\n",
+    "In seaborn, there are several different ways to visualize a relationship involving categorical data. Similar to the relationship between :func:`relplot` and either :func:`scatterplot` or :func:`lineplot`, there are two ways to make these plots. There are a number of axes-level functions for plotting categorical data in different ways and a figure-level interface, :func:`catplot`, that gives unified higher-level access to them.\n",
     "\n",
-    "Much like the relationship between :func:`regplot` and :func:`lmplot`, in seaborn there are both relatively low-level and relatively high-level approaches for making categorical plots. The functions named above are all low-level in that they plot onto a specific matplotlib axes. There is also the higher-level :func:`catplot`, which combines these functions with a :class:`FacetGrid` to apply a categorical plot across a grid of figure panels.\n",
+    "It's helpful to think of the different categorical plot kinds as belonging to three different families, which we'll discuss in detail below. They are:\n",
     "\n",
-    "It is easiest and best to invoke these functions with a DataFrame that is in `\"tidy\" <https://vita.had.co.nz/papers/tidy-data.pdf>`_ format, although the lower-level functions also accept wide-form DataFrames or simple vectors of observations. See below for examples."
+    "Categorical scatterplots:\n",
+    "\n",
+    "- :func:`stripplot` (with ``kind=\"strip\"``; the default)\n",
+    "- :func:`swarmplot` (with ``kind=\"swarm\"``)\n",
+    "\n",
+    "Categorical distribution plots:\n",
+    "\n",
+    "- :func:`boxplot` (with ``kind=\"box\"``)\n",
+    "- :func:`violinplot` (with ``kind=\"violin\"``)\n",
+    "- :func:`lvplot` (with ``kind=\"lv\"``)\n",
+    "\n",
+    "Categorical estimate plots:\n",
+    "\n",
+    "- :func:`pointplot` (with ``kind=\"point\"``)\n",
+    "- :func:`barplot` (with ``kind=\"bar\"``)\n",
+    "- :func:`countplot` (with ``kind=\"count\"``)\n",
+    "\n",
+    "These families represent the data using different levels of granularity. When knowing which to use, you'll have to think about the question that you want to answer. The unified API makes it easy to switch between different kinds and see your data from several perspectives.\n",
+    "\n",
+    "In this tutorial, we'll mostly focus on the figure-level interface, :func:`catplot`. Remember that this function is a higher-level interface each of the functions above, so we'll reference them when we show each kind of plot, keeping the more verbose kind-specific API documentation at hand."
    ]
   },
   {
@@ -41,7 +55,8 @@
    "outputs": [],
    "source": [
     "import seaborn as sns\n",
-    "import matplotlib.pyplot as plt"
+    "import matplotlib.pyplot as plt\n",
+    "sns.set(style=\"ticks\", color_codes=True)"
    ]
   },
   {
@@ -60,22 +75,13 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "sns.set(style=\"darkgrid\", color_codes=True)"
-   ]
-  },
-  {
    "cell_type": "raw",
    "metadata": {},
    "source": [
     "Categorical scatterplots\n",
     "------------------------\n",
     "\n",
-    "A simple way to show the the values of some quantitative variable across the levels of a categorical variable uses :func:`stripplot`, which generalizes a scatterplot to the case where one of the variables is categorical:"
+    "The default representation of the data in :func:`catplot` uses a scatterplot. There are actually two different categorical scatter plots in seaborn. They take different approaches to resolving the main challenge in representing categorical data with a scatter plot, which is that all of the points belonging to one category would fall on the same position along the axes corresponding to the categorical variable. The approach used by :func:`stripplot`, which is the default \"kind\" in :func:`catplot` is to adjust the positions of points on the categorical axis with a small amount of random \"jitter\":"
    ]
   },
   {
@@ -85,14 +91,14 @@
    "outputs": [],
    "source": [
     "tips = sns.load_dataset(\"tips\")\n",
-    "sns.catplot(x=\"day\", y=\"total_bill\",  data=tips);"
+    "sns.catplot(x=\"day\", y=\"total_bill\", data=tips);"
    ]
   },
   {
    "cell_type": "raw",
    "metadata": {},
    "source": [
-    "In a strip plot, the scatterplot points will usually overlap. This makes it difficult to see the full distribution of data. One easy solution is to adjust the positions (only along the categorical axis) using some random \"jitter\": "
+    "The ``jitter`` parameter controls the magnitude of jitter or disables it altogether:"
    ]
   },
   {
@@ -101,15 +107,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.catplot(x=\"day\", y=\"total_bill\",\n",
-    "            kind=\"strip\", jitter=True, data=tips);"
+    "sns.catplot(x=\"day\", y=\"total_bill\", jitter=False, data=tips);"
    ]
   },
   {
    "cell_type": "raw",
    "metadata": {},
    "source": [
-    "A different approach would be to use the function :func:`swarmplot`, which positions each scatterplot point on the categorical axis with an algorithm that avoids overlapping points:"
+    "The second approach adjusts the points along the categorical axis using an algorithm that prevents them from overlapping. It can give a better representation of the distribution of observations, although it only works well for relatively small datasets. This kind of plot is sometimes called a \"beeswarm\" and is drawn in seaborn by :func:`swarmplot`, which is activated by setting ``kind=\"swarm\"`` in :func:`catplot`:"
    ]
   },
   {
@@ -125,7 +130,7 @@
    "cell_type": "raw",
    "metadata": {},
    "source": [
-    "It's also possible to add a nested categorical variable with the ``hue`` parameter. Above the color and position on the categorical axis are redundant, but now each provides information about one of the two variables:"
+    "Similar to the relational plots, it's possible to add another dimension to a categorical plot by using a ``hue`` semantic. (The categorical plots do not currently support ``size`` or ``style`` semantics). Each different categorical plotting function handles the ``hue`` semantic differently. For the scatter plots, it is only necessary to change the color of the points:"
    ]
   },
   {
@@ -141,7 +146,7 @@
    "cell_type": "raw",
    "metadata": {},
    "source": [
-    "In general, the seaborn categorical plotting functions try to infer the order of categories from the data. If your data have a pandas ``Categorical`` datatype, then the default order of the categories can be set there. For other datatypes, string-typed categories will be plotted in the order they appear in the DataFrame, but categories that look numerical will be sorted:"
+    "Unlike with numerical data, it is not always obvious how to order the levels of the categorical variable along its axis. In general, the seaborn categorical plotting functions try to infer the order of categories from the data. If your data have a pandas ``Categorical`` datatype, then the default order of the categories can be set there. If the variable passed to the categorical axis looks numerical, the levels will be sorted. But the data are still treated as categorical and drawn at ordinal positions on the categorical axes (specifically, at 0, 1, ...) even when numbers are used to label them:"
    ]
   },
   {
@@ -150,14 +155,31 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.catplot(x=\"size\", y=\"total_bill\", kind=\"swarm\", data=tips);"
+    "sns.catplot(x=\"size\", y=\"total_bill\", kind=\"swarm\",\n",
+    "            data=tips.query(\"size != 3\"));"
    ]
   },
   {
    "cell_type": "raw",
    "metadata": {},
    "source": [
-    "With these plots, it's often helpful to put the categorical variable on the vertical axis (this is particularly useful when the category names are relatively long or there are many categories). You can force an orientation using the ``orient`` keyword, but usually plot orientation can be inferred from the datatypes of the variables passed to ``x`` and/or ``y``:"
+    "The other option for chosing a default ordering is to take the levels of the category as they appear in the dataset. The ordering can also be controlled on a plot-specific basis using the ``order`` parameter. This can be important when drawing multiple categorical plots in the same figure, which we'll see more of below:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sns.catplot(x=\"smoker\", y=\"tip\", order=[\"No\", \"Yes\"], data=tips);"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "We've referred to the idea of \"categorical axis\". In these examples, that's always corresponded to the horizontal axis. But it's often helpful to put the categorical variable on the vertical axis (particularly when the category names are relatively long or there are many categories). To do this, swap the assignment of variables to axes:"
    ]
   },
   {
@@ -176,12 +198,12 @@
     "Distributions of observations within categories\n",
     "-----------------------------------------------\n",
     "\n",
-    "At a certain point, the categorical scatterplot approach becomes limited in the information it can provide about the distribution of values within each category. There are several ways to summarize this information in ways that facilitate easy comparisons across the category levels. These generalize some of the approaches we discussed in the :ref:`chapter <distribution_tutorial>` to the case where we want to quickly compare across several distributions.\n",
+    "As the size of the dataset grows,, categorical scatter plots become limited in the information they can provide about the distribution of values within each category. When this happens, there are several approaches for summarizing the distributional information in ways that facilitate easy comparisons across the category levels.\n",
     "\n",
     "Boxplots\n",
     "^^^^^^^^\n",
     "\n",
-    "The first is the familiar :func:`boxplot`. This kind of plot shows the three quartile values of the distribution along with extreme values. The \"whiskers\" extend to points that lie within 1.5 IQRs of the lower and upper quartile, and then observations that fall outside this range are displayed independently. Importantly, this means that each value in the boxplot corresponds to an actual observation in the data:"
+    "The first is the familiar :func:`boxplot`. This kind of plot shows the three quartile values of the distribution along with extreme values. The \"whiskers\" extend to points that lie within 1.5 IQRs of the lower and upper quartile, and then observations that fall outside this range are displayed independently. Importantly, this means that each value in the boxplot corresponds to an actual observation in the data."
    ]
   },
   {
@@ -190,14 +212,30 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.catplot(x=\"day\", y=\"total_bill\", hue=\"time\", kind=\"box\", data=tips);"
+    "sns.catplot(x=\"day\", y=\"total_bill\", kind=\"box\", data=tips);"
    ]
   },
   {
    "cell_type": "raw",
    "metadata": {},
    "source": [
-    "For boxplots, the assumption when using a ``hue`` variable is that it is nested within the ``x`` or ``y`` variable. This means that by default, the boxes for different levels of ``hue`` will be offset, as you can see above. If your ``hue`` variable is not nested, you can set the ``dodge`` parameter to disable offsetting:"
+    "When adding a ``hue`` semantic, the box for each level of the semantic variable are moved along the categorical axis so they don't overlap:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sns.catplot(x=\"day\", y=\"total_bill\", hue=\"smoker\", kind=\"box\", data=tips);"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "This behavior is called \"dodging\" and is turned on by default because it is assumed that the semantic variable is nested within the main categorical variable. If that's not the case, you can disable the dodging:"
    ]
   },
   {
@@ -235,7 +273,7 @@
    "cell_type": "raw",
    "metadata": {},
    "source": [
-    "This approach uses the kernel density estimate to provide a better description of the distribution of values. Additionally, the quartile and whikser values from the boxplot are shown inside the violin. Because the violinplot uses a KDE, there are some other parameters that may need tweaking, adding some complexity relative to the straightforward boxplot:"
+    "This approach uses the kernel density estimate to provide a richer description of the distribution of values. Additionally, the quartile and whikser values from the boxplot are shown inside the violin. The downside is that, because the violinplot uses a KDE, there are some other parameters that may need tweaking, adding some complexity relative to the straightforward boxplot:"
    ]
   },
   {
@@ -245,8 +283,8 @@
    "outputs": [],
    "source": [
     "sns.catplot(x=\"total_bill\", y=\"day\", hue=\"time\",\n",
-    "            kind=\"violin\", bw=.1, scale=\"count\", scale_hue=False,\n",
-    "            data=tips);"
+    "            bw=.15, cut=0, scale=\"count\", scale_hue=False,\n",
+    "            kind=\"violin\", data=tips);"
    ]
   },
   {
@@ -288,7 +326,7 @@
    "cell_type": "raw",
    "metadata": {},
    "source": [
-    "It can also be useful to combine :func:`swarmplot` or :func:`striplot` with :func:`violinplot` or :func:`boxplot` to show each observation along with a summary of the distribution:"
+    "It can also be useful to combine :func:`swarmplot` or :func:`striplot` with a box plot or violin plot to show each observation along with a summary of the distribution:"
    ]
   },
   {
@@ -308,12 +346,12 @@
     "Statistical estimation within categories\n",
     "----------------------------------------\n",
     "\n",
-    "Often, rather than showing the distribution within each category, you might want to show the central tendency of the values. Seaborn has two main ways to show this information, but importantly, the basic API for these functions is identical to that for the ones discussed above.\n",
+    "For other applications, rather than showing the distribution within each category, you might want to show the central tendency of the values. Seaborn has two main ways to show this information. Importantly, the basic API for these functions is identical to that for the ones discussed above.\n",
     "\n",
     "Bar plots\n",
     "^^^^^^^^^\n",
     "\n",
-    "A familiar style of plot that accomplishes this goal is a bar plot. In seaborn, the :func:`barplot` function operates on a full dataset and shows an arbitrary estimate, using the mean by default. When there are multiple observations in each category, it also uses bootstrapping to compute a confidence interval around the estimate and plots that using error bars:"
+    "A familiar style of plot that accomplishes this goal is a bar plot. In seaborn, the :func:`barplot` function operates on a full dataset and applies a function to obtain the estimate (taking the mean by default). When there are multiple observations in each category, it also uses bootstrapping to compute a confidence interval around the estimate and plots that using error bars:"
    ]
   },
   {
@@ -339,7 +377,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.catplot(x=\"deck\", kind=\"count\", data=titanic);"
+    "sns.catplot(x=\"deck\", kind=\"count\", palette=\"ch:.25\", data=titanic);"
    ]
   },
   {
@@ -367,7 +405,7 @@
     "Point plots\n",
     "^^^^^^^^^^^\n",
     "\n",
-    "An alternative style for visualizing the same information is offered by the :func:`pointplot` function. This function also encodes the value of the estimate with height on the other axis, but rather than show a full bar it just plots the point estimate and confidence interval. Additionally, :func:`pointplot` connects points from the same ``hue`` category. This makes it easy to see how the main relationship is changing as a function of a second variable, because your eyes are quite good at picking up on differences of slopes:"
+    "An alternative style for visualizing the same information is offered by the :func:`pointplot` function. This function also encodes the value of the estimate with height on the other axis, but rather than showing a full bar, it plots the point estimate and confidence interval. Additionally, :func:`pointplot` connects points from the same ``hue`` category. This makes it easy to see how the main relationship is changing as a function of the hue semantic, because your eyes are quite good at picking up on differences of slopes:"
    ]
   },
   {
@@ -383,7 +421,7 @@
    "cell_type": "raw",
    "metadata": {},
    "source": [
-    "To make figures that reproduce well in black and white, it can be good to use different markers and line styles for the levels of the ``hue`` category:"
+    "When the categorical functions lack the ``style`` semantic of the relational functions, it can still be a good idea to vary the marker and/or linestyle along with the hue to make figures that are maximally accessible and reproduce well in black and white:"
    ]
   },
   {
@@ -455,42 +493,10 @@
    "cell_type": "raw",
    "metadata": {},
    "source": [
-    "Drawing multi-panel categorical plots\n",
-    "-------------------------------------\n",
+    "Showing multiple relationships with facets\n",
+    "------------------------------------------\n",
     "\n",
-    "As we mentioned above, there are two ways to draw categorical plots in seaborn. Similar to the duality in the regression plots, you can either use the functions introduced above, or the higher-level function :func:`catplot`, which combines these functions with a :func:`FacetGrid` to add the ability to examine additional categories through the larger structure of the figure. By default, :func:`catplot` produces a :func:`pointplot`:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "sns.catplot(x=\"day\", y=\"total_bill\", hue=\"smoker\", kind=\"point\", data=tips);"
-   ]
-  },
-  {
-   "cell_type": "raw",
-   "metadata": {},
-   "source": [
-    "However, the ``kind`` parameter lets you chose any of the kinds of plots discussed above:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "sns.catplot(x=\"day\", y=\"total_bill\", hue=\"smoker\", kind=\"bar\", data=tips);"
-   ]
-  },
-  {
-   "cell_type": "raw",
-   "metadata": {},
-   "source": [
-    "The main advantage of using a :func:`catplot` is that it is very easy to \"facet\" the plot and investigate the role of other categorical variables:"
+    "Just like :func:`relplot`, the fact that :func:`catplot` is built on a :class:`FacetGrid` means that it is easy to add faceting variables to visualize higher-dimensional relationships:"
    ]
   },
   {
@@ -500,14 +506,15 @@
    "outputs": [],
    "source": [
     "sns.catplot(x=\"day\", y=\"total_bill\", hue=\"smoker\",\n",
-    "            col=\"time\", kind=\"swarm\", data=tips);"
+    "            col=\"time\", aspect=.6,\n",
+    "            kind=\"swarm\", data=tips);"
    ]
   },
   {
    "cell_type": "raw",
    "metadata": {},
    "source": [
-    "Any kind of plot can be drawn. Because of the way :class:`FacetGrid` works, to change the size and shape of the figure you need to specify the ``size`` and ``aspect`` arguments, which apply to each facet:"
+    "For further customization of the plot, you can use the methods on the :class:`FacetGrid` object that it returns:"
    ]
   },
   {
@@ -516,8 +523,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.catplot(x=\"time\", y=\"total_bill\", hue=\"smoker\", col=\"day\",\n",
-    "            height=4, aspect=.5, kind=\"box\", data=tips);"
+    "g = sns.catplot(x=\"fare\", y=\"survived\", row=\"class\",\n",
+    "                kind=\"box\", orient=\"h\", height=1.5, aspect=4,\n",
+    "                data=titanic.query(\"fare > 0\"))\n",
+    "g.set(xscale=\"log\");"
    ]
   },
   {

--- a/doc/tutorial/categorical.ipynb
+++ b/doc/tutorial/categorical.ipynb
@@ -20,7 +20,7 @@
     "\n",
     "   <div class=col-md-9>\n",
     "   \n",
-    "In the :ref:`relational plot tutorial <relational_tutorial>` we saw how to use visual different representations to show the relationship between multiple variables in a dataset. In the examples, we focused on cases where the main relationship was between two numerical variables. If one of the main variables is \"categorical\" (divided into discrete groups) it may be helpful to use a more specialized approach to visualization.\n",
+    "In the :ref:`relational plot tutorial <relational_tutorial>` we saw how to use different visual representations to show the relationship between multiple variables in a dataset. In the examples, we focused on cases where the main relationship was between two numerical variables. If one of the main variables is \"categorical\" (divided into discrete groups) it may be helpful to use a more specialized approach to visualization.\n",
     "\n",
     "In seaborn, there are several different ways to visualize a relationship involving categorical data. Similar to the relationship between :func:`relplot` and either :func:`scatterplot` or :func:`lineplot`, there are two ways to make these plots. There are a number of axes-level functions for plotting categorical data in different ways and a figure-level interface, :func:`catplot`, that gives unified higher-level access to them.\n",
     "\n",
@@ -81,7 +81,7 @@
     "Categorical scatterplots\n",
     "------------------------\n",
     "\n",
-    "The default representation of the data in :func:`catplot` uses a scatterplot. There are actually two different categorical scatter plots in seaborn. They take different approaches to resolving the main challenge in representing categorical data with a scatter plot, which is that all of the points belonging to one category would fall on the same position along the axes corresponding to the categorical variable. The approach used by :func:`stripplot`, which is the default \"kind\" in :func:`catplot` is to adjust the positions of points on the categorical axis with a small amount of random \"jitter\":"
+    "The default representation of the data in :func:`catplot` uses a scatterplot. There are actually two different categorical scatter plots in seaborn. They take different approaches to resolving the main challenge in representing categorical data with a scatter plot, which is that all of the points belonging to one category would fall on the same position along the axis corresponding to the categorical variable. The approach used by :func:`stripplot`, which is the default \"kind\" in :func:`catplot` is to adjust the positions of points on the categorical axis with a small amount of random \"jitter\":"
    ]
   },
   {
@@ -203,7 +203,7 @@
     "Boxplots\n",
     "^^^^^^^^\n",
     "\n",
-    "The first is the familiar :func:`boxplot`. This kind of plot shows the three quartile values of the distribution along with extreme values. The \"whiskers\" extend to points that lie within 1.5 IQRs of the lower and upper quartile, and then observations that fall outside this range are displayed independently. Importantly, this means that each value in the boxplot corresponds to an actual observation in the data."
+    "The first is the familiar :func:`boxplot`. This kind of plot shows the three quartile values of the distribution along with extreme values. The \"whiskers\" extend to points that lie within 1.5 IQRs of the lower and upper quartile, and then observations that fall outside this range are displayed independently. This means that each value in the boxplot corresponds to an actual observation in the data."
    ]
   },
   {
@@ -219,7 +219,7 @@
    "cell_type": "raw",
    "metadata": {},
    "source": [
-    "When adding a ``hue`` semantic, the box for each level of the semantic variable are moved along the categorical axis so they don't overlap:"
+    "When adding a ``hue`` semantic, the box for each level of the semantic variable is moved along the categorical axis so they don't overlap:"
    ]
   },
   {
@@ -283,8 +283,8 @@
    "outputs": [],
    "source": [
     "sns.catplot(x=\"total_bill\", y=\"day\", hue=\"time\",\n",
-    "            bw=.15, cut=0, scale=\"count\", scale_hue=False,\n",
-    "            kind=\"violin\", data=tips);"
+    "            kind=\"violin\", bw=.15, cut=0,\n",
+    "            data=tips);"
    ]
   },
   {
@@ -346,7 +346,7 @@
     "Statistical estimation within categories\n",
     "----------------------------------------\n",
     "\n",
-    "For other applications, rather than showing the distribution within each category, you might want to show the central tendency of the values. Seaborn has two main ways to show this information. Importantly, the basic API for these functions is identical to that for the ones discussed above.\n",
+    "For other applications, rather than showing the distribution within each category, you might want to show an estimate of the central tendency of the values. Seaborn has two main ways to show this information. Importantly, the basic API for these functions is identical to that for the ones discussed above.\n",
     "\n",
     "Bar plots\n",
     "^^^^^^^^^\n",
@@ -476,7 +476,7 @@
    "cell_type": "raw",
    "metadata": {},
    "source": [
-    "To control the size and shape of plots made by the functions discussed above, you must set up the figure yourself using matplotlib commands. Of course, this also means that the plots can happily coexist in a multi-panel figure with other kinds of plots:"
+    "To control the size and shape of plots made by the functions discussed above, you must set up the figure yourself using matplotlib commands:"
    ]
   },
   {
@@ -493,6 +493,8 @@
    "cell_type": "raw",
    "metadata": {},
    "source": [
+    "This is the approach you should take when you need a categorical figure to happily coexist in a more complex figure with other kinds of plots.\n",
+    "\n",
     "Showing multiple relationships with facets\n",
     "------------------------------------------\n",
     "\n",

--- a/doc/tutorial/relational.ipynb
+++ b/doc/tutorial/relational.ipynb
@@ -20,7 +20,7 @@
     "\n",
     "   <div class=col-md-9>\n",
     "\n",
-    "Statistical analysis is a process of understanding how variables in a dataset relate to each other and how those relationships depend on other variables. Visualization can be a core component of this process because, when data are visualized properly, the eye can see trends and patterns that indicate a relationship.\n",
+    "Statistical analysis is a process of understanding how variables in a dataset relate to each other and how those relationships depend on other variables. Visualization can be a core component of this process because, when data are visualized properly, the human visual system can see trends and patterns that indicate a relationship.\n",
     "\n",
     "We will discuss three seaborn functions in this tutorial. The one we will use most is :func:`relplot`. This is a :ref:`figure-level function <intro_func_types>` for visualizing statistical relationships using two common approaches: scatter plots and line plots. :func:`relplot` combines a :class:`FacetGrid` with one of two axes-level functions:\n",
     "\n",

--- a/examples/grouped_barplot.py
+++ b/examples/grouped_barplot.py
@@ -11,7 +11,7 @@ sns.set(style="whitegrid")
 titanic = sns.load_dataset("titanic")
 
 # Draw a nested barplot to show survival for class and sex
-g = sns.factorplot(x="class", y="survived", hue="sex", data=titanic,
-                   height=6, kind="bar", palette="muted")
+g = sns.catplot(x="class", y="survived", hue="sex", data=titanic,
+                height=6, kind="bar", palette="muted")
 g.despine(left=True)
 g.set_ylabels("survival probability")

--- a/examples/large_distributions.py
+++ b/examples/large_distributions.py
@@ -9,6 +9,6 @@ sns.set(style="whitegrid")
 diamonds = sns.load_dataset("diamonds")
 clarity_ranking = ["I1", "SI2", "SI1", "VS2", "VS1", "VVS2", "VVS1", "IF"]
 
-sns.lvplot(x="clarity", y="carat",
-           color="b", order=clarity_ranking,
-           scale="linear", data=diamonds)
+sns.boxenplot(x="clarity", y="carat",
+              color="b", order=clarity_ranking,
+              scale="linear", data=diamonds)

--- a/examples/pointplot_anova.py
+++ b/examples/pointplot_anova.py
@@ -11,6 +11,7 @@ sns.set(style="whitegrid")
 df = sns.load_dataset("exercise")
 
 # Draw a pointplot to show pulse as a function of three categorical factors
-g = sns.factorplot(x="time", y="pulse", hue="kind", col="diet", data=df,
-                   capsize=.2, palette="YlGnBu_d", height=6, aspect=.75)
+g = sns.catplot(x="time", y="pulse", hue="kind", col="diet",
+                capsize=.2, palette="YlGnBu_d", height=6, aspect=.75,
+                kind="point", data=df)
 g.despine(left=True)

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -394,7 +394,7 @@ class FacetGrid(Grid):
         When using seaborn functions that infer semantic mappings from a
         dataset, care must be taken to synchronize those mappings across
         facets. In most cases, it will be better to use a figure-level function
-        (e.g. :func:`relplot` or :func:`factorplot`) than to use
+        (e.g. :func:`relplot` or :func:`catplot`) than to use
         :class:`FacetGrid` directly.
 
         The basic workflow is to initialize the :class:`FacetGrid` object with
@@ -445,8 +445,9 @@ class FacetGrid(Grid):
         See Also
         --------
         PairGrid : Subplot grid for plotting pairwise relationships.
+        relplot : Combine a relational plot and a :class:`FacetGrid`.
+        catplot : Combine a categorical plot and a :class:`FacetGrid`.
         lmplot : Combine a regression plot and a :class:`FacetGrid`.
-        factorplot : Combine a categorical plot and a :class:`FacetGrid`.
 
         Examples
         --------

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -3602,33 +3602,34 @@ def catplot(x=None, y=None, hue=None, data=None, row=None, col=None,
 
 
 catplot.__doc__ = dedent("""\
-    Figure-level function for drawing categorical plots onto a FacetGrid.
+    Figure-level interface for drawing categorical plots onto a FacetGrid.
 
-    The default plot that is shown is a strip plot, but other seaborn
-    categorical plots can be chosen with the ``kind`` parameter. These are
-    best thought of in three categories:
+    This function provides access to several axes-level functions that
+    show the relationship between a numerical and one or more categorical
+    variables using one of several visual representations. The ``kind``
+    parameter selects the underlying axes-level function to use:
 
     Categorical scatterplots:
 
-    - ``strip`` (using :func:`stripplot`)
-    - ``swarm`` (using :func:`swarmplot`)
+    - :func:`stripplot` (with ``kind="strip"``; the default)
+    - :func:`swarmplot` (with ``kind="swarm"``)
 
     Categorical distribution plots:
 
-    - ``box`` (using :func:`boxplot`)
-    - ``violin`` (using :func:`violinplot`)
-    - ``lv`` (using :func:`lvplot`)
+    - :func:`boxplot` (with ``kind="box"``)
+    - :func:`violinplot` (with ``kind="violin"``)
+    - :func:`lvplot` (with ``kind="lv"``)
 
     Categorical estimate plots:
 
-    - ``point`` (using :func:`pointplot`)
-    - ``bar`` (using :func:`barplot`)
-    - ``count`` (using :func:`countplot`)
+    - :func:`pointplot` (with ``kind="point"``)
+    - :func:`barplot` (with ``kind="bar"``)
+    - :func:`countplot` (with ``kind="count"``)
 
     Extra keyword arguments are passed to the underlying function, so you
     should refer to the documentation for each to see kind-specific options.
 
-    Unlike when using the underlying plotting functions directly, data must be
+    Note that unlike when using the axes-level functions directly, data must be
     passed in a long-form DataFrame with variables specified by passing strings
     to ``x``, ``y``, ``hue``, etc.
 

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -2584,7 +2584,7 @@ violinplot.__doc__ = dedent("""\
 
     Use :func:`catplot` to combine a :func:`violinplot` and a
     :class:`FacetGrid`. This allows grouping within additional categorical
-    variables. Using :func:`factorplot` is safer than using :class:`FacetGrid`
+    variables. Using :func:`catplot` is safer than using :class:`FacetGrid`
     directly, as it ensures synchronization of variable order across facets:
 
     .. plot::
@@ -2782,7 +2782,7 @@ stripplot.__doc__ = dedent("""\
 
     Use :func:`catplot` to combine a :func:`stripplot` and a
     :class:`FacetGrid`. This allows grouping within additional categorical
-    variables. Using :func:`factorplot` is safer than using :class:`FacetGrid`
+    variables. Using :func:`catplot` is safer than using :class:`FacetGrid`
     directly, as it ensures synchronization of variable order across facets:
 
     .. plot::
@@ -3498,8 +3498,13 @@ def factorplot(*args, **kwargs):
     )
     warnings.warn(msg)
 
+    if "size" in kwargs:
+        kwargs["height"] = kwargs.pop("size")
+        msg = ("The `size` paramter has been renamed to `height`; "
+               "please update your code.")
+        warnings.warn(msg, UserWarning)
+
     kwargs.setdefault("kind", "point")
-    kwargs.setdefault("size", 4)
 
     return catplot(*args, **kwargs)
 
@@ -3599,10 +3604,29 @@ def catplot(x=None, y=None, hue=None, data=None, row=None, col=None,
 catplot.__doc__ = dedent("""\
     Figure-level function for drawing categorical plots onto a FacetGrid.
 
-    The default plot that is shown is a point plot, but other seaborn
-    categorical plots can be chosen with the ``kind`` parameter, including
-    box plots, violin plots, lv plots, bar plots, count plots, strip plots,
-    or swarm plots.
+    The default plot that is shown is a strip plot, but other seaborn
+    categorical plots can be chosen with the ``kind`` parameter. These are
+    best thought of in three categories:
+
+    Categorical scatterplots:
+
+    - ``strip`` (using :func:`stripplot`)
+    - ``swarm`` (using :func:`swarmplot`)
+
+    Categorical distribution plots:
+
+    - ``box`` (using :func:`boxplot`)
+    - ``violin`` (using :func:`violinplot`)
+    - ``lv`` (using :func:`lvplot`)
+
+    Categorical estimate plots:
+
+    - ``point`` (using :func:`pointplot`)
+    - ``bar`` (using :func:`barplot`)
+    - ``count`` (using :func:`countplot`)
+
+    Extra keyword arguments are passed to the underlying function, so you
+    should refer to the documentation for each to see kind-specific options.
 
     Unlike when using the underlying plotting functions directly, data must be
     passed in a long-form DataFrame with variables specified by passing strings
@@ -3868,7 +3892,7 @@ lvplot.__doc__ = dedent("""\
 
     Use :func:`catplot` to combine a :func:`lvplot` and a :class:`FacetGrid`.
     This allows grouping within additional categorical variables. Using
-    :func:`factorplot` is safer than using :class:`FacetGrid` directly, as it
+    :func:`catplot` is safer than using :class:`FacetGrid` directly, as it
     ensures synchronization of variable order across facets:
 
     .. plot::

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -21,7 +21,7 @@ from .axisgrid import FacetGrid, _facet_docs
 
 
 __all__ = ["boxplot", "violinplot", "stripplot", "swarmplot", "lvplot",
-           "pointplot", "barplot", "countplot", "factorplot"]
+           "pointplot", "barplot", "countplot", "catplot", "factorplot"]
 
 
 class _CategoricalPlotter(object):
@@ -2205,8 +2205,8 @@ _categorical_docs = dict(
     pointplot : Show point estimates and confidence intervals using scatterplot
                 glyphs.\
     """),
-    factorplot=dedent("""\
-    factorplot : Combine categorical plots and a class:`FacetGrid`.\
+    catplot=dedent("""\
+    catplot : Combine a categorical plot with a class:`FacetGrid`.\
     """),
     lvplot=dedent("""\
     lvplot : An extension of the boxplot for long-tailed and large data sets.
@@ -2355,18 +2355,18 @@ boxplot.__doc__ = dedent("""\
         >>> ax = sns.boxplot(x="day", y="total_bill", data=tips)
         >>> ax = sns.swarmplot(x="day", y="total_bill", data=tips, color=".25")
 
-    Use :func:`factorplot` to combine a :func:`pointplot` and a
+    Use :func:`catplot` to combine a :func:`pointplot` and a
     :class:`FacetGrid`. This allows grouping within additional categorical
-    variables. Using :func:`factorplot` is safer than using :class:`FacetGrid`
+    variables. Using :func:`catplot` is safer than using :class:`FacetGrid`
     directly, as it ensures synchronization of variable order across facets:
 
     .. plot::
         :context: close-figs
 
-        >>> g = sns.factorplot(x="sex", y="total_bill",
-        ...                    hue="smoker", col="time",
-        ...                    data=tips, kind="box",
-        ...                    height=6, aspect=.7);
+        >>> g = sns.catplot(x="sex", y="total_bill",
+        ...                 hue="smoker", col="time",
+        ...                 data=tips, kind="box",
+        ...                 height=4, aspect=.7);
 
     """).format(**_categorical_docs)
 
@@ -2582,7 +2582,7 @@ violinplot.__doc__ = dedent("""\
         >>> ax = sns.violinplot(x="day", y="total_bill", hue="weekend",
         ...                     data=tips, dodge=False)
 
-    Use :func:`factorplot` to combine a :func:`violinplot` and a
+    Use :func:`catplot` to combine a :func:`violinplot` and a
     :class:`FacetGrid`. This allows grouping within additional categorical
     variables. Using :func:`factorplot` is safer than using :class:`FacetGrid`
     directly, as it ensures synchronization of variable order across facets:
@@ -2590,10 +2590,10 @@ violinplot.__doc__ = dedent("""\
     .. plot::
         :context: close-figs
 
-        >>> g = sns.factorplot(x="sex", y="total_bill",
-        ...                    hue="smoker", col="time",
-        ...                    data=tips, kind="violin", split=True,
-        ...                    height=6, aspect=.7);
+        >>> g = sns.catplot(x="sex", y="total_bill",
+        ...                 hue="smoker", col="time",
+        ...                 data=tips, kind="violin", split=True,
+        ...                 height=4, aspect=.7);
 
     """).format(**_categorical_docs)
 
@@ -2780,7 +2780,7 @@ stripplot.__doc__ = dedent("""\
         ...                     inner=None, color=".8")
         >>> ax = sns.stripplot(x="day", y="total_bill", data=tips, jitter=True)
 
-    Use :func:`factorplot` to combine a :func:`stripplot` and a
+    Use :func:`catplot` to combine a :func:`stripplot` and a
     :class:`FacetGrid`. This allows grouping within additional categorical
     variables. Using :func:`factorplot` is safer than using :class:`FacetGrid`
     directly, as it ensures synchronization of variable order across facets:
@@ -2788,11 +2788,11 @@ stripplot.__doc__ = dedent("""\
     .. plot::
         :context: close-figs
 
-        >>> g = sns.factorplot(x="sex", y="total_bill",
-        ...                    hue="smoker", col="time",
-        ...                    data=tips, kind="strip",
-        ...                    jitter=True,
-        ...                    height=6, aspect=.7);
+        >>> g = sns.catplot(x="sex", y="total_bill",
+        ...                 hue="smoker", col="time",
+        ...                 data=tips, kind="strip",
+        ...                 jitter=True,
+        ...                 height=4, aspect=.7);
 
     """).format(**_categorical_docs)
 
@@ -2878,7 +2878,7 @@ swarmplot.__doc__ = dedent("""\
     {boxplot}
     {violinplot}
     {stripplot}
-    {factorplot}
+    {catplot}
 
     Examples
     --------
@@ -2954,18 +2954,18 @@ swarmplot.__doc__ = dedent("""\
         >>> ax = sns.swarmplot(x="day", y="total_bill", data=tips,
         ...                    color="white", edgecolor="gray")
 
-    Use :func:`factorplot` to combine a :func:`swarmplot` and a
+    Use :func:`catplot` to combine a :func:`swarmplot` and a
     :class:`FacetGrid`. This allows grouping within additional categorical
-    variables. Using :func:`factorplot` is safer than using :class:`FacetGrid`
+    variables. Using :func:`catplot` is safer than using :class:`FacetGrid`
     directly, as it ensures synchronization of variable order across facets:
 
     .. plot::
         :context: close-figs
 
-        >>> g = sns.factorplot(x="sex", y="total_bill",
-        ...                    hue="smoker", col="time",
-        ...                    data=tips, kind="swarm",
-        ...                    height=6, aspect=.7);
+        >>> g = sns.catplot(x="sex", y="total_bill",
+        ...                 hue="smoker", col="time",
+        ...                 data=tips, kind="swarm",
+        ...                 height=4, aspect=.7);
 
     """).format(**_categorical_docs)
 
@@ -3040,7 +3040,7 @@ barplot.__doc__ = dedent("""\
     --------
     {countplot}
     {pointplot}
-    {factorplot}
+    {catplot}
 
     Examples
     --------
@@ -3140,18 +3140,18 @@ barplot.__doc__ = dedent("""\
         ...                  linewidth=2.5, facecolor=(1, 1, 1, 0),
         ...                  errcolor=".2", edgecolor=".2")
 
-    Use :func:`factorplot` to combine a :func:`barplot` and a
-    :class:`FacetGrid`. This allows grouping within additional categorical
-    variables. Using :func:`factorplot` is safer than using :class:`FacetGrid`
-    directly, as it ensures synchronization of variable order across facets:
+    Use :func:`catplot` to combine a :func:`barplot` and a :class:`FacetGrid`.
+    This allows grouping within additional categorical variables. Using
+    :func:`catplot` is safer than using :class:`FacetGrid` directly, as it
+    ensures synchronization of variable order across facets:
 
     .. plot::
         :context: close-figs
 
-        >>> g = sns.factorplot(x="sex", y="total_bill",
-        ...                    hue="smoker", col="time",
-        ...                    data=tips, kind="bar",
-        ...                    height=6, aspect=.7);
+        >>> g = sns.catplot(x="sex", y="total_bill",
+        ...                 hue="smoker", col="time",
+        ...                 data=tips, kind="bar",
+        ...                 height=4, aspect=.7);
 
     """).format(**_categorical_docs)
 
@@ -3232,7 +3232,7 @@ pointplot.__doc__ = dedent("""\
     See Also
     --------
     {barplot}
-    {factorplot}
+    {catplot}
 
     Examples
     --------
@@ -3340,19 +3340,19 @@ pointplot.__doc__ = dedent("""\
 
         >>> ax = sns.pointplot(x="day", y="tip", data=tips, capsize=.2)
 
-    Use :func:`factorplot` to combine a :func:`barplot` and a
+    Use :func:`catplot` to combine a :func:`barplot` and a
     :class:`FacetGrid`. This allows grouping within additional categorical
-    variables. Using :func:`factorplot` is safer than using :class:`FacetGrid`
+    variables. Using :func:`catplot` is safer than using :class:`FacetGrid`
     directly, as it ensures synchronization of variable order across facets:
 
     .. plot::
         :context: close-figs
 
-        >>> g = sns.factorplot(x="sex", y="total_bill",
-        ...                    hue="smoker", col="time",
-        ...                    data=tips, kind="point",
-        ...                    dodge=True,
-        ...                    height=6, aspect=.7);
+        >>> g = sns.catplot(x="sex", y="total_bill",
+        ...                 hue="smoker", col="time",
+        ...                 data=tips, kind="point",
+        ...                 dodge=True,
+        ...                 height=4, aspect=.7);
 
     """).format(**_categorical_docs)
 
@@ -3426,7 +3426,7 @@ countplot.__doc__ = dedent("""\
     See Also
     --------
     {barplot}
-    {factorplot}
+    {catplot}
 
     Examples
     --------
@@ -3472,28 +3472,45 @@ countplot.__doc__ = dedent("""\
         ...                    linewidth=5,
         ...                    edgecolor=sns.color_palette("dark", 3))
 
-    Use :func:`factorplot` to combine a :func:`countplot` and a
+    Use :func:`catplot` to combine a :func:`countplot` and a
     :class:`FacetGrid`. This allows grouping within additional categorical
-    variables. Using :func:`factorplot` is safer than using :class:`FacetGrid`
+    variables. Using :func:`catplot` is safer than using :class:`FacetGrid`
     directly, as it ensures synchronization of variable order across facets:
 
     .. plot::
         :context: close-figs
 
-        >>> g = sns.factorplot(x="class", hue="who", col="survived",
-        ...                    data=titanic, kind="count",
-        ...                    height=6, aspect=.7);
+        >>> g = sns.catplot(x="class", hue="who", col="survived",
+        ...                 data=titanic, kind="count",
+        ...                 height=4, aspect=.7);
 
     """).format(**_categorical_docs)
 
 
-def factorplot(x=None, y=None, hue=None, data=None, row=None, col=None,
-               col_wrap=None, estimator=np.mean, ci=95, n_boot=1000,
-               units=None, order=None, hue_order=None, row_order=None,
-               col_order=None, kind="point", height=5, aspect=1,
-               orient=None, color=None, palette=None,
-               legend=True, legend_out=True, sharex=True, sharey=True,
-               margin_titles=False, facet_kws=None, **kwargs):
+def factorplot(*args, **kwargs):
+    """Deprecated; please use `catplot` instead."""
+
+    msg = (
+        "The `factorplot` function has been renamed to `catplot`. It will "
+        "be removed in a future release. Please update your code. Note that "
+        "the default `kind` in `factorplot` (`'point'`) has changed to "
+        "`'strip'` in `catplot`."
+    )
+    warnings.warn(msg)
+
+    kwargs.setdefault("kind", "point")
+    kwargs.setdefault("size", 4)
+
+    return catplot(*args, **kwargs)
+
+
+def catplot(x=None, y=None, hue=None, data=None, row=None, col=None,
+            col_wrap=None, estimator=np.mean, ci=95, n_boot=1000,
+            units=None, order=None, hue_order=None, row_order=None,
+            col_order=None, kind="strip", height=5, aspect=1,
+            orient=None, color=None, palette=None,
+            legend=True, legend_out=True, sharex=True, sharey=True,
+            margin_titles=False, facet_kws=None, **kwargs):
 
     # Handle deprecations
     if "size" in kwargs:
@@ -3579,7 +3596,7 @@ def factorplot(x=None, y=None, hue=None, data=None, row=None, col=None,
     return g
 
 
-factorplot.__doc__ = dedent("""\
+catplot.__doc__ = dedent("""\
     Figure-level function for drawing categorical plots onto a FacetGrid.
 
     The default plot that is shown is a point plot, but other seaborn
@@ -3651,32 +3668,32 @@ factorplot.__doc__ = dedent("""\
         >>> import seaborn as sns
         >>> sns.set(style="ticks")
         >>> exercise = sns.load_dataset("exercise")
-        >>> g = sns.factorplot(x="time", y="pulse", hue="kind", data=exercise)
+        >>> g = sns.catplot(x="time", y="pulse", hue="kind", data=exercise)
 
     Use a different plot kind to visualize the same data:
 
     .. plot::
         :context: close-figs
 
-        >>> g = sns.factorplot(x="time", y="pulse", hue="kind",
-        ...                    data=exercise, kind="violin")
+        >>> g = sns.catplot(x="time", y="pulse", hue="kind",
+        ...                data=exercise, kind="violin")
 
     Facet along the columns to show a third categorical variable:
 
     .. plot::
         :context: close-figs
 
-        >>> g = sns.factorplot(x="time", y="pulse", hue="kind",
-        ...                    col="diet", data=exercise)
+        >>> g = sns.catplot(x="time", y="pulse", hue="kind",
+        ...                 col="diet", data=exercise)
 
     Use a different height and aspect ratio for the facets:
 
     .. plot::
         :context: close-figs
 
-        >>> g = sns.factorplot(x="time", y="pulse", hue="kind",
-        ...                    col="diet", data=exercise,
-        ...                    height=5, aspect=.8)
+        >>> g = sns.catplot(x="time", y="pulse", hue="kind",
+        ...                 col="diet", data=exercise,
+        ...                 height=5, aspect=.8)
 
     Make many column facets and wrap them into the rows of the grid:
 
@@ -3684,29 +3701,29 @@ factorplot.__doc__ = dedent("""\
         :context: close-figs
 
         >>> titanic = sns.load_dataset("titanic")
-        >>> g = sns.factorplot("alive", col="deck", col_wrap=4,
-        ...                    data=titanic[titanic.deck.notnull()],
-        ...                    kind="count", height=2.5, aspect=.8)
+        >>> g = sns.catplot("alive", col="deck", col_wrap=4,
+        ...                 data=titanic[titanic.deck.notnull()],
+        ...                 kind="count", height=2.5, aspect=.8)
 
     Plot horizontally and pass other keyword arguments to the plot function:
 
     .. plot::
         :context: close-figs
 
-        >>> g = sns.factorplot(x="age", y="embark_town",
-        ...                    hue="sex", row="class",
-        ...                    data=titanic[titanic.embark_town.notnull()],
-        ...                    orient="h", height=2, aspect=3, palette="Set3",
-        ...                    kind="violin", dodge=True, cut=0, bw=.2)
+        >>> g = sns.catplot(x="age", y="embark_town",
+        ...                 hue="sex", row="class",
+        ...                 data=titanic[titanic.embark_town.notnull()],
+        ...                 orient="h", height=2, aspect=3, palette="Set3",
+        ...                 kind="violin", dodge=True, cut=0, bw=.2)
 
     Use methods on the returned :class:`FacetGrid` to tweak the presentation:
 
     .. plot::
         :context: close-figs
 
-        >>> g = sns.factorplot(x="who", y="survived", col="class",
-        ...                    data=titanic, saturation=.5,
-        ...                    kind="bar", ci=None, aspect=.6)
+        >>> g = sns.catplot(x="who", y="survived", col="class",
+        ...                 data=titanic, saturation=.5,
+        ...                 kind="bar", ci=None, aspect=.6)
         >>> (g.set_axis_labels("", "Survival Rate")
         ...   .set_xticklabels(["Men", "Women", "Children"])
         ...   .set_titles("{{col_name}} {{col_var}}")
@@ -3849,17 +3866,17 @@ lvplot.__doc__ = dedent("""\
         >>> ax = sns.stripplot(x="day", y="total_bill", data=tips,
         ...                    size=4, jitter=True, color="gray")
 
-    Use :func:`factorplot` to combine a :func:`lvplot` and a
-    :class:`FacetGrid`. This allows grouping within additional categorical
-    variables. Using :func:`factorplot` is safer than using :class:`FacetGrid`
-    directly, as it ensures synchronization of variable order across facets:
+    Use :func:`catplot` to combine a :func:`lvplot` and a :class:`FacetGrid`.
+    This allows grouping within additional categorical variables. Using
+    :func:`factorplot` is safer than using :class:`FacetGrid` directly, as it
+    ensures synchronization of variable order across facets:
 
     .. plot::
         :context: close-figs
 
-        >>> g = sns.factorplot(x="sex", y="total_bill",
-        ...                    hue="smoker", col="time",
-        ...                    data=tips, kind="lv",
-        ...                    height=4, aspect=.7);
+        >>> g = sns.catplot(x="sex", y="total_bill",
+        ...                 hue="smoker", col="time",
+        ...                 data=tips, kind="lv",
+        ...                 height=4, aspect=.7);
 
     """).format(**_categorical_docs)

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -2599,7 +2599,7 @@ violinplot.__doc__ = dedent("""\
 
 
 def stripplot(x=None, y=None, hue=None, data=None, order=None, hue_order=None,
-              jitter=False, dodge=False, orient=None, color=None, palette=None,
+              jitter=True, dodge=False, orient=None, color=None, palette=None,
               size=5, edgecolor="gray", linewidth=0, ax=None, **kwargs):
 
     if "split" in kwargs:

--- a/seaborn/relational.py
+++ b/seaborn/relational.py
@@ -1623,12 +1623,20 @@ def relplot(x=None, y=None, hue=None, size=None, style=None, data=None,
 
 
 relplot.__doc__ = dedent("""\
-    Draw a relational plot onto a FacetGrid.
+    Figure-level interface for drawing relational plots onto a FacetGrid.
+
+    This function provides access to several different axes-level functions
+    that show the relationship between two variables with semantic mappings
+    of subsets. The ``kind`` parameter selects the underlying axes-level
+    function to use:
+
+    - :func:`scatterplot` (with ``kind="scatter"``; the default)
+    - :func:`lineplot` (with ``kind="line"``)
+
+    Extra keyword arguments are passed to the underlying function, so you
+    should refer to the documentation for each to see kind-specific options.
 
     {main_api_narrative}
-
-    By default a :func:`scatterplot` is drawn, but it is also possible
-    to draw a :func:`lineplot` using ``kind='line'``.
 
     After plotting, the :class:`FacetGrid` with the plot is returned and can
     be used directly to tweak supporting plot details or add other layers.

--- a/seaborn/tests/test_categorical.py
+++ b/seaborn/tests/test_categorical.py
@@ -2472,7 +2472,7 @@ class TestCatPlot(CategoricalFixture):
         nt.assert_equal(len(g.ax.lines), want_lines)
 
 
-class TestLVPlotter(CategoricalFixture):
+class TestBoxenPlotter(CategoricalFixture):
 
     default_kws = dict(x=None, y=None, hue=None, data=None,
                        order=None, hue_order=None,
@@ -2567,13 +2567,13 @@ class TestLVPlotter(CategoricalFixture):
 
     def test_axes_data(self):
 
-        ax = cat.lvplot("g", "y", data=self.df)
+        ax = cat.boxenplot("g", "y", data=self.df)
         patches = filter(self.ispatch, ax.collections)
         nt.assert_equal(len(list(patches)), 3)
 
         plt.close("all")
 
-        ax = cat.lvplot("g", "y", "h", data=self.df)
+        ax = cat.boxenplot("g", "y", "h", data=self.df)
         patches = filter(self.ispatch, ax.collections)
         nt.assert_equal(len(list(patches)), 6)
 
@@ -2581,14 +2581,14 @@ class TestLVPlotter(CategoricalFixture):
 
     def test_box_colors(self):
 
-        ax = cat.lvplot("g", "y", data=self.df, saturation=1)
+        ax = cat.boxenplot("g", "y", data=self.df, saturation=1)
         pal = palettes.color_palette(n_colors=3)
         for patch, color in zip(ax.artists, pal):
             nt.assert_equal(patch.get_facecolor()[:3], color)
 
         plt.close("all")
 
-        ax = cat.lvplot("g", "y", "h", data=self.df, saturation=1)
+        ax = cat.boxenplot("g", "y", "h", data=self.df, saturation=1)
         pal = palettes.color_palette(n_colors=2)
         for patch, color in zip(ax.artists, pal * 2):
             nt.assert_equal(patch.get_facecolor()[:3], color)
@@ -2597,8 +2597,8 @@ class TestLVPlotter(CategoricalFixture):
 
     def test_draw_missing_boxes(self):
 
-        ax = cat.lvplot("g", "y", data=self.df,
-                        order=["a", "b", "c", "d"])
+        ax = cat.boxenplot("g", "y", data=self.df,
+                           order=["a", "b", "c", "d"])
 
         patches = filter(self.ispatch, ax.collections)
         nt.assert_equal(len(list(patches)), 3)
@@ -2611,48 +2611,48 @@ class TestLVPlotter(CategoricalFixture):
         y = self.rs.randn(8)
         y[-2:] = np.nan
 
-        ax = cat.lvplot(x, y)
+        ax = cat.boxenplot(x, y)
         nt.assert_equal(len(ax.lines), 3)
 
         plt.close("all")
 
         y[-1] = 0
-        ax = cat.lvplot(x, y, h)
+        ax = cat.boxenplot(x, y, h)
         nt.assert_equal(len(ax.lines), 7)
 
         plt.close("all")
 
-    def test_lvplots(self):
+    def test_boxenplots(self):
 
-        # Smoke test the high level lvplot options
+        # Smoke test the high level boxenplot options
 
-        cat.lvplot("y", data=self.df)
+        cat.boxenplot("y", data=self.df)
         plt.close("all")
 
-        cat.lvplot(y="y", data=self.df)
+        cat.boxenplot(y="y", data=self.df)
         plt.close("all")
 
-        cat.lvplot("g", "y", data=self.df)
+        cat.boxenplot("g", "y", data=self.df)
         plt.close("all")
 
-        cat.lvplot("y", "g", data=self.df, orient="h")
+        cat.boxenplot("y", "g", data=self.df, orient="h")
         plt.close("all")
 
-        cat.lvplot("g", "y", "h", data=self.df)
+        cat.boxenplot("g", "y", "h", data=self.df)
         plt.close("all")
 
-        cat.lvplot("g", "y", "h", order=list("nabc"), data=self.df)
+        cat.boxenplot("g", "y", "h", order=list("nabc"), data=self.df)
         plt.close("all")
 
-        cat.lvplot("g", "y", "h", hue_order=list("omn"), data=self.df)
+        cat.boxenplot("g", "y", "h", hue_order=list("omn"), data=self.df)
         plt.close("all")
 
-        cat.lvplot("y", "g", "h", data=self.df, orient="h")
+        cat.boxenplot("y", "g", "h", data=self.df, orient="h")
         plt.close("all")
 
     def test_axes_annotation(self):
 
-        ax = cat.lvplot("g", "y", data=self.df)
+        ax = cat.boxenplot("g", "y", data=self.df)
         nt.assert_equal(ax.get_xlabel(), "g")
         nt.assert_equal(ax.get_ylabel(), "y")
         nt.assert_equal(ax.get_xlim(), (-.5, 2.5))
@@ -2662,7 +2662,7 @@ class TestLVPlotter(CategoricalFixture):
 
         plt.close("all")
 
-        ax = cat.lvplot("g", "y", "h", data=self.df)
+        ax = cat.boxenplot("g", "y", "h", data=self.df)
         nt.assert_equal(ax.get_xlabel(), "g")
         nt.assert_equal(ax.get_ylabel(), "y")
         npt.assert_array_equal(ax.get_xticks(), [0, 1, 2])
@@ -2673,12 +2673,22 @@ class TestLVPlotter(CategoricalFixture):
 
         plt.close("all")
 
-        ax = cat.lvplot("y", "g", data=self.df, orient="h")
+        ax = cat.boxenplot("y", "g", data=self.df, orient="h")
         nt.assert_equal(ax.get_xlabel(), "y")
         nt.assert_equal(ax.get_ylabel(), "g")
         nt.assert_equal(ax.get_ylim(), (2.5, -.5))
         npt.assert_array_equal(ax.get_yticks(), [0, 1, 2])
         npt.assert_array_equal([l.get_text() for l in ax.get_yticklabels()],
                                ["a", "b", "c"])
+
+        plt.close("all")
+
+    def test_lvplot(self):
+
+        with pytest.warns(UserWarning):
+            ax = cat.lvplot("g", "y", data=self.df)
+
+        patches = filter(self.ispatch, ax.collections)
+        nt.assert_equal(len(list(patches)), 3)
 
         plt.close("all")

--- a/seaborn/tests/test_categorical.py
+++ b/seaborn/tests/test_categorical.py
@@ -8,6 +8,7 @@ from matplotlib.colors import rgb2hex
 
 from distutils.version import LooseVersion
 
+import pytest
 import nose.tools as nt
 import numpy.testing as npt
 from numpy.testing.decorators import skipif
@@ -2332,130 +2333,139 @@ class TestCountPlot(CategoricalFixture):
             cat.countplot(x="g", y="h", data=self.df)
 
 
-class TestFactorPlot(CategoricalFixture):
+class TestCatPlot(CategoricalFixture):
 
     def test_facet_organization(self):
 
-        g = cat.factorplot("g", "y", data=self.df)
+        g = cat.catplot("g", "y", data=self.df)
         nt.assert_equal(g.axes.shape, (1, 1))
 
-        g = cat.factorplot("g", "y", col="h", data=self.df)
+        g = cat.catplot("g", "y", col="h", data=self.df)
         nt.assert_equal(g.axes.shape, (1, 2))
 
-        g = cat.factorplot("g", "y", row="h", data=self.df)
+        g = cat.catplot("g", "y", row="h", data=self.df)
         nt.assert_equal(g.axes.shape, (2, 1))
 
-        g = cat.factorplot("g", "y", col="u", row="h", data=self.df)
+        g = cat.catplot("g", "y", col="u", row="h", data=self.df)
         nt.assert_equal(g.axes.shape, (2, 3))
 
     def test_plot_elements(self):
 
-        g = cat.factorplot("g", "y", data=self.df)
+        g = cat.catplot("g", "y", data=self.df, kind="point")
         nt.assert_equal(len(g.ax.collections), 1)
         want_lines = self.g.unique().size + 1
         nt.assert_equal(len(g.ax.lines), want_lines)
 
-        g = cat.factorplot("g", "y", "h", data=self.df)
+        g = cat.catplot("g", "y", "h", data=self.df, kind="point")
         want_collections = self.h.unique().size
         nt.assert_equal(len(g.ax.collections), want_collections)
         want_lines = (self.g.unique().size + 1) * self.h.unique().size
         nt.assert_equal(len(g.ax.lines), want_lines)
 
-        g = cat.factorplot("g", "y", data=self.df, kind="bar")
+        g = cat.catplot("g", "y", data=self.df, kind="bar")
         want_elements = self.g.unique().size
         nt.assert_equal(len(g.ax.patches), want_elements)
         nt.assert_equal(len(g.ax.lines), want_elements)
 
-        g = cat.factorplot("g", "y", "h", data=self.df, kind="bar")
+        g = cat.catplot("g", "y", "h", data=self.df, kind="bar")
         want_elements = self.g.unique().size * self.h.unique().size
         nt.assert_equal(len(g.ax.patches), want_elements)
         nt.assert_equal(len(g.ax.lines), want_elements)
 
-        g = cat.factorplot("g", data=self.df, kind="count")
+        g = cat.catplot("g", data=self.df, kind="count")
         want_elements = self.g.unique().size
         nt.assert_equal(len(g.ax.patches), want_elements)
         nt.assert_equal(len(g.ax.lines), 0)
 
-        g = cat.factorplot("g", hue="h", data=self.df, kind="count")
+        g = cat.catplot("g", hue="h", data=self.df, kind="count")
         want_elements = self.g.unique().size * self.h.unique().size
         nt.assert_equal(len(g.ax.patches), want_elements)
         nt.assert_equal(len(g.ax.lines), 0)
 
-        g = cat.factorplot("g", "y", data=self.df, kind="box")
+        g = cat.catplot("g", "y", data=self.df, kind="box")
         want_artists = self.g.unique().size
         nt.assert_equal(len(g.ax.artists), want_artists)
 
-        g = cat.factorplot("g", "y", "h", data=self.df, kind="box")
+        g = cat.catplot("g", "y", "h", data=self.df, kind="box")
         want_artists = self.g.unique().size * self.h.unique().size
         nt.assert_equal(len(g.ax.artists), want_artists)
 
-        g = cat.factorplot("g", "y", data=self.df,
-                           kind="violin", inner=None)
+        g = cat.catplot("g", "y", data=self.df,
+                        kind="violin", inner=None)
         want_elements = self.g.unique().size
         nt.assert_equal(len(g.ax.collections), want_elements)
 
-        g = cat.factorplot("g", "y", "h", data=self.df,
-                           kind="violin", inner=None)
+        g = cat.catplot("g", "y", "h", data=self.df,
+                        kind="violin", inner=None)
         want_elements = self.g.unique().size * self.h.unique().size
         nt.assert_equal(len(g.ax.collections), want_elements)
 
-        g = cat.factorplot("g", "y", data=self.df, kind="strip")
+        g = cat.catplot("g", "y", data=self.df, kind="strip")
         want_elements = self.g.unique().size
         nt.assert_equal(len(g.ax.collections), want_elements)
 
-        g = cat.factorplot("g", "y", "h", data=self.df, kind="strip")
+        g = cat.catplot("g", "y", "h", data=self.df, kind="strip")
         want_elements = self.g.unique().size + self.h.unique().size
         nt.assert_equal(len(g.ax.collections), want_elements)
 
     def test_bad_plot_kind_error(self):
 
         with nt.assert_raises(ValueError):
-            cat.factorplot("g", "y", data=self.df, kind="not_a_kind")
+            cat.catplot("g", "y", data=self.df, kind="not_a_kind")
 
     def test_count_x_and_y(self):
 
         with nt.assert_raises(ValueError):
-            cat.factorplot("g", "y", data=self.df, kind="count")
+            cat.catplot("g", "y", data=self.df, kind="count")
 
     def test_plot_colors(self):
 
         ax = cat.barplot("g", "y", data=self.df)
-        g = cat.factorplot("g", "y", data=self.df, kind="bar")
+        g = cat.catplot("g", "y", data=self.df, kind="bar")
         for p1, p2 in zip(ax.patches, g.ax.patches):
             nt.assert_equal(p1.get_facecolor(), p2.get_facecolor())
         plt.close("all")
 
         ax = cat.barplot("g", "y", data=self.df, color="purple")
-        g = cat.factorplot("g", "y", data=self.df,
-                           kind="bar", color="purple")
+        g = cat.catplot("g", "y", data=self.df,
+                        kind="bar", color="purple")
         for p1, p2 in zip(ax.patches, g.ax.patches):
             nt.assert_equal(p1.get_facecolor(), p2.get_facecolor())
         plt.close("all")
 
         ax = cat.barplot("g", "y", data=self.df, palette="Set2")
-        g = cat.factorplot("g", "y", data=self.df,
-                           kind="bar", palette="Set2")
+        g = cat.catplot("g", "y", data=self.df,
+                        kind="bar", palette="Set2")
         for p1, p2 in zip(ax.patches, g.ax.patches):
             nt.assert_equal(p1.get_facecolor(), p2.get_facecolor())
         plt.close("all")
 
         ax = cat.pointplot("g", "y", data=self.df)
-        g = cat.factorplot("g", "y", data=self.df)
+        g = cat.catplot("g", "y", data=self.df)
         for l1, l2 in zip(ax.lines, g.ax.lines):
             nt.assert_equal(l1.get_color(), l2.get_color())
         plt.close("all")
 
         ax = cat.pointplot("g", "y", data=self.df, color="purple")
-        g = cat.factorplot("g", "y", data=self.df, color="purple")
+        g = cat.catplot("g", "y", data=self.df, color="purple")
         for l1, l2 in zip(ax.lines, g.ax.lines):
             nt.assert_equal(l1.get_color(), l2.get_color())
         plt.close("all")
 
         ax = cat.pointplot("g", "y", data=self.df, palette="Set2")
-        g = cat.factorplot("g", "y", data=self.df, palette="Set2")
+        g = cat.catplot("g", "y", data=self.df, palette="Set2")
         for l1, l2 in zip(ax.lines, g.ax.lines):
             nt.assert_equal(l1.get_color(), l2.get_color())
         plt.close("all")
+
+    def test_factorplot(self):
+
+        with pytest.warns(UserWarning):
+            g = cat.factorplot("g", "y", data=self.df)
+
+        nt.assert_equal(len(g.ax.collections), 1)
+        want_lines = self.g.unique().size + 1
+        nt.assert_equal(len(g.ax.lines), want_lines)
 
 
 class TestLVPlotter(CategoricalFixture):

--- a/seaborn/tests/test_categorical.py
+++ b/seaborn/tests/test_categorical.py
@@ -1563,7 +1563,7 @@ class TestStripPlotter(CategoricalFixture):
 
         pal = palettes.color_palette()
 
-        ax = cat.stripplot("g", "y", data=self.df)
+        ax = cat.stripplot("g", "y", jitter=False, data=self.df)
         for i, (_, vals) in enumerate(self.y.groupby(self.g)):
 
             x, y = ax.collections[i].get_offsets().T
@@ -1579,7 +1579,7 @@ class TestStripPlotter(CategoricalFixture):
         df = self.df.copy()
         df.g = df.g.astype("category")
 
-        ax = cat.stripplot("y", "g", data=df)
+        ax = cat.stripplot("y", "g", jitter=False, data=df)
         for i, (_, vals) in enumerate(self.y.groupby(self.g)):
 
             x, y = ax.collections[i].get_offsets().T
@@ -1606,7 +1606,8 @@ class TestStripPlotter(CategoricalFixture):
 
         pal = palettes.color_palette()
 
-        ax = cat.stripplot("g", "y", "h", data=self.df, dodge=True)
+        ax = cat.stripplot("g", "y", "h", data=self.df,
+                           jitter=False, dodge=True)
         for i, (_, group_vals) in enumerate(self.y.groupby(self.g)):
             for j, (_, vals) in enumerate(group_vals.groupby(self.h)):
 
@@ -1624,7 +1625,8 @@ class TestStripPlotter(CategoricalFixture):
         df = self.df.copy()
         df.g = df.g.astype("category")
 
-        ax = cat.stripplot("y", "g", "h", data=df, dodge=True)
+        ax = cat.stripplot("y", "g", "h", data=df,
+                           jitter=False, dodge=True)
         for i, (_, group_vals) in enumerate(self.y.groupby(self.g)):
             for j, (_, vals) in enumerate(group_vals.groupby(self.h)):
 
@@ -1636,7 +1638,8 @@ class TestStripPlotter(CategoricalFixture):
     def test_nested_stripplot_vertical(self):
 
         # Test a simple vertical strip plot
-        ax = cat.stripplot("g", "y", "h", data=self.df, dodge=False)
+        ax = cat.stripplot("g", "y", "h", data=self.df,
+                           jitter=False, dodge=False)
         for i, (_, group_vals) in enumerate(self.y.groupby(self.g)):
 
             x, y = ax.collections[i].get_offsets().T
@@ -1650,7 +1653,8 @@ class TestStripPlotter(CategoricalFixture):
         df = self.df.copy()
         df.g = df.g.astype("category")
 
-        ax = cat.stripplot("y", "g", "h", data=df, dodge=False)
+        ax = cat.stripplot("y", "g", "h", data=df,
+                           jitter=False, dodge=False)
         for i, (_, group_vals) in enumerate(self.y.groupby(self.g)):
 
             x, y = ax.collections[i].get_offsets().T

--- a/seaborn/tests/test_categorical.py
+++ b/seaborn/tests/test_categorical.py
@@ -380,7 +380,8 @@ class TestCategoricalPlotter(CategoricalFixture):
             p = cat._CategoricalPlotter()
             p.establish_variables("g", "y", data=self.df)
             p.establish_colors(None, None, 1)
-            npt.assert_array_equal(p.colors, palettes.husl_palette(3, l=.7))
+            npt.assert_array_equal(p.colors,
+                                   palettes.husl_palette(3, l=.7))  # noqa
 
     def test_specific_color(self):
 
@@ -2159,15 +2160,15 @@ class TestPointPlotter(CategoricalFixture):
         nt.assert_equal(len(ax.lines),
                         len(p.plot_data) * len(p.hue_names) + len(p.hue_names))
 
-        for points, stats, color in zip(ax.collections,
-                                        p.statistic.T,
-                                        p.colors):
+        for points, numbers, color in zip(ax.collections,
+                                          p.statistic.T,
+                                          p.colors):
 
             nt.assert_equal(len(points.get_offsets()), len(p.plot_data))
 
             x, y = points.get_offsets().T
             npt.assert_array_equal(x, np.arange(len(p.plot_data)))
-            npt.assert_array_equal(y, stats)
+            npt.assert_array_equal(y, numbers)
 
             for got_color in points.get_facecolors():
                 npt.assert_array_equal(got_color[:-1], color)
@@ -2185,14 +2186,14 @@ class TestPointPlotter(CategoricalFixture):
         nt.assert_equal(len(ax.lines),
                         len(p.plot_data) * len(p.hue_names) + len(p.hue_names))
 
-        for points, stats, color in zip(ax.collections,
-                                        p.statistic.T,
-                                        p.colors):
+        for points, numbers, color in zip(ax.collections,
+                                          p.statistic.T,
+                                          p.colors):
 
             nt.assert_equal(len(points.get_offsets()), len(p.plot_data))
 
             x, y = points.get_offsets().T
-            npt.assert_array_equal(x, stats)
+            npt.assert_array_equal(x, numbers)
             npt.assert_array_equal(y, np.arange(len(p.plot_data)))
 
             for got_color in points.get_facecolors():
@@ -2460,11 +2461,11 @@ class TestFactorPlot(CategoricalFixture):
 class TestLVPlotter(CategoricalFixture):
 
     default_kws = dict(x=None, y=None, hue=None, data=None,
-                            order=None, hue_order=None,
-                            orient=None, color=None, palette=None,
-                            saturation=.75, width=.8, dodge=True,
-                            k_depth='proportion', linewidth=None,
-                            scale='exponential', outlier_prop=None)
+                       order=None, hue_order=None,
+                       orient=None, color=None, palette=None,
+                       saturation=.75, width=.8, dodge=True,
+                       k_depth='proportion', linewidth=None,
+                       scale='exponential', outlier_prop=None)
 
     def ispatch(self, c):
 
@@ -2597,7 +2598,6 @@ class TestLVPlotter(CategoricalFixture):
         y[-2:] = np.nan
 
         ax = cat.lvplot(x, y)
-        patches = filter(self.ispatch, ax.collections)
         nt.assert_equal(len(ax.lines), 3)
 
         plt.close("all")


### PR DESCRIPTION
Moderately disruptive but well-intentioned changes herein:

First:

I've decided to abandon the original R-inflected name for `factorplot` and change it to `catplot`, which better corresponds to the appropriate terminology in pandas (and the terminology that is used more broadly in seaborn).

Along with a better name, it gives the opportunity for a less-disruptive approach to changing the default kind to "strip", which is a much better place to start with categorical plotting. (Originally factorplot *only* drew what are now called point plots, and it kept that default when it was expanded to a more general interface to categorical plots).

The other part of the change is to make `jitter=True` the default in `stripplot`. I found myself setting this 98% of the time I made a stripplot, which is a strong argument for making it a default.

Also as part of the change, the default `height` is increasing to `5` to match `lmplot` and the default for the new `relplot`.

`factorplot` will issue a warning but otherwise pass its arguments down to `catplot` (setting `kind="point"` and `height=4` as defaults) so existing code won't break. I don't plan to remove the `factorplot` stub any time soon.

Second:

To try to pack most of the disruptive changes I've had in mind into the same release, I've also changed the name of `lvplot` to `boxenplot`. `lvplot` was never a good name because it's not clear what it stands for, and even when it does, "letter value plot" was not a good name because the concept of letter values is (at least in my experience) quite obscure. So I expect that a name that describes what the plot looks like will make it fit in better with "box" and "violin" plot. (If you're wondering, "boxen" is of course the plural of box).