### PR TITLE
FIX: Ignore masked cells when finding heatmap data limits

### DIFF
--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -198,15 +198,15 @@ class _HeatMapper(object):
         # plot_data is a np.ma.array instance
         calc_data = plot_data.filled(np.nan)
         if vmin is None:
-            vmin = (
-                np.nanpercentile(calc_data, 2)
-                if robust else np.nanmin(calc_data)
-            )
+            if robust:
+                vmin = np.nanpercentile(calc_data, 2)
+            else:
+                vmin = np.nanmin(calc_data)
         if vmax is None:
-            vmax = (
-                np.nanpercentile(calc_data, 98)
-                if robust else np.nanmax(calc_data)
-            )
+            if robust:
+                vmax = np.nanpercentile(calc_data, 98)
+            else:
+                vmax = np.nanmax(calc_data)
         self.vmin, self.vmax = vmin, vmax
 
         # Choose default colormaps if not provided

--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -194,11 +194,19 @@ class _HeatMapper(object):
     def _determine_cmap_params(self, plot_data, vmin, vmax,
                                cmap, center, robust):
         """Use some heuristics to set good defaults for colorbar and range."""
-        calc_data = plot_data.filled(np.nan) #plot_data is a np.ma.array instance
+
+        # plot_data is a np.ma.array instance
+        calc_data = plot_data.filled(np.nan)
         if vmin is None:
-            vmin = np.nanpercentile(calc_data, 2) if robust else np.nanmin(calc_data)
+            vmin = (
+                np.nanpercentile(calc_data, 2)
+                if robust else np.nanmin(calc_data)
+            )
         if vmax is None:
-            vmax = np.nanpercentile(calc_data, 98) if robust else np.nanmax(calc_data)
+            vmax = (
+                np.nanpercentile(calc_data, 98)
+                if robust else np.nanmax(calc_data)
+            )
         self.vmin, self.vmax = vmin, vmax
 
         # Choose default colormaps if not provided

--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -194,11 +194,11 @@ class _HeatMapper(object):
     def _determine_cmap_params(self, plot_data, vmin, vmax,
                                cmap, center, robust):
         """Use some heuristics to set good defaults for colorbar and range."""
-        calc_data = plot_data.data[~np.isnan(plot_data.data)]
+        calc_data = plot_data.filled(np.nan) #plot_data is a np.ma.array instance
         if vmin is None:
-            vmin = np.percentile(calc_data, 2) if robust else calc_data.min()
+            vmin = np.nanpercentile(calc_data, 2) if robust else np.nanmin(calc_data)
         if vmax is None:
-            vmax = np.percentile(calc_data, 98) if robust else calc_data.max()
+            vmax = np.nanpercentile(calc_data, 98) if robust else np.nanmax(calc_data)
         self.vmin, self.vmax = vmin, vmax
 
         # Choose default colormaps if not provided

--- a/seaborn/tests/test_matrix.py
+++ b/seaborn/tests/test_matrix.py
@@ -96,6 +96,25 @@ class TestHeatmap(object):
 
         npt.assert_array_equal(p.plot_data, plot_data)
 
+    def test_mask_limits(self):
+        """Make sure masked cells are not used to calculate extremes"""
+
+        kws = self.default_kws.copy()
+
+        mask = self.x_norm > 0
+        kws['mask'] = mask
+        p = mat._HeatMapper(self.x_norm, **kws)
+
+        assert p.vmax == np.ma.array(self.x_norm, mask=mask).max()
+        assert p.vmin == np.ma.array(self.x_norm, mask=mask).min()
+
+        mask = self.x_norm < 0
+        kws['mask'] = mask
+        p = mat._HeatMapper(self.x_norm, **kws)
+
+        assert p.vmin == np.ma.array(self.x_norm, mask=mask).min()
+        assert p.vmax == np.ma.array(self.x_norm, mask=mask).max()
+
     def test_default_vlims(self):
 
         p = mat._HeatMapper(self.df_unif, **self.default_kws)


### PR DESCRIPTION
Masked cells are ignored from heatmap annotations and are not color-mapped, however they currently participate in cmap limits calculation. This is not documented, and seems surprising to some users (#1622 , #1617). Furthermore, Matplotlib's ``pcolormesh`` (used by heatmap) does not use masked cells in cmap limits calculation. This PR makes data limits calculation ignore masked cells. 

Fixes #1617 
Fixes #1622 