### PR TITLE
Support numpy datetime64 datatype in scatter hue/style (fixes #1693)

### DIFF
--- a/seaborn/relational.py
+++ b/seaborn/relational.py
@@ -367,7 +367,7 @@ class _RelationalPlotter(object):
                 # List comprehension here is required to
                 # overcome differences in the way pandas
                 # externalizes numpy datetime64
-                [v for v in data], order, palette
+                list(data), order, palette
             )
 
         # -- Option 2: sequential color palette
@@ -492,7 +492,7 @@ class _RelationalPlotter(object):
                 # List comprehension here is required to
                 # overcome differences in the way pandas
                 # coerces numpy datatypes
-                levels = categorical_order([v for v in data])
+                levels = categorical_order(list(data))
             else:
                 levels = order
 

--- a/seaborn/relational.py
+++ b/seaborn/relational.py
@@ -364,7 +364,10 @@ class _RelationalPlotter(object):
             cmap = None
             limits = None
             levels, palette = self.categorical_to_palette(
-                data, order, palette
+                # List comprehension here is required to 
+                # overcome differences in the way pandas 
+                # externalizes numpy datetime64
+                [v for v in data], order, palette
             )
 
         # -- Option 2: sequential color palette
@@ -482,7 +485,10 @@ class _RelationalPlotter(object):
         else:
 
             if order is None:
-                levels = categorical_order(data)
+                # List comprehension here is required to 
+                # overcome differences in the way pandas 
+                # coerces numpy datatypes
+                levels = categorical_order([v for v in data])
             else:
                 levels = order
 

--- a/seaborn/relational.py
+++ b/seaborn/relational.py
@@ -364,8 +364,8 @@ class _RelationalPlotter(object):
             cmap = None
             limits = None
             levels, palette = self.categorical_to_palette(
-                # List comprehension here is required to 
-                # overcome differences in the way pandas 
+                # List comprehension here is required to
+                # overcome differences in the way pandas
                 # externalizes numpy datetime64
                 [v for v in data], order, palette
             )
@@ -485,8 +485,8 @@ class _RelationalPlotter(object):
         else:
 
             if order is None:
-                # List comprehension here is required to 
-                # overcome differences in the way pandas 
+                # List comprehension here is required to
+                # overcome differences in the way pandas
                 # coerces numpy datatypes
                 levels = categorical_order([v for v in data])
             else:

--- a/seaborn/tests/test_relational.py
+++ b/seaborn/tests/test_relational.py
@@ -82,6 +82,7 @@ class TestRelationalPlotter(object):
             a=np.take(list("abc"), rs.randint(0, 3, n)),
             b=np.take(list("mnop"), rs.randint(0, 4, n)),
             c=np.take(list([0, 1]), rs.randint(0, 2, n)),
+            d=np.repeat(np.datetime64('2005-02-25'), n),
             s=np.take([2, 4, 8], rs.randint(0, 3, n)),
         ))
 
@@ -472,6 +473,12 @@ class TestRelationalPlotter(object):
         # Test binary data
         p = rel._LinePlotter(x="x", y="y", hue="c", data=long_df)
         assert p.hue_levels == [0, 1]
+        assert p.hue_type is "categorical"
+
+        # Test Timestamp data
+        p = rel._LinePlotter(x="x", y="y", hue="d", data=long_df)
+        print p.hue_levels
+        assert p.hue_levels == [pd.Timestamp('2005-02-25')]
         assert p.hue_type is "categorical"
 
     def test_parse_hue_numeric(self, long_df):

--- a/seaborn/tests/test_relational.py
+++ b/seaborn/tests/test_relational.py
@@ -477,7 +477,6 @@ class TestRelationalPlotter(object):
 
         # Test Timestamp data
         p = rel._LinePlotter(x="x", y="y", hue="d", data=long_df)
-        print p.hue_levels
         assert p.hue_levels == [pd.Timestamp('2005-02-25')]
         assert p.hue_type is "categorical"
 


### PR DESCRIPTION
Issue #1693 describes a bug where providing ``hue`` (or ``style``) with a pandas column of type ``np.datetime64`` to scatterplot results in no points plotted. This PR fixes both ``hue`` and ``style``.