### PR TITLE
Format doc tables similar to the Jupyter Notebook

### DIFF
--- a/doc/_static/style.css
+++ b/doc/_static/style.css
@@ -68,3 +68,41 @@ ul.dropdown-menu {
   height: 75px; 
   visibility: hidden; 
 }
+
+table {
+    /*Uncomment to center tables horizontally*/
+    /* margin-left: auto; */
+    /* margin-right: auto; */
+    border: none;
+    border-collapse: collapse;
+    border-spacing: 0;
+    font-size: 12px;
+    table-layout: fixed;
+}
+
+thead {
+    border-bottom: 1px solid;
+    vertical-align: bottom;
+}
+
+tr, th, td {
+    text-align: right;
+    vertical-align: middle;
+    padding: 0.5em 0.5em;
+    line-height: normal;
+    white-space: normal;
+    max-width: none;
+    border: none;
+}
+
+th {
+    font-weight: bold;
+}
+
+tbody tr:nth-child(odd) {
+    background: #f5f5f5;
+}
+
+tbody tr:hover {
+    background: rgba(66, 165, 245, 0.2);
+}


### PR DESCRIPTION
I added the [css from the jupyter-notebook](https://github.com/jupyter/notebook/blob/c8841b68c4c0739bbee1291e0214771f24194079/notebook/static/notebook/less/renderedhtml.less#L59-L90) to style the tables in the documentation. I modified it slightly to left-align instead of center (to be consistent with what you had previously) and removed a couple of references to `@rendered_html_border_color`.


## Old style
![image](https://user-images.githubusercontent.com/4560057/43020439-fadd641a-8c2d-11e8-80ad-564148299982.png)

## New style
![image](https://user-images.githubusercontent.com/4560057/43020462-0717dd8c-8c2e-11e8-8979-7830f0f5fdec.png)
