### PR TITLE
Expose RNG seed where bootstrapping is used

### DIFF
--- a/doc/releases/v0.9.1.txt
+++ b/doc/releases/v0.9.1.txt
@@ -19,6 +19,8 @@ New features
 
 - Added the ability to pass hierarchical label names to the :class:`FacetGrid` legend, which also fixes a bug in :func:`relplot` when the same label appeared in diffent semantics.
 
+- Added the ability to seed the random number generator for the bootstrap used to define error bars in several plots. Relevant functions now have a ``seed`` parameter, which can take either fixed seed (typically an ``int``) or a numpy random number generator object (either the newer ``numpy.random.Generator`` or the older ``numpy.random.RandomState``).
+
 Bug fixes and adaptations
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/seaborn/algorithms.py
+++ b/seaborn/algorithms.py
@@ -132,7 +132,7 @@ def _smooth_bootstrap(args, n_boot, func, func_kwargs):
 
 
 def _handle_random_seed(seed=None):
-    """Given a seed in many formats, return a random number generator.
+    """Given a seed in one of many formats, return a random number generator.
 
     Generalizes across the numpy 1.17 changes, preferring newer functionality.
 

--- a/seaborn/algorithms.py
+++ b/seaborn/algorithms.py
@@ -1,5 +1,6 @@
 """Algorithms to support fitting routines in seaborn plotting functions."""
 from __future__ import division
+import numbers
 import numpy as np
 from scipy import stats
 import warnings
@@ -29,7 +30,7 @@ def bootstrap(*args, **kwargs):
         func : string or callable, default np.mean
             Function to call on the args that are passed in. If string, tries
             to use as named method on numpy array.
-        random_seed : int | None, default None
+        seed : Generator | SeedSequence | RandomState | int | None
             Seed for the random number generator; useful if you want
             reproducible resamples.
 
@@ -51,13 +52,17 @@ def bootstrap(*args, **kwargs):
     units = kwargs.get("units", None)
     smooth = kwargs.get("smooth", False)
     random_seed = kwargs.get("random_seed", None)
+    if random_seed is not None:
+        msg = "`random_seed` has been renamed to `seed` and will be removed"
+        warnings.warn(msg)
+    seed = kwargs.get("seed", random_seed)
     if axis is None:
         func_kwargs = dict()
     else:
         func_kwargs = dict(axis=axis)
 
     # Initialize the resampler
-    rs = np.random.RandomState(random_seed)
+    rng = _handle_random_seed(seed)
 
     # Coerce to arrays
     args = list(map(np.asarray, args))
@@ -71,6 +76,12 @@ def bootstrap(*args, **kwargs):
     else:
         f = func
 
+    # Handle numpy changes
+    try:
+        integers = rng.integers
+    except AttributeError:
+        integers = rng.randint
+
     # Do the bootstrap
     if smooth:
         msg = "Smooth bootstraps are deprecated and will be removed."
@@ -79,17 +90,17 @@ def bootstrap(*args, **kwargs):
 
     if units is not None:
         return _structured_bootstrap(args, n_boot, units, f,
-                                     func_kwargs, rs)
+                                     func_kwargs, integers)
 
     boot_dist = []
     for i in range(int(n_boot)):
-        resampler = rs.randint(0, n, n)
+        resampler = integers(0, n, n)
         sample = [a.take(resampler, axis=0) for a in args]
         boot_dist.append(f(*sample, **func_kwargs))
     return np.array(boot_dist)
 
 
-def _structured_bootstrap(args, n_boot, units, func, func_kwargs, rs):
+def _structured_bootstrap(args, n_boot, units, func, func_kwargs, integers):
     """Resample units instead of datapoints."""
     unique_units = np.unique(units)
     n_units = len(unique_units)
@@ -98,10 +109,10 @@ def _structured_bootstrap(args, n_boot, units, func, func_kwargs, rs):
 
     boot_dist = []
     for i in range(int(n_boot)):
-        resampler = rs.randint(0, n_units, n_units)
+        resampler = integers(0, n_units, n_units)
         sample = [np.take(a, resampler, axis=0) for a in args]
         lengths = map(len, sample[0])
