### PR TITLE
Add support for per-category width on boxplot.

### DIFF
--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -1,4 +1,4 @@
-from __future__ import division
+/from __future__ import division
 from textwrap import dedent
 import colorsys
 import numpy as np
@@ -457,11 +457,11 @@ class _BoxPlotter(_CategoricalPlotter):
         for obj in ["box", "whisker", "cap", "median", "flier"]:
             props[obj] = kws.pop(obj + "props", {})
 
-        if not np.isscalar(self.width):
-          # If width is an array-like structure, check the dimensions match.
-          if len(self.width) != len(self.plot_data):
-            raise ValueError("Length of `width` should be the same than the "
-                              "categorical data.")
+        if self.width and not np.isscalar(self.width):
+            # If width is an array-like structure, check the dimensions match.
+            if len(self.width) != len(self.plot_data):
+                raise ValueError("Length of `width` should be the same than the "
+                                 "categorical data.")
 
         for i, group_data in enumerate(self.plot_data):
 
@@ -480,10 +480,10 @@ class _BoxPlotter(_CategoricalPlotter):
                     continue
 
                 # Support per column width.
-                if np.isscalar(self.width):
-                  width = self.width
+                if self.width and not np.isscalar(self.width):
+                    width = self.width[i]
                 else:
-                  width = self.width[i]
+                    width = self.width
 
                 artist_dict = ax.boxplot(box_data,
                                          vert=vert,
@@ -2164,7 +2164,7 @@ _categorical_docs = dict(
     width : float, list, optional
         Width of a full element when not using hue nesting, or width of all the
         elements for one level of the major grouping variable. If list, width
-        of each of the boxes for onle level of the major grouping variable.\
+        of each of the boxes for one level of the major grouping variable.\
     """),
     dodge=dedent("""\
     dodge : bool, optional

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -457,6 +457,12 @@ class _BoxPlotter(_CategoricalPlotter):
         for obj in ["box", "whisker", "cap", "median", "flier"]:
             props[obj] = kws.pop(obj + "props", {})
 
+        if not np.isscalar(self.width):
+          # If width is an array-like structure, check the dimensions match.
+          if len(self.width) != len(self.plot_data):
+            raise ValueError("Length of `width` should be the same than the "
+                              "categorical data.")
+
         for i, group_data in enumerate(self.plot_data):
 
             if self.plot_hues is None:
@@ -473,11 +479,17 @@ class _BoxPlotter(_CategoricalPlotter):
                 if box_data.size == 0:
                     continue
 
+                # Support per column width.
+                if np.isscalar(self.width):
+                  width = self.width
+                else:
+                  width = self.width[i]
+
                 artist_dict = ax.boxplot(box_data,
                                          vert=vert,
                                          patch_artist=True,
                                          positions=[i],
-                                         widths=self.width,
+                                         widths=width,
                                          **kws)
                 color = self.colors[i]
                 self.restyle_boxplot(artist_dict, color, props)
@@ -2149,9 +2161,10 @@ _categorical_docs = dict(
              Thickness of error bar lines (and caps).\
          """),
     width=dedent("""\
-    width : float, optional
+    width : float, list, optional
         Width of a full element when not using hue nesting, or width of all the
-        elements for one level of the major grouping variable.\
+        elements for one level of the major grouping variable. If list, width
+        of each of the boxes for onle level of the major grouping variable.\
     """),
     dodge=dedent("""\
     dodge : bool, optional

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -1,4 +1,4 @@
-/from __future__ import division
+from __future__ import division
 from textwrap import dedent
 import colorsys
 import numpy as np

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -458,10 +458,11 @@ class _BoxPlotter(_CategoricalPlotter):
             props[obj] = kws.pop(obj + "props", {})
 
         if self.width and not np.isscalar(self.width):
-            # If width is an array-like structure, check the dimensions match.
+            # If width is an array-like structure, check the dimensions.
             if len(self.width) != len(self.plot_data):
-                raise ValueError("Length of `width` should be the same than the "
-                                 "categorical data.")
+                raise ValueError(
+                    "Length of `width` should be the same than the "
+                    "categorical data.")
 
         for i, group_data in enumerate(self.plot_data):
 


### PR DESCRIPTION
Support per-category width on boxplot. As discused on https://github.com/mwaskom/seaborn/issues/1668, this is done by passing an array of widths on the sns.boxplot(width) argument.

Please let me know if this makes sense. I can add further testing.