### PR TITLE
correct lineplot documentation for err_kws

### DIFF
--- a/seaborn/relational.py
+++ b/seaborn/relational.py
@@ -1136,7 +1136,7 @@ lineplot.__doc__ = dedent("""\
     err_style : "band" or "bars", optional
         Whether to draw the confidence intervals with translucent error bands
         or discrete error bars.
-    err_band : dict of keyword arguments
+    err_kws : dict of keyword arguments
         Additional paramters to control the aesthetics of the error bars. The
         kwargs are passed either to ``ax.fill_between`` or ``ax.errorbar``,
         depending on the ``err_style``.


### PR DESCRIPTION
The variable `err_band` isn't used by lineplot. This seems to be a typo for `err_kws`.