### PR TITLE
Don't error on singular data in kdeplot

### DIFF
--- a/doc/releases/v0.9.1.txt
+++ b/doc/releases/v0.9.1.txt
@@ -4,6 +4,8 @@ v0.9.1 (Unreleased)
 
 This is a minor release, comprising mostly bug fixes and compatibility with dependency updates.
 
+- Avoided an error when singular data is passed to :func:`kdeplot`, issuing a warning instead. This makes :func:`pairplot` more robust.
+
 - Fixed an issue where :func:`regplot` could interfere with other axes in a multi-plot matplotlib figure.
 
 - Semantic variables with a ``category`` data type will always be treated as categorical in relational plots.

--- a/seaborn/distributions.py
+++ b/seaborn/distributions.py
@@ -278,7 +278,7 @@ def _univariate_kdeplot(data, shade, vertical, kernel, bw, gridsize, cut,
 
     # Calculate the KDE
 
-    if data.var() == 0:
+    if np.nan_to_num(data.var()) == 0:
         # Don't try to compute KDE on singular data
         msg = "Data must have variance to compute a kernel density estimate."
         warnings.warn(msg, UserWarning)

--- a/seaborn/distributions.py
+++ b/seaborn/distributions.py
@@ -277,7 +277,14 @@ def _univariate_kdeplot(data, shade, vertical, kernel, bw, gridsize, cut,
         clip = (-np.inf, np.inf)
 
     # Calculate the KDE
-    if _has_statsmodels:
+
+    if data.var() == 0:
+        # Don't try to compute KDE on singular data
+        msg = "Data must have variance to compute a kernel density estimate."
+        warnings.warn(msg, UserWarning)
+        x, y = np.array([]), np.array([])
+
+    elif _has_statsmodels:
         # Prefer using statsmodels for kernel flexibility
         x, y = _statsmodels_univariate_kde(data, kernel, bw,
                                            gridsize, cut, clip,

--- a/seaborn/tests/test_distributions.py
+++ b/seaborn/tests/test_distributions.py
@@ -97,6 +97,13 @@ class TestKDE(object):
         with npt.assert_raises(TypeError):
             dist.kdeplot(self.x, data2=self.y, cumulative=True)
 
+    def test_kde_singular(self):
+
+        with pytest.warns(UserWarning):
+            ax = dist.kdeplot(np.ones(10))
+        line = ax.lines[0]
+        assert not line.get_xydata().size
+
     def test_bivariate_kde_series(self):
         df = pd.DataFrame({'x': self.x, 'y': self.y})
 

--- a/seaborn/tests/test_distributions.py
+++ b/seaborn/tests/test_distributions.py
@@ -104,6 +104,11 @@ class TestKDE(object):
         line = ax.lines[0]
         assert not line.get_xydata().size
 
+        with pytest.warns(UserWarning):
+            ax = dist.kdeplot(np.ones(10) * np.nan)
+        line = ax.lines[1]
+        assert not line.get_xydata().size
+
     def test_bivariate_kde_series(self):
         df = pd.DataFrame({'x': self.x, 'y': self.y})
 

--- a/seaborn/tests/test_matrix.py
+++ b/seaborn/tests/test_matrix.py
@@ -306,6 +306,8 @@ class TestHeatmap(object):
         nt.assert_equal(len(f.axes), 2)
         plt.close(f)
 
+    @pytest.mark.xfail(mpl.__version__ == "3.1.1",
+                       reason="matplotlib 3.1.1 bug")
     def test_heatmap_axes(self):
 
         ax = mat.heatmap(self.df_norm)
@@ -591,6 +593,8 @@ class TestDendrogram(object):
         nt.assert_equal(len(ax.collections[0].get_paths()),
                         len(d.dependent_coord))
 
+    @pytest.mark.xfail(mpl.__version__ == "3.1.1",
+                       reason="matplotlib 3.1.1 bug")
     def test_dendrogram_rotate(self):
         kws = self.default_kws.copy()
         kws['rotate'] = True


### PR DESCRIPTION
The approach here is to fire a warning and add an empty line artist to the axes rather than let the statistical machinery barf when the input data are singular. This will keep `pairplot` from being non-functional, although the warnings might be confusing or annoying. Perhaps best considered a stop-gap measure. Another option might be to plot a delta function at the singular value. But that's kind of wrong, because really the delta function should be convolved with the kernel. But then *that* would be very misleading about what's going on too. So I guess I've convinced myself this is best for now.

Fixes #1502
Fixes #1699