### PR TITLE
Use a persistant internal random number generator for boostrapping

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ before_install:
   - hash -r
   - conda config --set always_yes yes --set changeps1 no 
   - conda config --add channels conda-forge
-  - conda update -q conda
+  # - conda update -q conda  TODO Re-enable on resolution to conda/conda#9583
   - conda config --set channel_priority false
   - conda info -a
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ before_install:
   - conda config --set always_yes yes --set changeps1 no 
   - conda config --add channels conda-forge
   # - conda update -q conda  TODO Re-enable on resolution to conda/conda#9583
+  - conda install conda=4.6.14  # TODO remove after re-enabling above line
   - conda config --set channel_priority false
   - conda info -a
 

--- a/doc/releases/v0.9.1.txt
+++ b/doc/releases/v0.9.1.txt
@@ -19,6 +19,7 @@ New features
 
 - Added the ability to pass hierarchical label names to the :class:`FacetGrid` legend, which also fixes a bug in :func:`relplot` when the same label appeared in diffent semantics.
 
+
 Bug fixes and adaptations
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/seaborn/__init__.py
+++ b/seaborn/__init__.py
@@ -18,4 +18,5 @@ from .widgets import *
 from .colors import xkcd_rgb, crayons
 from . import cm
 
+
 __version__ = "0.9.1.dev0"

--- a/seaborn/algorithms.py
+++ b/seaborn/algorithms.py
@@ -7,6 +7,9 @@ from .external.six import string_types
 from .external.six.moves import range
 
 
+_rng = np.random.RandomState()
+
+
 def bootstrap(*args, **kwargs):
     """Resample one or more arrays with replacement and store aggregate values.
 
@@ -57,7 +60,10 @@ def bootstrap(*args, **kwargs):
         func_kwargs = dict(axis=axis)
 
     # Initialize the resampler
-    rs = np.random.RandomState(random_seed)
+    if random_seed is None:
+        rs = _rng
+    else:
+        rs = np.random.RandomState(random_seed)
 
     # Coerce to arrays
     args = list(map(np.asarray, args))

--- a/seaborn/tests/test_algorithms.py
+++ b/seaborn/tests/test_algorithms.py
@@ -76,6 +76,20 @@ def test_bootstrap_random_seed(random):
     assert_array_equal(boots1, boots2)
 
 
+def test_bootstrap_internal_random_state(random):
+    """Test that bootstrapping uses the internal random state."""
+    data = np.random.randn(50)
+    orig_rng = algo._rng
+    try:
+        algo._rng = np.random.RandomState(100)
+        boots1 = algo.bootstrap(data)
+        algo._rng = np.random.RandomState(100)
+        boots2 = algo.bootstrap(data)
+        assert_array_equal(boots1, boots2)
+    finally:
+        algo._rng = orig_rng
+
+
 def test_smooth_bootstrap(random):
     """Test smooth bootstrap."""
     x = np.random.randn(15)


### PR DESCRIPTION
Fixes #1924 

This provides part of a stop-gap solution for deterministic bootstrapping.

As written, it affords control over the random state for those who are willing to use a hack by assigning a `RandomState` object to `seaborn.algorithms._rng`.

The open question is whether expose a proper mechanism for setting the seed in the public API. I think this is kind of a hacky approach either way, so I'm not wild about doing so. There's not much precedent that I am aware of for libraries having their own private but internally-global random state. Punting would allow me to decide later on to add a parameter to every function that does bootstrapping such that users could pass a `RandomState` there, which is "best practices".