### PR TITLE
Fix `add_legend` to always populate `_legend`

### DIFF
--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -128,6 +128,7 @@ class Grid(object):
 
             leg = ax.legend(handles, labels, **kwargs)
             leg.set_title(title, prop={"size": title_size})
+            self._legend = leg
 
         return self
 


### PR DESCRIPTION
It gets populated when `legend_out` is `True`, but not when it is `False`.
This patch fixes this consistency problem.