### PR TITLE
Support Python3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,9 @@ env:
   - PYTHON=3.5 DEPS=latest BACKEND=agg DOCTESTS=true
   - PYTHON=3.6 DEPS=latest BACKEND=agg DOCTESTS=true
   - PYTHON=3.7 DEPS=latest BACKEND=agg DOCTESTS=true
-  - PYTHON=3.7 DEPS=latest BACKEND=qtagg DOCTESTS=true
-  - PYTHON=3.7 DEPS=minimal BACKEND=agg DOCTESTS=false
+  - PYTHON=3.8 DEPS=latest BACKEND=agg DOCTESTS=true
+  - PYTHON=3.8 DEPS=latest BACKEND=qtagg DOCTESTS=true
+  - PYTHON=3.8 DEPS=minimal BACKEND=agg DOCTESTS=false
 
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_install:
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r
-  - conda config --set always_yes yes --set changeps1 no
+  - conda config --set always_yes yes --set changeps1 no --set channel_priority false
   - conda config --add channels conda-forge
   - conda update -q conda
   - conda info -a

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ before_install:
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r
   - conda config --set always_yes yes --set changeps1 no
+  - conda config --add channels conda-forge
   - conda update -q conda
   - conda info -a
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,10 @@ before_install:
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r
-  - conda config --set always_yes yes --set changeps1 no --set channel_priority false
+  - conda config --set always_yes yes --set changeps1 no 
   - conda config --add channels conda-forge
   - conda update -q conda
+  - conda config --set channel_priority false
   - conda info -a
 
 

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ CLASSIFIERS = [
     'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',
+    'Programming Language :: Python :: 3.8',
     'License :: OSI Approved :: BSD License',
     'Topic :: Scientific/Engineering :: Visualization',
     'Topic :: Multimedia :: Graphics',


### PR DESCRIPTION
In addition to ``python=3.8`` CI support, this PR also adds ``conda-forge`` channel when resolving dependencies (removed by [previous commit](https://github.com/mwaskom/seaborn/commit/24542c79aafd6d59795204cd7ceeb1a5c5192053)) - this ensured ``matplotlib=3.1.2`` support as well (still not available through the ``defaults`` conda channel). 