### PR TITLE
Allow named categorical palette to force interpretation of hue variable in relational plots

### DIFF
--- a/doc/releases/v0.9.1.txt
+++ b/doc/releases/v0.9.1.txt
@@ -15,6 +15,8 @@ New features
 
 - Exposed the ``layout_pad`` parameter in :class:`PairGrid` and set a smaller default than what matptlotlib sets for more efficient use of space in dense grids.
 
+- It is now possible to force a categorical interpretation of the ``hue`` varaible in a relational plot by passing the name of a categorical palette (e.g. ``"deep"``, or ``"Set2"``). This complements the (previously supported) option of passig a list/dict of colors.
+
 Bug fixes and adaptations
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/seaborn/palettes.py
+++ b/seaborn/palettes.py
@@ -55,8 +55,12 @@ MPL_QUAL_PALS = {
 }
 
 
-QUAL_PALETTE_SIZES = MPL_QUAL_PALS.copy()
-QUAL_PALETTE_SIZES.update({k: len(v) for k, v in SEABORN_PALETTES.items()})
+CATEGORICAL_PALETTE_SIZES = MPL_QUAL_PALS.copy()
+CATEGORICAL_PALETTE_SIZES.update(
+    {k: len(v) for k, v in SEABORN_PALETTES.items()}
+)
+
+CATEGORICAL_PALETTES = list(CATEGORICAL_PALETTE_SIZES.keys())
 
 
 class _ColorPalette(list):
@@ -203,7 +207,7 @@ def color_palette(palette=None, n_colors=None, desat=None):
 
         if n_colors is None:
             # Use all colors in a qualitative palette or 6 of another kind
-            n_colors = QUAL_PALETTE_SIZES.get(palette, 6)
+            n_colors = CATEGORICAL_PALETTE_SIZES.get(palette, 6)
 
         if palette in SEABORN_PALETTES:
             # Named "seaborn variant" of old matplotlib default palette

--- a/seaborn/palettes.py
+++ b/seaborn/palettes.py
@@ -44,7 +44,7 @@ SEABORN_PALETTES = dict(
                 "#CA9161", "#FBAFE4", "#949494", "#ECE133", "#56B4E9"],
     colorblind6=["#0173B2", "#029E73", "#D55E00",
                  "#CC78BC", "#ECE133", "#56B4E9"]
-    )
+)
 
 
 MPL_QUAL_PALS = {
@@ -55,12 +55,9 @@ MPL_QUAL_PALS = {
 }
 
 
-CATEGORICAL_PALETTE_SIZES = MPL_QUAL_PALS.copy()
-CATEGORICAL_PALETTE_SIZES.update(
-    {k: len(v) for k, v in SEABORN_PALETTES.items()}
-)
-
-CATEGORICAL_PALETTES = list(CATEGORICAL_PALETTE_SIZES.keys())
+QUAL_PALETTE_SIZES = MPL_QUAL_PALS.copy()
+QUAL_PALETTE_SIZES.update({k: len(v) for k, v in SEABORN_PALETTES.items()})
+QUAL_PALETTES = list(QUAL_PALETTE_SIZES.keys())
 
 
 class _ColorPalette(list):
@@ -207,7 +204,7 @@ def color_palette(palette=None, n_colors=None, desat=None):
 
         if n_colors is None:
             # Use all colors in a qualitative palette or 6 of another kind
-            n_colors = CATEGORICAL_PALETTE_SIZES.get(palette, 6)
+            n_colors = QUAL_PALETTE_SIZES.get(palette, 6)
 
         if palette in SEABORN_PALETTES:
             # Named "seaborn variant" of old matplotlib default palette

--- a/seaborn/relational.py
+++ b/seaborn/relational.py
@@ -15,7 +15,7 @@ from .utils import (categorical_order, get_color_cycle, ci_to_errsize, sort_df,
                     remove_na, locator_to_legend_entries)
 from .algorithms import bootstrap
 from .palettes import (color_palette, cubehelix_palette,
-                       _parse_cubehelix_args, CATEGORICAL_PALETTE_SIZES)
+                       _parse_cubehelix_args, QUAL_PALETTES)
 from .axisgrid import FacetGrid, _facet_docs
 
 
@@ -357,7 +357,7 @@ class _RelationalPlotter(object):
             # Override depending on the type of the palette argument
             if isinstance(palette, (dict, list)):
                 var_type = "categorical"
-            elif palette in CATEGORICAL_PALETTE_SIZES:
+            elif palette in QUAL_PALETTES:
                 var_type = "categorical"
 
         # -- Option 1: categorical color palette

