### PR TITLE
Make FacetGrid a bit more convenient

### DIFF
--- a/doc/releases/v0.11.0.txt
+++ b/doc/releases/v0.11.0.txt
@@ -3,3 +3,7 @@ v0.11.0 (Unreleased)
 --------------------
 
 - Added an explicit warning in :func:`swarmplot` when more than 2% of the points are overlap in the "gutters" of the swarm.
+
+- Added the ``axes_dict`` attribute to :class:`FacetGrid` for named access to the component axes.
+
+- Made :meth:`FacetGrid.set_axis_labels` clear labels from "interior" axes.

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -886,30 +886,37 @@ class FacetGrid(Grid):
         utils.despine(self.fig, **kwargs)
         return self
 
-    def set_axis_labels(self, x_var=None, y_var=None):
+    def set_axis_labels(self, x_var=None, y_var=None, clear_inner=True):
         """Set axis labels on the left column and bottom row of the grid."""
         if x_var is not None:
             self._x_var = x_var
-            self.set_xlabels(x_var)
+            self.set_xlabels(x_var, clear_inner=clear_inner)
         if y_var is not None:
             self._y_var = y_var
-            self.set_ylabels(y_var)
+            self.set_ylabels(y_var, clear_inner=clear_inner)
+
         return self
 
-    def set_xlabels(self, label=None, **kwargs):
+    def set_xlabels(self, label=None, clear_inner=True, **kwargs):
         """Label the x axis on the bottom row of the grid."""
         if label is None:
             label = self._x_var
         for ax in self._bottom_axes:
             ax.set_xlabel(label, **kwargs)
+        if clear_inner:
+            for ax in self._not_bottom_axes:
+                ax.set_xlabel("")
         return self
 
-    def set_ylabels(self, label=None, **kwargs):
+    def set_ylabels(self, label=None, clear_inner=True, **kwargs):
         """Label the y axis on the left column of the grid."""
         if label is None:
             label = self._y_var
         for ax in self._left_axes:
             ax.set_ylabel(label, **kwargs)
+        if clear_inner:
+            for ax in self._not_left_axes:
+                ax.set_ylabel("")
         return self
 
     def set_xticklabels(self, labels=None, step=None, **kwargs):

--- a/seaborn/tests/test_axisgrid.py
+++ b/seaborn/tests/test_axisgrid.py
@@ -521,6 +521,15 @@ class TestFacetGrid(object):
         npt.assert_array_equal(got_x, xlab)
         npt.assert_array_equal(got_y, ylab)
 
+        for ax in g.axes.flat:
+            ax.set(xlabel="x", ylabel="y")
+
+        g.set_axis_labels(xlab, ylab)
+        for ax in g._not_bottom_axes:
+            assert not ax.get_xlabel()
+        for ax in g._not_left_axes:
+            assert not ax.get_ylabel()
+
     def test_axis_lims(self):
 
         g = ag.FacetGrid(self.df, row="a", col="b", xlim=(0, 4), ylim=(-2, 3))

--- a/seaborn/tests/test_axisgrid.py
+++ b/seaborn/tests/test_axisgrid.py
@@ -158,6 +158,33 @@ class TestFacetGrid(object):
         npt.assert_array_equal(g._not_left_axes, g.axes[np.array([1])].flat)
         npt.assert_array_equal(g._inner_axes, null)
 
+    def test_axes_dict(self):
+
+        g = ag.FacetGrid(self.df)
+        assert isinstance(g.axes_dict, dict)
+        assert not g.axes_dict
+
+        g = ag.FacetGrid(self.df, row="c")
+        assert list(g.axes_dict.keys()) == g.row_names
+        for (name, ax) in zip(g.row_names, g.axes.flat):
+            assert g.axes_dict[name] is ax
+
+        g = ag.FacetGrid(self.df, col="c")
+        assert list(g.axes_dict.keys()) == g.col_names
+        for (name, ax) in zip(g.col_names, g.axes.flat):
+            assert g.axes_dict[name] is ax
+
+        g = ag.FacetGrid(self.df, col="a", col_wrap=2)
+        assert list(g.axes_dict.keys()) == g.col_names
+        for (name, ax) in zip(g.col_names, g.axes.flat):
+            assert g.axes_dict[name] is ax
+
+        g = ag.FacetGrid(self.df, row="a", col="c")
+        for (row_var, col_var), ax in g.axes_dict.items():
+            i = g.row_names.index(row_var)
+            j = g.col_names.index(col_var)
+            assert g.axes[i, j] is ax
+
     def test_figure_size(self):
 
         g = ag.FacetGrid(self.df, row="a", col="b")


### PR DESCRIPTION
- Add the `FacetGrid.axes_dict` attribute which allows name access to the axes.
- Calling `FacetGrid.set_axis_labels` will turn off the labels on the interior of the grid in addition to setting the ones on the exterior.