### PR TITLE
Handle missing values within distplot automatically

### DIFF
--- a/seaborn/distributions.py
+++ b/seaborn/distributions.py
@@ -177,6 +177,14 @@ def distplot(a, bins=None, hist=True, kde=True, rug=False, fit=None,
     if a.ndim > 1:
         a = a.squeeze()
 
+    # Remove np.nans, warn user if present
+    nan_mask = np.isnan(a)
+    if nan_mask.sum() > 0:
+        msg = ("a contains missing values, plotting "
+               "only those that are present.")
+        warnings.warn(msg, UserWarning)
+        a = a[~nan_mask]
+
     # Decide if the hist is normed
     norm_hist = norm_hist or kde or (fit is not None)
 

--- a/seaborn/distributions.py
+++ b/seaborn/distributions.py
@@ -177,12 +177,9 @@ def distplot(a, bins=None, hist=True, kde=True, rug=False, fit=None,
     if a.ndim > 1:
         a = a.squeeze()
 
-    # Remove np.nans, warn user if present
+    # Remove np.nans
     nan_mask = np.isnan(a)
     if nan_mask.sum() > 0:
-        msg = ("a contains missing values, plotting "
-               "only those that are present.")
-        warnings.warn(msg, UserWarning)
         a = a[~nan_mask]
 
     # Decide if the hist is normed

--- a/seaborn/distributions.py
+++ b/seaborn/distributions.py
@@ -179,7 +179,7 @@ def distplot(a, bins=None, hist=True, kde=True, rug=False, fit=None,
 
     # Remove np.nans
     nan_mask = np.isnan(a)
-    if nan_mask.sum() > 0:
+    if np.any(nan_mask):
         a = a[~nan_mask]
 
     # Decide if the hist is normed


### PR DESCRIPTION
As the title suggests, the proposed change is to remove missing values automatically within `distplot` and issue a warning instead of an error. Fixes #1542.