### PR TITLE
output normalization for husl_to_rgb

### DIFF
--- a/seaborn/palettes.py
+++ b/seaborn/palettes.py
@@ -382,7 +382,7 @@ def husl_palette(n_colors=6, h=.01, s=.9, l=.65):  # noqa
     hues *= 359
     s *= 99
     l *= 99  # noqa
-    palette = [husl.husl_to_rgb(h_i, s, l) for h_i in hues]
+    palette = [_color_to_rgb((h_i, s, l), input='husl') for h_i in hues]
     return _ColorPalette(palette)
 
 
@@ -465,10 +465,18 @@ def mpl_palette(name, n_colors=6):
 
 def _color_to_rgb(color, input):
     """Add some more flexibility to color choices."""
+    def normalize(x):
+        if x > 1:
+            return 1
+        if x < 0:
+            return 0
+        return x
+
     if input == "hls":
         color = colorsys.hls_to_rgb(*color)
     elif input == "husl":
         color = husl.husl_to_rgb(*color)
+        color = tuple(map(normalize, color))
     elif input == "xkcd":
         color = xkcd_rgb[color]
     return color

--- a/seaborn/tests/test_palettes.py
+++ b/seaborn/tests/test_palettes.py
@@ -10,6 +10,7 @@ import matplotlib.pyplot as plt
 from .. import palettes, utils, rcmod
 from ..external import husl
 from ..colors import xkcd_rgb, crayons
+from random import randint
 
 
 class TestColorPalettes(object):
@@ -193,10 +194,21 @@ class TestColorPalettes(object):
 
     def test_rgb_from_husl(self):
 
-        color = 120, 50, 40
-        rgb_got = palettes._color_to_rgb(color, "husl")
-        rgb_want = husl.husl_to_rgb(*color)
-        nt.assert_equal(rgb_got, rgb_want)
+        colors = [
+            (120, 50, 40),
+            (randint(0, 360), randint(0, 100), 100),
+            (randint(0, 360), 100, randint(0, 100)),
+            (250, 100, 50)
+        ]
+
+        for color in colors:
+            rgb_got = palettes._color_to_rgb(color, "husl")
+            rgb_want = husl.husl_to_rgb(*color)
+
+            npt.assert_almost_equal(rgb_got, rgb_want, decimal=4)
+            for channel in rgb_got:
+                nt.assert_less_equal(channel, 1)
+                nt.assert_less_equal(0, channel)
 
     def test_rgb_from_xkcd(self):
 


### PR DESCRIPTION
This fix #1994. Note that I needed to add
```python
npt.assert_almost_equal(rgb_got, rgb_want, decimal=4)
```
in the tests with 4 decimal places because the library have poor precision, i.e.
```python
husl.husl_to_rgb(250, 100, 50)
>>> [1., 1.00004, 0.9999]
```

I emphasize that this is a good reason to consider #1995.