### PR TITLE
Reduce navbar padding to resemble top level links

### DIFF
--- a/doc/_static/style.css
+++ b/doc/_static/style.css
@@ -64,7 +64,7 @@ ul.dropdown-menu {
 *[id]:before { 
   display: block; 
   content: " "; 
-  margin-top: -75px; 
-  height: 75px; 
+  margin-top: -60px; 
+  height: 60px; 
   visibility: hidden; 
 }


### PR DESCRIPTION
Minor suggestion. Reduce the padding between the navbar and section headings so that it is more similar to how close top level headings are to the navbar.

## Before
![image](https://user-images.githubusercontent.com/4560057/43023446-e84a9556-8c38-11e8-8488-3d8d1b8f763d.png)


## After
 ![image](https://user-images.githubusercontent.com/4560057/43023422-d2684fa8-8c38-11e8-9413-90d6f65a8816.png)

## Top level heading
![image](https://user-images.githubusercontent.com/4560057/43023457-f61b729a-8c38-11e8-916e-511d08a237ae.png)

