### PR TITLE
Two small fixes in regplot

### DIFF
--- a/doc/releases/v0.9.1.txt
+++ b/doc/releases/v0.9.1.txt
@@ -38,6 +38,8 @@ Bug fixes and adpatations
 
 - Fixed a bug when setting the rotation of x tick labels on a :class:`FacetGrid`.
 
+- Fixed a bug when using ``Series`` objects as arguments for ``x_partial`` or ``y_partial`` in :func:`regplot`.
+
 - Fixed a bug when passing a ``norm`` object and using color annotations in :func:`clustermap`.
 
 - Fixed a bug when trying to call :func:`set` while specifying a list of colors for the palette.

--- a/seaborn/regression.py
+++ b/seaborn/regression.py
@@ -45,11 +45,17 @@ class _LinearPlotter(object):
         # Set the variables
         for var, val in kws.items():
             if isinstance(val, string_types):
-                setattr(self, var, data[val])
+                vector = data[val]
             elif isinstance(val, list):
-                setattr(self, var, np.asarray(val))
+                vector = np.asarray(val)
             else:
-                setattr(self, var, val)
+                vector = val
+            if vector is not None:
+                vector = np.squeeze(vector)
+            if np.ndim(vector) > 1:
+                err = "regplot inputs must be 1d"
+                raise ValueError(err)
+            setattr(self, var, vector)
 
     def dropna(self, *vars):
         """Remove observations with missing data."""

--- a/seaborn/regression.py
+++ b/seaborn/regression.py
@@ -318,7 +318,7 @@ class _RegressionPlotter(_LinearPlotter):
         b = b - b.mean()
         b = np.c_[b]
         a_prime = a - b.dot(np.linalg.pinv(b).dot(a))
-        return (a_prime + a_mean).reshape(a.shape)
+        return np.asarray(a_prime + a_mean).reshape(a.shape)
 
     def plot(self, ax, scatter_kws, line_kws):
         """Draw the full plot."""

--- a/seaborn/tests/test_regression.py
+++ b/seaborn/tests/test_regression.py
@@ -364,6 +364,12 @@ class TestRegressionPlotter(object):
         _, r_partial = np.corrcoef(p.x, p.y)[0]
         nt.assert_less(r_partial, r_orig)
 
+        x = pd.Series(x)
+        y = pd.Series(y)
+        p = lm._RegressionPlotter(y, z, x_partial=x, y_partial=x)
+        _, r_partial = np.corrcoef(p.x, p.y)[0]
+        nt.assert_less(r_partial, r_orig)
+
     @pytest.mark.skipif(_no_statsmodels, reason="no statsmodels")
     def test_logistic_regression(self):
 

--- a/seaborn/tests/test_regression.py
+++ b/seaborn/tests/test_regression.py
@@ -148,6 +148,15 @@ class TestRegressionPlotter(object):
         npt.assert_array_equal(p.y, self.df.y + 1)
         pdt.assert_frame_equal(p.data, self.df)
 
+    def test_variables_must_be_1d(self):
+
+        array_2d = np.random.randn(20, 2)
+        array_1d = np.random.randn(20)
+        with pytest.raises(ValueError):
+            lm._RegressionPlotter(array_2d, array_1d)
+        with pytest.raises(ValueError):
+            lm._RegressionPlotter(array_1d, array_2d)
+
     def test_dropna(self):
 
         p = lm._RegressionPlotter("x", "y_na", data=self.df)


### PR DESCRIPTION
- Check dimensionality of input and error out when net vectors
- Don't crash when partialling variables are passed as pandas series