### PR TITLE
Fix doc typing error : "an grid" --> "a grid"

### DIFF
--- a/seaborn/distributions.py
+++ b/seaborn/distributions.py
@@ -66,7 +66,7 @@ def distplot(a, bins=None, hist=True, kde=True, rug=False, fit=None,
         Whether to draw a rugplot on the support axis.
     fit : random variable object, optional
         An object with `fit` method, returning a tuple that can be passed to a
-        `pdf` method a positional arguments following an grid of values to
+        `pdf` method a positional arguments following a grid of values to
         evaluate the pdf on.
     {hist, kde, rug, fit}_kws : dictionaries, optional
         Keyword arguments for underlying plotting functions.


### PR DESCRIPTION
In documentation of "distplot", argument "fit", Fix typing error : "an grid" --> "a grid"