### PR TITLE
Prevent _finalize_grid from breaking legend_out.

### DIFF
--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -845,7 +845,8 @@ class FacetGrid(Grid):
         """Finalize the annotations and layout."""
         self.set_axis_labels(*axlabels)
         self.set_titles()
-        self.fig.tight_layout()
+        # NOTE: Removed figure tightening because it doesn't respect legend_out=True
+        # self.fig.tight_layout()
 
     def facet_axis(self, row_i, col_j):
         """Make the axis identified by these indices active and return it."""


### PR DESCRIPTION
Hi!

In 0.9.0, using the FacetGrid.map or FacetGrid.map_dataframe functions breaks the alignment on legend_out=True. This is shown in the plot below, in which the "grouped_barplot.py" example has g.map() called with a dummy function before rendering. 

![original_grouped_barplot](https://user-images.githubusercontent.com/3657774/46549947-79d66000-c888-11e8-9c77-83d383dda833.png)

This is came from the function _finalize_grid, which was calling tight_layout as a final step. This pull-request removes that line.

![new_grouped_barplot](https://user-images.githubusercontent.com/3657774/46549946-79d66000-c888-11e8-81f3-cb7c6616157d.png)

Thanks for such an awesome package! ✨ 

Code to reproduce: 

`
import seaborn as sns

sns.set(style="whitegrid")

titanic = sns.load_dataset("titanic")

g = sns.catplot(x="class", y="survived", hue="sex", data=titanic,
                height=6, kind="bar", palette="muted")
g.despine(left=True)
g.set_ylabels("survival probability")

def f(*args, **kwargs):
    pass

g.map(f)
`
