### PR TITLE
Remove nan/inf-containing data points from relational plots data

### DIFF
--- a/seaborn/relational.py
+++ b/seaborn/relational.py
@@ -167,8 +167,12 @@ class _RelationalPlotter(object):
 
         # ---- Post-processing
 
+        # Make sure rows with nan-containing semantics are not used #GH1761
+        plot_data.dropna(axis=1, how='all', inplace=True)
+        plot_data.dropna(axis=0, how='any', inplace=True)
+
         # Assign default values for missing attribute variables
-        for attr in ["hue", "style", "size", "units"]:
+        for attr in ["x", "y", "hue", "style", "size", "units"]:
             if attr not in plot_data:
                 plot_data[attr] = None
 

--- a/seaborn/relational.py
+++ b/seaborn/relational.py
@@ -167,9 +167,12 @@ class _RelationalPlotter(object):
 
         # ---- Post-processing
 
-        # Make sure rows with nan-containing semantics are not used #GH1761
-        plot_data.dropna(axis=1, how='all', inplace=True)
-        plot_data.dropna(axis=0, how='any', inplace=True)
+        # Make sure nan/inf-containing semantics are not used #GH1761
+        plot_data = (
+            plot_data.replace([np.inf, -np.inf], np.nan)
+            .dropna(axis=1, how="all")
+            .dropna(axis=0, how="any")
+        )
 
         # Assign default values for missing attribute variables
         for attr in ["x", "y", "hue", "style", "size", "units"]:


### PR DESCRIPTION
Issue #1761 describes a behavior where relational plots continuous numeric semantics (``hue``/``size``) are calculated based on all available data points for the semantic, even if for points that are not plotted (i.e. nan- or inf-containing points). This PR removes such points from participation in relational plots, so the ``hue`` and ``size`` ranges will be calculated based on valid data points only. 

Fixes #1761 