### PR TITLE
The "test plot" to determine the color is now performed without actualy plotting anything

### DIFF
--- a/seaborn/regression.py
+++ b/seaborn/regression.py
@@ -324,9 +324,7 @@ class _RegressionPlotter(_LinearPlotter):
 
         # Use the current color cycle state as a default
         if self.color is None:
-            lines, = plt.plot(self.x.mean(), self.y.mean())
-            color = lines.get_color()
-            lines.remove()
+            color = ax._get_lines.get_next_color()
         else:
             color = self.color
 


### PR DESCRIPTION

This solves #1609 and prevents the regplot function from updating properties of the wrong axes in case an `ax` object is provided, which is not equal to the currently active axes