### PR TITLE
Allow colors= in bivariate kdeplot

### DIFF
--- a/doc/releases/v0.9.1.txt
+++ b/doc/releases/v0.9.1.txt
@@ -66,6 +66,8 @@ Bug fixes and adaptations
 
 - Avoided error/warning in :func:`lineplot` when plotting categoricals with empty levels.
 
+- Allowed ``colors`` to be passed through to a bivariabe :func:`kdeplot`.
+
 - Standardized the output format of custom color palette functions.
 
 - Fixed a bug where legends for numerical variables in a relational plot could show a surprisingly large number of decimal places.

--- a/examples/pair_grid_with_kde.py
+++ b/examples/pair_grid_with_kde.py
@@ -10,6 +10,6 @@ sns.set(style="white")
 df = sns.load_dataset("iris")
 
 g = sns.PairGrid(df, diag_sharey=False)
-g.map_lower(sns.kdeplot)
 g.map_upper(sns.scatterplot)
-g.map_diag(sns.kdeplot, lw=3)
+g.map_lower(sns.kdeplot, colors="C0")
+g.map_diag(sns.kdeplot, lw=2)

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -1241,9 +1241,9 @@ class PairGrid(Grid):
             :context: close-figs
 
             >>> g = sns.PairGrid(iris)
-            >>> g = g.map_upper(plt.scatter)
-            >>> g = g.map_lower(sns.kdeplot, cmap="Blues_d")
-            >>> g = g.map_diag(sns.kdeplot, lw=3, legend=False)
+            >>> g = g.map_upper(sns.scatterplot)
+            >>> g = g.map_lower(sns.kdeplot, colors="C0")
+            >>> g = g.map_diag(sns.kdeplot, lw=2)
 
         Use different colors and markers for each categorical level:
 

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -582,7 +582,7 @@ class FacetGrid(Grid):
             >>> def qqplot(x, y, **kwargs):
             ...     _, xr = stats.probplot(x, fit=False)
             ...     _, yr = stats.probplot(y, fit=False)
-            ...     plt.scatter(xr, yr, **kwargs)
+            ...     sns.scatterplot(xr, yr, **kwargs)
             >>> g = sns.FacetGrid(tips, col="smoker", hue="sex")
             >>> g = (g.map(qqplot, "total_bill", "tip", **kws)
             ...       .add_legend())
@@ -1252,7 +1252,7 @@ class PairGrid(Grid):
 
             >>> g = sns.PairGrid(iris, hue="species", palette="Set2",
             ...                  hue_kws={"marker": ["o", "s", "D"]})
-            >>> g = g.map(plt.scatter, linewidths=1, edgecolor="w", s=40)
+            >>> g = g.map(sns.scatterplot, linewidths=1, edgecolor="w", s=40)
             >>> g = g.add_legend()
 
         """
@@ -1619,7 +1619,7 @@ class JointGrid(object):
 
             >>> import matplotlib.pyplot as plt
             >>> g = sns.JointGrid(x="total_bill", y="tip", data=tips)
-            >>> g = g.plot_joint(plt.scatter, color=".5", edgecolor="white")
+            >>> g = g.plot_joint(sns.scatterplot, color=".5")
             >>> g = g.plot_marginals(sns.distplot, kde=False, color=".5")
 
         Draw the two marginal plots separately:

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -1629,38 +1629,12 @@ class JointGrid(object):
 
             >>> import numpy as np
             >>> g = sns.JointGrid(x="total_bill", y="tip", data=tips)
-            >>> g = g.plot_joint(plt.scatter, color="m", edgecolor="white")
+            >>> g = g.plot_joint(sns.scatterplot, color="m")
             >>> _ = g.ax_marg_x.hist(tips["total_bill"], color="b", alpha=.6,
             ...                      bins=np.arange(0, 60, 5))
             >>> _ = g.ax_marg_y.hist(tips["tip"], color="r", alpha=.6,
             ...                      orientation="horizontal",
             ...                      bins=np.arange(0, 12, 1))
-
-        Add an annotation with a statistic summarizing the bivariate
-        relationship:
-
-        .. plot::
-            :context: close-figs
-
-            >>> from scipy import stats
-            >>> g = sns.JointGrid(x="total_bill", y="tip", data=tips)
-            >>> g = g.plot_joint(plt.scatter,
-            ...                  color="g", s=40, edgecolor="white")
-            >>> g = g.plot_marginals(sns.distplot, kde=False, color="g")
-            >>> g = g.annotate(stats.pearsonr)
-
-        Use a custom function and formatting for the annotation
-
-        .. plot::
-            :context: close-figs
-
-            >>> g = sns.JointGrid(x="total_bill", y="tip", data=tips)
-            >>> g = g.plot_joint(plt.scatter,
-            ...                  color="g", s=40, edgecolor="white")
-            >>> g = g.plot_marginals(sns.distplot, kde=False, color="g")
-            >>> rsquare = lambda a, b: stats.pearsonr(a, b)[0] ** 2
-            >>> g = g.annotate(rsquare, template="{stat}: {val:.2f}",
-            ...                stat="$R^2$", loc="upper left", fontsize=12)
 
         Remove the space between the joint and marginal axes:
 

--- a/seaborn/distributions.py
+++ b/seaborn/distributions.py
@@ -411,14 +411,9 @@ def _bivariate_kdeplot(x, y, filled, fill_lowest,
     default_color = scout.get_color()
     scout.remove()
 
-    color = kwargs.pop("color", None)
-    colors = kwargs.pop("colors", None)
     cmap = kwargs.pop("cmap", None)
-    if color is not None and cmap is not None:
-        raise ValueError("Either color or cmap must be None")
-    if color is not None and colors is not None:
-        raise ValueError("Either color or colors must be None")
-    if cmap is None and colors is None:
+    color = kwargs.pop("color", None)
+    if cmap is None and "colors" not in kwargs:
         if color is None:
             color = default_color
         if filled:
@@ -436,7 +431,6 @@ def _bivariate_kdeplot(x, y, filled, fill_lowest,
     label = kwargs.pop("label", None)
 
     kwargs["cmap"] = cmap
-    kwargs["colors"] = colors
     contour_func = ax.contourf if filled else ax.contour
     cset = contour_func(xx, yy, z, n_levels, **kwargs)
     if filled and not fill_lowest:

--- a/seaborn/tests/test_distributions.py
+++ b/seaborn/tests/test_distributions.py
@@ -240,6 +240,12 @@ class TestKDE(object):
         high = ax.collections[-1].get_facecolor().mean()
         assert low > high
 
+        f, ax = plt.subplots()
+        dist.kdeplot(self.x, self.y, shade=True, colors=[rgb])
+        for level in ax.collections:
+            level_rgb = tuple(level.get_facecolor().squeeze()[:3])
+            assert level_rgb == rgb
+
 
 class TestRugPlot(object):
 


### PR DESCRIPTION
This adds onto #1777, but simplifies the error checking. Disallowing color= and colors= breaks in a Grid context (hence the failing tests in #1777), and the other checks just duplicate what happens in matplotlib. It also adds a test that would have failed before the change.

I also updated a couple of examples and changed a few issues in the examples that I caught while doing so.

Closes #1777 
Fixes #1748