--- a/seaborn/relational.py
+++ b/seaborn/relational.py
@@ -964,6 +964,16 @@ _relational_docs = dict(
     See the :ref:`tutorial <relational_tutorial>` for more information.\
     """),
 
+    relational_semantic_narrative=dedent("""\
+    The default treatment of the ``hue`` (and to a lesser extent, ``size``)
+    semantic, if present, depends on whether the variable is inferred to
+    represent "numeric" or "categorical" data. In particular, numeric variables
+    are represented with a sequential colormap by default, and the legend
+    entries show regular "ticks" with values that may or may not exist in the
+    data. This behavior can be controlled through various parameters, as
+    described and illustrated below.\
+    """),
+
     # --- Shared function parameters
     data_vars=dedent("""\
     x, y : names of variables in ``data`` or vector data, optional
@@ -1105,6 +1115,8 @@ lineplot.__doc__ = dedent("""\
     Draw a line plot with possibility of several semantic groupings.
 
     {main_api_narrative}
+
+    {relational_semantic_narrative}
 
     By default, the plot aggregates over multiple ``y`` values at each value of
     ``x`` and shows an estimate of the central tendency and a confidence
@@ -1362,6 +1374,8 @@ scatterplot.__doc__ = dedent("""\
     Draw a scatter plot with possibility of several semantic groupings.
 
     {main_api_narrative}
+
+    {relational_semantic_narrative}
 
     Parameters
     ----------
@@ -1652,6 +1666,8 @@ relplot.__doc__ = dedent("""\
     should refer to the documentation for each to see kind-specific options.
 
     {main_api_narrative}
+
+    {relational_semantic_narrative}
 
     After plotting, the :class:`FacetGrid` with the plot is returned and can
     be used directly to tweak supporting plot details or add other layers.

--- a/seaborn/relational.py
+++ b/seaborn/relational.py
@@ -14,7 +14,8 @@ from . import utils
 from .utils import (categorical_order, get_color_cycle, ci_to_errsize, sort_df,
                     remove_na, locator_to_legend_entries)
 from .algorithms import bootstrap
-from .palettes import color_palette, cubehelix_palette, _parse_cubehelix_args
+from .palettes import (color_palette, cubehelix_palette,
+                       _parse_cubehelix_args, CATEGORICAL_PALETTE_SIZES)
 from .axisgrid import FacetGrid, _facet_docs
 
 
@@ -355,6 +356,8 @@ class _RelationalPlotter(object):
 
             # Override depending on the type of the palette argument
             if isinstance(palette, (dict, list)):
+                var_type = "categorical"
+            elif palette in CATEGORICAL_PALETTE_SIZES:
                 var_type = "categorical"
 
         # -- Option 1: categorical color palette

--- a/seaborn/tests/test_palettes.py
+++ b/seaborn/tests/test_palettes.py
@@ -51,13 +51,13 @@ class TestColorPalettes(object):
     def test_palette_size(self):
 
         pal = palettes.color_palette("deep")
-        assert len(pal) == palettes.QUAL_PALETTE_SIZES["deep"]
+        assert len(pal) == palettes.CATEGORICAL_PALETTE_SIZES["deep"]
 
         pal = palettes.color_palette("pastel6")
-        assert len(pal) == palettes.QUAL_PALETTE_SIZES["pastel6"]
+        assert len(pal) == palettes.CATEGORICAL_PALETTE_SIZES["pastel6"]
 
         pal = palettes.color_palette("Set3")
-        assert len(pal) == palettes.QUAL_PALETTE_SIZES["Set3"]
+        assert len(pal) == palettes.CATEGORICAL_PALETTE_SIZES["Set3"]
 
         pal = palettes.color_palette("husl")
         assert len(pal) == 6

--- a/seaborn/tests/test_palettes.py
+++ b/seaborn/tests/test_palettes.py
@@ -51,13 +51,13 @@ class TestColorPalettes(object):
     def test_palette_size(self):
 
         pal = palettes.color_palette("deep")
-        assert len(pal) == palettes.CATEGORICAL_PALETTE_SIZES["deep"]
+        assert len(pal) == palettes.QUAL_PALETTE_SIZES["deep"]
 
         pal = palettes.color_palette("pastel6")
-        assert len(pal) == palettes.CATEGORICAL_PALETTE_SIZES["pastel6"]
+        assert len(pal) == palettes.QUAL_PALETTE_SIZES["pastel6"]
 
         pal = palettes.color_palette("Set3")
-        assert len(pal) == palettes.CATEGORICAL_PALETTE_SIZES["Set3"]
+        assert len(pal) == palettes.QUAL_PALETTE_SIZES["Set3"]
 
         pal = palettes.color_palette("husl")
         assert len(pal) == 6

--- a/seaborn/tests/test_relational.py
+++ b/seaborn/tests/test_relational.py
@@ -499,6 +499,16 @@ class TestRelationalPlotter(object):
         assert p.hue_type == "categorical"
         assert p.cmap is None
 
+        # Test categorical palette specified for numeric data
+        palette = "deep"
+        p = rel._LinePlotter(x="x", y="y", hue="s",
+                             palette=palette, data=long_df)
+        expected_colors = color_palette(palette, n_colors=len(levels))
+        hue_levels = categorical_order(long_df["s"])
+        expected_palette = dict(zip(hue_levels, expected_colors))
+        assert p.palette == expected_palette
+        assert p.hue_type == "categorical"
+
     def test_parse_hue_numeric(self, long_df):
 
         p = rel._LinePlotter(x="x", y="y", hue="s", data=long_df)

--- a/seaborn/tests/test_relational.py
+++ b/seaborn/tests/test_relational.py
@@ -416,7 +416,7 @@ class TestRelationalPlotter(object):
 
         p = rel._LinePlotter(data=wide_df)
         assert p.hue_levels == wide_df.columns.tolist()
-        assert p.hue_type is "categorical"
+        assert p.hue_type == "categorical"
         assert p.cmap is None
 
         # Test named palette
@@ -456,7 +456,7 @@ class TestRelationalPlotter(object):
         # Test long data
         p = rel._LinePlotter(x="x", y="y", hue="a", data=long_df)
         assert p.hue_levels == categorical_order(long_df.a)
-        assert p.hue_type is "categorical"
+        assert p.hue_type == "categorical"
         assert p.cmap is None
 
         # Test default palette
@@ -476,27 +476,27 @@ class TestRelationalPlotter(object):
         # Test binary data
         p = rel._LinePlotter(x="x", y="y", hue="c", data=long_df)
         assert p.hue_levels == [0, 1]
-        assert p.hue_type is "categorical"
+        assert p.hue_type == "categorical"
 
-        df=long_df[long_df["c"]==0]
+        df = long_df[long_df["c"] == 0]
         p = rel._LinePlotter(x="x", y="y", hue="c", data=df)
         assert p.hue_levels == [0]
-        assert p.hue_type is "categorical"
+        assert p.hue_type == "categorical"
 
-        df=long_df[long_df["c"]==1]
+        df = long_df[long_df["c"] == 1]
         p = rel._LinePlotter(x="x", y="y", hue="c", data=df)
         assert p.hue_levels == [1]
-        assert p.hue_type is "categorical"
+        assert p.hue_type == "categorical"
 
         # Test Timestamp data
         p = rel._LinePlotter(x="x", y="y", hue="d", data=long_df)
         assert p.hue_levels == [pd.Timestamp('2005-02-25')]
-        assert p.hue_type is "categorical"
+        assert p.hue_type == "categorical"
 
         # Test numeric data with category type
         p = rel._LinePlotter(x="x", y="y", hue="s_cat", data=long_df)
         assert p.hue_levels == categorical_order(long_df.s_cat)
-        assert p.hue_type is "categorical"
+        assert p.hue_type == "categorical"
         assert p.cmap is None
 
     def test_parse_hue_numeric(self, long_df):
@@ -504,7 +504,7 @@ class TestRelationalPlotter(object):
         p = rel._LinePlotter(x="x", y="y", hue="s", data=long_df)
         hue_levels = list(np.sort(long_df.s.unique()))
         assert p.hue_levels == hue_levels
-        assert p.hue_type is "numeric"
+        assert p.hue_type == "numeric"
         assert p.cmap.name == "seaborn_cubehelix"
 
         # Test named colormap
@@ -1365,7 +1365,7 @@ class TestScatterPlotter(TestRelationalPlotter):
         # --
 
         ax.clear()
-        sizes_list=[10,100,200]
+        sizes_list = [10, 100, 200]
         p = rel._ScatterPlotter(x="x", y="y", size="s", sizes=sizes_list,
                                   data=long_df, legend="full")
         p.add_legend_data(ax)
@@ -1378,7 +1378,7 @@ class TestScatterPlotter(TestRelationalPlotter):
         # --
 
         ax.clear()
-        sizes_dict={2:10,4:100,8:200}
+        sizes_dict = {2: 10, 4: 100, 8: 200}
         p = rel._ScatterPlotter(x="x", y="y", size="s", sizes=sizes_dict,
                                   data=long_df, legend="full")
         p.add_legend_data(ax)
@@ -1387,7 +1387,7 @@ class TestScatterPlotter(TestRelationalPlotter):
         expected_sizes = [0] + [p.sizes[l] for l in p.size_levels]
         assert labels == ["s"] + [str(l) for l in p.size_levels]
         assert sizes == expected_sizes
-        
+
         # --
 
         x, y = np.random.randn(2, 40)


### PR DESCRIPTION
e.g. 

```python
sns.lineplot(x=[0, 1, 0, 1], y=[0, 1, 1, 2], hue=[0, 0, 2, 2], palette="deep")
```
![image](https://user-images.githubusercontent.com/315810/71551155-3052c300-29ae-11ea-8cfa-fa425ef0b0ad.png)

Also added some more information to the relational plot docstrings about what's going on here.

Addresses #1653 and others