### PR TITLE
Fix horizontal boxenplot warning

### DIFF
--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -1956,6 +1956,7 @@ class _LVPlotter(_CategoricalPlotter):
 
             # Calculate the outliers and plot
             outliers = self._lv_outliers(box_data, k)
+            hex_color = mpl.colors.rgb2hex(color)
 
             if vert:
                 boxes = [vert_perc_box(x, b[0], i, k, b[1])
@@ -1966,7 +1967,7 @@ class _LVPlotter(_CategoricalPlotter):
                         c='.15', alpha=.45, **kws)
 
                 ax.scatter(np.repeat(x, len(outliers)), outliers,
-                           marker='d', c=mpl.colors.rgb2hex(color), **kws)
+                           marker='d', c=hex_color, **kws)
             else:
                 boxes = [horz_perc_box(x, b[0], i, k, b[1])
                          for i, b in enumerate(zip(box_ends, w_area))]
@@ -1976,10 +1977,10 @@ class _LVPlotter(_CategoricalPlotter):
                         c='.15', alpha=.45, **kws)
 
                 ax.scatter(outliers, np.repeat(x, len(outliers)),
-                           marker='d', c=color, **kws)
+                           marker='d', c=hex_color, **kws)
 
             # Construct a color map from the input color
-            rgb = [[1, 1, 1], list(color)]
+            rgb = [[1, 1, 1], hex_color]
             cmap = mpl.colors.LinearSegmentedColormap.from_list('new_map', rgb)
             collection = PatchCollection(boxes, cmap=cmap)
 

--- a/seaborn/tests/test_categorical.py
+++ b/seaborn/tests/test_categorical.py
@@ -2646,6 +2646,12 @@ class TestBoxenPlotter(CategoricalFixture):
         cat.boxenplot("y", "g", "h", data=self.df, orient="h")
         plt.close("all")
 
+        cat.boxenplot("y", "g", "h", data=self.df, orient="h", palette="Set2")
+        plt.close("all")
+
+        cat.boxenplot("y", "g", "h", data=self.df, orient="h", color="b")
+        plt.close("all")
+
     def test_axes_annotation(self):
 
         ax = cat.boxenplot("g", "y", data=self.df)


### PR DESCRIPTION
Horizontal boxenplots log warnings from ``matplotlib`` due to incorrect color input to scatterplot of the outliers (see #1629 ). The proposed PR makes horizontal plots color usage equal to vertical plots. 

Fixes #1629 