### PR TITLE
Handle matplotlib 3.1.0 tick1On/tick2On deprecation warnings

### DIFF
--- a/seaborn/tests/test_utils.py
+++ b/seaborn/tests/test_utils.py
@@ -232,38 +232,38 @@ class TestSpineUtils(object):
         utils.despine(trim=True)
         nt.assert_equal(ax.get_yticks().size, 0)
 
-    def test_despine_moved_tickes(self):
+    def test_despine_moved_ticks(self):
 
         f, ax = plt.subplots()
         for t in ax.yaxis.majorTicks:
-            t.tick1On = True
+            t.tick1line.set_visible(True)
         utils.despine(ax=ax, left=True, right=False)
         for y in ax.yaxis.majorTicks:
-            assert t.tick2On
+            assert t.tick2line.get_visible()
         plt.close(f)
 
         f, ax = plt.subplots()
         for t in ax.yaxis.majorTicks:
-            t.tick1On = False
+            t.tick1line.set_visible(False)
         utils.despine(ax=ax, left=True, right=False)
         for y in ax.yaxis.majorTicks:
-            assert not t.tick2On
+            assert not t.tick2line.get_visible()
         plt.close(f)
 
         f, ax = plt.subplots()
         for t in ax.xaxis.majorTicks:
-            t.tick1On = True
+            t.tick1line.set_visible(True)
         utils.despine(ax=ax, bottom=True, top=False)
         for y in ax.xaxis.majorTicks:
-            assert t.tick2On
+            assert t.tick2line.get_visible()
         plt.close(f)
 
         f, ax = plt.subplots()
         for t in ax.xaxis.majorTicks:
-            t.tick1On = False
+            t.tick1line.set_visible(False)
         utils.despine(ax=ax, bottom=True, top=False)
         for y in ax.xaxis.majorTicks:
-            assert not t.tick2On
+            assert not t.tick2line.get_visible()
         plt.close(f)
 
 

--- a/seaborn/utils.py
+++ b/seaborn/utils.py
@@ -231,8 +231,14 @@ def despine(fig=None, ax=None, top=True, right=True, left=False,
 
         # Potentially move the ticks
         if left and not right:
-            maj_on = any(t.tick1line.get_visible() for t in ax_i.yaxis.majorTicks)
-            min_on = any(t.tick1line.get_visible() for t in ax_i.yaxis.minorTicks)
+            maj_on = any(
+                t.tick1line.get_visible()
+                for t in ax_i.yaxis.majorTicks
+            )
+            min_on = any(
+                t.tick1line.get_visible()
+                for t in ax_i.yaxis.minorTicks
+            )
             ax_i.yaxis.set_ticks_position("right")
             for t in ax_i.yaxis.majorTicks:
                 t.tick2line.set_visible(maj_on)
@@ -240,8 +246,14 @@ def despine(fig=None, ax=None, top=True, right=True, left=False,
                 t.tick2line.set_visible(min_on)
 
         if bottom and not top:
-            maj_on = any(t.tick1line.get_visible() for t in ax_i.xaxis.majorTicks)
-            min_on = any(t.tick1line.get_visible() for t in ax_i.xaxis.minorTicks)
+            maj_on = any(
+                t.tick1line.get_visible()
+                for t in ax_i.xaxis.majorTicks
+            )
+            min_on = any(
+                t.tick1line.get_visible()
+                for t in ax_i.xaxis.minorTicks
+            )
             ax_i.xaxis.set_ticks_position("top")
             for t in ax_i.xaxis.majorTicks:
                 t.tick2line.set_visible(maj_on)

--- a/seaborn/utils.py
+++ b/seaborn/utils.py
@@ -231,22 +231,22 @@ def despine(fig=None, ax=None, top=True, right=True, left=False,
 
         # Potentially move the ticks
         if left and not right:
-            maj_on = any(t.tick1On for t in ax_i.yaxis.majorTicks)
-            min_on = any(t.tick1On for t in ax_i.yaxis.minorTicks)
+            maj_on = any(t.tick1line.get_visible() for t in ax_i.yaxis.majorTicks)
+            min_on = any(t.tick1line.get_visible() for t in ax_i.yaxis.minorTicks)
             ax_i.yaxis.set_ticks_position("right")
             for t in ax_i.yaxis.majorTicks:
-                t.tick2On = maj_on
+                t.tick2line.set_visible(maj_on)
             for t in ax_i.yaxis.minorTicks:
-                t.tick2On = min_on
+                t.tick2line.set_visible(min_on)
 
         if bottom and not top:
-            maj_on = any(t.tick1On for t in ax_i.xaxis.majorTicks)
-            min_on = any(t.tick1On for t in ax_i.xaxis.minorTicks)
+            maj_on = any(t.tick1line.get_visible() for t in ax_i.xaxis.majorTicks)
+            min_on = any(t.tick1line.get_visible() for t in ax_i.xaxis.minorTicks)
             ax_i.xaxis.set_ticks_position("top")
             for t in ax_i.xaxis.majorTicks:
-                t.tick2On = maj_on
+                t.tick2line.set_visible(maj_on)
             for t in ax_i.xaxis.minorTicks:
-                t.tick2On = min_on
+                t.tick2line.set_visible(min_on)
 
         if trim:
             # clip off the parts of the spines that extend past major ticks


### PR DESCRIPTION
Matplotlib 3.1.0 introduced deprecation warnings to ``tick1On`` and ``tick2On``. The proposed PR fixes these (and also fixes a typo in the test method's name).