### PR TITLE
Error raised in lineplot, but not barplot, when certain grouped bins have NaN values

### DIFF
--- a/seaborn/algorithms.py
+++ b/seaborn/algorithms.py
@@ -82,10 +82,11 @@ def bootstrap(*args, **kwargs):
                                      func_kwargs, rs)
 
     boot_dist = []
-    for i in range(int(n_boot)):
-        resampler = rs.randint(0, n, n)
-        sample = [a.take(resampler, axis=0) for a in args]
-        boot_dist.append(f(*sample, **func_kwargs))
+    if n > 0:
+        for i in range(int(n_boot)):
+            resampler = rs.randint(0, n, n)
+            sample = [a.take(resampler, axis=0) for a in args]
+            boot_dist.append(f(*sample, **func_kwargs))
     return np.array(boot_dist)
 
 


### PR DESCRIPTION
Code to reproduce the error with current `master` branch:

```python
from pathlib import Path

import matplotlib.pyplot as plt
import numpy as np
import pandas as pd
import seaborn as sns


if __name__ == '__main__':
    main('plot.png', 10, 'line')  # change 'line' to 'bar' and the error disappears!


def main(outfile, conf_bins, plot_type):
    df = generate_data()
    fig, ax = confplot(df, conf_bins, plot_type)
    fig.savefig(outfile)


def generate_data():
    def prob_round(x):
        return (np.random.random(x.shape) < x).astype(int)
    conf = np.random.rand(200)
    df1 = pd.DataFrame({'correct': prob_round(conf), 'confidence': conf * 100})
    df1['type'] = 'type1'
    conf = np.random.rand(200)
    df2 = pd.DataFrame({'correct': prob_round(conf), 'confidence': conf * 50 + 50})
    df2['type'] = 'type2'
    return pd.concat([df1, df2], ignore_index=True)


def confplot(df, conf_bins, plot_type):
    bins = np.linspace(0, 100, conf_bins + 1)
    labels = [f'{int(x)}-{int(y)}' for x, y in zip(bins, bins[1:])]
    df['confidence'] = pd.cut(df['confidence'], bins, labels=labels)

    plotargs = {'y': 'correct', 'x': 'confidence', 'hue': 'type', 'data': df}

    fig, _ = plt.subplots(figsize=(8, 4))
    if plot_type == 'bar':
        ax = sns.barplot(**plotargs)
    elif plot_type == 'line':
        ax = sns.lineplot(**plotargs)

    return fig, ax
```

Traceback:
```
Traceback (most recent call last):
  File ".../site-packages/pandas/core/groupby/groupby.py", line 918, in apply
    result = self._python_apply_general(f)
  File ".../site-packages/pandas/core/groupby/groupby.py", line 936, in _python_apply_general
    self.axis)
  File ".../site-packages/pandas/core/groupby/groupby.py", line 2273, in apply
    res = f(group)
  File ".../site-packages/seaborn/relational.py", line 699, in bootstrapped_cis
    boots = bootstrap(vals, func=func, n_boot=n_boot)
  File ".../site-packages/seaborn/algorithms.py", line 86, in bootstrap
    resampler = rs.randint(0, n, n)
  File "mtrand.pyx", line 993, in mtrand.RandomState.randint
ValueError: low >= high

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "seaborn-bug.py", line 53, in <module>
    main()
  File ".../site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File ".../site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File ".../site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File ".../site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "seaborn-bug.py", line 20, in main
    fig, ax = confplot(df, conf_bins, plot_type=plot_type)
  File "seaborn-bug.py", line 47, in confplot
    ax = sns.lineplot(**plotargs)
  File ".../site-packages/seaborn/relational.py", line 1084, in lineplot
    p.plot(ax, kwargs)
  File ".../site-packages/seaborn/relational.py", line 775, in plot
    x, y, y_ci = self.aggregate(y, x, units)
  File ".../site-packages/seaborn/relational.py", line 718, in aggregate
    cis = grouped.apply(bootstrapped_cis)
  File ".../site-packages/pandas/core/groupby/groupby.py", line 3469, in apply
    return super(SeriesGroupBy, self).apply(func, *args, **kwargs)
  File ".../site-packages/pandas/core/groupby/groupby.py", line 930, in apply
    return self._python_apply_general(f)
  File ".../site-packages/pandas/core/groupby/groupby.py", line 936, in _python_apply_general
    self.axis)
  File ".../site-packages/pandas/core/groupby/groupby.py", line 2273, in apply
    res = f(group)
  File ".../site-packages/seaborn/relational.py", line 699, in bootstrapped_cis
    boots = bootstrap(vals, func=func, n_boot=n_boot)
  File ".../site-packages/seaborn/algorithms.py", line 86, in bootstrap
    resampler = rs.randint(0, n, n)
  File "mtrand.pyx", line 993, in mtrand.RandomState.randint
ValueError: low >= high
```

This PR fixes this error for me and the code above produces the following plot:

![bug](https://user-images.githubusercontent.com/21051830/49858861-6a9c0180-fe39-11e8-9b3c-64c325021440.png)