### PR TITLE
Avoid seeing an error from statsmodels in kdeplot when data IQR == 0

### DIFF
--- a/doc/releases/v0.10.1.txt
+++ b/doc/releases/v0.10.1.txt
@@ -18,6 +18,8 @@ This is minor release with bug fixes for issues identified since 0.10.0.
 
 - Added the ``showfliers`` parameter to :func:`boxenplot` to suppress plotting of outlier data points, matching the API of :func:`boxplot`.
 
+- Avoided seeing an error from statmodels when data with an IQR of 0 is passed to :func:`kdeplot`.
+
 - Added the ``legend.title_fontsize`` to the :func:`plotting_context` definition.
 
 - Several utility functions that are no longer used internally (``percentiles``, ``sig_stars``, ``pmf_hist``, and ``sort_df``) have been deprecated and marked for future removal.

--- a/seaborn/distributions.py
+++ b/seaborn/distributions.py
@@ -359,7 +359,16 @@ def _statsmodels_univariate_kde(data, kernel, bw, gridsize, cut, clip,
     """Compute a univariate kernel density estimate using statsmodels."""
     fft = kernel == "gau"
     kde = smnp.KDEUnivariate(data)
-    kde.fit(kernel, bw, fft, gridsize=gridsize, cut=cut, clip=clip)
+
+    try:
+        kde.fit(kernel, bw, fft, gridsize=gridsize, cut=cut, clip=clip)
+    except RuntimeError as err:  # GH#1990
+        if stats.iqr(data) > 0:
+            raise err
+        msg = "Default bandwidth for data is 0; skipping density estimation."
+        warnings.warn(msg, UserWarning)
+        return np.array([]), np.array([])
+
     if cumulative:
         grid, y = kde.support, kde.cdf
     else:

--- a/seaborn/distributions.py
+++ b/seaborn/distributions.py
@@ -378,14 +378,7 @@ def _statsmodels_univariate_kde(data, kernel, bw, gridsize, cut, clip,
 
 def _scipy_univariate_kde(data, bw, gridsize, cut, clip):
     """Compute a univariate kernel density estimate using scipy."""
-    try:
-        kde = stats.gaussian_kde(data, bw_method=bw)
-    except TypeError:
-        kde = stats.gaussian_kde(data)
-        if bw != "scott":  # scipy default
-            msg = ("Ignoring bandwidth choice, "
-                   "please upgrade scipy to use a different bandwidth.")
-            warnings.warn(msg, UserWarning)
+    kde = stats.gaussian_kde(data, bw_method=bw)
     if isinstance(bw, str):
         bw = "scotts" if bw == "scott" else bw
         bw = getattr(kde, "%s_factor" % bw)() * np.std(data)


### PR DESCRIPTION
Fixes #1990
Related to https://github.com/statsmodels/statsmodels/issues/5419

This PR takes the same approach to making kdeplot robust to statistical corner cases as when the variance of the data is 0.

The current behavior is to warn and plot an empty line only when statsmodels raises a `RuntimeError` *and* the IQR of the data is 0. Therefore, we shouldn't ignore other unrelated `RuntimeError` instances, and if the statsmodels behavior changes in the future not to throw an error, the code won't take this path. The test for this behavior tries to anticipate a change in statsmodels by asserting that a warning appears only when the statsmodels bandwidth selection raises.

This PR also removes a conditional that added compatibility for an older, no-longer supported version of scipy.