### PR TITLE
Fix default color codes.

### DIFF
--- a/seaborn/palettes.py
+++ b/seaborn/palettes.py
@@ -1065,7 +1065,7 @@ def set_color_codes(palette="deep"):
 
     """
     if palette == "reset":
-        colors = [(0., 0., 1.), (0., .5, 0.), (1., 0., 0.), (.75, .75, 0.),
+        colors = [(0., 0., 1.), (0., .5, 0.), (1., 0., 0.), (.75, 0., .75),
                   (.75, .75, 0.), (0., .75, .75), (0., 0., 0.)]
     elif not isinstance(palette, string_types):
         err = "set_color_codes requires a named seaborn palette"


### PR DESCRIPTION
The default colors in `set_color_codes()` (used for `palette = "reset"`) uses the wrong color code for m (magenta) and instead duplicates yellow. Fixing this only requires changing the RGB numbers for the array entry associated with magenta.