### PR TITLE
Allow specifying a function to calculate confidence intervals

### DIFF
--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -1499,7 +1499,13 @@ class _CategoricalStatPlotter(_CategoricalPlotter):
                         confint.append([np.nan, np.nan])
                         continue
 
-                    if ci == "sd":
+                    if callable(ci):
+
+                        estimate = estimator(stat_data)
+                        cival = ci(stat_data)
+                        confint.append((estimate - ci_val, estimate + ci_val))
+
+                    elif ci == "sd":
 
                         estimate = estimator(stat_data)
                         sd = np.std(stat_data)
@@ -1549,7 +1555,14 @@ class _CategoricalStatPlotter(_CategoricalPlotter):
                             confint[i].append([np.nan, np.nan])
                             continue
 
-                        if ci == "sd":
+                        if callable(ci):
+
+                            estimate = estimator(stat_data)
+                            ci_val = ci(stat_data)
+                            confint.append((estimate - ci_val,
+                                            estimate + ci_val))
+
+                        elif ci == "sd":
 
                             estimate = estimator(stat_data)
                             sd = np.std(stat_data)
@@ -2117,11 +2130,12 @@ _categorical_docs = dict(
     stat_api_params=dedent("""\
     estimator : callable that maps vector -> scalar, optional
         Statistical function to estimate within each categorical bin.
-    ci : float or "sd" or None, optional
+    ci : float or "sd" or function or None, optional
         Size of confidence intervals to draw around estimated values.  If
         "sd", skip bootstrapping and draw the standard deviation of the
-        observations. If ``None``, no bootstrapping will be performed, and
-        error bars will not be drawn.
+        observations. If a function, the function should take a vector and
+        return a single value.  If ``None``, no bootstrapping will be
+        performed, and error bars will not be drawn.
     n_boot : int, optional
         Number of bootstrap iterations to use when computing confidence
         intervals.

--- a/seaborn/tests/test_categorical.py
+++ b/seaborn/tests/test_categorical.py
@@ -650,6 +650,52 @@ class TestCategoricalStatPlotter(CategoricalFixture):
                 ci_want = mean - half_ci, mean + half_ci
                 npt.assert_array_almost_equal(ci_want, ci, 2)
 
+    def test_func_error_bars(self):
+
+        p = cat._CategoricalStatPlotter()
+
+        g = pd.Series(np.repeat(list("abc"), 100))
+        y = pd.Series(np.random.RandomState(0).randn(300))
+
+        p.establish_variables(g, y)
+        p.estimate_statistic(np.mean, np.std, None)
+
+        nt.assert_equal(p.statistic.shape, (3,))
+        nt.assert_equal(p.confint.shape, (3, 2))
+
+        npt.assert_array_almost_equal(p.statistic,
+                                      y.groupby(g).mean())
+
+        for ci, (_, grp_y) in zip(p.confint, y.groupby(g)):
+            mean = grp_y.mean()
+            half_ci = np.std(grp_y)
+            ci_want = mean - half_ci, mean + half_ci
+            npt.assert_array_almost_equal(ci_want, ci, 2)
+
+    def test_nested_func_error_bars(self):
+
+        p = cat._CategoricalStatPlotter()
+
+        g = pd.Series(np.repeat(list("abc"), 100))
+        h = pd.Series(np.tile(list("xy"), 150))
+        y = pd.Series(np.random.RandomState(0).randn(300))
+
+        p.establish_variables(g, y, h)
+        p.estimate_statistic(np.mean, np.std, None)
+
+        nt.assert_equal(p.statistic.shape, (3, 2))
+        nt.assert_equal(p.confint.shape, (3, 2, 2))
+
+        npt.assert_array_almost_equal(p.statistic,
+                                      y.groupby([g, h]).mean().unstack())
+
+        for ci_g, (_, grp_y) in zip(p.confint, y.groupby(g)):
+            for ci, hue_y in zip(ci_g, [grp_y[::2], grp_y[1::2]]):
+                mean = hue_y.mean()
+                half_ci = np.std(hue_y)
+                ci_want = mean - half_ci, mean + half_ci
+                npt.assert_array_almost_equal(ci_want, ci, 2)
+
     def test_draw_cis(self):
 
         p = cat._CategoricalStatPlotter()


### PR DESCRIPTION
This change allows users to specify their own function to calculate the confidence interval.  For example someone could use [`scipy.stats.sem`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.sem.html).