### PR TITLE
Avoid mapping color codes for non-string palettes in sns.set()

### DIFF
--- a/seaborn/rcmod.py
+++ b/seaborn/rcmod.py
@@ -4,6 +4,7 @@ import functools
 import matplotlib as mpl
 import warnings
 from . import palettes, _orig_rc_params
+from .external.six import string_types
 
 
 mpl_ge_150 = LooseVersion(mpl.__version__) >= '1.5.0'
@@ -119,6 +120,9 @@ def set(context="notebook", style="darkgrid", palette="deep",
     """
     set_context(context, font_scale)
     set_style(style, rc={"font.family": font})
+    # Avoid mapping color codes for non-string palettes
+    if not isinstance(palette, string_types):
+        color_codes = False
     set_palette(palette, color_codes=color_codes)
     if rc is not None:
         mpl.rcParams.update(rc)

--- a/seaborn/tests/test_rcmod.py
+++ b/seaborn/tests/test_rcmod.py
@@ -87,6 +87,29 @@ class TestAxesStyle(RCParamTester):
         nt.assert_equal(mpl.rcParams["lines.linewidth"], 4)
         rcmod.set()
 
+    def test_set_with_palette(self):
+
+        rcmod.reset_orig()
+
+        rcmod.set(palette="deep")
+        assert utils.get_color_cycle() == palettes.color_palette("deep", 10)
+        rcmod.reset_orig()
+
+        rcmod.set(palette="deep", color_codes=False)
+        assert utils.get_color_cycle() == palettes.color_palette("deep", 10)
+        rcmod.reset_orig()
+
+        pal = palettes.color_palette("deep")
+        rcmod.set(palette=pal)
+        assert utils.get_color_cycle() == palettes.color_palette("deep", 10)
+        rcmod.reset_orig()
+
+        rcmod.set(palette=pal, color_codes=False)
+        assert utils.get_color_cycle() == palettes.color_palette("deep", 10)
+        rcmod.reset_orig()
+
+        rcmod.set()
+
     def test_reset_defaults(self):
 
         # Changes to the rc parameters make this test hard to manage


### PR DESCRIPTION
Running ``sns.set(palette=pal)`` with ``pal`` created through ``color_palette()`` fails without specifying ``color_codes=False``(#1546 ). The proposed PR uses ``color_codes=False`` in case of a non-string palette input.

Fixes #1546 
