### PR TITLE
Enhancements and fixes to PairGrid

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -43,8 +43,6 @@ Distribution plots
 .. autosummary::
     :toctree: generated/
 
-    jointplot
-    pairplot
     distplot
     kdeplot
     rugplot
@@ -93,6 +91,7 @@ Pair grids
 .. autosummary::
    :toctree: generated/
 
+    pairplot
     PairGrid
     PairGrid.map
     PairGrid.map_diag
@@ -106,6 +105,7 @@ Joint grids
 .. autosummary::
    :toctree: generated/
 
+    jointplot
     JointGrid
     JointGrid.plot
     JointGrid.plot_joint

--- a/doc/releases/v0.9.1.txt
+++ b/doc/releases/v0.9.1.txt
@@ -12,6 +12,8 @@ This is a minor release, comprising mostly bug fixes and compatibility with depe
 
 - Fixed the behavior of ``dropna`` in :class:`PairGrid` to properly exclude null datapoints from each plot when set to ``True``.
 
+- Exposed the ``layout_pad`` parameter in :class:`PairGrid` and set a smaller default than what matptlotlib sets for more efficient use of space in dense grids.
+
 - Avoided an error when singular data is passed to :func:`kdeplot`, issuing a warning instead. This makes :func:`pairplot` more robust.
 
 - Fixed an issue where :func:`regplot` could interfere with other axes in a multi-plot matplotlib figure.

--- a/doc/releases/v0.9.1.txt
+++ b/doc/releases/v0.9.1.txt
@@ -6,6 +6,10 @@ This is a minor release, comprising mostly bug fixes and compatibility with depe
 
 - Generalized the idea of "diagonal" axes in :class:`PairGrid` to any axes that share an x and y variable.
 
+- In :class:`PairGrid`, the ``hue`` variable is now excluded from the default list of variables that make up the rows and columns of the grid.
+
+- Fixed the behavior of ``dropna`` in :class:`PairGrid` to properly exclude null datapoints from each plot when set to ``True``.
+
 - Avoided an error when singular data is passed to :func:`kdeplot`, issuing a warning instead. This makes :func:`pairplot` more robust.
 
 - Fixed an issue where :func:`regplot` could interfere with other axes in a multi-plot matplotlib figure.

--- a/doc/releases/v0.9.1.txt
+++ b/doc/releases/v0.9.1.txt
@@ -4,9 +4,9 @@ v0.9.1 (Unreleased)
 
 This is a minor release, comprising mostly bug fixes and compatibility with dependency updates.
 
-- Generalized the idea of "diagonal" axes in :class:`PairGrid` to any axes that share an x and y variable.
-
 - Added the ``corner`` option to :class:`PairGrid` and :func:`pairplot` to make a grid with only the lower triangle of bivariate axes.
+
+- Generalized the idea of "diagonal" axes in :class:`PairGrid` to any axes that share an x and y variable.
 
 - In :class:`PairGrid`, the ``hue`` variable is now excluded from the default list of variables that make up the rows and columns of the grid.
 

--- a/doc/releases/v0.9.1.txt
+++ b/doc/releases/v0.9.1.txt
@@ -6,6 +6,8 @@ This is a minor release, comprising mostly bug fixes and compatibility with depe
 
 - Generalized the idea of "diagonal" axes in :class:`PairGrid` to any axes that share an x and y variable.
 
+- Added the ``corner`` option to :class:`PairGrid` and :func:`pairplot` to make a grid with only the lower triangle of bivariate axes.
+
 - In :class:`PairGrid`, the ``hue`` variable is now excluded from the default list of variables that make up the rows and columns of the grid.
 
 - Fixed the behavior of ``dropna`` in :class:`PairGrid` to properly exclude null datapoints from each plot when set to ``True``.

--- a/doc/releases/v0.9.1.txt
+++ b/doc/releases/v0.9.1.txt
@@ -4,6 +4,8 @@ v0.9.1 (Unreleased)
 
 This is a minor release, comprising mostly bug fixes and compatibility with dependency updates.
 
