### PR TITLE
Treat scatter size variable as categorical on list/dict sizes input

### DIFF
--- a/seaborn/relational.py
+++ b/seaborn/relational.py
@@ -428,6 +428,10 @@ class _RelationalPlotter(object):
                 except TypeError:
                     limits = None
 
+                # enforce numeric data to be treated as categorical -
+                # this ensures no size norm is used for legend (#GH1570)
+                var_type = "categorical"
+
             else:
 
                 # Infer the range of sizes to use

--- a/seaborn/tests/test_relational.py
+++ b/seaborn/tests/test_relational.py
@@ -1331,6 +1331,32 @@ class TestScatterPlotter(TestRelationalPlotter):
 
         # --
 
+        ax.clear()
+        sizes_list=[10,100,200]
+        p = rel._ScatterPlotter(x="x", y="y", size="s", sizes=sizes_list,
+                                  data=long_df, legend="full")
+        p.add_legend_data(ax)
+        handles, labels = ax.get_legend_handles_labels()
+        sizes = [h.get_sizes()[0] for h in handles]
+        expected_sizes = [0] + [p.sizes[l] for l in p.size_levels]
+        assert labels == ["s"] + [str(l) for l in p.size_levels]
+        assert sizes == expected_sizes
+
+        # --
+
+        ax.clear()
+        sizes_dict={2:10,4:100,8:200}
+        p = rel._ScatterPlotter(x="x", y="y", size="s", sizes=sizes_dict,
+                                  data=long_df, legend="full")
+        p.add_legend_data(ax)
+        handles, labels = ax.get_legend_handles_labels()
+        sizes = [h.get_sizes()[0] for h in handles]
+        expected_sizes = [0] + [p.sizes[l] for l in p.size_levels]
+        assert labels == ["s"] + [str(l) for l in p.size_levels]
+        assert sizes == expected_sizes
+        
+        # --
+
         x, y = np.random.randn(2, 40)
         z = np.tile(np.arange(20), 2)
 


### PR DESCRIPTION
Providing dict/list ``sizes`` input on numeric column for ``scatterplot`` fails on missing ``norm`` at the time of legend drawing. This PR treats numeric size variable as categorical if dict/list ``sizes`` input is provided and so the ``norm`` lookup is avoided. This is consistent with the current ``hue`` treatment for dict/list palette input. 

Fixes #1570 