### PR TITLE
Format numeric legend entries in relational plots

### DIFF
--- a/seaborn/relational.py
+++ b/seaborn/relational.py
@@ -271,7 +271,7 @@ class _RelationalPlotter(object):
         """Return nice legend entries for numeric hue/size variables."""
         levels = ticker.tick_values(*limits).astype(dtype)
         if len(levels) > 1 and levels[1]-levels[0] < 1:
-            sig_digits=int(1-(floor(log10(levels[1]-levels[0]))))
+            sig_digits = int(1-(floor(log10(levels[1]-levels[0]))))
             levels = np.around(levels, decimals=sig_digits)
         return levels
 

--- a/seaborn/relational.py
+++ b/seaborn/relational.py
@@ -2,6 +2,7 @@ from __future__ import division
 from itertools import product
 from textwrap import dedent
 from distutils.version import LooseVersion
+from math import floor, log10
 
 import numpy as np
 import pandas as pd
@@ -265,6 +266,14 @@ class _RelationalPlotter(object):
         # palette = {l: cmap(norm([l, 1]))[0] for l in levels}
 
         return levels, palette, cmap, norm
+
+    def ticker_to_legend_entries(self, ticker, limits, dtype):
+        """Return nice legend entries for numeric hue/size variables."""
+        levels = ticker.tick_values(*limits).astype(dtype)
+        if len(levels) > 1 and levels[1]-levels[0] < 1:
+            sig_digits=int(1-(floor(log10(levels[1]-levels[0]))))
+            levels = np.around(levels, decimals=sig_digits)
+        return levels
 
     def color_lookup(self, key):
         """Return the color corresponding to the hue level."""
@@ -572,8 +581,8 @@ class _RelationalPlotter(object):
                 ticker = mpl.ticker.LogLocator(numticks=3)
             else:
                 ticker = mpl.ticker.MaxNLocator(nbins=3)
-            hue_levels = (ticker.tick_values(*self.hue_limits)
-                                .astype(self.plot_data["hue"].dtype))
+            hue_levels = self.ticker_to_legend_entries(
+                ticker, self.hue_limits, self.plot_data["hue"].dtype)
         else:
             hue_levels = self.hue_levels
 
@@ -594,8 +603,8 @@ class _RelationalPlotter(object):
                 ticker = mpl.ticker.LogLocator(numticks=3)
             else:
                 ticker = mpl.ticker.MaxNLocator(nbins=3)
-            size_levels = (ticker.tick_values(*self.size_limits)
-                                 .astype(self.plot_data["size"].dtype))
+            size_levels = self.ticker_to_legend_entries(
+                ticker, self.size_limits, self.plot_data["size"].dtype)
         else:
             size_levels = self.size_levels
 

--- a/seaborn/relational.py
+++ b/seaborn/relational.py
@@ -12,7 +12,7 @@ from .external.six import string_types
 
 from . import utils
 from .utils import (categorical_order, get_color_cycle, ci_to_errsize, sort_df,
-                    remove_na)
+                    remove_na, locator_to_legend_entries)
 from .algorithms import bootstrap
 from .palettes import color_palette, cubehelix_palette, _parse_cubehelix_args
 from .axisgrid import FacetGrid, _facet_docs
@@ -564,22 +564,6 @@ class _RelationalPlotter(object):
                 keys.append(key)
 
                 legend_kwargs[key] = dict(**kws)
-
-        def locator_to_legend_entries(locator, limits, dtype):
-            """Return levels and formatted levels for brief numeric legends."""
-            raw_levels = locator.tick_values(*limits).astype(dtype)
-
-            class dummy_axis:
-                def get_view_interval(self):
-                    return limits
-
-            if isinstance(locator, mpl.ticker.LogLocator):
-                formatter = mpl.ticker.LogFormatter()
-            else:
-                formatter = mpl.ticker.ScalarFormatter()
-            formatter.axis = dummy_axis()
-            formatted_levels = np.asarray(formatter.format_ticks(raw_levels))
-            return raw_levels, formatted_levels
 
         # -- Add a legend for hue semantics
         if verbosity == "brief" and self.hue_type == "numeric":