+- Generalized the idea of "diagonal" axes in :class:`PairGrid` to any axes that share an x and y variable.
+
 - Avoided an error when singular data is passed to :func:`kdeplot`, issuing a warning instead. This makes :func:`pairplot` more robust.
 
 - Fixed an issue where :func:`regplot` could interfere with other axes in a multi-plot matplotlib figure.

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -1101,8 +1101,8 @@ class PairGrid(Grid):
 
     def __init__(self, data, hue=None, hue_order=None, palette=None,
                  hue_kws=None, vars=None, x_vars=None, y_vars=None,
-                 diag_sharey=True, height=2.5, aspect=1, corner=False,
-                 despine=True, dropna=True, size=None):
+                 corner=False, diag_sharey=True, height=2.5, aspect=1,
+                 layout_pad=0, despine=True, dropna=True, size=None):
         """Initialize the plot figure and PairGrid object.
 
         Parameters
@@ -1128,13 +1128,15 @@ class PairGrid(Grid):
         {x, y}_vars : lists of variable names, optional
             Variables within ``data`` to use separately for the rows and
             columns of the figure; i.e. to make a non-square plot.
+        corner : bool, optional
+            If True, don't add axes to the upper (off-diagonal) triangle of the
+            grid, making this a "corner" plot.
         height : scalar, optional
             Height (in inches) of each facet.
         aspect : scalar, optional
             Aspect * height gives the width (in inches) of each facet.
-        corner : bool, optional
-            If True, don't add axes to the upper (off-diagonal) triangle of the
-            grid, making this a "corner" plot.
+        layout_pad : scalar, optional
+            Padding between axes; passed to ``fig.tight_layout``.
         despine : boolean, optional
             Remove the top and right spines from the plots.
         dropna : boolean, optional
@@ -1332,7 +1334,7 @@ class PairGrid(Grid):
         if despine:
             self._despine = True
             utils.despine(fig=fig)
-        fig.tight_layout()
+        fig.tight_layout(pad=layout_pad)
 
     def map(self, func, **kwargs):
         """Plot with the same function in every subplot.

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -1415,17 +1415,27 @@ class PairGrid(Grid):
             for i, y_var in enumerate(self.y_vars):
                 for j, x_var in enumerate(self.x_vars):
                     if x_var == y_var:
+
+                        # Make the density axes
                         diag_vars.append(x_var)
                         ax = self.axes[i, j]
                         diag_ax = ax.twinx()
                         diag_ax.set_axis_off()
+                        diag_axes.append(diag_ax)
+
+                        # Work around matplotlib bug
+                        # https://github.com/matplotlib/matplotlib/issues/15188
+                        if not plt.rcParams.get("ytick.left", True):
+                            for tick in ax.yaxis.majorTicks:
+                                tick.tick1line.set_visible(False)
+
+                        # Remove main y axis from density axes in a corner plot
                         if self._corner:
                             ax.yaxis.set_visible(False)
                             if self._despine:
                                 utils.despine(ax=ax, left=True)
                             # TODO add optional density ticks (on the right)
                             # when drawing a corner plot?
-                        diag_axes.append(diag_ax)
 
             if self.diag_sharey:
                 # This may change in future matplotlibs

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -1279,6 +1279,7 @@ class PairGrid(Grid):
 
         # Save what we are going to do with the diagonal
         self.diag_sharey = diag_sharey
+        self.diag_vars = None
         self.diag_axes = None
 
         # Label the axes
