### PR TITLE
Implemented dropna bug fix for pairplot

### DIFF
--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -1273,6 +1273,9 @@ class PairGrid(Grid):
         self.axes = axes
         self.data = data
 
+        # Save dropna variable to dictate filtering steps when plotting
+        self._dropna = dropna
+
         # Save what we are going to do with the diagonal
         self.diag_sharey = diag_sharey
         self.diag_axes = None
@@ -1390,6 +1393,12 @@ class PairGrid(Grid):
                     data_k = np.asarray(hue_grouped.get_group(label_k))
                 except KeyError:
                     data_k = np.array([])
+
+                if self._dropna:
+                    data_k = utils.remove_na(data_k)
+                else:
+                    if np.sum(np.isnan(data_k), axis=0).sum() > 0:
+                        raise ValueError("Cannot plot histograms for data containing NAs. Please filter out NAs or pass `dropna=True`.")
 
                 if fixed_color is None:
                     color = self.palette[k]

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -1398,7 +1398,9 @@ class PairGrid(Grid):
                     data_k = utils.remove_na(data_k)
                 else:
                     if np.sum(np.isnan(data_k), axis=0).sum() > 0:
-                        raise ValueError("Cannot plot histograms for data containing NAs. Please filter out NAs or pass `dropna=True`.")
+                        raise ValueError(("Cannot plot histograms for data",
+                                          " containing NAs. Please filter out",
+                                          "NAs or pass `dropna=True`."))
 
                 if fixed_color is None:
                     color = self.palette[k]

--- a/seaborn/tests/test_axisgrid.py
+++ b/seaborn/tests/test_axisgrid.py
@@ -931,6 +931,9 @@ class TestPairGrid(object):
         g5 = ag.PairGrid(na_df, dropna=True)
         g5.map_diag(plt.hist)
 
+        g6 = ag.PairGrid(na_df, dropna=False)
+        nt.assert_raises(ValueError, g6.map_diag, plt.hist)
+
     def test_map_diag_color(self):
 
         color = "red"

--- a/seaborn/tests/test_axisgrid.py
+++ b/seaborn/tests/test_axisgrid.py
@@ -924,6 +924,13 @@ class TestPairGrid(object):
             for ptch in ax.patches:
                 nt.assert_equal(ptch.fill, False)
 
+        na_df = self.df.copy()
+        for i, var in enumerate(self.df.columns.values):
+            na_df.iloc[np.random.randint(len(na_df)), i] = np.nan
+
+        g5 = ag.PairGrid(na_df, dropna=True)
+        g5.map_diag(plt.hist)
+
     def test_map_diag_color(self):
 
         color = "red"


### PR DESCRIPTION
Issue #407 describes an issue where creating a PairGrid on data with `NA`s raises an error even when `dropna=True`. This is an issue only with pyplot's `hist` function and is discussed in [this issue](https://github.com/matplotlib/matplotlib/issues/6483). The NA filtering case does not apply during a `scatter` call as matplotlib already filters out NA data. There is a fix that is supposed to go into matplotlib version 3.0.0 that addresses the issue, but unless seaborn wants to make that restriction on versioning, this PR addresses the issue. 

There is already a [PR](https://github.com/mwaskom/seaborn/pull/409) in progress, but looks stale and figured I'd pick it up and give it a shot.