### PR TITLE
[WIP] Add check for categorical hue variable (fixes #1515)

### DIFF
--- a/seaborn/relational.py
+++ b/seaborn/relational.py
@@ -357,6 +357,10 @@ class _RelationalPlotter(object):
             if isinstance(palette, (dict, list)):
                 var_type = "categorical"
 
+            # Override if data is pandas categorical series
+            if isinstance(data, pd.Series) and data.dtype.name == "category":
+                var_type = "categorical"
+
         # -- Option 1: categorical color palette
 
         if var_type == "categorical":

--- a/seaborn/relational.py
+++ b/seaborn/relational.py
@@ -357,10 +357,6 @@ class _RelationalPlotter(object):
             if isinstance(palette, (dict, list)):
                 var_type = "categorical"
 
-            # Override if data is pandas categorical series
-            if isinstance(data, pd.Series) and data.dtype.name == "category":
-                var_type = "categorical"
-
         # -- Option 1: categorical color palette
 
         if var_type == "categorical":
@@ -527,6 +523,8 @@ class _RelationalPlotter(object):
     def _semantic_type(self, data):
         """Determine if data should considered numeric or categorical."""
         if self.input_format == "wide":
+            return "categorical"
+        elif isinstance(data, pd.Series) and data.dtype.name == "category":
             return "categorical"
         else:
             try:


### PR DESCRIPTION
To fix the issue I was seeing on #1515, I added a check that overrides the variable type returned by `_semantic_type()` if the data is a Pandas categorical type. I agree that it makes sense to convert numeric strings into numbers since, as you said in #1515,

>it is not uncommon in pandas (i.e. the data library most commonly used with seaborn) to have numeric data stored with an object datatype, for example if you have integers and missing data.

but I can't think of a case where a series would be a categorical variable if the user didn't explicitly do that. Please let me know if I'm mistaken.

Let me know if you're open to a change like this, and I can look into adding necessary tests for this.