### PR TITLE
Improvements and fixes to clustermap

### DIFF
--- a/doc/releases/v0.9.1.txt
+++ b/doc/releases/v0.9.1.txt
@@ -21,6 +21,8 @@ New features
 
 - Added the ability to seed the random number generator for the bootstrap used to define error bars in several plots. Relevant functions now have a ``seed`` parameter, which can take either fixed seed (typically an ``int``) or a numpy random number generator object (either the newer ``numpy.random.Generator`` or the older ``numpy.random.RandomState``).
 
+- Added more control over the arrangement of the elements drawn by :func:`clustermap` with the ``{dendrogram,colors}_ratio`` and ``cbar_pos`` parameters. Additionally, the default scaling with different figure sizes has been improved.
+
 Bug fixes and adaptations
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/releases/v0.9.1.txt
+++ b/doc/releases/v0.9.1.txt
@@ -56,6 +56,8 @@ Bug fixes and adaptations
 
 - Fixed a bug when passing a ``norm`` object and using color annotations in :func:`clustermap`.
 
+- Fixed a bug where annotations were not rearranged to match the clustering in :func:`clustermap`.
+
 - Fixed a bug when trying to call :func:`set` while specifying a list of colors for the palette.
 
 - Fixed a bug when resetting the color code short-hands to the matplotlib default.

--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -620,7 +620,7 @@ class _DendrogramPlotter(object):
             return self._calculate_linkage_fastcluster()
         except ImportError:
             if np.product(self.shape) >= 10000:
