### PR TITLE
Disable autoscaling on categorical axes. Closes #2049

### DIFF
--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -400,10 +400,10 @@ class _CategoricalPlotter(object):
 
         if self.orient == "v":
             ax.xaxis.grid(False)
-            ax.set_xlim(-.5, len(self.plot_data) - .5, auto=None)
+            ax.set_xlim(-.5, len(self.plot_data) - .5, auto=False)
         else:
             ax.yaxis.grid(False)
-            ax.set_ylim(-.5, len(self.plot_data) - .5, auto=None)
+            ax.set_ylim(-.5, len(self.plot_data) - .5, auto=False)
 
         if self.hue_names is not None:
             leg = ax.legend(loc="best", title=self.hue_title)


### PR DESCRIPTION
As discussed in issue. 

This PR changes the `auto=None` to `auto=False` in the set_{x,y}lim calls for the stripplot. This will prevent matplotlib rescaling the image to limits that just contain data, but instead will not rescale and keep the provided limits. 

Previously `auto=None` did not rescale as well, but this changed in matplotlib version 3.2.2. As this might be considered a bug this is possible reverted in next releases. See matplotlib/matplotlib#17331