--- a/seaborn/tests/test_relational.py
+++ b/seaborn/tests/test_relational.py
@@ -83,6 +83,7 @@ class TestRelationalPlotter(object):
             b=np.take(list("mnop"), rs.randint(0, 4, n)),
             c=np.take(list([0, 1]), rs.randint(0, 2, n)),
             s=np.take([2, 4, 8], rs.randint(0, 3, n)),
+            f=np.take(list([0.2, 0.3]), rs.randint(0, 2, n)),
         ))
 
     @pytest.fixture
@@ -1015,6 +1016,26 @@ class TestLinePlotter(TestRelationalPlotter):
         p.add_legend_data(ax)
         handles, labels = ax.get_legend_handles_labels()
         assert float(labels[2]) / float(labels[1]) == 10
+
+        ax.clear()
+        p = rel._LinePlotter(
+            x="x", y="y", hue="f", legend="brief", data=long_df)
+        p.add_legend_data(ax)
+        ticker = mpl.ticker.MaxNLocator(nbins=3)
+        levels = ticker.tick_values(0.2,0.3)
+        str_levels = np.around(levels,decimals=2).astype(str).tolist()
+        handles, labels = ax.get_legend_handles_labels()
+        assert labels == ["f"] + str_levels
+
+        ax.clear()
+        p = rel._LinePlotter(
+            x="x", y="y", size="f", legend="brief", data=long_df)
+        p.add_legend_data(ax)
+        ticker = mpl.ticker.MaxNLocator(nbins=3)
+        levels = ticker.tick_values(0.2,0.3)
+        str_levels = np.around(levels,decimals=2).astype(str).tolist()
+        handles, labels = ax.get_legend_handles_labels()
+        assert labels == ["f"] + str_levels
 
     def test_plot(self, long_df, repeated_df):
 

--- a/seaborn/tests/test_relational.py
+++ b/seaborn/tests/test_relational.py
@@ -1021,21 +1021,17 @@ class TestLinePlotter(TestRelationalPlotter):
         p = rel._LinePlotter(
             x="x", y="y", hue="f", legend="brief", data=long_df)
         p.add_legend_data(ax)
-        ticker = mpl.ticker.MaxNLocator(nbins=3)
-        levels = ticker.tick_values(0.2,0.3)
-        str_levels = np.around(levels,decimals=2).astype(str).tolist()
+        expected_levels = ['0.20', '0.24', '0.28', '0.32']
         handles, labels = ax.get_legend_handles_labels()
-        assert labels == ["f"] + str_levels
+        assert labels == ["f"] + expected_levels
 
         ax.clear()
         p = rel._LinePlotter(
             x="x", y="y", size="f", legend="brief", data=long_df)
         p.add_legend_data(ax)
-        ticker = mpl.ticker.MaxNLocator(nbins=3)
-        levels = ticker.tick_values(0.2,0.3)
-        str_levels = np.around(levels,decimals=2).astype(str).tolist()
+        expected_levels = ['0.20', '0.24', '0.28', '0.32']
         handles, labels = ax.get_legend_handles_labels()
-        assert labels == ["f"] + str_levels
+        assert labels == ["f"] + expected_levels
 
     def test_plot(self, long_df, repeated_df):
 

--- a/seaborn/tests/test_utils.py
+++ b/seaborn/tests/test_utils.py
@@ -334,6 +334,31 @@ def test_categorical_order():
     nt.assert_equal(out, ["a", "c", "b", "d"])
 
 
