### PR TITLE
Add example with dictionary-specified colors for catplot.

### DIFF
--- a/examples/custom_catplot_colors.py
+++ b/examples/custom_catplot_colors.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env pythonw
+# -*- coding: utf8 -*-
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import seaborn as sns
+sns.set(style='whitegrid')
+
+
+# Generate som artificial wine rating data
+np.random.seed(42)
+ratings = 2*np.random.randn(250, 3, ) + 3 + np.array([2, -1, 1])
+ratings[(ratings > 5) | (ratings < 0)] = np.NaN  # set outliers to NaN
+df = pd.DataFrame(ratings, columns=['Red', 'White', 'Rose'])
+
+# Define colors in dict, with keys correspinding to DataFrame column names
+color_dict = {'Red': '#920e16',
+              'White': '#ebdeb4',
+              'Rose': (0.988, 0.482, 0.498)}  # rgb and rgba is also supported
+sns.catplot(data=df, palette=color_dict)
+plt.show()


### PR DESCRIPTION
I've added an example demonstrating how to specify colors of a catplot using a dictionary of – it was something I've struggled with, and previously posted an issue about [#1573](https://github.com/mwaskom/seaborn/issues/1573).

The example use artificial randomly generated data showing wine ratings, and coloring each type of wine in an associated color:

![wine_example](https://user-images.githubusercontent.com/2641327/46416572-1e8d5c00-c728-11e8-9359-9524bd49a367.png)