-        resampler = [rs.randint(0, n, n) for n in lengths]
+        resampler = [integers(0, n, n) for n in lengths]
         sample = [[c.take(r, axis=0) for c, r in zip(a, resampler)]
                   for a in sample]
         sample = list(map(np.concatenate, sample))
@@ -118,3 +129,27 @@ def _smooth_bootstrap(args, n_boot, func, func_kwargs):
         sample = [a.resample(n).T for a in kde]
         boot_dist.append(func(*sample, **func_kwargs))
     return np.array(boot_dist)
+
+
+def _handle_random_seed(seed=None):
+    """Given a seed in many formats, return a random number generator.
+
+    Generalizes across the numpy 1.17 changes, preferring newer functionality.
+
+    """
+    if isinstance(seed, np.random.RandomState):
+        rng = seed
+    else:
+        try:
+            # General interface for seeding on numpy >= 1.17
+            rng = np.random.default_rng(seed)
+        except AttributeError:
+            # We are on numpy < 1.17, handle options ourselves
+            if isinstance(seed, (numbers.Integral, np.integer)):
+                rng = np.random.RandomState(seed)
+            elif seed is None:
+                rng = np.random.RandomState()
+            else:
+                err = "{} cannot be used to seed the randomn number generator"
+                raise ValueError(err.format(seed))
+    return rng

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -1470,7 +1470,7 @@ class _CategoricalStatPlotter(_CategoricalPlotter):
             width = self.width
         return width
 
-    def estimate_statistic(self, estimator, ci, n_boot):
+    def estimate_statistic(self, estimator, ci, n_boot, seed):
 
         if self.hue_names is None:
             statistic = []
@@ -1518,7 +1518,8 @@ class _CategoricalStatPlotter(_CategoricalPlotter):
 
                         boots = bootstrap(stat_data, func=estimator,
                                           n_boot=n_boot,
-                                          units=unit_data)
+                                          units=unit_data,
+                                          seed=seed)
                         confint.append(utils.ci(boots, ci))
 
             # Option 2: we are grouping by a hue layer
@@ -1568,7 +1569,8 @@ class _CategoricalStatPlotter(_CategoricalPlotter):
 
                             boots = bootstrap(stat_data, func=estimator,
                                               n_boot=n_boot,
-                                              units=unit_data)
+                                              units=unit_data,
+                                              seed=seed)
                             confint[i].append(utils.ci(boots, ci))
 
         # Save the resulting values for plotting
@@ -1608,14 +1610,14 @@ class _BarPlotter(_CategoricalStatPlotter):
     """Show point estimates and confidence intervals with bars."""
 
     def __init__(self, x, y, hue, data, order, hue_order,
-                 estimator, ci, n_boot, units,
+                 estimator, ci, n_boot, units, seed,
                  orient, color, palette, saturation, errcolor,
                  errwidth, capsize, dodge):
         """Initialize the plotter."""
         self.establish_variables(x, y, hue, data, orient,
                                  order, hue_order, units)
         self.establish_colors(color, palette, saturation)
-        self.estimate_statistic(estimator, ci, n_boot)
+        self.estimate_statistic(estimator, ci, n_boot, seed)
 
         self.dodge = dodge
 
@@ -1679,14 +1681,14 @@ class _PointPlotter(_CategoricalStatPlotter):
 
     """Show point estimates and confidence intervals with (joined) points."""
     def __init__(self, x, y, hue, data, order, hue_order,
-                 estimator, ci, n_boot, units,
+                 estimator, ci, n_boot, units, seed,
                  markers, linestyles, dodge, join, scale,
                  orient, color, palette, errwidth=None, capsize=None):
         """Initialize the plotter."""
         self.establish_variables(x, y, hue, data, orient,
                                  order, hue_order, units)
         self.establish_colors(color, palette, 1)
-        self.estimate_statistic(estimator, ci, n_boot)
+        self.estimate_statistic(estimator, ci, n_boot, seed)
 
         # Override the default palette for single-color plots
         if hue is None and color is None and palette is None:
