### PR TITLE
Remove NaN values from input array before passing it into statsmodels…

### DIFF
--- a/seaborn/distributions.py
+++ b/seaborn/distributions.py
@@ -178,6 +178,11 @@ def distplot(a, bins=None, hist=True, kde=True, rug=False, fit=None,
     if a.ndim > 1:
         a = a.squeeze()
 
+    # Drop null values from array
+    mask = np.isnan(a)
+    if mask.any():
+        a = a[~mask]
+
     # Decide if the hist is normed
     norm_hist = norm_hist or kde or (fit is not None)
 


### PR DESCRIPTION
... for KDE fitting. Avoids roundoff error in CDF fitting.

This pull request modifies 
```
seaborn.distplot(a, bins=None, hist=True, kde=True, rug=False, fit=None,
             hist_kws=None, kde_kws=None, rug_kws=None, fit_kws=None,
             color=None, vertical=False, norm_hist=False, axlabel=None,
             label=None, ax=None)
```
such that if there are any NaN values the input array, `a`,  then those values are removed prior to `a` being passed to `statsmodels` for KDE fitting. This avoids roundoff error in the CDF KDE fitting, which results in `statsmodels` returning an array of NaNs, and a blank CDF plot. 

This is the proposed solution to issue #1908 