### PR TITLE
Make dogplot more tolerant

### DIFF
--- a/seaborn/miscplot.py
+++ b/seaborn/miscplot.py
@@ -29,7 +29,7 @@ def palplot(pal, size=1):
     ax.set_yticklabels([])
 
 
-def dogplot():
+def dogplot(*_, **__):
     """Who's a good boy?"""
     try:
         from urllib.request import urlopen


### PR DESCRIPTION
I really like this easter egg :-)

However, when you suggest someone to use `dogplot` instead of `catplot`, they will receive a `TypeError` explaining that they provided too many arguments. This kind of spoils the fun. What about making it more tolerant?