@@ -1365,24 +1366,31 @@ class PairGrid(Grid):
 
         """
         # Add special diagonal axes for the univariate plot
-        if self.square_grid and self.diag_axes is None:
+        if self.diag_axes is None:
+            diag_vars = []
             diag_axes = []
-            for i, (var, ax) in enumerate(zip(self.x_vars,
-                                              np.diag(self.axes))):
-                if i and self.diag_sharey:
-                    diag_ax = ax._make_twin_axes(sharex=ax,
-                                                 sharey=diag_axes[0],
-                                                 frameon=False)
-                else:
-                    diag_ax = ax._make_twin_axes(sharex=ax, frameon=False)
-                diag_ax.set_axis_off()
-                diag_axes.append(diag_ax)
+            for i, y_var in enumerate(self.y_vars):
+                for j, x_var in enumerate(self.x_vars):
+                    if x_var == y_var:
+                        ax = self.axes[i, j]
+                        diag_vars.append(x_var)
+                        if self.diag_axes and self.diag_sharey:
+                            diag_ax = ax._make_twin_axes(sharex=ax,
+                                                         sharey=diag_axes[0],
+                                                         frameon=False)
+                        else:
+                            diag_ax = ax._make_twin_axes(sharex=ax,
+                                                         frameon=False)
+                        diag_ax.set_axis_off()
+                        diag_axes.append(diag_ax)
+
+            self.diag_vars = np.array(diag_vars, np.object)
             self.diag_axes = np.array(diag_axes, np.object)
 
         # Plot on each of the diagonal axes
         fixed_color = kwargs.pop("color", None)
-        for i, var in enumerate(self.x_vars):
-            ax = self.diag_axes[i]
+
+        for var, ax in zip(self.diag_vars, self.diag_axes):
             hue_grouped = self.data[var].groupby(self.hue_vals)
 
             plt.sca(ax)

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -1374,15 +1374,16 @@ class PairGrid(Grid):
                     if x_var == y_var:
                         ax = self.axes[i, j]
                         diag_vars.append(x_var)
-                        if self.diag_axes and self.diag_sharey:
-                            diag_ax = ax._make_twin_axes(sharex=ax,
-                                                         sharey=diag_axes[0],
-                                                         frameon=False)
-                        else:
-                            diag_ax = ax._make_twin_axes(sharex=ax,
-                                                         frameon=False)
+                        diag_ax = ax.twinx()
                         diag_ax.set_axis_off()
                         diag_axes.append(diag_ax)
+
+            if self.diag_sharey:
+                # This may change in future matplotlibs
+                # See https://github.com/matplotlib/matplotlib/pull/9923
+                group = diag_axes[0].get_shared_y_axes()
+                for ax in diag_axes[1:]:
+                    group.join(ax)
 
             self.diag_vars = np.array(diag_vars, np.object)
             self.diag_axes = np.array(diag_axes, np.object)

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -1925,7 +1925,7 @@ def pairplot(data, hue=None, hue_order=None, palette=None,
              plot_kws=None, diag_kws=None, grid_kws=None, size=None):
     """Plot pairwise relationships in a dataset.
 
-    By default, this function will create a grid of Axes such that each
+    By default, this function will create a grid of Axes such that each numeric
     variable in ``data`` will by shared in the y-axis across a single row and
     in the x-axis across a single column. The diagonal Axes are treated
     differently, drawing a plot to show the univariate distribution of the data
