### PR TITLE
More improvements to clustergrid layout

### DIFF
--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -1300,6 +1300,33 @@ def clustermap(data, pivot_kws=None, method='average', metric='euclidean',
         >>> species = iris.pop("species")
         >>> g = sns.clustermap(iris)
 
+    Change the size and layout of the figure:
+
+    .. plot::
+        :context: close-figs
+
+        >>> g = sns.clustermap(iris,
+        ...                    figsize=(7, 5),
+        ...                    row_cluster=False,
+        ...                    dendrogram_ratio=(.1, .2),
+        ...                    cbar_pos=(0, .2, .03, .4))
+
+    Add colored labels to identify observations:
+
+    .. plot::
+        :context: close-figs
+
+        >>> lut = dict(zip(species.unique(), "rbg"))
+        >>> row_colors = species.map(lut)
+        >>> g = sns.clustermap(iris, row_colors=row_colors)
+
+    Use a different colormap and adjust the limits of the color range:
+
+    .. plot::
+        :context: close-figs
+
+        >>> g = sns.clustermap(iris, cmap="mako", vmin=0, vmax=10)
+
     Use a different similarity metric:
 
     .. plot::
@@ -1314,39 +1341,6 @@ def clustermap(data, pivot_kws=None, method='average', metric='euclidean',
 
         >>> g = sns.clustermap(iris, method="single")
 
-    Use a different colormap and ignore outliers in colormap limits:
-
-    .. plot::
-        :context: close-figs
-
-        >>> g = sns.clustermap(iris, cmap="mako", robust=True)
-
-    Change the size and layout of the figure:
-
-    .. plot::
-        :context: close-figs
-
-        >>> g = sns.clustermap(iris, row_cluster=False,
-        ...                    figsize=(7, 5),
-        ...                    dendrogram_ratio=(.1, .2),
-        ...                    cbar_pos=(0, .2, .03, .4))
-
-    Plot one of the axes in its original organization:
-
-    .. plot::
-        :context: close-figs
-
-        >>> g = sns.clustermap(iris, col_cluster=False)
-
-    Add colored labels:
-
-    .. plot::
-        :context: close-figs
-
-        >>> lut = dict(zip(species.unique(), "rbg"))
-        >>> row_colors = species.map(lut)
-        >>> g = sns.clustermap(iris, row_colors=row_colors)
-
     Standardize the data within the columns:
 
     .. plot::
@@ -1359,7 +1353,7 @@ def clustermap(data, pivot_kws=None, method='average', metric='euclidean',
     .. plot::
         :context: close-figs
 
-        >>> g = sns.clustermap(iris, z_score=0)
+        >>> g = sns.clustermap(iris, z_score=0, cmap="vlag")
 
 
     """

--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -798,8 +798,6 @@ class ClusterGrid(Grid):
         ncols = 2 if self.row_colors is None else 3
 
         self.gs = gridspec.GridSpec(nrows, ncols,
-                                    # wspace=.01, hspace=.01,
-                                    # left=.01, right=.99, bottom=.01, top=.99,
                                     width_ratios=width_ratios,
                                     height_ratios=height_ratios)
 

--- a/seaborn/tests/test_matrix.py
+++ b/seaborn/tests/test_matrix.py
@@ -1191,6 +1191,10 @@ class TestClustermap(object):
         assert pytest.approx(pos.width) == kws["cbar_pos"][2]
         assert pytest.approx(pos.height) == kws["cbar_pos"][3]
 
+        kws["cbar_pos"] = None
+        g = mat.clustermap(self.df_norm, **kws)
+        assert g.ax_cbar is None
+
     def test_square_warning(self):
 
         kws = self.default_kws.copy()


### PR DESCRIPTION
This enables use of tight_layout within clustermap. Ideally most plots will
now have everything in the figure and looking nice out of the box. It uses
a somewhat hacky approach that should be revisted as constrained_layout matures.

e.g., here is what a QT window looks like for the following code, with no other adjustments:

```python
import seaborn as sns
iris = sns.load_dataset("iris").drop("species", axis=1)
g = sns.clustermap(iris,
                   col_cluster=False,
                   yticklabels=False,
                   figsize=(7, 6),
                   dendrogram_ratio=(.15, .12),
                   cbar_pos=(.3, .95, .55, .04),
                   cbar_kws={"orientation": "horizontal",
                             "label": "Measurement (mm)"})
```
<img width="768" alt="Screenshot 2020-01-21 20 09 00" src="https://user-images.githubusercontent.com/315810/72856907-fbbee800-3c89-11ea-8347-f50c74860b3e.png">


Also updates the docs a little bit and adds a rule where cbar_pos=None implies
that no colorbar will be drawn.