### PR TITLE
included parametric CIs and updated help

### DIFF
--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -2134,12 +2134,11 @@ _categorical_docs = dict(
     stat_api_params=dedent("""\
     estimator : callable that maps vector -> scalar, optional
         Statistical function to estimate within each categorical bin.
-    ci : float or "sd" or "sem" or None, optional
+    ci : float or "sd" or None, optional
         Size of confidence intervals to draw around estimated values.  If
-        "sd" or "sem", skip bootstrapping and draw the standard deviation 
-        or standard error of the mean of the observations, respectively.
-        If ``None``, no bootstrapping will be performed, and error bars will
-        not be drawn.
+        "sd" , skip bootstrapping and draw the standard deviation of the 
+        observations. If ``None``, no bootstrapping will be performed, and
+        error bars will not be drawn.
     n_boot : int, optional
         Number of bootstrap iterations to use when computing confidence
         intervals. If ``None``, confidence intervals will be calculated

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -1501,13 +1501,7 @@ class _CategoricalStatPlotter(_CategoricalPlotter):
                         estimate = estimator(stat_data)
                         sd = np.std(stat_data)
                         confint.append((estimate - sd, estimate + sd))
-
-                    elif ci == "sem":
-
-                        estimate = estimator(stat_data)
-                        sem = sbstats.sem(stat_data)
-                        confint.append((estimate - sem, estimate + sem))
-
+                    
                     else:
 
                         if n_boot is not None:
@@ -1516,6 +1510,8 @@ class _CategoricalStatPlotter(_CategoricalPlotter):
                                                     units=unit_data)
                             confint.append(utils.ci(boots, ci))
                         else:
+                            assert estimator is np.mean, \
+                                "analytic CIs not implemented for estimator '%s'" % estimator
                             sem = sbstats.sem(stat_data)
                             z_se = stats.norm.ppf((ci + (100 - ci) * .5) / 100.)
                             ci_lo = stat_data.mean() - z_se * sem
@@ -1565,12 +1561,6 @@ class _CategoricalStatPlotter(_CategoricalPlotter):
                             sd = np.std(stat_data)
                             confint[i].append((estimate - sd, estimate + sd))
 
-                        elif ci == "sem":
-
-                            estimate = estimator(stat_data)
-                            sem = sbstats.sem(stat_data)
-                            confint[i].append((estimate - sem, estimate + sem))
-
                         else:
 
                             if n_boot is not None:
@@ -1579,6 +1569,8 @@ class _CategoricalStatPlotter(_CategoricalPlotter):
                                                       units=unit_data)
                                 confint[i].append(utils.ci(boots, ci))
                             else:
+                                assert estimator is np.mean, \
+                                    "analytic CIs not implemented for estimator '%s'" % estimator
                                 sem = sbstats.sem(stat_data)
                                 z_se = stats.norm.ppf((ci + (100 - ci) * .5) / 100.)
                                 ci_lo = stat_data.mean() - z_se * sem


### PR DESCRIPTION
Dear MIchael,

Thanks for creating seaborn - it's been of tremendous help in my daily work.

However, I have not found an easy way to create confidence intervals parametrically based on the standard error of the mean (sem): "ci" let's you specify "sd" in order to plot standard deviations or perhaps "68" to plot something >>like<< sem via one (of numerous possible) bootstrap methods.

There has been an increasing interest in quantifying measurement error in the form of confidence intervals (CI) over the last few years ("The New Statistics: Why and How", Cumming, 2014) and it is probably advisable to be consistent across studies about the way confidence intervals are constructed (or - if there is variability across fields - to have more flexibility).

Since most research surely uses parametric confidence intervals, I have added the possibility to (1) easily plot sem CIs by setting the "ci" parameter to "sem" (similar to the "sd" option) and (2) to calculate CIs parametricelly (and deterministically) for any desired level of estimation error simply from the sems without having to run any bootstraps. In order to use this functionality, the n_boot parameter simply has to be None. This results in confidence intervals that in my experience are just as "good" as the previous ones while preserving consistency across studies, which commonly rely on parametric CIs as well. 

I have updated the function help accordingly.

Cheers,
Michael