### PR TITLE
Fixes issue with string array input to hue and size in relplot

### DIFF
--- a/seaborn/relational.py
+++ b/seaborn/relational.py
@@ -526,7 +526,7 @@ class _RelationalPlotter(object):
             return "categorical"
         else:
             if data.dtype in [bool] + np.sctypes['int'] + np.sctypes['uint'] + \
-                    np.sctypes['float'] + np.sctype['complex']:
+                    np.sctypes['float'] + np.sctypes['complex']:
                 try:
                     float_data = data.astype(np.float)
                     values = np.unique(float_data.dropna())

--- a/seaborn/relational.py
+++ b/seaborn/relational.py
@@ -525,13 +525,17 @@ class _RelationalPlotter(object):
         if self.input_format == "wide":
             return "categorical"
         else:
-            try:
-                float_data = data.astype(np.float)
-                values = np.unique(float_data.dropna())
-                if np.array_equal(values, np.array([0., 1.])):
+            if data.dtype in [bool] + np.sctypes['int'] + np.sctypes['uint'] + \
+                    np.sctypes['float'] + np.sctype['complex']:
+                try:
+                    float_data = data.astype(np.float)
+                    values = np.unique(float_data.dropna())
+                    if np.array_equal(values, np.array([0., 1.])):
+                        return "categorical"
+                    return "numeric"
+                except (ValueError, TypeError):
                     return "categorical"
-                return "numeric"
-            except (ValueError, TypeError):
+            else:
                 return "categorical"
 
     def label_axes(self, ax):


### PR DESCRIPTION
> Treats all non-numeric array inputs to hue and size as categorical. This prevents a string array from being passed to `numeric_to_palette` and causing the error in issue #1653 

When an array (`data`) is passed to the `hue` or `size` argument of  a `_RelationalPlotter` object, it is passed on to the method [`_semantic_type`](https://github.com/mwaskom/seaborn/blob/fe172c44777f87159e9e2b00e919bbd055d6f696/seaborn/relational.py#L523), which determines the array's data type (either `'categorical'` or `'numeric'`). If the array is made up of numeric-like strings (those that can be converted into floats), then the `'numeric'` type is returned, but the original `data` array variable is not converted to a numeric type and is passed to [`numeric_to_palette`](https://github.com/mwaskom/seaborn/blob/fe172c44777f87159e9e2b00e919bbd055d6f696/seaborn/relational.py#L230), which is expecting an array of numeric type.

It is possible to overwrite the `data` variable within the scope of `parse_hue` and `parse_size` with a numeric-converted array returned by `_semantic_type`, but this change would need to be propagated outside of the method to the object for use by other methods.

I think an easier solution is to treat only array types that can be parsed by `numeric_to_palette` as `'numeric'` and the rest as categorical. This change is made by checking the dtype of the passed `data` array against the options in `numpy.sctypes`.

This shouldn't contradict the documentation, which specifies that the array to the `hue` or `size` argument:
>Can be either categorical or numeric, although size mapping will behave differently in latter case.
