### PR TITLE
Avoid altering input dicts

### DIFF
--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -2110,12 +2110,9 @@ def pairplot(data, hue=None, hue_order=None, palette=None,
             "'data' must be pandas DataFrame object, not: {typefound}".format(
                 typefound=type(data)))
 
-    if plot_kws is None:
-        plot_kws = {}
-    if diag_kws is None:
-        diag_kws = {}
-    if grid_kws is None:
-        grid_kws = {}
+    plot_kws = {} if plot_kws is None else plot_kws.copy()
+    diag_kws = {} if diag_kws is None else diag_kws.copy()
+    grid_kws = {} if grid_kws is None else grid_kws.copy()
 
     # Set up the PairGrid
     grid_kws.setdefault("diag_sharey", diag_kind == "hist")
@@ -2302,13 +2299,10 @@ def jointplot(x, y, data=None, kind="scatter", stat_func=None,
         warnings.warn(msg, UserWarning)
 
     # Set up empty default kwarg dicts
-    if joint_kws is None:
-        joint_kws = {}
+    joint_kws = {} if joint_kws is None else joint_kws.copy()
     joint_kws.update(kwargs)
-    if marginal_kws is None:
-        marginal_kws = {}
-    if annot_kws is None:
-        annot_kws = {}
+    marginal_kws = {} if marginal_kws is None else marginal_kws.copy()
+    annot_kws = {} if annot_kws is None else annot_kws.copy()
 
     # Make a colormap based off the plot color
     if color is None:

--- a/seaborn/distributions.py
+++ b/seaborn/distributions.py
@@ -185,14 +185,10 @@ def distplot(a, bins=None, hist=True, kde=True, rug=False, fit=None,
     norm_hist = norm_hist or kde or (fit is not None)
 
     # Handle dictionary defaults
-    if hist_kws is None:
-        hist_kws = dict()
-    if kde_kws is None:
-        kde_kws = dict()
-    if rug_kws is None:
-        rug_kws = dict()
-    if fit_kws is None:
-        fit_kws = dict()
+    hist_kws = {} if hist_kws is None else hist_kws.copy()
+    kde_kws = {} if kde_kws is None else kde_kws.copy()
+    rug_kws = {} if rug_kws is None else rug_kws.copy()
+    fit_kws = {} if fit_kws is None else fit_kws.copy()
 
     # Get the color from the current color cycle
     if color is None:

--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -193,9 +193,9 @@ class _HeatMapper(object):
         self.annot_data = annot_data
 
         self.fmt = fmt
-        self.annot_kws = {} if annot_kws is None else annot_kws
+        self.annot_kws = {} if annot_kws is None else annot_kws.copy()
         self.cbar = cbar
-        self.cbar_kws = {} if cbar_kws is None else cbar_kws
+        self.cbar_kws = {} if cbar_kws is None else cbar_kws.copy()
         self.cbar_kws.setdefault('ticks', mpl.ticker.MaxNLocator(6))
 
     def _determine_cmap_params(self, plot_data, vmin, vmax,

--- a/seaborn/regression.py
+++ b/seaborn/regression.py
@@ -1066,7 +1066,7 @@ def residplot(x, y, data=None, lowess=False, x_partial=None, y_partial=None,
     ax.axhline(0, ls=":", c=".2")
 
     # Draw the scatterplot
-    scatter_kws = {} if scatter_kws is None else scatter_kws
-    line_kws = {} if line_kws is None else line_kws
+    scatter_kws = {} if scatter_kws is None else scatter_kws.copy()
+    line_kws = {} if line_kws is None else line_kws.copy()
     plotter.plot(ax, scatter_kws, line_kws)
     return ax

--- a/seaborn/tests/test_axisgrid.py
+++ b/seaborn/tests/test_axisgrid.py
@@ -1600,3 +1600,12 @@ class TestJointPlot(object):
 
         with nt.assert_raises(ValueError):
             ag.jointplot("x", "y", self.data, kind="not_a_kind")
+
+    def test_leaky_dict(self):
+        # Validate input dicts are unchanged by jointplot plotting function
+
+        for kwarg in ("joint_kws", "marginal_kws", "annot_kws"):
+            for kind in ("hex", "kde", "resid", "reg", "scatter"):
+                empty_dict={}
+                g = ag.jointplot("x", "y", self.data, kind=kind, **{kwarg:empty_dict})
+                assert empty_dict == {}


### PR DESCRIPTION
Some plotting functions alter input dicts. Example:
```python
import seaborn as sns; sns.set(color_codes=True)
tips = sns.load_dataset("tips")
empty_dict={}
g = sns.jointplot(x="total_bill", y="tip", data=tips, joint_kws=empty_dict)
print(empty_dict) 
>>> {'color': (0.2980392156862745, 0.4470588235294118, 0.6901960784313725)}
```
The proposed PR makes sure the original dict input for such functions remains unaltered by shallow copying these dictionaries.