@@ -2136,7 +2138,9 @@ _categorical_docs = dict(
         intervals.
     units : name of variable in ``data`` or vector data, optional
         Identifier of sampling units, which will be used to perform a
-        multilevel bootstrap and account for repeated measures design.\
+        multilevel bootstrap and account for repeated measures design.
+    seed : int, numpy.random.Generator, or numpy.random.RandomState, optional
+        Seed or random number generator for reproducible bootstrapping.\
     """),
     orient=dedent("""\
     orient : "v" | "h", optional
@@ -3139,13 +3143,13 @@ swarmplot.__doc__ = dedent("""\
 
 
 def barplot(x=None, y=None, hue=None, data=None, order=None, hue_order=None,
-            estimator=np.mean, ci=95, n_boot=1000, units=None,
+            estimator=np.mean, ci=95, n_boot=1000, units=None, seed=None,
             orient=None, color=None, palette=None, saturation=.75,
             errcolor=".26", errwidth=None, capsize=None, dodge=True,
             ax=None, **kwargs):
 
     plotter = _BarPlotter(x, y, hue, data, order, hue_order,
-                          estimator, ci, n_boot, units,
+                          estimator, ci, n_boot, units, seed,
                           orient, color, palette, saturation,
                           errcolor, errwidth, capsize, dodge)
 
@@ -3325,13 +3329,13 @@ barplot.__doc__ = dedent("""\
 
 
 def pointplot(x=None, y=None, hue=None, data=None, order=None, hue_order=None,
-              estimator=np.mean, ci=95, n_boot=1000, units=None,
+              estimator=np.mean, ci=95, n_boot=1000, units=None, seed=None,
               markers="o", linestyles="-", dodge=False, join=True, scale=1,
               orient=None, color=None, palette=None, errwidth=None,
               capsize=None, ax=None, **kwargs):
 
     plotter = _PointPlotter(x, y, hue, data, order, hue_order,
-                            estimator, ci, n_boot, units,
+                            estimator, ci, n_boot, units, seed,
                             markers, linestyles, dodge, join, scale,
                             orient, color, palette, errwidth, capsize)
 
@@ -3533,6 +3537,7 @@ def countplot(x=None, y=None, hue=None, data=None, order=None, hue_order=None,
     ci = None
     n_boot = 0
     units = None
+    seed = None
     errcolor = None
     errwidth = None
     capsize = None
@@ -3549,7 +3554,7 @@ def countplot(x=None, y=None, hue=None, data=None, order=None, hue_order=None,
         raise TypeError("Must pass values for either `x` or `y`")
 
     plotter = _BarPlotter(x, y, hue, data, order, hue_order,
-                          estimator, ci, n_boot, units,
+                          estimator, ci, n_boot, units, seed,
                           orient, color, palette, saturation,
                           errcolor, errwidth, capsize, dodge)
 
@@ -3679,7 +3684,7 @@ def factorplot(*args, **kwargs):
 
 def catplot(x=None, y=None, hue=None, data=None, row=None, col=None,
             col_wrap=None, estimator=np.mean, ci=95, n_boot=1000,
-            units=None, order=None, hue_order=None, row_order=None,
+            units=None, seed=None, order=None, hue_order=None, row_order=None,
             col_order=None, kind="strip", height=5, aspect=1,
             orient=None, color=None, palette=None,
             legend=True, legend_out=True, sharex=True, sharey=True,
@@ -3753,7 +3758,7 @@ def catplot(x=None, y=None, hue=None, data=None, row=None, col=None,
 
     if kind in ["bar", "point"]:
         plot_kws.update(
-            estimator=estimator, ci=ci, n_boot=n_boot, units=units,
+            estimator=estimator, ci=ci, n_boot=n_boot, units=units, seed=seed,
             )
 
     # Initialize the facets

--- a/seaborn/relational.py
+++ b/seaborn/relational.py
@@ -695,7 +695,7 @@ class _LinePlotter(_RelationalPlotter):
                  palette=None, hue_order=None, hue_norm=None,
                  sizes=None, size_order=None, size_norm=None,
                  dashes=None, markers=None, style_order=None,
-                 units=None, estimator=None, ci=None, n_boot=None,
+                 units=None, estimator=None, ci=None, n_boot=None, seed=None,
                  sort=True, err_style=None, err_kws=None, legend=None):
 
         plot_data = self.establish_variables(
@@ -714,6 +714,7 @@ class _LinePlotter(_RelationalPlotter):
         self.estimator = estimator
         self.ci = ci
         self.n_boot = n_boot
+        self.seed = seed
         self.sort = sort
         self.err_style = err_style
         self.err_kws = {} if err_kws is None else err_kws
@@ -725,6 +726,7 @@ class _LinePlotter(_RelationalPlotter):
         func = self.estimator
         ci = self.ci
         n_boot = self.n_boot
+        seed = self.seed
 
         # Define a "null" CI for when we only have one value
         null_ci = pd.Series(index=["low", "high"], dtype=np.float)
@@ -735,7 +737,7 @@ class _LinePlotter(_RelationalPlotter):
             if len(vals) == 1:
                 return null_ci
 
-            boots = bootstrap(vals, func=func, n_boot=n_boot)
+            boots = bootstrap(vals, func=func, n_boot=n_boot, seed=seed)
             cis = utils.ci(boots, ci)
             return pd.Series(cis, ["low", "high"])
 
@@ -1085,6 +1087,10 @@ _relational_docs = dict(
     n_boot : int, optional
         Number of bootstraps to use for computing the confidence interval.\
     """),
+    seed=dedent("""\
+    seed : int, numpy.random.Generator, or numpy.random.RandomState, optional
+        Seed or random number generator for reproducible bootstrapping.\
+    """),
     legend=dedent("""\
     legend : "brief", "full", or False, optional
         How to draw the legend. If "brief", numeric ``hue`` and ``size``
@@ -1114,7 +1120,7 @@ def lineplot(x=None, y=None, hue=None, size=None, style=None, data=None,
              palette=None, hue_order=None, hue_norm=None,
              sizes=None, size_order=None, size_norm=None,
              dashes=True, markers=None, style_order=None,
-             units=None, estimator="mean", ci=95, n_boot=1000,
+             units=None, estimator="mean", ci=95, n_boot=1000, seed=None,
              sort=True, err_style="band", err_kws=None,
              legend="brief", ax=None, **kwargs):
 
@@ -1123,7 +1129,7 @@ def lineplot(x=None, y=None, hue=None, size=None, style=None, data=None,
         palette=palette, hue_order=hue_order, hue_norm=hue_norm,
         sizes=sizes, size_order=size_order, size_norm=size_norm,
         dashes=dashes, markers=markers, style_order=style_order,
-        units=units, estimator=estimator, ci=ci, n_boot=n_boot,
+        units=units, estimator=estimator, ci=ci, n_boot=n_boot, seed=seed,
         sort=sort, err_style=err_style, err_kws=err_kws, legend=legend,
     )
 
@@ -1180,6 +1186,7 @@ lineplot.__doc__ = dedent("""\
     {estimator}
     {ci}
     {n_boot}
+    {seed}
     sort : boolean, optional
         If True, the data will be sorted by the x and y variables, otherwise
         lines will connect points in the order they appear in the dataset.

--- a/seaborn/tests/test_algorithms.py
+++ b/seaborn/tests/test_algorithms.py
@@ -1,8 +1,10 @@
 import numpy as np
+import numpy.random as npr
 from ..external.six.moves import range
 
-from numpy.testing import assert_array_equal
 import pytest
+from numpy.testing import assert_array_equal
+from distutils.version import LooseVersion
 
 from .. import algorithms as algo
 
@@ -67,12 +69,12 @@ def test_bootstrap_axis(random):
     assert out_axis.shape, (n_boot, x.shape[1])
 
 
-def test_bootstrap_random_seed(random):
+def test_bootstrap_seed(random):
     """Test that we can get reproducible resamples by seeding the RNG."""
     data = np.random.randn(50)
     seed = 42
-    boots1 = algo.bootstrap(data, random_seed=seed)
-    boots2 = algo.bootstrap(data, random_seed=seed)
+    boots1 = algo.bootstrap(data, seed=seed)
+    boots2 = algo.bootstrap(data, seed=seed)
     assert_array_equal(boots1, boots2)
 
 
@@ -80,8 +82,9 @@ def test_smooth_bootstrap(random):
     """Test smooth bootstrap."""
     x = np.random.randn(15)
     n_boot = 100
-    out_smooth = algo.bootstrap(x, n_boot=n_boot,
-                                smooth=True, func=np.median)
+    with pytest.warns(UserWarning):
+        out_smooth = algo.bootstrap(x, n_boot=n_boot,
+                                    smooth=True, func=np.median)
     assert not np.median(out_smooth) in x
 
 
@@ -118,8 +121,8 @@ def test_bootstrap_units(random):
     data_rm = data + bwerr
     seed = 77
 
-    boots_orig = algo.bootstrap(data_rm, random_seed=seed)
-    boots_rm = algo.bootstrap(data_rm, units=ids, random_seed=seed)
+    boots_orig = algo.bootstrap(data_rm, seed=seed)
+    boots_rm = algo.bootstrap(data_rm, units=ids, seed=seed)
     assert boots_rm.std() > boots_orig.std()
 
 
@@ -133,13 +136,78 @@ def test_bootstrap_string_func():
     """Test that named numpy methods are the same as the numpy function."""
     x = np.random.randn(100)
 
-    res_a = algo.bootstrap(x, func="mean", random_seed=0)
-    res_b = algo.bootstrap(x, func=np.mean, random_seed=0)
+    res_a = algo.bootstrap(x, func="mean", seed=0)
+    res_b = algo.bootstrap(x, func=np.mean, seed=0)
     assert np.array_equal(res_a, res_b)
 
-    res_a = algo.bootstrap(x, func="std", random_seed=0)
-    res_b = algo.bootstrap(x, func=np.std, random_seed=0)
+    res_a = algo.bootstrap(x, func="std", seed=0)
+    res_b = algo.bootstrap(x, func=np.std, seed=0)
     assert np.array_equal(res_a, res_b)
 
     with pytest.raises(AttributeError):
         algo.bootstrap(x, func="not_a_method_name")
+
+
+def test_bootstrap_reproducibility(random):
+    """Test that bootstrapping uses the internal random state."""
+    data = np.random.randn(50)
+    boots1 = algo.bootstrap(data, seed=100)
+    boots2 = algo.bootstrap(data, seed=100)
+    assert_array_equal(boots1, boots2)
+
+    with pytest.warns(UserWarning):
+        # Deprecatd, remove when removing random_seed
+        boots1 = algo.bootstrap(data, random_seed=100)
+        boots2 = algo.bootstrap(data, random_seed=100)
+        assert_array_equal(boots1, boots2)
+
+
+@pytest.mark.skipif(LooseVersion(np.__version__) < "1.17",
+                    reason="Tests new numpy random functionality")
+def test_seed_new():
+
+    # Can't use pytest parametrize because tests will fail where the new
+    # Generator object and related function are not defined
+
+    test_bank = [
+        (None, None, npr.Generator, False),
+        (npr.RandomState(0), npr.RandomState(0), npr.RandomState, True),
+        (npr.RandomState(0), npr.RandomState(1), npr.RandomState, False),
+        (npr.default_rng(1), npr.default_rng(1), npr.Generator, True),
+        (npr.default_rng(1), npr.default_rng(2), npr.Generator, False),
+        (npr.SeedSequence(10), npr.SeedSequence(10), npr.Generator, True),
+        (npr.SeedSequence(10), npr.SeedSequence(20), npr.Generator, False),
+        (100, 100, npr.Generator, True),
+        (100, 200, npr.Generator, False),
+    ]
+    for seed1, seed2, rng_class, match in test_bank:
+        rng1 = algo._handle_random_seed(seed1)
+        rng2 = algo._handle_random_seed(seed2)
+        assert isinstance(rng1, rng_class)
+        assert isinstance(rng2, rng_class)
+        assert (rng1.uniform() == rng2.uniform()) == match
+
+
+@pytest.mark.skipif(LooseVersion(np.__version__) >= "1.17",
+                    reason="Tests old numpy random functionality")
+@pytest.mark.parametrize("seed1, seed2, match", [
+    (None, None, False),
+    (npr.RandomState(0), npr.RandomState(0), True),
+    (npr.RandomState(0), npr.RandomState(1), False),
+    (100, 100, True),
+    (100, 200, False),
+])
+def test_seed_old(seed1, seed2, match):
+    rng1 = algo._handle_random_seed(seed1)
+    rng2 = algo._handle_random_seed(seed2)
+    assert isinstance(rng1, np.random.RandomState)
+    assert isinstance(rng2, np.random.RandomState)
+    assert (rng1.uniform() == rng2.uniform()) == match
+
+
+@pytest.mark.skipif(LooseVersion(np.__version__) >= "1.17",
+                    reason="Tests old numpy random functionality")
+def test_bad_seed_old():
+
+    with pytest.raises(ValueError):
+        algo._handle_random_seed("not_a_random_seed")

--- a/seaborn/tests/test_regression.py
+++ b/seaborn/tests/test_regression.py
@@ -256,6 +256,18 @@ class TestRegressionPlotter(object):
         _, boots_smod = p.fit_statsmodels(self.grid, smlm.OLS)
         nt.assert_is(boots_smod, None)
 
+    def test_regress_bootstrap_seed(self):
+
+        seed = 200
+        p1 = lm._RegressionPlotter("x", "y", data=self.df,
+                                   n_boot=self.n_boot, seed=seed)
+        p2 = lm._RegressionPlotter("x", "y", data=self.df,
+                                   n_boot=self.n_boot, seed=seed)
+
+        _, boots1 = p1.fit_fast(self.grid)
+        _, boots2 = p2.fit_fast(self.grid)
+        npt.assert_array_equal(boots1, boots2)
+
     def test_numeric_bins(self):
 
         p = lm._RegressionPlotter(self.df.x, self.df.y)
@@ -314,15 +326,14 @@ class TestRegressionPlotter(object):
 
     def test_estimate_cis(self):
 
-        # set known good seed to avoid the test stochastically failing
-        np.random.seed(123)
+        seed = 123
 
         p = lm._RegressionPlotter(self.df.d, self.df.y,
-                                  x_estimator=np.mean, ci=95)
+                                  x_estimator=np.mean, ci=95, seed=seed)
         _, _, ci_big = p.estimate_data
 
         p = lm._RegressionPlotter(self.df.d, self.df.y,
-                                  x_estimator=np.mean, ci=50)
+                                  x_estimator=np.mean, ci=50, seed=seed)
         _, _, ci_wee = p.estimate_data
         npt.assert_array_less(np.diff(ci_wee), np.diff(ci_big))
 
@@ -334,14 +345,14 @@ class TestRegressionPlotter(object):
     def test_estimate_units(self):
 
         # Seed the RNG locally
-        np.random.seed(345)
+        seed = 345
 
         p = lm._RegressionPlotter("x", "y", data=self.df,
-                                  units="s", x_bins=3)
+                                  units="s", seed=seed, x_bins=3)
         _, _, ci_big = p.estimate_data
         ci_big = np.diff(ci_big, axis=1)
 
-        p = lm._RegressionPlotter("x", "y", data=self.df, x_bins=3)
+        p = lm._RegressionPlotter("x", "y", data=self.df, seed=seed, x_bins=3)
         _, _, ci_wee = p.estimate_data
         ci_wee = np.diff(ci_wee, axis=1)
 

--- a/seaborn/tests/test_relational.py
+++ b/seaborn/tests/test_relational.py
@@ -906,6 +906,11 @@ class TestLinePlotter(TestRelationalPlotter):
         assert cis.values == pytest.approx(y_cis.values, 4)
         assert list(cis.columns) == ["low", "high"]
 
+        p.seed = 0
+        _, _, ci1 = p.aggregate(y, x)
+        _, _, ci2 = p.aggregate(y, x)
+        assert np.array_equal(ci1, ci2)
+
         y_std = y.groupby(x).std()
         y_cis = pd.DataFrame(dict(low=y_mean - y_std,
                                   high=y_mean + y_std),


### PR DESCRIPTION
Alternative to #1925 that exposes a seed argument on a per-function basis and has no global state.

Closes #1924