### PR TITLE
BUGfix for kind 'point' in catplot

### DIFF
--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -1801,6 +1801,7 @@ class _PointPlotter(_CategoricalStatPlotter):
                     x, y = offpos, statistic
                 if not len(remove_na(statistic)):
                     x, y = [], []
+                    point_colors = []
                 ax.scatter(x, y, label=hue_level,
                            c=point_colors, edgecolor=point_colors,
                            linewidth=mew, marker=marker, s=markersize,

--- a/seaborn/tests/test_catplot.py
+++ b/seaborn/tests/test_catplot.py
@@ -1,0 +1,25 @@
+import numpy as np
+import pandas as pd
+from matplotlib import pyplot as plt
+import seaborn as sns
+
+
+def test_catplot_point():
+    data = np.random.rand(100, 4)
+    data[np.random.randint(0, len(data), 25), 0] = np.nan
+    data[:, 1] = np.tile(np.arange(1, 6), 20)
+    data[:, 2] = np.repeat(np.arange(1, 11), 10)
+    data[:, 3] = np.tile(np.concatenate((np.repeat(1, 5), np.repeat(2, 5))), 10)
+    data = pd.DataFrame(data=data,
+                        columns=['resp', 'response', 'subject', 'task'])
+
+    try:
+        sns.catplot(x='task', y='resp', hue='response', col='subject',
+                    data=data, kind='point')
+        plt.show()
+    except ValueError as error:
+        print('ValueError raised:')
+        print(error)
+
+
+test_catplot_point()


### PR DESCRIPTION
When one of the data points is NaN there is a mismatch between color array and position arrays. 

`ValueError: 'c' argument has 2 elements, which is not acceptable for use with 'x' with size 0, 'y' with size 0.`

For those cases, emptying the color array fixes the error.