+def test_locator_to_legend_entries():
+
+    locator = mpl.ticker.MaxNLocator(nbins=3)
+    limits = (0.09, 0.4)
+    levels, str_levels = utils.locator_to_legend_entries(locator, limits, float)
+    assert str_levels == ["0.00", "0.15", "0.30", "0.45"]
+
+    limits = (0.8, 0.9)
+    levels, str_levels = utils.locator_to_legend_entries(locator, limits, float)
+    assert str_levels == ["0.80", "0.84", "0.88", "0.92"]    
+
+    limits = (1,6)
+    levels, str_levels = utils.locator_to_legend_entries(locator, limits, int)
+    assert str_levels == ["0", "2", "4", "6"]    
+
+    locator=mpl.ticker.LogLocator(numticks=3)
+    limits = (5,1425)
+    levels, str_levels = utils.locator_to_legend_entries(locator, limits, int)
+    assert str_levels == ['0', '1', '100', '10000', '1e+06']
+
+    limits = (0.00003, 0.02)
+    levels, str_levels = utils.locator_to_legend_entries(locator, limits, float)
+    assert str_levels == ['1e-07', '1e-05', '1e-03', '1e-01', '10']
+
+
 if LooseVersion(pd.__version__) >= "0.15":
 
     def check_load_dataset(name):

--- a/seaborn/tests/test_utils.py
+++ b/seaborn/tests/test_utils.py
@@ -352,11 +352,13 @@ def test_locator_to_legend_entries():
     locator=mpl.ticker.LogLocator(numticks=3)
     limits = (5,1425)
     levels, str_levels = utils.locator_to_legend_entries(locator, limits, int)
-    assert str_levels == ['0', '1', '100', '10000', '1e+06']
+    if LooseVersion(mpl.__version__) >= "3.1":
+        assert str_levels == ['0', '1', '100', '10000', '1e+06']
 
     limits = (0.00003, 0.02)
     levels, str_levels = utils.locator_to_legend_entries(locator, limits, float)
-    assert str_levels == ['1e-07', '1e-05', '1e-03', '1e-01', '10']
+    if LooseVersion(mpl.__version__) >= "3.1":
+        assert str_levels == ['1e-07', '1e-05', '1e-03', '1e-01', '10']
 
 
 if LooseVersion(pd.__version__) >= "0.15":

--- a/seaborn/utils.py
+++ b/seaborn/utils.py
@@ -531,6 +531,29 @@ def categorical_order(values, order=None):
     return list(order)
 
 
+def locator_to_legend_entries(locator, limits, dtype):
+    """Return levels and formatted levels for brief numeric legends."""
+    raw_levels = locator.tick_values(*limits).astype(dtype)
+
+    class dummy_axis:
+        def get_view_interval(self):
+            return limits
+
+    if isinstance(locator, mpl.ticker.LogLocator):
+        formatter = mpl.ticker.LogFormatter()
+    else:
+        formatter = mpl.ticker.ScalarFormatter()
+    formatter.axis = dummy_axis()
+
+    # TODO: The following two lines should be replaced 
+    # once pinned matplotlib>=3.1.0 with:
+    # formatted_levels = formatter.format_ticks(raw_levels)
+    formatter.set_locs(raw_levels)
+    formatted_levels = [formatter(x) for x in raw_levels]
+
+    return raw_levels, formatted_levels
+
+
 def get_color_cycle():
     """Return the list of colors in the current matplotlib color cycle."""
     try:

--- a/seaborn/utils.py
+++ b/seaborn/utils.py
@@ -545,7 +545,7 @@ def locator_to_legend_entries(locator, limits, dtype):
         formatter = mpl.ticker.ScalarFormatter()
     formatter.axis = dummy_axis()
 
-    # TODO: The following two lines should be replaced 
+    # TODO: The following two lines should be replaced
     # once pinned matplotlib>=3.1.0 with:
     # formatted_levels = formatter.format_ticks(raw_levels)
     formatter.set_locs(raw_levels)


### PR DESCRIPTION
Issues #1653 and #1703 describe relational plots legend entries that look affected by some floating point calculations. This is due to non-rounded values returned by matplotlib's ``ticker`` used for obtaining the hue/size legend entries. The proposed PR fixes this behavior by using matplotlib formatters on the obtained tick values to get a nice string representation.
![1703-a](https://user-images.githubusercontent.com/13831112/56099324-38e49580-5f14-11e9-9079-5e17b5f61755.png)
![1703](https://user-images.githubusercontent.com/13831112/56099326-3c781c80-5f14-11e9-87ab-a4fd38f1bc69.png)
Fixes #1653 
Fixes #1703 