### PR TITLE
MNT: Fix Travis-CI tests with latest conda

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,10 +33,10 @@ before_install:
   - conda config --add channels conda-forge
   # Pinned deps aren't happy when conda>4.6.14
   - if [[ "$DEPS" == "PINNED" ]]; then
-      conda update -q conda=4.6.14
+      conda update -q conda=4.6.14;
     else
-      conda update -q conda
-  fi
+      conda update -q conda;
+    fi
   - conda config --set channel_priority false
   # Workaround py2.7/conda4.8 tqdm absence 
   - if [[ "$PYTHON" == "2.7" ]]; then pip install tqdm; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,12 @@ before_install:
   - hash -r
   - conda config --set always_yes yes --set changeps1 no 
   - conda config --add channels conda-forge
-  - conda update -q conda
+  # Pinned deps aren't happy when conda>4.6.14
+  - if [[ "$DEPS" == "PINNED" ]]; then
+      conda update -q conda=4.6.14
+    else
+      conda update -q conda
+  fi
   - conda config --set channel_priority false
   # Workaround py2.7/conda4.8 tqdm absence 
   - if [[ "$PYTHON" == "2.7" ]]; then pip install tqdm; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ before_install:
   - conda config --add channels conda-forge
   # Pinned deps aren't happy when conda>4.6.14
   - if [[ "$DEPS" == "PINNED" ]]; then
-      conda update -q conda=4.6.14;
+      conda install -q conda=4.6.14;
     else
       conda update -q conda;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,8 @@ install:
   - source activate testenv
   - cat testing/deps_${DEPS}.txt testing/utils.txt > deps.txt
   - conda install --file deps.txt
+  # TODO address broken conda-forge package for v45
+  - if [ $PYTHON == "2.7" ]; then conda install setuptools=44; fi
   - pip install .
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,11 @@ env:
 before_install:
   - sudo apt-get update -yq
   - sudo sh testing/getmsfonts.sh
-  - wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
+  - if [[ "$PYTHON" == "2.7" ]]; then
+      wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
+    else
+      wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+    fi  
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ before_install:
   - conda config --set always_yes yes --set changeps1 no 
   - conda config --add channels conda-forge
   # Pinned deps aren't happy when conda>4.6.14
-  - if [[ "$DEPS" == "PINNED" ]]; then
+  - if [[ "$DEPS" == "pinned" ]]; then
       conda install -q conda=4.6.14;
     else
       conda update -q conda;

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,8 @@ before_install:
   - conda config --add channels conda-forge
   - conda update -q conda
   - conda config --set channel_priority false
+  # Workaround py2.7/conda4.8 tqdm absence 
+  - if [[ "$PYTHON" == "2.7" ]]; then pip install tqdm; fi
   - conda info -a
 
 


### PR DESCRIPTION
The proposed PR allows for conda4.8 to install and run, including tests on python3.5. Builds for python3 are also faster by ~15% by downloading the proper miniconda. The only test mode that requires conda4.6.14 is python2.7 with pinned dependencies. 