### PR TITLE
Use the correct platform integer type

### DIFF
--- a/seaborn/algorithms.py
+++ b/seaborn/algorithms.py
@@ -83,7 +83,7 @@ def bootstrap(*args, **kwargs):
 
     boot_dist = []
     for i in range(int(n_boot)):
-        resampler = rs.randint(0, n, n)
+        resampler = rs.randint(0, n, n, dtype=np.int_)
         sample = [a.take(resampler, axis=0) for a in args]
         boot_dist.append(f(*sample, **func_kwargs))
     return np.array(boot_dist)
@@ -98,10 +98,11 @@ def _structured_bootstrap(args, n_boot, units, func, func_kwargs, rs):
 
     boot_dist = []
     for i in range(int(n_boot)):
-        resampler = rs.randint(0, n_units, n_units)
+        resampler = rs.randint(0, n_units, n_units, dtype=np.int_)
         sample = [np.take(a, resampler, axis=0) for a in args]
         lengths = map(len, sample[0])
-        resampler = [rs.randint(0, n, n) for n in lengths]
+        resampler = [rs.randint(0, n, n, dtype=np.int_)
+                     for n in lengths]
         sample = [[c.take(r, axis=0) for c, r in zip(a, resampler)]
                   for a in sample]
         sample = list(map(np.concatenate, sample))


### PR DESCRIPTION
`np.array.take` requires that the index be the platform integer type (`int32` for 32bit and `int64` for 64bit), but `np.random.RandomState.randint` returns an `int64` on any platform by default.  This makes sure it returns the right type of integer for the current platform.