### PR TITLE
 Consider binary hue data with one unique value categorical (#1722)

### DIFF
--- a/seaborn/relational.py
+++ b/seaborn/relational.py
@@ -530,7 +530,7 @@ class _RelationalPlotter(object):
             try:
                 float_data = data.astype(np.float)
                 values = np.unique(float_data.dropna())
-                if np.array_equal(values, np.array([0., 1.])):
+                if np.all(np.isin(values, np.array([0., 1.]))):
                     return "categorical"
                 return "numeric"
             except (ValueError, TypeError):

--- a/seaborn/relational.py
+++ b/seaborn/relational.py
@@ -530,7 +530,8 @@ class _RelationalPlotter(object):
             try:
                 float_data = data.astype(np.float)
                 values = np.unique(float_data.dropna())
-                if np.all(np.isin(values, np.array([0., 1.]))):
+                # TODO replace with isin when pinned np version >= 1.13
+                if np.all(np.in1d(values, np.array([0., 1.]))):
                     return "categorical"
                 return "numeric"
             except (ValueError, TypeError):

--- a/seaborn/tests/test_relational.py
+++ b/seaborn/tests/test_relational.py
@@ -476,6 +476,16 @@ class TestRelationalPlotter(object):
         assert p.hue_levels == [0, 1]
         assert p.hue_type is "categorical"
 
+        df=long_df[long_df["c"]==0]
+        p = rel._LinePlotter(x="x", y="y", hue="c", data=df)
+        assert p.hue_levels == [0]
+        assert p.hue_type is "categorical"
+
+        df=long_df[long_df["c"]==1]
+        p = rel._LinePlotter(x="x", y="y", hue="c", data=df)
+        assert p.hue_levels == [1]
+        assert p.hue_type is "categorical"
+
         # Test numeric data with category type
         p = rel._LinePlotter(x="x", y="y", hue="s_cat", data=long_df)
         assert p.hue_levels == categorical_order(long_df.s_cat)


### PR DESCRIPTION
The current behavior of relational plots considers binary values as categorical for ``hue`` or ``size`` purposes, but only if both 0 (or ``False``) and 1 (or ``True``) values present in the data (see #1722). This PR makes relational plots consider single-valued binary data in the ``hue`` and ``size`` columns of relational plots as categorical.
![1722](https://user-images.githubusercontent.com/13831112/56126670-2a35c700-5f84-11e9-8a6c-cc9e435e7879.png)

Fixes #1722 