### PR TITLE
FIX: avoid squeezing singleton vectors in regression plotter

### DIFF
--- a/seaborn/regression.py
+++ b/seaborn/regression.py
@@ -48,7 +48,7 @@ class _LinearPlotter(object):
                 vector = np.asarray(val)
             else:
                 vector = val
-            if vector is not None:
+            if vector is not None and vector.shape != (1,):
                 vector = np.squeeze(vector)
             if np.ndim(vector) > 1:
                 err = "regplot inputs must be 1d"

--- a/seaborn/tests/test_regression.py
+++ b/seaborn/tests/test_regression.py
@@ -165,6 +165,11 @@ class TestRegressionPlotter(object):
         p = lm._RegressionPlotter("x", "y_na", data=self.df, dropna=False)
         nt.assert_equal(len(p.x), len(self.df.y_na))
 
+    def test_singleton(self):
+        lm._RegressionPlotter([1.5], [2])
+        lm._RegressionPlotter(np.asarray([1.5]), np.asarray([2]))
+        lm._RegressionPlotter(pd.Series(1.5), pd.Series(2))
+
     def test_ci(self):
 
         p = lm._RegressionPlotter("x", "y", data=self.df, ci=95)


### PR DESCRIPTION
As reported in #1949 , ``regplot`` fails when its array-like input is single-valued. This may be pandas series, python list or numpy array (although different errors may appear according to the input type). For example, the following code fails on master with recent ``numpy`` and ``pandas`` packages:
```python
import seaborn as sns
sns.regplot([1.5], [2])
```
with ``IndexError: too many indices for array`` raised in ``_RegressionPlotter.dropna()``. This is because the input vector is reduced by ``np.squeeze`` and singletons lose that dimension and no longer support select operations. 
The proposed fix avoids squeezing singletons, so "array-like" properties are retained. This means that the single point will be plotted and (if ``fit_reg==True``) a regression will be fitted (although, no line will be plotted).

Fixes #1949 