### PR TITLE
Make remaining links use https:// (issue #1984, follow-up to #1985)

### DIFF
--- a/doc/tutorial/color_palettes.ipynb
+++ b/doc/tutorial/color_palettes.ipynb
@@ -221,7 +221,7 @@
     "Using categorical Color Brewer palettes\n",
     "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n",
     "\n",
-    "Another source of visually pleasing categorical palettes comes from the `Color Brewer <http://colorbrewer2.org/>`_ tool (which also has sequential and diverging palettes, as we'll see below). These also exist as matplotlib colormaps, but they are not handled properly. In seaborn, when you ask for a qualitative Color Brewer palette, you'll always get the discrete colors, but this means that at a certain point they will begin to cycle.\n",
+    "Another source of visually pleasing categorical palettes comes from the `Color Brewer <https://colorbrewer2.org/>`_ tool (which also has sequential and diverging palettes, as we'll see below). These also exist as matplotlib colormaps, but they are not handled properly. In seaborn, when you ask for a qualitative Color Brewer palette, you'll always get the discrete colors, but this means that at a certain point they will begin to cycle.\n",
     "\n",
     "A nice feature of the Color Brewer website is that it provides some guidance on which palettes are color blind safe. There is a variety of `kinds <https://en.wikipedia.org/wiki/Color_blindness>`_ of color blindness, but the most common variant leads to difficulty distinguishing reds and greens. It's generally a good idea to avoid using red and green for plot elements that need to be discriminated based on color. [This comparison](https://gist.github.com/mwaskom/b35f6ebc2d4b340b4f64a4e28e778486) can be helpful to understand how the the seaborn color palettes perform for different type of colorblindess."
    ]


### PR DESCRIPTION
As a result of https://github.com/axismaps/colorbrewer/issues/28 URL https://colorbrewer2.org/ is working now :tada: so here's one last update regarding https. Best! :beers: 

Related to:
- issue #1984
- pull request #1985