### PR TITLE
Fix documentation on distplot bins

### DIFF
--- a/seaborn/distributions.py
+++ b/seaborn/distributions.py
@@ -57,7 +57,7 @@ def distplot(a, bins=None, hist=True, kde=True, rug=False, fit=None,
         Observed data. If this is a Series object with a ``name`` attribute,
         the name will be used to label the data axis.
     bins : argument for matplotlib hist(), or None, optional
-        Specification of hist bins. None to use Freedman-Diaconis rule or 50, 
+        Specification of hist bins. None to use Freedman-Diaconis rule or 50,
         depends on which is smaller.
     hist : bool, optional
         Whether to plot a (normed) histogram.

--- a/seaborn/distributions.py
+++ b/seaborn/distributions.py
@@ -57,7 +57,8 @@ def distplot(a, bins=None, hist=True, kde=True, rug=False, fit=None,
         Observed data. If this is a Series object with a ``name`` attribute,
         the name will be used to label the data axis.
     bins : argument for matplotlib hist(), or None, optional
-        Specification of hist bins, or None to use Freedman-Diaconis rule.
+        Specification of hist bins. None to use Freedman-Diaconis rule or 50, 
+        depends on which is smaller.
     hist : bool, optional
         Whether to plot a (normed) histogram.
     kde : bool, optional


### PR DESCRIPTION
Distplot bins documentation is misleading. If Freedman-Diaconis rule gives a value greater than 50, 50 will be used as the bin size.