@@ -1976,12 +1976,15 @@ def pairplot(data, hue=None, hue_order=None, palette=None,
     dropna : boolean, optional
         Drop missing values from the data before plotting.
     {plot, diag, grid}_kws : dicts, optional
-        Dictionaries of keyword arguments.
+        Dictionaries of keyword arguments. ``plot_kws`` are passed to the
+        bivariate plotting function, ``diag_kws`` are passed to the univariate
+        plotting function, and ``grid_kws`` are passed to the :class:`PairGrid`
+        constructor.
 
     Returns
     -------
-    grid : PairGrid
-        Returns the underlying ``PairGrid`` instance for further tweaking.
+    grid : :class:`PairGrid`
+        Returns the underlying :class:`PairGrid` instance for further tweaking.
 
     See Also
     --------

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -1442,7 +1442,7 @@ class PairGrid(Grid):
                 # See https://github.com/matplotlib/matplotlib/pull/9923
                 group = diag_axes[0].get_shared_y_axes()
                 for ax in diag_axes[1:]:
-                    group.join(ax)
+                    group.join(ax, diag_axes[0])
 
             self.diag_vars = np.array(diag_vars, np.object)
             self.diag_axes = np.array(diag_axes, np.object)
@@ -2099,10 +2099,9 @@ def pairplot(data, hue=None, hue_order=None, palette=None,
         grid_kws = {}
 
     # Set up the PairGrid
-    diag_sharey = diag_kind == "hist"
+    grid_kws.setdefault("diag_sharey", diag_kind == "hist")
     grid = PairGrid(data, vars=vars, x_vars=x_vars, y_vars=y_vars, hue=hue,
-                    hue_order=hue_order, palette=palette,
-                    diag_sharey=diag_sharey, corner=corner,
+                    hue_order=hue_order, palette=palette, corner=corner,
                     height=height, aspect=aspect, dropna=dropna, **grid_kws)
 
     # Add the markers here as PairGrid has figured out how many levels of the

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -1288,7 +1288,10 @@ class PairGrid(Grid):
         if corner:
             hide_indices = np.triu_indices_from(axes, 1)
             for i, j in zip(*hide_indices):
-                axes[i, j].remove()
+                try:
+                    axes[i, j].remove()
+                except NotImplementedError:  # Problem on old matplotlibs?
+                    axes[i, j].set_axis_off()
                 axes[i, j] = None
 
         self.fig = fig

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -1111,7 +1111,8 @@ class PairGrid(Grid):
             Tidy (long-form) dataframe where each column is a variable and
             each row is an observation.
         hue : string (variable name), optional
-            Variable in ``data`` to map plot aspects to different colors.
+            Variable in ``data`` to map plot aspects to different colors. This
+            variable will be excluded from the default x and y variables.
         hue_order : list of strings
             Order for the levels of the hue variable in the palette
         palette : dict or seaborn color palette

--- a/seaborn/tests/test_axisgrid.py
+++ b/seaborn/tests/test_axisgrid.py
@@ -768,6 +768,18 @@ class TestPairGrid(object):
         nt.assert_equal(g.y_vars, vars)
         nt.assert_true(g.square_grid)
 
+    def test_remove_hue_from_default(self):
+
+        hue = "z"
+        g = ag.PairGrid(self.df, hue=hue)
+        assert hue not in g.x_vars
+        assert hue not in g.y_vars
+
+        vars = ["x", "y", "z"]
+        g = ag.PairGrid(self.df, hue=hue, vars=vars)
+        assert hue in g.x_vars
+        assert hue in g.y_vars
+
     def test_specific_nonsquare_axes(self):
 
         x_vars = ["x", "y"]

--- a/seaborn/tests/test_axisgrid.py
+++ b/seaborn/tests/test_axisgrid.py
@@ -901,27 +901,60 @@ class TestPairGrid(object):
         g1 = ag.PairGrid(self.df)
         g1.map_diag(plt.hist)
 
-        for ax in g1.diag_axes:
+        for var, ax in zip(g1.diag_vars, g1.diag_axes):
             nt.assert_equal(len(ax.patches), 10)
+            assert pytest.approx(ax.patches[0].get_x()) == self.df[var].min()
 
-        g2 = ag.PairGrid(self.df)
-        g2.map_diag(plt.hist, bins=15)
+        g2 = ag.PairGrid(self.df, hue="a")
+        g2.map_diag(plt.hist)
 
         for ax in g2.diag_axes:
-            nt.assert_equal(len(ax.patches), 15)
-
-        g3 = ag.PairGrid(self.df, hue="a")
-        g3.map_diag(plt.hist)
-
-        for ax in g3.diag_axes:
             nt.assert_equal(len(ax.patches), 30)
 
-        g4 = ag.PairGrid(self.df, hue="a")
-        g4.map_diag(plt.hist, histtype='step')
+        g3 = ag.PairGrid(self.df, hue="a")
+        g3.map_diag(plt.hist, histtype='step')
 
-        for ax in g4.diag_axes:
+        for ax in g3.diag_axes:
             for ptch in ax.patches:
                 nt.assert_equal(ptch.fill, False)
+
+    def test_map_diag_rectangular(self):
+
+        x_vars = ["x", "y"]
+        y_vars = ["x", "y", "z"]
+        g1 = ag.PairGrid(self.df, x_vars=x_vars, y_vars=y_vars)
+        g1.map_diag(plt.hist)
+
+        assert set(g1.diag_vars) == (set(x_vars) & set(y_vars))
+
+        for var, ax in zip(g1.diag_vars, g1.diag_axes):
+            nt.assert_equal(len(ax.patches), 10)
+            assert pytest.approx(ax.patches[0].get_x()) == self.df[var].min()
+
+        for i, ax in enumerate(np.diag(g1.axes)):
+            assert ax.bbox.bounds == g1.diag_axes[i].bbox.bounds
+
+        g2 = ag.PairGrid(self.df, x_vars=x_vars, y_vars=y_vars, hue="a")
+        g2.map_diag(plt.hist)
+
+        assert set(g2.diag_vars) == (set(x_vars) & set(y_vars))
+
+        for ax in g2.diag_axes:
+            nt.assert_equal(len(ax.patches), 30)
+
+        x_vars = ["x", "y", "z"]
+        y_vars = ["x", "y"]
+        g3 = ag.PairGrid(self.df, x_vars=x_vars, y_vars=y_vars)
+        g3.map_diag(plt.hist)
+
+        assert set(g3.diag_vars) == (set(x_vars) & set(y_vars))
+
+        for var, ax in zip(g3.diag_vars, g3.diag_axes):
+            nt.assert_equal(len(ax.patches), 10)
+            assert pytest.approx(ax.patches[0].get_x()) == self.df[var].min()
+
+        for i, ax in enumerate(np.diag(g3.axes)):
+            assert ax.bbox.bounds == g3.diag_axes[i].bbox.bounds
 
     def test_map_diag_color(self):
 

--- a/seaborn/tests/test_axisgrid.py
+++ b/seaborn/tests/test_axisgrid.py
@@ -1144,14 +1144,14 @@ class TestPairGrid(object):
 
         df = self.df.copy().set_index("b")
 
-        vars = ["x", "y", "z"]
+        plot_vars = ["x", "y", "z"]
         g1 = ag.PairGrid(df)
         g1.map(plt.scatter)
 
         for i, axes_i in enumerate(g1.axes):
             for j, ax in enumerate(axes_i):
-                x_in = self.df[vars[j]]
-                y_in = self.df[vars[i]]
+                x_in = self.df[plot_vars[j]]
+                y_in = self.df[plot_vars[i]]
                 x_out, y_out = ax.collections[0].get_offsets().T
                 npt.assert_array_equal(x_in, x_out)
                 npt.assert_array_equal(y_in, y_out)
@@ -1161,14 +1161,47 @@ class TestPairGrid(object):
 
         for i, axes_i in enumerate(g2.axes):
             for j, ax in enumerate(axes_i):
-                x_in = self.df[vars[j]]
-                y_in = self.df[vars[i]]
+                x_in = self.df[plot_vars[j]]
+                y_in = self.df[plot_vars[i]]
                 for k, k_level in enumerate(self.df.a.unique()):
                     x_in_k = x_in[self.df.a == k_level]
                     y_in_k = y_in[self.df.a == k_level]
                     x_out, y_out = ax.collections[k].get_offsets().T
                 npt.assert_array_equal(x_in_k, x_out)
                 npt.assert_array_equal(y_in_k, y_out)
+
+    def test_dropna(self):
+
+        df = self.df.copy()
+        n_null = 20
+        df.loc[np.arange(n_null), "x"] = np.nan
+
+        plot_vars = ["x", "y", "z"]
+
+        g1 = ag.PairGrid(df, vars=plot_vars, dropna=True)
+        g1.map(plt.scatter)
+
+        for i, axes_i in enumerate(g1.axes):
+            for j, ax in enumerate(axes_i):
+                x_in = df[plot_vars[j]]
+                y_in = df[plot_vars[i]]
+                x_out, y_out = ax.collections[0].get_offsets().T
+
+                n_valid = (x_in * y_in).notnull().sum()
+
+                assert n_valid == len(x_out)
+                assert n_valid == len(y_out)
+
+        g2 = ag.PairGrid(df, vars=plot_vars, dropna=False)
+        g2.map(plt.scatter)
+
+        for i, axes_i in enumerate(g2.axes):
+            for j, ax in enumerate(axes_i):
+                x_in = df[plot_vars[j]]
+                y_in = df[plot_vars[i]]
+                x_out, y_out = ax.collections[0].get_offsets().T
+                assert len(x_in) == len(x_out)
+                assert len(y_in) == len(y_out)
 
     def test_pairplot(self):
 

--- a/seaborn/tests/test_axisgrid.py
+++ b/seaborn/tests/test_axisgrid.py
@@ -1192,17 +1192,6 @@ class TestPairGrid(object):
                 assert n_valid == len(x_out)
                 assert n_valid == len(y_out)
 
-        g2 = ag.PairGrid(df, vars=plot_vars, dropna=False)
-        g2.map(plt.scatter)
-
-        for i, axes_i in enumerate(g2.axes):
-            for j, ax in enumerate(axes_i):
-                x_in = df[plot_vars[j]]
-                y_in = df[plot_vars[i]]
-                x_out, y_out = ax.collections[0].get_offsets().T
-                assert len(x_in) == len(x_out)
-                assert len(y_in) == len(y_out)
-
     def test_pairplot(self):
 
         vars = ["x", "y", "z"]

--- a/seaborn/tests/test_axisgrid.py
+++ b/seaborn/tests/test_axisgrid.py
@@ -817,6 +817,20 @@ class TestPairGrid(object):
         nt.assert_equal(g.y_vars, list(y_vars))
         nt.assert_true(not g.square_grid)
 
+    def test_corner(self):
+
+        plot_vars = ["x", "y", "z"]
+        g1 = ag.PairGrid(self.df, vars=plot_vars, corner=True)
+        corner_size = sum([i + 1 for i in range(len(plot_vars))])
+        assert len(g1.fig.axes) == corner_size
+
+        g1.map_diag(plt.hist)
+        assert len(g1.fig.axes) == (corner_size + len(plot_vars))
+
+        for ax in np.diag(g1.axes):
+            assert not ax.yaxis.get_visible()
+            assert not g1.axes[0, 0].get_ylabel()
+
     def test_size(self):
 
         g1 = ag.PairGrid(self.df, height=3)

--- a/seaborn/tests/test_axisgrid.py
+++ b/seaborn/tests/test_axisgrid.py
@@ -14,6 +14,8 @@ try:
 except ImportError:
     import pandas.util.testing as tm
 
+from distutils.version import LooseVersion
+
 from .. import axisgrid as ag
 from .. import rcmod
 from ..palettes import color_palette
@@ -817,6 +819,8 @@ class TestPairGrid(object):
         nt.assert_equal(g.y_vars, list(y_vars))
         nt.assert_true(not g.square_grid)
 
+    @pytest.mark.xfail(LooseVersion(mpl.__version__) < "1.5",
+                       reason="Expected failure on older matplotlib")
     def test_corner(self):
 
         plot_vars = ["x", "y", "z"]

--- a/seaborn/tests/test_axisgrid.py
+++ b/seaborn/tests/test_axisgrid.py
@@ -1045,6 +1045,13 @@ class TestPairGrid(object):
             ax = g.axes[i, j]
             nt.assert_equal(len(ax.collections), 0)
 
+    def test_diag_sharey(self):
+
+        g = ag.PairGrid(self.df, diag_sharey=True)
+        g.map_diag(kdeplot)
+        for ax in g.diag_axes[1:]:
+            assert ax.get_ylim() == g.diag_axes[0].get_ylim()
+
     def test_palette(self):
 
         rcmod.set()


### PR DESCRIPTION
A number of small enhancements are combined here:

- Added the ``corner`` option to :class:`PairGrid` and :func:`pairplot` to make a grid with only the lower triangle of bivariate axes. (I don't believe there is an open issue about this but there's a [popular SO question](https://stackoverflow.com/questions/34087126/plot-lower-triangle-in-a-seaborn-pairgrid).)

```python
iris = sns.load_dataset("iris")
g = sns.pairplot(iris, height=1.5, corner=True)
```
![image](https://user-images.githubusercontent.com/315810/64357251-52c16a80-cfd2-11e9-87b9-2186ac09ed2a.png)


- Generalized the idea of "diagonal" axes in :class:`PairGrid` to any axes that share an x and y variable. (Closes #1125)

```python
iris = sns.load_dataset("iris").drop("species", axis=1)
g = sns.PairGrid(iris, height=1.5, x_vars=iris.columns, y_vars=iris.columns[:3])
g.map_diag(sns.kdeplot)
g.map_offdiag(sns.scatterplot)
```
![image](https://user-images.githubusercontent.com/315810/64357289-61a81d00-cfd2-11e9-881d-c6db59663b83.png)

- In :class:`PairGrid`, the ``hue`` variable is now excluded from the default list of variables that make up the rows and columns of the grid. (Supersedes and closes #1525 

- Exposed the ``layout_pad`` parameter in :class:`PairGrid` and set a smaller default than what matptlotlib sets for more efficient use of space in dense grids.

- Fixed the behavior of ``dropna`` in :class:`PairGrid` to properly exclude null datapoints from each plot when set to ``True``.  This is relatively less necessary these days as matplotlib is generally better about handling nans, but still potentially useful. This also prompted a helpful refactor of the `PairGrid` code. Closes #407, closes #409 (!), and supersedes and closes #1718.



