### PR TITLE
GH1571 Fix test_cbar_ticks in test_matrix.py

### DIFF
--- a/seaborn/tests/test_matrix.py
+++ b/seaborn/tests/test_matrix.py
@@ -390,7 +390,7 @@ class TestHeatmap(object):
     def test_cbar_ticks(self):
         max_n_ticks = 3
 
-        locator = mpl.ticker.MaxNLocator(max_n_ticks)
+        locator = mpl.ticker.LinearLocator(max_n_ticks)
         f, (ax1, ax2) = plt.subplots(2)
         mat.heatmap(self.df_norm, ax=ax1, cbar_ax=ax2,
                     cbar_kws=dict(ticks=locator))


### PR DESCRIPTION
Closes #1571 

This test has been causing many failures in PR's. Printing the ticks given in the test gives
```
Text(1, -2.0, '−2')
Text(1, -1.0, '−1')
Text(1, 0.0, '0')
Text(1, 1.0, '1')
Text(1, 2.0, '2')
```
so although in this case the ticker returns the correct number of ticks (-2 and 2 are not visible) calling len on this returns 5 while only 3 are visible, as the figure below (test output) demonstrates.

![test_cbar_ticks](https://user-images.githubusercontent.com/29615021/48309835-8b212500-e536-11e8-952c-9774fc09faa6.png)

Unfortunately, the python2 tests behave as intended, so changing the expected answer would only cause those to start failing instead. This PR replaces the test in question with a similar one that works on both versions, but still tests the intended functionality.