### PR TITLE
Kdeplot color clarification

### DIFF
--- a/seaborn/distributions.py
+++ b/seaborn/distributions.py
@@ -401,10 +401,16 @@ def _bivariate_kdeplot(x, y, filled, fill_lowest,
     default_color = scout.get_color()
     scout.remove()
 
-    color = kwargs.pop("color", default_color)
+    color = kwargs.pop("color", None)
     colors = kwargs.pop("colors", None)
     cmap = kwargs.pop("cmap", None)
+    if color is not None and cmap is not None:
+        raise ValueError("Either color or cmap must be None")
+    if color is not None and colors is not None:
+        raise ValueError("Either color or colors must be None")
     if cmap is None and colors is None:
+        if color is None:
+            color = default_color
         if filled:
             cmap = light_palette(color, as_cmap=True)
         else:

--- a/seaborn/distributions.py
+++ b/seaborn/distributions.py
@@ -402,8 +402,9 @@ def _bivariate_kdeplot(x, y, filled, fill_lowest,
     scout.remove()
 
     color = kwargs.pop("color", default_color)
+    colors = kwargs.pop("colors", None)
     cmap = kwargs.pop("cmap", None)
-    if cmap is None:
+    if cmap is None and colors is None:
         if filled:
             cmap = light_palette(color, as_cmap=True)
         else:
@@ -419,6 +420,7 @@ def _bivariate_kdeplot(x, y, filled, fill_lowest,
     label = kwargs.pop("label", None)
 
     kwargs["cmap"] = cmap
+    kwargs["colors"] = colors
     contour_func = ax.contourf if filled else ax.contour
     cset = contour_func(xx, yy, z, n_levels, **kwargs)
     if filled and not fill_lowest:


### PR DESCRIPTION
* Closes https://github.com/mwaskom/seaborn/issues/1748
* Add `colors` kwarg handling for contour plotting, based on matplotlib docs (which now say to pick either `colors` or `cmap`)
* Modify kdeplot to accept one of `color`, `colors`, or `cmap` and raise an error if more than 1 is provided