### PR TITLE
MNT: tweak access to tick label to avoid warning

### DIFF
--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -265,7 +265,7 @@ class _HeatMapper(object):
         size = [bbox.width, bbox.height][axis]
         axis = [ax.xaxis, ax.yaxis][axis]
         tick, = axis.set_ticks([0])
-        fontsize = tick.label.get_size()
+        fontsize = tick.label1.get_size()
         max_ticks = int(size // (fontsize / 72))
         if max_ticks < 1:
             return [], []


### PR DESCRIPTION
The Tick.label property will be deprecated and begin warning in a
future version of Matplotlib.  Explicitly using the correct property
will avoid this.

See https://github.com/matplotlib/matplotlib/pull/10088 and
https://github.com/matplotlib/matplotlib/pull/13631