### PR TITLE
fixing regplot to work with multiple subplots

### DIFF
--- a/seaborn/regression.py
+++ b/seaborn/regression.py
@@ -324,7 +324,7 @@ class _RegressionPlotter(_LinearPlotter):
 
         # Use the current color cycle state as a default
         if self.color is None:
-            lines, = plt.plot(self.x.mean(), self.y.mean())
+            lines, = ax.plot(self.x.mean(), self.y.mean())
             color = lines.get_color()
             lines.remove()
         else:


### PR DESCRIPTION
The proposed change in this PR is to replace a call to `plt.plot()` with `ax.plot()` in `_RegressionPlotter` in regression.py. The reason for the change is to solve problems that emerge when `regplot()` is used to plot data on a figure with multiple axes. (See issue #1568) 

A side effect of this change is that multiple calls to `regplot`, each on a different axes, will now be plotted in the same colour by default, as opposed to each using different colours, as is the case now. However, using the same colour will also be more consistent with `lmplot`.

The behaviour of `regplot` when not using multiple subfigures, or not specifying an `ax` is unchanged.