### PR TITLE
Allow presence of norm to force numeric interpretation of hue/size

### DIFF
--- a/seaborn/tests/test_relational.py
+++ b/seaborn/tests/test_relational.py
@@ -1709,8 +1709,20 @@ class TestRelPlotter(TestRelationalPlotter):
     def test_relplot_stringy_numerics(self, long_df):
 
         long_df["x_str"] = long_df["x"].astype(str)
+
         g = rel.relplot(x="x", y="y", hue="x_str", data=long_df)
-        assert g._legend.texts[0].get_text() == "x_str"
+        points = g.ax.collections[0]
+        xys = points.get_offsets()
+        mask = np.ma.getmask(xys)
+        assert not mask.any()
+        assert np.array_equal(xys, long_df[["x", "y"]])
+
+        g = rel.relplot(x="x", y="y", size="x_str", data=long_df)
+        points = g.ax.collections[0]
+        xys = points.get_offsets()
+        mask = np.ma.getmask(xys)
+        assert not mask.any()
+        assert np.array_equal(xys, long_df[["x", "y"]])
 
     def test_relplot_legend(self, long_df):
 


### PR DESCRIPTION
Follow-up fix to #1515. (#1905 avoided the error but lead to some cases where the plot would appear with no data. Oops).

The problem was that relplot internally sets up  the palette dictionary and then passes it to the axes-level  functions, causing them to treat the variable as categorical. (The palette is always made and used internally, but this is a good heuristic for avoiding the numeric mapping). The solution is to treat the presence of `hue_norm` or `size_norm` as a signal that the respective semantic variable should be treated as numeric, superseding the inference related to the palette.