### PR TITLE
Don't fail on 'loc' kwarg for Grid.add_legend()

### DIFF
--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -82,10 +82,10 @@ class Grid(object):
         if self._legend_out:
 
             kwargs.setdefault("frameon", False)
+            kwargs.setdefault("loc", "center right")
 
             # Draw a full-figure legend outside the grid
-            figlegend = self.fig.legend(handles, label_order, "center right",
-                                        **kwargs)
+            figlegend = self.fig.legend(handles, label_order, **kwargs)
             self._legend = figlegend
             figlegend.set_title(title, prop={"size": title_size})
 
@@ -115,7 +115,8 @@ class Grid(object):
         else:
             # Draw a legend in the first axis
             ax = self.axes.flat[0]
-            leg = ax.legend(handles, label_order, loc="best", **kwargs)
+            kwargs.setdefault("loc", "best")
+            leg = ax.legend(handles, label_order, **kwargs)
             leg.set_title(title, prop={"size": title_size})
 
         return self

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -96,7 +96,7 @@ class Grid(object):
             kwargs.setdefault("loc", "center right")
 
             # Draw a full-figure legend outside the grid
-            figlegend = self.fig.legend(handles, label_order, **kwargs)
+            figlegend = self.fig.legend(handles, labels, **kwargs)
 
             self._legend = figlegend
             figlegend.set_title(title, prop={"size": title_size})
@@ -129,7 +129,7 @@ class Grid(object):
             ax = self.axes.flat[0]
             kwargs.setdefault("loc", "best")
             
-            leg = ax.legend(handles, label_order, **kwargs)
+            leg = ax.legend(handles, labels, **kwargs)
             leg.set_title(title, prop={"size": title_size})
 
         return self

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -128,7 +128,7 @@ class Grid(object):
             # Draw a legend in the first axis
             ax = self.axes.flat[0]
             kwargs.setdefault("loc", "best")
-            
+
             leg = ax.legend(handles, labels, **kwargs)
             leg.set_title(title, prop={"size": title_size})
 


### PR DESCRIPTION
This fixes #1561  , and handles both cases where ``Grid.add_legend(loc="location")`` is provided where the grid was either initialized with ``legend_out=True`` (currently the default) or ``legend_out=False``. 