### PR TITLE
Add deprecation notice for sig_stars

### DIFF
--- a/seaborn/tests/test_utils.py
+++ b/seaborn/tests/test_utils.py
@@ -6,6 +6,7 @@ import numpy as np
 import pandas as pd
 import matplotlib as mpl
 import matplotlib.pyplot as plt
+import pytest
 import nose
 import nose.tools as nt
 from nose.tools import assert_equal, raises
@@ -105,22 +106,14 @@ def test_saturate():
     assert_equal(out, (1, 0, 0))
 
 
-def test_sig_stars():
+@pytest.mark.parametrize(
+    "p,annot", [(.0001, "***"), (.001, "**"), (.01, "*"), (.09, "."), (1, "")]
+)
+def test_sig_stars(p, annot):
     """Test the sig stars function."""
-    stars = utils.sig_stars(0.0001)
-    assert_equal(stars, "***")
-
-    stars = utils.sig_stars(0.001)
-    assert_equal(stars, "**")
-
-    stars = utils.sig_stars(0.01)
-    assert_equal(stars, "*")
-
-    stars = utils.sig_stars(0.09)
-    assert_equal(stars, ".")
-
-    stars = utils.sig_stars(1)
-    assert_equal(stars, "")
+    with pytest.warns(UserWarning):
+        stars = utils.sig_stars(p)
+        assert_equal(stars, annot)
 
 
 def test_iqr():

--- a/seaborn/utils.py
+++ b/seaborn/utils.py
@@ -10,6 +10,7 @@ import matplotlib as mpl
 import matplotlib.colors as mplcol
 import matplotlib.pyplot as plt
 
+import warnings
 from urllib.request import urlopen, urlretrieve
 from http.client import HTTPException
 
@@ -356,7 +357,13 @@ def ci(a, which=95, axis=None):
 
 
 def sig_stars(p):
-    """Return a R-style significance string corresponding to p values."""
+    """Return a R-style significance string corresponding to p values.
+
+    DEPRECATED: will be removed in a future version.
+
+    """
+    msg = "sig_stars is deprecated and will be removed in a future version."
+    warnings.warn(msg)
     if p < 0.001:
         return "***"
     elif p < 0.01:


### PR DESCRIPTION
This utility is leftover from a previously removed function and is a candidate for removal.