### PR TITLE
Meaningless change to re-trigger CI with matplotlib 3.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,3 +52,4 @@ script:
 after_success:
     - pip install codecov
     - codecov
+


### PR DESCRIPTION
My testing suggests that Seaborn's test suite fails with matplotlib 3.1.0. This will reveal is this is true on CI or merely a quirk of our local setup.