### PR TITLE
Add setup.cfg for the wheel distribution

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,5 @@
+[bdist_wheel]
+universal = 1
+
+[metadata]
+license_file = LICENSE


### PR DESCRIPTION
setup.cfg contains information relevant to the creation of the wheel distribution (when running `python setup.py bdist_wheel`).
* `universal = 1` means create a universal wheel, i.e. one that is not only "pure Python" but matches both Python 2 and 3 versions. Currently the [wheel on PyPI](https://pypi.org/project/seaborn/#files) is for Python 3 only although this package is compatible with both versions.
* `license_file` is the directive for including the license file in the "dist-info" folder inside the wheel (the manifest makes the license included in the sdist, but not the wheel).