### PR TITLE
handled bug in regress_out function when using {x,y}_partial argument…

### DIFF
--- a/seaborn/regression.py
+++ b/seaborn/regression.py
@@ -312,7 +312,7 @@ class _RegressionPlotter(_LinearPlotter):
         b = b - b.mean()
         b = np.c_[b]
         a_prime = a - b.dot(np.linalg.pinv(b).dot(a))
-        return (a_prime + a_mean).reshape(a.shape)
+        return (a_prime + a_mean).values.reshape(a.shape)
 
     def plot(self, ax, scatter_kws, line_kws):
         """Draw the full plot."""


### PR DESCRIPTION
… in lmplot

Motivated by this post  -> https://stackoverflow.com/questions/56419714/series-object-has-no-attribute-reshape-when-using-x-partial-argument-in-l