### PR TITLE
added "fixed" option for the scale parameter for violinplot

### DIFF
--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -596,7 +596,7 @@ class _ViolinPlotter(_CategoricalPlotter):
             size = len(self.group_names), len(self.hue_names)
             counts = np.zeros(size)
             max_density = np.zeros(size)
-            print(counts)
+
         for i, group_data in enumerate(self.plot_data):
 
             # Option 1: we have a single level of grouping


### PR DESCRIPTION
For anyone who wants to make multiple violin plots that share the same scaling parameter, but want the appearance to follow scale="counts" mode, I have added a "fixed" option that allows for overriding the maximum counts determination that is made in "counts" mode, since this latter value cannot be transferred to other plots.