### PR TITLE
Fix grid ticklabels rotation

### DIFF
--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -892,7 +892,7 @@ class FacetGrid(Grid):
         return self
 
     def set_xticklabels(self, labels=None, step=None, **kwargs):
-        """Set x axis tick labels of the grid."""      
+        """Set x axis tick labels of the grid."""
         for ax in self.axes.flat:
             if labels is None:
                 curr_labels = [l.get_text() for l in ax.get_xticklabels()]

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -892,23 +892,27 @@ class FacetGrid(Grid):
         return self
 
     def set_xticklabels(self, labels=None, step=None, **kwargs):
-        """Set x axis tick labels on the bottom row of the grid."""
+        """Set x axis tick labels of the grid."""      
         for ax in self.axes.flat:
             if labels is None:
-                labels = [l.get_text() for l in ax.get_xticklabels()]
+                curr_labels = [l.get_text() for l in ax.get_xticklabels()]
                 if step is not None:
                     xticks = ax.get_xticks()[::step]
-                    labels = labels[::step]
+                    curr_labels = curr_labels[::step]
                     ax.set_xticks(xticks)
-            ax.set_xticklabels(labels, **kwargs)
+                ax.set_xticklabels(curr_labels, **kwargs)
+            else:
+                ax.set_xticklabels(labels, **kwargs)
         return self
 
     def set_yticklabels(self, labels=None, **kwargs):
         """Set y axis tick labels on the left column of the grid."""
         for ax in self.axes.flat:
             if labels is None:
-                labels = [l.get_text() for l in ax.get_yticklabels()]
-            ax.set_yticklabels(labels, **kwargs)
+                curr_labels = [l.get_text() for l in ax.get_yticklabels()]
+                ax.set_yticklabels(curr_labels, **kwargs)
+            else:
+                ax.set_yticklabels(labels, **kwargs)
         return self
 
     def set_titles(self, template=None, row_template=None,  col_template=None,


### PR DESCRIPTION
Issue #1598 describes a bug where using ``g.set_xticklabels(rotation=rotation)`` on an FacetGrid that has ``row`` faceting (with ``sharex=True``) makes the xtick labels (that are on the bottom row only) disappear. This is due to local variable overriding with the xtick labels from hidden empty labels introduced by #1384 and is fixed by this PR:

<img src="https://user-images.githubusercontent.com/13831112/55707336-09053180-59ec-11e9-9635-de75ca95c3fa.png" width=200>

See the conversation in #1313 regarding the possibility of adding a rotation function to the FacetGrid API. 

Fixes #1598 
Fixes #1743 