-                msg = ("Clustering large matrix with scipy. Installing
+                msg = ("Clustering large matrix with scipy. Installing "
                        "`fastcluster` may give better performance.")
                 warnings.warn(msg)
 
@@ -1293,7 +1293,7 @@ def clustermap(data, pivot_kws=None, method='average', metric='euclidean',
 
         >>> g = sns.clustermap(iris, row_cluster=False,
         ...                    figsize=(7, 5),
-        ...                    dendrogram_ratio=(.1 .2),
+        ...                    dendrogram_ratio=(.1, .2),
         ...                    cbar_pos=(0, .2, .03, .4))
 
     Plot one of the axes in its original organization:

--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -168,22 +168,17 @@ class _HeatMapper(object):
                                     cmap, center, robust)
 
         # Sort out the annotations
-        if annot is None:
+        if annot is None or annot is False:
             annot = False
             annot_data = None
-        elif isinstance(annot, bool):
-            if annot:
+        else:
+            if isinstance(annot, bool):
                 annot_data = plot_data
             else:
-                annot_data = None
-        else:
-            try:
-                annot_data = annot.values
-            except AttributeError:
-                annot_data = annot
-            if annot.shape != plot_data.shape:
-                raise ValueError('Data supplied to "annot" must be the same '
-                                 'shape as the data to plot.')
+                annot_data = np.asarray(annot)
+                if annot_data.shape != plot_data.shape:
+                    err = "`data` and `annot` must have same shape."
+                    raise ValueError(err)
             annot = True
 
         # Save other attributes to the object
@@ -365,7 +360,7 @@ def heatmap(data, vmin=None, vmax=None, cmap=None, center=None, robust=False,
     annot : bool or rectangular dataset, optional
         If True, write the data value in each cell. If an array-like with the
         same shape as ``data``, then use this to annotate the heatmap instead
-        of the raw data.
+        of the data. Note that DataFrames will match on position, not index.
     fmt : string, optional
         String formatting code to use when adding annotations.
     annot_kws : dict of key, value mappings, optional
@@ -1116,27 +1111,19 @@ class ClusterGrid(Grid):
         except (TypeError, IndexError):
             pass
 
-        # Sort out the annotations
+        # Reorganize the annotations to match the heatmap
         annot = kws.pop("annot", None)
         if annot is None:
             pass
-        elif isinstance(annot, bool):
-            if annot:
+        else:
+            if isinstance(annot, bool):
                 annot_data = self.data2d
             else:
-                annot_data = None
-        else:
-            try:
-                annot_data = annot.values
-            except AttributeError:
-                annot_data = annot
-            if annot.shape != self.data2d.shape:
-                raise ValueError('Data supplied to "annot" must be the same '
-                                 'shape as the data to plot.')
-            annot_data = annot_data[np.array(yind)[:, None],
-                                    np.array(xind)]
-            annot = True
-        if annot:
+                annot_data = np.asarray(annot)
+                if annot_data.shape != self.data2d.shape:
+                    err = "`data` and `annot` must have same shape."
+                    raise ValueError(err)
+                annot_data = annot_data[yind][:, xind]
             annot = annot_data
 
         heatmap(self.data2d, ax=self.ax_heatmap, cbar_ax=self.ax_cbar,

--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -1139,7 +1139,7 @@ def clustermap(data, pivot_kws=None, method='average', metric='euclidean',
                row_linkage=None, col_linkage=None,
                row_colors=None, col_colors=None, mask=None,
                dendrogram_ratio=.2, colors_ratio=0.03,
-               cbar_pos=(0, .8, .05, .2),
+               cbar_pos=(.02, .8, .05, .18),
                **kwargs):
     """Plot a matrix dataset as a hierarchically-clustered heatmap.
 
@@ -1193,10 +1193,10 @@ def clustermap(data, pivot_kws=None, method='average', metric='euclidean',
         If passed, data will not be shown in cells where ``mask`` is True.
         Cells with missing values are automatically masked. Only used for
         visualizing, not for calculating.
-    dendrogram_ratio: float, optional
-        Size (in the same units as figsize) of the dendrograms
-    colors_ratio: float, optional
-        Size (in the same units as figsize) of size for row/col colors.
+    {dendrogram,colors}_ratio: float, optional
+        Proportion of the figure size devoted to the two marginal elements.
+    cbar_pos : (left, bottom, width, height), optional
+        Position of the colorbar axes in the figure.
     kwargs : other keyword arguments
         All other keyword arguments are passed to ``sns.heatmap``
 

--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -774,10 +774,23 @@ class ClusterGrid(Grid):
         self.col_colors, self.col_color_labels = \
             self._preprocess_colors(data, col_colors, axis=1)
 
+        try:
+            row_dendrogram_ratio, col_dendrogram_ratio = dendrogram_ratio
+        except TypeError:
+            row_dendrogram_ratio = col_dendrogram_ratio = dendrogram_ratio
+
+        try:
+            row_colors_ratio, col_colors_ratio = colors_ratio
+        except TypeError:
+            row_colors_ratio = col_colors_ratio = colors_ratio
+
         width_ratios = self.dim_ratios(self.row_colors,
-                                       dendrogram_ratio, colors_ratio)
+                                       row_dendrogram_ratio,
+                                       row_colors_ratio)
         height_ratios = self.dim_ratios(self.col_colors,
-                                        dendrogram_ratio, colors_ratio)
+                                        col_dendrogram_ratio,
+                                        col_colors_ratio)
+
         nrows = 2 if self.col_colors is None else 3
         ncols = 2 if self.row_colors is None else 3
 
@@ -1193,8 +1206,9 @@ def clustermap(data, pivot_kws=None, method='average', metric='euclidean',
         If passed, data will not be shown in cells where ``mask`` is True.
         Cells with missing values are automatically masked. Only used for
         visualizing, not for calculating.
-    {dendrogram,colors}_ratio: float, optional
-        Proportion of the figure size devoted to the two marginal elements.
+    {dendrogram,colors}_ratio: float, or pair of floats, optional
+        Proportion of the figure size devoted to the two marginal elements. If
+        a pair is given, they correspond to (row, col) ratios.
     cbar_pos : (left, bottom, width, height), optional
         Position of the colorbar axes in the figure.
     kwargs : other keyword arguments
@@ -1250,12 +1264,15 @@ def clustermap(data, pivot_kws=None, method='average', metric='euclidean',
 
         >>> g = sns.clustermap(iris, cmap="mako", robust=True)
 
-    Change the size of the figure:
+    Change the size and layout of the figure:
 
     .. plot::
         :context: close-figs
 
-        >>> g = sns.clustermap(iris, figsize=(6, 7))
+        >>> g = sns.clustermap(iris, row_cluster=False,
+        ...                    figsize=(7, 5),
+        ...                    dendrogram_ratio=(.1 .2),
+        ...                    cbar_pos=(0, .2, .03, .4))
 
     Plot one of the axes in its original organization:
 

--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -1177,7 +1177,10 @@ def clustermap(data, pivot_kws=None, method='average', metric='euclidean',
                z_score=None, standard_scale=None, figsize=None, cbar_kws=None,
                row_cluster=True, col_cluster=True,
                row_linkage=None, col_linkage=None,
-               row_colors=None, col_colors=None, mask=None, **kwargs):
+               row_colors=None, col_colors=None, mask=None,
+               expected_size_dendrogram=1.0,
+               expected_size_colors=0.25,
+               **kwargs):
     """Plot a matrix dataset as a hierarchically-clustered heatmap.
 
     Parameters
@@ -1230,6 +1233,10 @@ def clustermap(data, pivot_kws=None, method='average', metric='euclidean',
         If passed, data will not be shown in cells where ``mask`` is True.
         Cells with missing values are automatically masked. Only used for
         visualizing, not for calculating.
+    expected_size_dendrogram: float, optional
+        Size (in the same units as figsize) of the dendrogram size
+    expected_size_colors: float, optional
+        Size (in the same units as figsize) of size for row/col columns, if passed.
     kwargs : other keyword arguments
         All other keyword arguments are passed to ``sns.heatmap``
 
@@ -1325,7 +1332,8 @@ def clustermap(data, pivot_kws=None, method='average', metric='euclidean',
     plotter = ClusterGrid(data, pivot_kws=pivot_kws, figsize=figsize,
                           row_colors=row_colors, col_colors=col_colors,
                           z_score=z_score, standard_scale=standard_scale,
-                          mask=mask)
+                          mask=mask, expected_size_dendrogram=expected_size_dendrogram,
+                          expected_size_colors=expected_size_colors)
 
     return plotter.plot(metric=metric, method=method,
                         colorbar_kws=cbar_kws,

--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -802,7 +802,8 @@ class ClusterGrid(Grid):
                 self.gs[1, -1])
 
         self.ax_heatmap = self.fig.add_subplot(self.gs[-1, -1])
-        self.cax = self.fig.add_axes(cbar_pos)
+        self.ax_cbar = self.fig.add_axes(cbar_pos)
+        self.cax = self.ax_cbar  # Backwards compatability
 
         self.dendrogram_row = None
         self.dendrogram_col = None
@@ -1101,7 +1102,7 @@ class ClusterGrid(Grid):
         except (TypeError, IndexError):
             pass
 
-        heatmap(self.data2d, ax=self.ax_heatmap, cbar_ax=self.cax,
+        heatmap(self.data2d, ax=self.ax_heatmap, cbar_ax=self.ax_cbar,
                 cbar_kws=colorbar_kws, mask=self.mask,
                 xticklabels=xtl, yticklabels=ytl, **kws)
 

--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -930,29 +930,35 @@ class ClusterGrid(Grid):
         else:
             return standardized.T
 
-    def dim_ratios(self, side_colors, axis, figsize, side_colors_ratio=0.05):
+    def dim_ratios(self, side_colors, axis, figsize):
         """Get the proportions of the figure taken up by each axes
         """
         figdim = figsize[axis]
+
+        expected_size_for_dendrogram = 1.0  # Inches
+        expected_size_for_side_colors = 0.25  # Inches
+
         # Get resizing proportion of this figure for the dendrogram and
         # colorbar, so only the heatmap gets bigger but the dendrogram stays
         # the same size.
-        dendrogram = min(2. / figdim, .2)
+        dendrogram = expected_size_for_dendrogram / figdim
 
         # add the colorbar
         colorbar_width = .8 * dendrogram
         colorbar_height = .2 * dendrogram
-        if axis == 0:
+        if axis == 1:
             ratios = [colorbar_width, colorbar_height]
         else:
             ratios = [colorbar_height, colorbar_width]
 
         if side_colors is not None:
+            side_colors_ratio = expected_size_for_side_colors / figdim
+
             # Add room for the colors
             ratios += [side_colors_ratio]
 
         # Add the ratio for the heatmap itself
-        ratios += [.8]
+        ratios.append(1 - sum(ratios))
 
         return ratios
 

--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -777,11 +777,11 @@ class ClusterGrid(Grid):
 
         width_ratios = self.dim_ratios(self.row_colors,
                                        figsize=figsize,
-                                       axis=1)
+                                       axis=0)
 
         height_ratios = self.dim_ratios(self.col_colors,
                                         figsize=figsize,
-                                        axis=0)
+                                        axis=1)
         nrows = 3 if self.col_colors is None else 4
         ncols = 3 if self.row_colors is None else 4
 

--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -812,7 +812,13 @@ class ClusterGrid(Grid):
         self.ax_heatmap = self.fig.add_subplot(self.gs[nrows - 1, ncols - 1])
 
         # colorbar for scale to left corner
-        self.cax = self.fig.add_subplot(self.gs[0, 0])
+
+        if self.col_colors is not None:
+            cbar_max = 3
+        else:
+            cbar_max = 2
+
+        self.cax = self.fig.add_subplot(self.gs[0:cbar_max, 0])
 
         self.dendrogram_row = None
         self.dendrogram_col = None
@@ -961,7 +967,7 @@ class ClusterGrid(Grid):
             # This happens when a series or a list is passed
             if len(colors_shape) <= 2:
                 n_colors = 1
-            # And this happens when a dataframe is passed
+            # And this happens when a dataframe is passed, the first dimension is number of colors
             else:
                 n_colors = colors_shape[0]
 

--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -592,9 +592,6 @@ class _DendrogramPlotter(object):
         self.independent_coord = self.dendrogram['icoord']
 
     def _calculate_linkage_scipy(self):
-        if np.product(self.shape) >= 10000:
-            UserWarning('This will be slow... (gentle suggestion: '
-                        '"pip install fastcluster")')
         linkage = hierarchy.linkage(self.array, method=self.method,
                                     metric=self.metric)
         return linkage
@@ -618,10 +615,16 @@ class _DendrogramPlotter(object):
 
     @property
     def calculated_linkage(self):
+
         try:
             return self._calculate_linkage_fastcluster()
         except ImportError:
-            return self._calculate_linkage_scipy()
+            if np.product(self.shape) >= 10000:
+                msg = ("Clustering large matrix with scipy. Installing
+                       "`fastcluster` may give better performance.")
+                warnings.warn(msg)
+
+        return self._calculate_linkage_scipy()
 
     def calculate_dendrogram(self):
         """Calculates a dendrogram based on the linkage matrix

--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -1,6 +1,7 @@
 """Functions to visualize matrices of data."""
 from __future__ import division
 import itertools
+import warnings
 
 import matplotlib as mpl
 from matplotlib.collections import LineCollection
@@ -1129,6 +1130,14 @@ class ClusterGrid(Grid):
 
     def plot(self, metric, method, colorbar_kws, row_cluster, col_cluster,
              row_linkage, col_linkage, **kws):
+
+        # heatmap square=True sets the aspect ratio on the axes, but that is
+        # not compatible with the multi-axes layout of clustergrid
+        if kws.get("square", False):
+            msg = "``square=True`` ignored in clustermap"
+            warnings.warn(msg)
+            kws.pop("square")
+
         colorbar_kws = {} if colorbar_kws is None else colorbar_kws
         self.plot_dendrograms(row_cluster, col_cluster, metric, method,
                               row_linkage=row_linkage, col_linkage=col_linkage)

--- a/seaborn/tests/test_matrix.py
+++ b/seaborn/tests/test_matrix.py
@@ -1206,5 +1206,9 @@ class TestClustermap(object):
     def test_clustermap_annotation(self):
 
         g = mat.clustermap(self.df_norm, annot=True, fmt=".1f")
-        for val, text in zip(self.x_norm.flat, g.ax_heatmap.texts):
+        for val, text in zip(np.asarray(g.data2d).flat, g.ax_heatmap.texts):
+            assert text.get_text() == "{:.1f}".format(val)
+
+        g = mat.clustermap(self.df_norm, annot=self.df_norm, fmt=".1f")
+        for val, text in zip(np.asarray(g.data2d).flat, g.ax_heatmap.texts):
             assert text.get_text() == "{:.1f}".format(val)

--- a/seaborn/tests/test_matrix.py
+++ b/seaborn/tests/test_matrix.py
@@ -1189,3 +1189,16 @@ class TestClustermap(object):
         assert pytest.approx(tuple(pos.p0)) == kws["cbar_pos"][:2]
         assert pytest.approx(pos.width) == kws["cbar_pos"][2]
         assert pytest.approx(pos.height) == kws["cbar_pos"][3]
+
+    def test_square_warning(self):
+
+        kws = self.default_kws.copy()
+        g1 = mat.clustermap(self.df_norm, **kws)
+
+        with pytest.warns(UserWarning):
+            kws["square"] = True
+            g2 = mat.clustermap(self.df_norm, **kws)
+
+        g1_shape = g1.ax_heatmap.get_position().get_points()
+        g2_shape = g2.ax_heatmap.get_position().get_points()
+        assert np.array_equal(g1_shape, g2_shape)

--- a/seaborn/tests/test_matrix.py
+++ b/seaborn/tests/test_matrix.py
@@ -1118,3 +1118,59 @@ class TestClustermap(object):
         ytl_actual = [t.get_text() for t in g.ax_heatmap.get_yticklabels()]
         nt.assert_equal(xtl_actual, [])
         nt.assert_equal(ytl_actual, [])
+
+    def test_size_ratios(self):
+
+        # The way that wspace/hspace work in GridSpec, the mapping from input
+        # ratio to actual width/height of each axes is complicated, so this
+        # test is just going to assert comparative relationships
+
+        kws1 = self.default_kws.copy()
+        kws1.update(dendrogram_ratio=.2, colors_ratio=.03,
+                    col_colors=self.col_colors, row_colors=self.row_colors)
+
+        kws2 = kws1.copy()
+        kws2.update(dendrogram_ratio=.3, colors_ratio=.05)
+
+        g1 = mat.clustermap(self.df_norm, **kws1)
+        g2 = mat.clustermap(self.df_norm, **kws2)
+
+        assert (g2.ax_col_dendrogram.get_position().height
+                > g1.ax_col_dendrogram.get_position().height)
+
+        assert (g2.ax_col_colors.get_position().height
+                > g1.ax_col_colors.get_position().height)
+
+        assert (g2.ax_heatmap.get_position().height
+                < g1.ax_heatmap.get_position().height)
+
+        assert (g2.ax_row_dendrogram.get_position().width
+                > g1.ax_row_dendrogram.get_position().width)
+
+        assert (g2.ax_row_colors.get_position().width
+                > g1.ax_row_colors.get_position().width)
+
+        assert (g2.ax_heatmap.get_position().width
+                < g1.ax_heatmap.get_position().width)
+
+        kws1 = self.default_kws.copy()
+        kws1.update(col_colors=self.col_colors)
+        kws2 = kws1.copy()
+        kws2.update(col_colors=[self.col_colors, self.col_colors])
+
+        g1 = mat.clustermap(self.df_norm, **kws1)
+        g2 = mat.clustermap(self.df_norm, **kws2)
+
+        assert (g2.ax_col_colors.get_position().height
+                > g1.ax_col_colors.get_position().height)
+
+    def test_cbar_pos(self):
+
+        kws = self.default_kws.copy()
+        kws["cbar_pos"] = (.2, .1, .4, .3)
+
+        g = mat.clustermap(self.df_norm, **kws)
+        pos = g.ax_cbar.get_position()
+        assert pytest.approx(tuple(pos.p0)) == kws["cbar_pos"][:2]
+        assert pytest.approx(pos.width) == kws["cbar_pos"][2]
+        assert pytest.approx(pos.height) == kws["cbar_pos"][3]

--- a/seaborn/tests/test_matrix.py
+++ b/seaborn/tests/test_matrix.py
@@ -1202,3 +1202,9 @@ class TestClustermap(object):
         g1_shape = g1.ax_heatmap.get_position().get_points()
         g2_shape = g2.ax_heatmap.get_position().get_points()
         assert np.array_equal(g1_shape, g2_shape)
+
+    def test_clustermap_annotation(self):
+
+        g = mat.clustermap(self.df_norm, annot=True, fmt=".1f")
+        for val, text in zip(self.x_norm.flat, g.ax_heatmap.texts):
+            assert text.get_text() == "{:.1f}".format(val)

--- a/seaborn/tests/test_matrix.py
+++ b/seaborn/tests/test_matrix.py
@@ -664,7 +664,9 @@ class TestClustermap(object):
     df_norm_leaves = np.asarray(df_norm.columns[x_norm_leaves])
 
     default_kws = dict(pivot_kws=None, z_score=None, standard_scale=None,
-                       figsize=None, row_colors=None, col_colors=None)
+                       figsize=(10, 10), row_colors=None, col_colors=None,
+                       dendrogram_ratio=.2, colors_ratio=.03,
+                       cbar_pos=(0, .8, .05, .2))
 
     default_plot_kws = dict(metric='euclidean', method='average',
                             colorbar_kws=None,

--- a/seaborn/tests/test_matrix.py
+++ b/seaborn/tests/test_matrix.py
@@ -1164,6 +1164,21 @@ class TestClustermap(object):
         assert (g2.ax_col_colors.get_position().height
                 > g1.ax_col_colors.get_position().height)
 
+        kws1 = self.default_kws.copy()
+        kws1.update(dendrogram_ratio=(.2, .2))
+
+        kws2 = kws1.copy()
+        kws2.update(dendrogram_ratio=(.2, .3))
+
+        g1 = mat.clustermap(self.df_norm, **kws1)
+        g2 = mat.clustermap(self.df_norm, **kws2)
+
+        assert (g2.ax_row_dendrogram.get_position().width
+                == g1.ax_row_dendrogram.get_position().width)
+
+        assert (g2.ax_col_dendrogram.get_position().height
+                > g1.ax_col_dendrogram.get_position().height)
+
     def test_cbar_pos(self):
 
         kws = self.default_kws.copy()


### PR DESCRIPTION
- Adds more control over the layout of the grid and improves how the default layout scales with different sizes/shapes of the figure. This follows up on the work done in #1393, but it changes the parameterization to work in terms of ratios instead of inches. It also lets row/col ratios be specified independently. And it adds a parameter for the location of the colorbar (#1598).

- Fixes a bug where the annotation array was not clustered to match the heatmap (#1752) 

- Avoids printing the fastcluser ImportError when an exception is raised from within scipy clustering, which confused people who don't read entire stacktraces and lead to errant bug reports (#1370)

Needs
- [x] Explicitly disable `square=True`
- [x] Unit tests
- [x] Parameter documentation
- [x] Docstring example
- [x] Release notes

Fixes #437
Closes #891
Closes #1393
Fixes #1752 
Closes #1753