### PR TITLE
Avoid error in despine when axis has matplotlib categories

### DIFF
--- a/doc/releases/v0.10.1.txt
+++ b/doc/releases/v0.10.1.txt
@@ -11,3 +11,5 @@ This is minor release with bug fixes issues in 0.10.0.
 - Fixed a bug where :func:`heatmap` would ignore user-specified under/over/bad values when recentering a colormap.
 
 - Fixed a bug where :func:`heatmap` would use values from masked cells when computing default colormap limits.
+
+- Fixed a bug where :func:`despine` would cause an error when trying to trim spines on a matplotlib categorical axis.

--- a/seaborn/tests/test_utils.py
+++ b/seaborn/tests/test_utils.py
@@ -211,6 +211,7 @@ class TestSpineUtils(object):
                                 self.original_position)
 
     def test_despine_trim_spines(self):
+
         f, ax = plt.subplots()
         ax.plot([1, 2, 3], [1, 2, 3])
         ax.set_xlim(.75, 3.25)
@@ -239,6 +240,19 @@ class TestSpineUtils(object):
         ax.set_yticks([])
         utils.despine(trim=True)
         nt.assert_equal(ax.get_yticks().size, 0)
+
+    def test_despine_trim_categorical(self):
+
+        f, ax = plt.subplots()
+        ax.plot(["a", "b", "c"], [1, 2, 3])
+
+        utils.despine(trim=True)
+
+        bounds = ax.spines["left"].get_bounds()
+        nt.assert_equal(bounds, (1, 3))
+
+        bounds = ax.spines["bottom"].get_bounds()
+        nt.assert_equal(bounds, (0, 2))
 
     def test_despine_moved_ticks(self):
 

--- a/seaborn/utils.py
+++ b/seaborn/utils.py
@@ -262,7 +262,7 @@ def despine(fig=None, ax=None, top=True, right=True, left=False,
 
         if trim:
             # clip off the parts of the spines that extend past major ticks
-            xticks = ax_i.get_xticks()
+            xticks = np.asarray(ax_i.get_xticks())
             if xticks.size:
                 firsttick = np.compress(xticks >= min(ax_i.get_xlim()),
                                         xticks)[0]
@@ -274,7 +274,7 @@ def despine(fig=None, ax=None, top=True, right=True, left=False,
                 newticks = newticks.compress(newticks >= firsttick)
                 ax_i.set_xticks(newticks)
 
-            yticks = ax_i.get_yticks()
+            yticks = np.asarray(ax_i.get_yticks())
             if yticks.size:
                 firsttick = np.compress(yticks >= min(ax_i.get_ylim()),
                                         yticks)[0]


### PR DESCRIPTION
Fixes #1978