### PR TITLE
ENH: Handle`legend.title_fontsize` rcparam

### DIFF
--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -1,6 +1,7 @@
 from itertools import product
 import warnings
 from textwrap import dedent
+from distutils.version import LooseVersion
 
 import numpy as np
 import pandas as pd
@@ -70,10 +71,13 @@ class Grid(object):
         blank_handle = mpl.patches.Patch(alpha=0, linewidth=0)
         handles = [legend_data.get(l, blank_handle) for l in label_order]
         title = self._hue_var if title is None else title
-        try:
-            title_size = mpl.rcParams["axes.labelsize"] * .85
-        except TypeError:  # labelsize is something like "large"
-            title_size = mpl.rcParams["axes.labelsize"]
+        if LooseVersion(mpl.__version__) < LooseVersion("3.0"):
+            try:
+                title_size = mpl.rcParams["axes.labelsize"] * .85
+            except TypeError:  # labelsize is something like "large"
+                title_size = mpl.rcParams["axes.labelsize"]
+        else:
+            title_size = mpl.rcParams["legend.title_fontsize"]
 
         # Unpack nested labels from a hierarchical legend
         labels = []

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -8,6 +8,7 @@ from matplotlib.collections import PatchCollection
 import matplotlib.patches as Patches
 import matplotlib.pyplot as plt
 import warnings
+from distutils.version import LooseVersion
 
 from . import utils
 from .utils import iqr, categorical_order, remove_na
@@ -405,15 +406,16 @@ class _CategoricalPlotter(object):
             ax.set_ylim(-.5, len(self.plot_data) - .5, auto=None)
 
         if self.hue_names is not None:
-            leg = ax.legend(loc="best")
+            leg = ax.legend(loc="best", title=self.hue_title)
             if self.hue_title is not None:
-                # Matplotlib rcParams does not expose legend title size?
-                try:
-                    title_size = mpl.rcParams["axes.labelsize"] * .85
-                except TypeError:  # labelsize is something like "large"
-                    title_size = mpl.rcParams["axes.labelsize"]
-                prop = mpl.font_manager.FontProperties(size=title_size)
-                leg.set_title(self.hue_title, prop=prop)
+                if LooseVersion(mpl.__version__) < "3.0":
+                    # Old Matplotlib has no legend title size rcparam
+                    try:
+                        title_size = mpl.rcParams["axes.labelsize"] * .85
+                    except TypeError:  # labelsize is something like "large"
+                        title_size = mpl.rcParams["axes.labelsize"]
+                    prop = mpl.font_manager.FontProperties(size=title_size)
+                    leg.set_title(self.hue_title, prop=prop)
 
     def add_legend_data(self, ax, color, label):
         """Add a dummy patch object so we can get legend data."""

--- a/seaborn/rcmod.py
+++ b/seaborn/rcmod.py
@@ -1,6 +1,7 @@
 """Control plot style and scaling using the matplotlib rcParams interface."""
 import warnings
 import functools
+from distutils.version import LooseVersion
 import matplotlib as mpl
 from cycler import cycler
 from . import palettes, _orig_rc_params
@@ -77,6 +78,9 @@ _context_keys = [
     "ytick.minor.size",
 
     ]
+
+if LooseVersion(mpl.__version__) >= "3.0":
+    _context_keys.append("legend.title_fontsize")
 
 
 def set(context="notebook", style="darkgrid", palette="deep",
@@ -404,6 +408,9 @@ def plotting_context(context=None, font_scale=1, rc=None):
             "ytick.minor.size": 4,
 
             }
+
+        if LooseVersion(mpl.__version__) >= "3.0":
+            base_context["legend.title_fontsize"] = 12
 
         # Scale all the parameters by the same factor depending on the context
         scaling = dict(paper=.8, notebook=1, talk=1.5, poster=2)[context]

--- a/seaborn/tests/test_categorical.py
+++ b/seaborn/tests/test_categorical.py
@@ -4,6 +4,7 @@ from scipy import stats, spatial
 import matplotlib as mpl
 import matplotlib.pyplot as plt
 from matplotlib.colors import rgb2hex
+from distutils.version import LooseVersion
 
 import pytest
 import nose.tools as nt
@@ -2866,11 +2867,6 @@ class TestBoxenPlotter(CategoricalFixture):
 
         plt.close("all")
 
-        with plt.rc_context(rc={"axes.labelsize": "large"}):
-            ax = cat.boxenplot("g", "y", "h", data=self.df)
-
-        plt.close("all")
-
         ax = cat.boxenplot("y", "g", data=self.df, orient="h")
         nt.assert_equal(ax.get_xlabel(), "y")
         nt.assert_equal(ax.get_ylabel(), "g")
@@ -2878,6 +2874,24 @@ class TestBoxenPlotter(CategoricalFixture):
         npt.assert_array_equal(ax.get_yticks(), [0, 1, 2])
         npt.assert_array_equal([l.get_text() for l in ax.get_yticklabels()],
                                ["a", "b", "c"])
+
+        plt.close("all")
+
+    @pytest.mark.parametrize("size", ["large", "medium", "small", 22, 12])
+    def test_legend_titlesize(self, size):
+
+        if LooseVersion(mpl.__version__) >= LooseVersion("3.0"):
+            rc_ctx = {"legend.title_fontsize": size}
+        else:  # Old matplotlib doesn't have legend.title_fontsize rcparam
+            rc_ctx = {"axes.labelsize": size}
+            if isinstance(size, int):
+                size = size * .85
+        exp = mpl.font_manager.FontProperties(size=size).get_size()
+
+        with plt.rc_context(rc=rc_ctx):
+            ax = cat.boxenplot("g", "y", "h", data=self.df)
+            obs = ax.get_legend().get_title().get_fontproperties().get_size()
+            assert obs == exp
 
         plt.close("all")
 


### PR DESCRIPTION
`legend.fontsize` rcparam is a part of seaborn context. However the legend title isn't, and the title font size is taken as 85% of `axes.labelsize` rcparam. `legend.title_fontsize` rcparam [has been added](https://github.com/matplotlib/matplotlib/pull/11172) in 
`matplotlib==3.0`. This PR incorporates `legend.title_fontsize` rcparam into seaborn, for both plotting functions and rcmod context (which was set to 12, one point above `legend.fontsize` which currently equals 11). 

The change, if accepted, affects categorical plots, `lmplot` and `pairplot` but not relational plots, as they currently use an empty handle to draw a title-like line. 