### PR TITLE
Require keyword arguments for most parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,6 @@ seaborn.egg-info/
 .cache/
 .coverage
 cover/
-.idea
+.idea/
+.vscode/
 .pytest_cache/

--- a/doc/releases/v0.11.0.txt
+++ b/doc/releases/v0.11.0.txt
@@ -2,6 +2,8 @@
 v0.11.0 (Unreleased)
 --------------------
 
+- Enforced keyword-only arguments for most parameters of most functions and classes.
+
 - Added an explicit warning in :func:`swarmplot` when more than 2% of the points are overlap in the "gutters" of the swarm.
 
 - Added the ``axes_dict`` attribute to :class:`FacetGrid` for named access to the component axes.

--- a/seaborn/_decorators.py
+++ b/seaborn/_decorators.py
@@ -1,0 +1,46 @@
+from inspect import signature, Parameter
+from functools import wraps
+import warnings
+
+
+# This function was adapted from scikit-learn
+# github.com/scikit-learn/scikit-learn/blob/master/sklearn/utils/validation.py
+def _deprecate_positional_args(f):
+    """Decorator for methods that issues warnings for positional arguments.
+
+    Using the keyword-only argument syntax in pep 3102, arguments after the
+    * will issue a warning when passed as a positional argument.
+
+    Parameters
+    ----------
+    f : function
+        function to check arguments on
+
+    """
+    sig = signature(f)
+    kwonly_args = []
+    all_args = []
+
+    for name, param in sig.parameters.items():
+        if param.kind == Parameter.POSITIONAL_OR_KEYWORD:
+            all_args.append(name)
+        elif param.kind == Parameter.KEYWORD_ONLY:
+            kwonly_args.append(name)
+
+    @wraps(f)
+    def inner_f(*args, **kwargs):
+        extra_args = len(args) - len(all_args)
+        if extra_args > 0:
+            # ignore first 'self' argument for instance methods
+            args_msg = ['{}={}'.format(name, arg)
+                        for name, arg in zip(kwonly_args[:extra_args],
+                                             args[-extra_args:])]
+            plural = "s" if len(args_msg) > 1 else ""
+            warnings.warn("Pass {} as keyword arg{}. From version 0.12, "
+                          "passing these as positional arguments will "
+                          "result in an error"
+                          .format(", ".join(args_msg), plural),
+                          FutureWarning)
+        kwargs.update({k: arg for k, arg in zip(sig.parameters, args)})
+        return f(**kwargs)
+    return inner_f

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -10,6 +10,7 @@ import matplotlib as mpl
 import matplotlib.pyplot as plt
 
 from . import utils
+from .utils import _deprecate_positional_args
 from .palettes import color_palette, blend_palette
 from .distributions import distplot, kdeplot,  _freedman_diaconis_bins
 
@@ -1919,6 +1920,7 @@ class JointGrid(object):
         self.fig.savefig(*args, **kwargs)
 
 
+@_deprecate_positional_args
 def pairplot(
     data,
     *,
@@ -2156,6 +2158,7 @@ def pairplot(
     return grid
 
 
+@_deprecate_positional_args
 def jointplot(
     x=None, y=None,
     *, data=None,

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -1921,6 +1921,7 @@ class JointGrid(object):
 
 def pairplot(
     data,
+    *,
     hue=None, hue_order=None, palette=None,
     vars=None, x_vars=None, y_vars=None,
     kind="scatter", diag_kind="auto", markers=None,
@@ -2156,7 +2157,7 @@ def pairplot(
 
 
 def jointplot(
-    x, y,
+    x=None, y=None,
     *, data=None,
     kind="scatter", stat_func=None,
     color=None, height=6, ratio=5, space=.2,

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -1919,11 +1919,14 @@ class JointGrid(object):
         self.fig.savefig(*args, **kwargs)
 
 
-def pairplot(data, hue=None, hue_order=None, palette=None,
-             vars=None, x_vars=None, y_vars=None,
-             kind="scatter", diag_kind="auto", markers=None,
-             height=2.5, aspect=1, corner=False, dropna=True,
-             plot_kws=None, diag_kws=None, grid_kws=None, size=None):
+def pairplot(
+    data,
+    hue=None, hue_order=None, palette=None,
+    vars=None, x_vars=None, y_vars=None,
+    kind="scatter", diag_kind="auto", markers=None,
+    height=2.5, aspect=1, corner=False, dropna=True,
+    plot_kws=None, diag_kws=None, grid_kws=None, size=None,
+):
     """Plot pairwise relationships in a dataset.
 
     By default, this function will create a grid of Axes such that each numeric
@@ -2152,10 +2155,15 @@ def pairplot(data, hue=None, hue_order=None, palette=None,
     return grid
 
 
-def jointplot(x, y, data=None, kind="scatter", stat_func=None,
-              color=None, height=6, ratio=5, space=.2,
-              dropna=True, xlim=None, ylim=None,
-              joint_kws=None, marginal_kws=None, annot_kws=None, **kwargs):
+def jointplot(
+    x, y,
+    *, data=None,
+    kind="scatter", stat_func=None,
+    color=None, height=6, ratio=5, space=.2,
+    dropna=True, xlim=None, ylim=None,
+    joint_kws=None, marginal_kws=None, annot_kws=None,
+    **kwargs
+):
     """Draw a plot of two variables with bivariate and univariate graphs.
 
     This function provides a convenient interface to the :class:`JointGrid`

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -10,9 +10,9 @@ import matplotlib as mpl
 import matplotlib.pyplot as plt
 
 from . import utils
-from .utils import _deprecate_positional_args
 from .palettes import color_palette, blend_palette
 from .distributions import distplot, kdeplot,  _freedman_diaconis_bins
+from ._decorators import _deprecate_positional_args
 
 
 __all__ = ["FacetGrid", "PairGrid", "JointGrid", "pairplot", "jointplot"]

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -229,12 +229,16 @@ _facet_docs = dict(
 
 class FacetGrid(Grid):
     """Multi-plot grid for plotting conditional relationships."""
-    def __init__(self, data, row=None, col=None, hue=None, col_wrap=None,
-                 sharex=True, sharey=True, height=3, aspect=1, palette=None,
-                 row_order=None, col_order=None, hue_order=None, hue_kws=None,
-                 dropna=True, legend_out=True, despine=True,
-                 margin_titles=False, xlim=None, ylim=None, subplot_kws=None,
-                 gridspec_kws=None, size=None):
+    @_deprecate_positional_args
+    def __init__(
+        self, data, *,
+        row=None, col=None, hue=None, col_wrap=None,
+        sharex=True, sharey=True, height=3, aspect=1, palette=None,
+        row_order=None, col_order=None, hue_order=None, hue_kws=None,
+        dropna=True, legend_out=True, despine=True,
+        margin_titles=False, xlim=None, ylim=None, subplot_kws=None,
+        gridspec_kws=None, size=None
+    ):
 
         # Handle deprecations
         if size is not None:
@@ -1127,11 +1131,14 @@ class PairGrid(Grid):
     See the :ref:`tutorial <grid_tutorial>` for more information.
 
     """
-
-    def __init__(self, data, hue=None, hue_order=None, palette=None,
-                 hue_kws=None, vars=None, x_vars=None, y_vars=None,
-                 corner=False, diag_sharey=True, height=2.5, aspect=1,
-                 layout_pad=0, despine=True, dropna=True, size=None):
+    @_deprecate_positional_args
+    def __init__(
+        self, data, *,
+        hue=None, hue_order=None, palette=None,
+        hue_kws=None, vars=None, x_vars=None, y_vars=None,
+        corner=False, diag_sharey=True, height=2.5, aspect=1,
+        layout_pad=0, despine=True, dropna=True, size=None
+    ):
         """Initialize the plot figure and PairGrid object.
 
         Parameters
@@ -1577,8 +1584,13 @@ class PairGrid(Grid):
 class JointGrid(object):
     """Grid for drawing a bivariate plot with marginal univariate plots."""
 
-    def __init__(self, x, y, data=None, height=6, ratio=5, space=.2,
-                 dropna=True, xlim=None, ylim=None, size=None):
+    @_deprecate_positional_args
+    def __init__(
+        self, x, y, *,
+        data=None,
+        height=6, ratio=5, space=.2,
+        dropna=True, xlim=None, ylim=None, size=None
+    ):
         """Set up the grid of subplots.
 
         Parameters
@@ -1922,8 +1934,7 @@ class JointGrid(object):
 
 @_deprecate_positional_args
 def pairplot(
-    data,
-    *,
+    data, *,
     hue=None, hue_order=None, palette=None,
     vars=None, x_vars=None, y_vars=None,
     kind="scatter", diag_kind="auto", markers=None,
@@ -2160,8 +2171,8 @@ def pairplot(
 
 @_deprecate_positional_args
 def jointplot(
-    x=None, y=None,
-    *, data=None,
+    x=None, y=None, *,
+    data=None,
     kind="scatter", stat_func=None,
     color=None, height=6, ratio=5, space=.2,
     dropna=True, xlim=None, ylim=None,

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -2321,9 +2321,11 @@ def jointplot(
     cmap = blend_palette(colors, as_cmap=True)
 
     # Initialize the JointGrid object
-    grid = JointGrid(x, y, data, dropna=dropna,
-                     height=height, ratio=ratio, space=space,
-                     xlim=xlim, ylim=ylim)
+    grid = JointGrid(
+        x, y, data=data,
+        dropna=dropna, height=height, ratio=ratio, space=space,
+        xlim=xlim, ylim=ylim
+    )
 
     # Plot the data using the grid
     if kind == "scatter":

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -11,7 +11,8 @@ import warnings
 from distutils.version import LooseVersion
 
 from . import utils
-from .utils import iqr, categorical_order, remove_na
+from .utils import (iqr, categorical_order, remove_na,
+                    _deprecate_positional_args)
 from .algorithms import bootstrap
 from .palettes import color_palette, husl_palette, light_palette, dark_palette
 from .axisgrid import FacetGrid, _facet_docs
@@ -2234,6 +2235,7 @@ _categorical_docs = dict(
 _categorical_docs.update(_facet_docs)
 
 
+@_deprecate_positional_args
 def boxplot(
     x=None, y=None, hue=None,
     *, data=None,
@@ -2389,6 +2391,7 @@ boxplot.__doc__ = dedent("""\
     """).format(**_categorical_docs)
 
 
+@_deprecate_positional_args
 def violinplot(
     x=None, y=None, hue=None,
     *, data=None,
@@ -2633,6 +2636,7 @@ def lvplot(*args, **kwargs):
     return boxenplot(*args, **kwargs)
 
 
+@_deprecate_positional_args
 def boxenplot(
     x=None, y=None, hue=None,
     *, data=None,
@@ -2793,6 +2797,7 @@ boxenplot.__doc__ = dedent("""\
     """).format(**_categorical_docs)
 
 
+@_deprecate_positional_args
 def stripplot(
     x=None, y=None, hue=None,
     *, data=None,
@@ -2988,6 +2993,7 @@ stripplot.__doc__ = dedent("""\
     """).format(**_categorical_docs)
 
 
+@_deprecate_positional_args
 def swarmplot(
     x=None, y=None, hue=None,
     *, data=None,
@@ -3167,6 +3173,7 @@ swarmplot.__doc__ = dedent("""\
     """).format(**_categorical_docs)
 
 
+@_deprecate_positional_args
 def barplot(
     x=None, y=None, hue=None,
     *, data=None,
@@ -3358,6 +3365,7 @@ barplot.__doc__ = dedent("""\
     """).format(**_categorical_docs)
 
 
+@_deprecate_positional_args
 def pointplot(
     x=None, y=None, hue=None,
     *, data=None,
@@ -3564,6 +3572,7 @@ pointplot.__doc__ = dedent("""\
     """).format(**_categorical_docs)
 
 
+@_deprecate_positional_args
 def countplot(
     x=None, y=None, hue=None,
     *, data=None,
@@ -3722,6 +3731,7 @@ def factorplot(*args, **kwargs):
     return catplot(*args, **kwargs)
 
 
+@_deprecate_positional_args
 def catplot(
     x=None, y=None, hue=None,
     *, data=None,

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -2234,10 +2234,14 @@ _categorical_docs = dict(
 _categorical_docs.update(_facet_docs)
 
 
-def boxplot(x=None, y=None, hue=None, data=None, order=None, hue_order=None,
-            orient=None, color=None, palette=None, saturation=.75,
-            width=.8, dodge=True, fliersize=5, linewidth=None,
-            whis=1.5, ax=None, **kwargs):
+def boxplot(
+    x=None, y=None, hue=None,
+    *, data=None, order=None, hue_order=None,
+    orient=None, color=None, palette=None, saturation=.75,
+    width=.8, dodge=True, fliersize=5, linewidth=None,
+    whis=1.5, ax=None,
+    **kwargs
+):
 
     plotter = _BoxPlotter(x, y, hue, data, order, hue_order,
                           orient, color, palette, saturation,
@@ -2384,11 +2388,15 @@ boxplot.__doc__ = dedent("""\
     """).format(**_categorical_docs)
 
 
-def violinplot(x=None, y=None, hue=None, data=None, order=None, hue_order=None,
-               bw="scott", cut=2, scale="area", scale_hue=True, gridsize=100,
-               width=.8, inner="box", split=False, dodge=True, orient=None,
-               linewidth=None, color=None, palette=None, saturation=.75,
-               ax=None, **kwargs):
+def violinplot(
+    x=None, y=None, hue=None,
+    *, data=None,
+    order=None, hue_order=None,
+    bw="scott", cut=2, scale="area", scale_hue=True, gridsize=100,
+    width=.8, inner="box", split=False, dodge=True, orient=None,
+    linewidth=None, color=None, palette=None, saturation=.75,
+    ax=None, **kwargs,
+):
 
     plotter = _ViolinPlotter(x, y, hue, data, order, hue_order,
                              bw, cut, scale, scale_hue, gridsize,
@@ -2624,11 +2632,15 @@ def lvplot(*args, **kwargs):
     return boxenplot(*args, **kwargs)
 
 
-def boxenplot(x=None, y=None, hue=None, data=None, order=None, hue_order=None,
-              orient=None, color=None, palette=None, saturation=.75,
-              width=.8, dodge=True, k_depth='proportion', linewidth=None,
-              scale='exponential', outlier_prop=None, showfliers=True, ax=None,
-              **kwargs):
+def boxenplot(
+    x=None, y=None, hue=None,
+    *, data=None,
+    order=None, hue_order=None,
+    orient=None, color=None, palette=None, saturation=.75,
+    width=.8, dodge=True, k_depth='proportion', linewidth=None,
+    scale='exponential', outlier_prop=None, showfliers=True, ax=None,
+    **kwargs
+):
 
     plotter = _LVPlotter(x, y, hue, data, order, hue_order,
                          orient, color, palette, saturation,
@@ -2780,9 +2792,14 @@ boxenplot.__doc__ = dedent("""\
     """).format(**_categorical_docs)
 
 
-def stripplot(x=None, y=None, hue=None, data=None, order=None, hue_order=None,
-              jitter=True, dodge=False, orient=None, color=None, palette=None,
-              size=5, edgecolor="gray", linewidth=0, ax=None, **kwargs):
+def stripplot(
+    x=None, y=None, hue=None,
+    *, data=None,
+    order=None, hue_order=None,
+    jitter=True, dodge=False, orient=None, color=None, palette=None,
+    size=5, edgecolor="gray", linewidth=0, ax=None,
+    **kwargs
+):
 
     if "split" in kwargs:
         dodge = kwargs.pop("split")
@@ -2970,9 +2987,14 @@ stripplot.__doc__ = dedent("""\
     """).format(**_categorical_docs)
 
 
-def swarmplot(x=None, y=None, hue=None, data=None, order=None, hue_order=None,
-              dodge=False, orient=None, color=None, palette=None,
-              size=5, edgecolor="gray", linewidth=0, ax=None, **kwargs):
+def swarmplot(
+    x=None, y=None, hue=None,
+    *, data=None,
+    order=None, hue_order=None,
+    dodge=False, orient=None, color=None, palette=None,
+    size=5, edgecolor="gray", linewidth=0, ax=None,
+    **kwargs
+):
 
     if "split" in kwargs:
         dodge = kwargs.pop("split")
@@ -3144,11 +3166,16 @@ swarmplot.__doc__ = dedent("""\
     """).format(**_categorical_docs)
 
 
-def barplot(x=None, y=None, hue=None, data=None, order=None, hue_order=None,
-            estimator=np.mean, ci=95, n_boot=1000, units=None, seed=None,
-            orient=None, color=None, palette=None, saturation=.75,
-            errcolor=".26", errwidth=None, capsize=None, dodge=True,
-            ax=None, **kwargs):
+def barplot(
+    x=None, y=None, hue=None,
+    *, data=None,
+    order=None, hue_order=None,
+    estimator=np.mean, ci=95, n_boot=1000, units=None, seed=None,
+    orient=None, color=None, palette=None, saturation=.75,
+    errcolor=".26", errwidth=None, capsize=None, dodge=True,
+    ax=None,
+    **kwargs,
+):
 
     plotter = _BarPlotter(x, y, hue, data, order, hue_order,
                           estimator, ci, n_boot, units, seed,
@@ -3330,11 +3357,16 @@ barplot.__doc__ = dedent("""\
     """).format(**_categorical_docs)
 
 
-def pointplot(x=None, y=None, hue=None, data=None, order=None, hue_order=None,
-              estimator=np.mean, ci=95, n_boot=1000, units=None, seed=None,
-              markers="o", linestyles="-", dodge=False, join=True, scale=1,
-              orient=None, color=None, palette=None, errwidth=None,
-              capsize=None, ax=None, **kwargs):
+def pointplot(
+    x=None, y=None, hue=None,
+    *, data=None,
+    order=None, hue_order=None,
+    estimator=np.mean, ci=95, n_boot=1000, units=None, seed=None,
+    markers="o", linestyles="-", dodge=False, join=True, scale=1,
+    orient=None, color=None, palette=None, errwidth=None,
+    capsize=None, ax=None,
+    **kwargs
+):
 
     plotter = _PointPlotter(x, y, hue, data, order, hue_order,
                             estimator, ci, n_boot, units, seed,
@@ -3531,9 +3563,13 @@ pointplot.__doc__ = dedent("""\
     """).format(**_categorical_docs)
 
 
-def countplot(x=None, y=None, hue=None, data=None, order=None, hue_order=None,
-              orient=None, color=None, palette=None, saturation=.75,
-              dodge=True, ax=None, **kwargs):
+def countplot(
+    x=None, y=None, hue=None,
+    *, data=None,
+    order=None, hue_order=None,
+    orient=None, color=None, palette=None, saturation=.75,
+    dodge=True, ax=None, **kwargs
+):
 
     estimator = len
     ci = None
@@ -3685,13 +3721,18 @@ def factorplot(*args, **kwargs):
     return catplot(*args, **kwargs)
 
 
-def catplot(x=None, y=None, hue=None, data=None, row=None, col=None,
-            col_wrap=None, estimator=np.mean, ci=95, n_boot=1000,
-            units=None, seed=None, order=None, hue_order=None, row_order=None,
-            col_order=None, kind="strip", height=5, aspect=1,
-            orient=None, color=None, palette=None,
-            legend=True, legend_out=True, sharex=True, sharey=True,
-            margin_titles=False, facet_kws=None, **kwargs):
+def catplot(
+    x=None, y=None, hue=None,
+    *, data=None,
+    row=None, col=None,
+    col_wrap=None, estimator=np.mean, ci=95, n_boot=1000,
+    units=None, seed=None, order=None, hue_order=None, row_order=None,
+    col_order=None, kind="strip", height=5, aspect=1,
+    orient=None, color=None, palette=None,
+    legend=True, legend_out=True, sharex=True, sharey=True,
+    margin_titles=False, facet_kws=None,
+    **kwargs
+):
 
     # Handle deprecations
     if "size" in kwargs:

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -2236,7 +2236,8 @@ _categorical_docs.update(_facet_docs)
 
 def boxplot(
     x=None, y=None, hue=None,
-    *, data=None, order=None, hue_order=None,
+    *, data=None,
+    order=None, hue_order=None,
     orient=None, color=None, palette=None, saturation=.75,
     width=.8, dodge=True, fliersize=5, linewidth=None,
     whis=1.5, ax=None,

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -11,11 +11,11 @@ import warnings
 from distutils.version import LooseVersion
 
 from . import utils
-from .utils import (iqr, categorical_order, remove_na,
-                    _deprecate_positional_args)
+from .utils import iqr, categorical_order, remove_na
 from .algorithms import bootstrap
 from .palettes import color_palette, husl_palette, light_palette, dark_palette
 from .axisgrid import FacetGrid, _facet_docs
+from ._decorators import _deprecate_positional_args
 
 
 __all__ = [

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -2237,8 +2237,8 @@ _categorical_docs.update(_facet_docs)
 
 @_deprecate_positional_args
 def boxplot(
-    x=None, y=None, hue=None,
-    *, data=None,
+    x=None, y=None, *,
+    hue=None, data=None,
     order=None, hue_order=None,
     orient=None, color=None, palette=None, saturation=.75,
     width=.8, dodge=True, fliersize=5, linewidth=None,
@@ -2393,8 +2393,8 @@ boxplot.__doc__ = dedent("""\
 
 @_deprecate_positional_args
 def violinplot(
-    x=None, y=None, hue=None,
-    *, data=None,
+    x=None, y=None, *,
+    hue=None, data=None,
     order=None, hue_order=None,
     bw="scott", cut=2, scale="area", scale_hue=True, gridsize=100,
     width=.8, inner="box", split=False, dodge=True, orient=None,
@@ -2638,8 +2638,8 @@ def lvplot(*args, **kwargs):
 
 @_deprecate_positional_args
 def boxenplot(
-    x=None, y=None, hue=None,
-    *, data=None,
+    x=None, y=None, *,
+    hue=None, data=None,
     order=None, hue_order=None,
     orient=None, color=None, palette=None, saturation=.75,
     width=.8, dodge=True, k_depth='proportion', linewidth=None,
@@ -2799,8 +2799,8 @@ boxenplot.__doc__ = dedent("""\
 
 @_deprecate_positional_args
 def stripplot(
-    x=None, y=None, hue=None,
-    *, data=None,
+    x=None, y=None, *,
+    hue=None, data=None,
     order=None, hue_order=None,
     jitter=True, dodge=False, orient=None, color=None, palette=None,
     size=5, edgecolor="gray", linewidth=0, ax=None,
@@ -2995,8 +2995,8 @@ stripplot.__doc__ = dedent("""\
 
 @_deprecate_positional_args
 def swarmplot(
-    x=None, y=None, hue=None,
-    *, data=None,
+    x=None, y=None, *,
+    hue=None, data=None,
     order=None, hue_order=None,
     dodge=False, orient=None, color=None, palette=None,
     size=5, edgecolor="gray", linewidth=0, ax=None,
@@ -3175,8 +3175,8 @@ swarmplot.__doc__ = dedent("""\
 
 @_deprecate_positional_args
 def barplot(
-    x=None, y=None, hue=None,
-    *, data=None,
+    x=None, y=None, *,
+    hue=None, data=None,
     order=None, hue_order=None,
     estimator=np.mean, ci=95, n_boot=1000, units=None, seed=None,
     orient=None, color=None, palette=None, saturation=.75,
@@ -3367,8 +3367,8 @@ barplot.__doc__ = dedent("""\
 
 @_deprecate_positional_args
 def pointplot(
-    x=None, y=None, hue=None,
-    *, data=None,
+    x=None, y=None, *,
+    hue=None, data=None,
     order=None, hue_order=None,
     estimator=np.mean, ci=95, n_boot=1000, units=None, seed=None,
     markers="o", linestyles="-", dodge=False, join=True, scale=1,
@@ -3574,8 +3574,8 @@ pointplot.__doc__ = dedent("""\
 
 @_deprecate_positional_args
 def countplot(
-    x=None, y=None, hue=None,
-    *, data=None,
+    x=None, y=None, *,
+    hue=None, data=None,
     order=None, hue_order=None,
     orient=None, color=None, palette=None, saturation=.75,
     dodge=True, ax=None, **kwargs
@@ -3733,9 +3733,9 @@ def factorplot(*args, **kwargs):
 
 @_deprecate_positional_args
 def catplot(
-    x=None, y=None, hue=None,
-    *, data=None,
-    row=None, col=None,
+    x=None, y=None, *,
+    hue=None, data=None,
+    row=None, col=None,  # TODO move in front of data when * is enforced
     col_wrap=None, estimator=np.mean, ci=95, n_boot=1000,
     units=None, seed=None, order=None, hue_order=None, row_order=None,
     col_order=None, kind="strip", height=5, aspect=1,

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -2955,8 +2955,8 @@ stripplot.__doc__ = dedent("""\
     .. plot::
         :context: close-figs
 
-        >>> ax =  sns.stripplot("day", "total_bill", "smoker", data=tips,
-        ...                    palette="Set2", size=20, marker="D",
+        >>> ax =  sns.stripplot(x="day", y="total_bill", hue="smoker",
+        ...                    data=tips, palette="Set2", size=20, marker="D",
         ...                    edgecolor="gray", alpha=.25)
 
     Draw strips of observations on top of a box plot:
@@ -3820,7 +3820,7 @@ def catplot(
     g = FacetGrid(**facet_kws)
 
     # Draw the plot onto the facets
-    g.map_dataframe(plot_func, x, y, hue, **plot_kws)
+    g.map_dataframe(plot_func, x, y, hue=hue, **plot_kws)
 
     # Special case axis labels for a count type plot
     if kind == "count":

--- a/seaborn/distributions.py
+++ b/seaborn/distributions.py
@@ -505,8 +505,8 @@ def _scipy_bivariate_kde(x, y, bw, gridsize, cut, clip):
 
 
 def kdeplot(
-    data, *,
-    data2=None, shade=False, vertical=False, kernel="gau",
+    data, data2=None,
+    *, shade=False, vertical=False, kernel="gau",
     bw="scott", gridsize=100, cut=3, clip=None, legend=True,
     cumulative=False, shade_lowest=True, cbar=False, cbar_ax=None,
     cbar_kws=None, ax=None,

--- a/seaborn/distributions.py
+++ b/seaborn/distributions.py
@@ -36,7 +36,8 @@ def _freedman_diaconis_bins(a):
 
 
 def distplot(
-    a, *,
+    a,
+    *,
     bins=None, hist=True, kde=True, rug=False, fit=None,
     hist_kws=None, kde_kws=None, rug_kws=None, fit_kws=None,
     color=None, vertical=False, norm_hist=False, axlabel=None,
@@ -506,7 +507,8 @@ def _scipy_bivariate_kde(x, y, bw, gridsize, cut, clip):
 
 def kdeplot(
     data, data2=None,
-    *, shade=False, vertical=False, kernel="gau",
+    *,
+    shade=False, vertical=False, kernel="gau",
     bw="scott", gridsize=100, cut=3, clip=None, legend=True,
     cumulative=False, shade_lowest=True, cbar=False, cbar_ax=None,
     cbar_kws=None, ax=None,
@@ -712,7 +714,8 @@ def kdeplot(
 
 
 def rugplot(
-    a, *,
+    a,
+    *,
     height=.05, axis="x", ax=None,
     **kwargs
 ):

--- a/seaborn/distributions.py
+++ b/seaborn/distributions.py
@@ -14,7 +14,7 @@ try:
 except ImportError:
     _has_statsmodels = False
 
-from .utils import iqr, _kde_support, remove_na
+from .utils import iqr, _kde_support, remove_na, _deprecate_positional_args
 from .palettes import color_palette, light_palette, dark_palette, blend_palette
 
 
@@ -35,6 +35,7 @@ def _freedman_diaconis_bins(a):
         return int(np.ceil((a.max() - a.min()) / h))
 
 
+@_deprecate_positional_args
 def distplot(
     a,
     *,
@@ -505,6 +506,7 @@ def _scipy_bivariate_kde(x, y, bw, gridsize, cut, clip):
     return xx, yy, z
 
 
+@_deprecate_positional_args
 def kdeplot(
     data, data2=None,
     *,
@@ -713,6 +715,7 @@ def kdeplot(
     return ax
 
 
+@_deprecate_positional_args
 def rugplot(
     a,
     *,

--- a/seaborn/distributions.py
+++ b/seaborn/distributions.py
@@ -35,10 +35,13 @@ def _freedman_diaconis_bins(a):
         return int(np.ceil((a.max() - a.min()) / h))
 
 
-def distplot(a, bins=None, hist=True, kde=True, rug=False, fit=None,
-             hist_kws=None, kde_kws=None, rug_kws=None, fit_kws=None,
-             color=None, vertical=False, norm_hist=False, axlabel=None,
-             label=None, ax=None):
+def distplot(
+    a, *,
+    bins=None, hist=True, kde=True, rug=False, fit=None,
+    hist_kws=None, kde_kws=None, rug_kws=None, fit_kws=None,
+    color=None, vertical=False, norm_hist=False, axlabel=None,
+    label=None, ax=None
+):
     """Flexibly plot a univariate distribution of observations.
 
     This function combines the matplotlib ``hist`` function (with automatic
@@ -501,10 +504,14 @@ def _scipy_bivariate_kde(x, y, bw, gridsize, cut, clip):
     return xx, yy, z
 
 
-def kdeplot(data, data2=None, shade=False, vertical=False, kernel="gau",
-            bw="scott", gridsize=100, cut=3, clip=None, legend=True,
-            cumulative=False, shade_lowest=True, cbar=False, cbar_ax=None,
-            cbar_kws=None, ax=None, **kwargs):
+def kdeplot(
+    data, *,
+    data2=None, shade=False, vertical=False, kernel="gau",
+    bw="scott", gridsize=100, cut=3, clip=None, legend=True,
+    cumulative=False, shade_lowest=True, cbar=False, cbar_ax=None,
+    cbar_kws=None, ax=None,
+    **kwargs,
+):
     """Fit and plot a univariate or bivariate kernel density estimate.
 
     Parameters
@@ -704,7 +711,11 @@ def kdeplot(data, data2=None, shade=False, vertical=False, kernel="gau",
     return ax
 
 
-def rugplot(a, height=.05, axis="x", ax=None, **kwargs):
+def rugplot(
+    a, *,
+    height=.05, axis="x", ax=None,
+    **kwargs
+):
     """Plot datapoints in an array as sticks on an axis.
 
     Parameters

--- a/seaborn/distributions.py
+++ b/seaborn/distributions.py
@@ -14,8 +14,9 @@ try:
 except ImportError:
     _has_statsmodels = False
 
-from .utils import iqr, _kde_support, remove_na, _deprecate_positional_args
+from .utils import iqr, _kde_support, remove_na
 from .palettes import color_palette, light_palette, dark_palette, blend_palette
+from ._decorators import _deprecate_positional_args
 
 
 __all__ = ["distplot", "kdeplot", "rugplot"]

--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -347,12 +347,16 @@ class _HeatMapper(object):
             self._annotate_heatmap(ax, mesh)
 
 
-def heatmap(data, vmin=None, vmax=None, cmap=None, center=None, robust=False,
-            annot=None, fmt=".2g", annot_kws=None,
-            linewidths=0, linecolor="white",
-            cbar=True, cbar_kws=None, cbar_ax=None,
-            square=False, xticklabels="auto", yticklabels="auto",
-            mask=None, ax=None, **kwargs):
+def heatmap(
+    data, *,
+    vmin=None, vmax=None, cmap=None, center=None, robust=False,
+    annot=None, fmt=".2g", annot_kws=None,
+    linewidths=0, linecolor="white",
+    cbar=True, cbar_kws=None, cbar_ax=None,
+    square=False, xticklabels="auto", yticklabels="auto",
+    mask=None, ax=None,
+    **kwargs
+):
     """Plot rectangular data as a color-encoded matrix.
 
     This is an Axes-level function and will draw the heatmap into the
@@ -1220,14 +1224,17 @@ class ClusterGrid(Grid):
         return self
 
 
-def clustermap(data, pivot_kws=None, method='average', metric='euclidean',
-               z_score=None, standard_scale=None, figsize=(10, 10),
-               cbar_kws=None, row_cluster=True, col_cluster=True,
-               row_linkage=None, col_linkage=None,
-               row_colors=None, col_colors=None, mask=None,
-               dendrogram_ratio=.2, colors_ratio=0.03,
-               cbar_pos=(.02, .8, .05, .18), tree_kws=None,
-               **kwargs):
+def clustermap(
+    data, *,
+    pivot_kws=None, method='average', metric='euclidean',
+    z_score=None, standard_scale=None, figsize=(10, 10),
+    cbar_kws=None, row_cluster=True, col_cluster=True,
+    row_linkage=None, col_linkage=None,
+    row_colors=None, col_colors=None, mask=None,
+    dendrogram_ratio=.2, colors_ratio=0.03,
+    cbar_pos=(.02, .8, .05, .18), tree_kws=None,
+    **kwargs
+):
     """Plot a matrix dataset as a hierarchically-clustered heatmap.
 
     Parameters

--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -13,7 +13,8 @@ from scipy.cluster import hierarchy
 from . import cm
 from .axisgrid import Grid
 from .utils import (despine, axis_ticklabels_overlap, relative_luminance,
-                    to_utf8, _deprecate_positional_args)
+                    to_utf8)
+from ._decorators import _deprecate_positional_args
 
 
 __all__ = ["heatmap", "clustermap"]

--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -13,7 +13,7 @@ from scipy.cluster import hierarchy
 from . import cm
 from .axisgrid import Grid
 from .utils import (despine, axis_ticklabels_overlap, relative_luminance,
-                    to_utf8)
+                    to_utf8, _deprecate_positional_args)
 
 
 __all__ = ["heatmap", "clustermap"]
@@ -347,6 +347,7 @@ class _HeatMapper(object):
             self._annotate_heatmap(ax, mesh)
 
 
+@_deprecate_positional_args
 def heatmap(
     data, *,
     vmin=None, vmax=None, cmap=None, center=None, robust=False,
@@ -732,8 +733,12 @@ class _DendrogramPlotter(object):
         return self
 
 
-def dendrogram(data, linkage=None, axis=1, label=True, metric='euclidean',
-               method='average', rotate=False, tree_kws=None, ax=None):
+@_deprecate_positional_args
+def dendrogram(
+    data, *,
+    linkage=None, axis=1, label=True, metric='euclidean',
+    method='average', rotate=False, tree_kws=None, ax=None
+):
     """Draw a tree diagram of relationships within a matrix
 
     Parameters
@@ -1224,6 +1229,7 @@ class ClusterGrid(Grid):
         return self
 
 
+@_deprecate_positional_args
 def clustermap(
     data, *,
     pivot_kws=None, method='average', metric='euclidean',

--- a/seaborn/regression.py
+++ b/seaborn/regression.py
@@ -555,15 +555,19 @@ _regression_docs = dict(
 _regression_docs.update(_facet_docs)
 
 
-def lmplot(x, y, data, hue=None, col=None, row=None, palette=None,
-           col_wrap=None, height=5, aspect=1, markers="o", sharex=True,
-           sharey=True, hue_order=None, col_order=None, row_order=None,
-           legend=True, legend_out=True, x_estimator=None, x_bins=None,
-           x_ci="ci", scatter=True, fit_reg=True, ci=95, n_boot=1000,
-           units=None, seed=None, order=1, logistic=False, lowess=False,
-           robust=False, logx=False, x_partial=None, y_partial=None,
-           truncate=True, x_jitter=None, y_jitter=None, scatter_kws=None,
-           line_kws=None, size=None):
+def lmplot(
+    x, y,
+    *, data=None,
+    hue=None, col=None, row=None,
+    palette=None, col_wrap=None, height=5, aspect=1, markers="o",
+    sharex=True, sharey=True, hue_order=None, col_order=None, row_order=None,
+    legend=True, legend_out=True, x_estimator=None, x_bins=None,
+    x_ci="ci", scatter=True, fit_reg=True, ci=95, n_boot=1000,
+    units=None, seed=None, order=1, logistic=False, lowess=False,
+    robust=False, logx=False, x_partial=None, y_partial=None,
+    truncate=True, x_jitter=None, y_jitter=None, scatter_kws=None,
+    line_kws=None, size=None
+):
 
     # Handle deprecations
     if size is not None:
@@ -794,13 +798,17 @@ lmplot.__doc__ = dedent("""\
     """).format(**_regression_docs)
 
 
-def regplot(x, y, data=None, x_estimator=None, x_bins=None, x_ci="ci",
-            scatter=True, fit_reg=True, ci=95, n_boot=1000, units=None,
-            seed=None, order=1, logistic=False, lowess=False, robust=False,
-            logx=False, x_partial=None, y_partial=None,
-            truncate=True, dropna=True, x_jitter=None, y_jitter=None,
-            label=None, color=None, marker="o",
-            scatter_kws=None, line_kws=None, ax=None):
+def regplot(
+    x, y,
+    *, data=None,
+    x_estimator=None, x_bins=None, x_ci="ci",
+    scatter=True, fit_reg=True, ci=95, n_boot=1000, units=None,
+    seed=None, order=1, logistic=False, lowess=False, robust=False,
+    logx=False, x_partial=None, y_partial=None,
+    truncate=True, dropna=True, x_jitter=None, y_jitter=None,
+    label=None, color=None, marker="o",
+    scatter_kws=None, line_kws=None, ax=None
+):
 
     plotter = _RegressionPlotter(x, y, data, x_estimator, x_bins, x_ci,
                                  scatter, fit_reg, ci, n_boot, units, seed,
@@ -987,9 +995,13 @@ regplot.__doc__ = dedent("""\
     """).format(**_regression_docs)
 
 
-def residplot(x, y, data=None, lowess=False, x_partial=None, y_partial=None,
-              order=1, robust=False, dropna=True, label=None, color=None,
-              scatter_kws=None, line_kws=None, ax=None):
+def residplot(
+    x, y,
+    *, data=None,
+    lowess=False, x_partial=None, y_partial=None,
+    order=1, robust=False, dropna=True, label=None, color=None,
+    scatter_kws=None, line_kws=None, ax=None
+):
     """Plot the residuals of a linear regression.
 
     This function will regress y on x (possibly as a robust or polynomial

--- a/seaborn/regression.py
+++ b/seaborn/regression.py
@@ -16,6 +16,7 @@ except ImportError:
     _has_statsmodels = False
 
 from . import utils
+from .utils import _deprecate_positional_args
 from . import algorithms as algo
 from .axisgrid import FacetGrid, _facet_docs
 
@@ -555,6 +556,7 @@ _regression_docs = dict(
 _regression_docs.update(_facet_docs)
 
 
+@_deprecate_positional_args
 def lmplot(
     x=None, y=None,
     *, data=None,
@@ -798,6 +800,7 @@ lmplot.__doc__ = dedent("""\
     """).format(**_regression_docs)
 
 
+@_deprecate_positional_args
 def regplot(
     x=None, y=None,
     *, data=None,
@@ -995,6 +998,7 @@ regplot.__doc__ = dedent("""\
     """).format(**_regression_docs)
 
 
+@_deprecate_positional_args
 def residplot(
     x=None, y=None,
     *, data=None,

--- a/seaborn/regression.py
+++ b/seaborn/regression.py
@@ -556,7 +556,7 @@ _regression_docs.update(_facet_docs)
 
 
 def lmplot(
-    x, y,
+    x=None, y=None,
     *, data=None,
     hue=None, col=None, row=None,
     palette=None, col_wrap=None, height=5, aspect=1, markers="o",
@@ -799,7 +799,7 @@ lmplot.__doc__ = dedent("""\
 
 
 def regplot(
-    x, y,
+    x=None, y=None,
     *, data=None,
     x_estimator=None, x_bins=None, x_ci="ci",
     scatter=True, fit_reg=True, ci=95, n_boot=1000, units=None,
@@ -996,7 +996,7 @@ regplot.__doc__ = dedent("""\
 
 
 def residplot(
-    x, y,
+    x=None, y=None,
     *, data=None,
     lowess=False, x_partial=None, y_partial=None,
     order=1, robust=False, dropna=True, label=None, color=None,

--- a/seaborn/regression.py
+++ b/seaborn/regression.py
@@ -584,11 +584,13 @@ def lmplot(
     data = data[cols]
 
     # Initialize the grid
-    facets = FacetGrid(data, row, col, hue, palette=palette,
-                       row_order=row_order, col_order=col_order,
-                       hue_order=hue_order, height=height, aspect=aspect,
-                       col_wrap=col_wrap, sharex=sharex, sharey=sharey,
-                       legend_out=legend_out)
+    facets = FacetGrid(
+        data, row=row, col=col, hue=hue,
+        palette=palette,
+        row_order=row_order, col_order=col_order, hue_order=hue_order,
+        height=height, aspect=aspect, col_wrap=col_wrap,
+        sharex=sharex, sharey=sharey, legend_out=legend_out
+    )
 
     # Add the markers here as FacetGrid has figured out how many levels of the
     # hue variable are needed and we don't want to duplicate that process

--- a/seaborn/regression.py
+++ b/seaborn/regression.py
@@ -16,9 +16,9 @@ except ImportError:
     _has_statsmodels = False
 
 from . import utils
-from .utils import _deprecate_positional_args
 from . import algorithms as algo
 from .axisgrid import FacetGrid, _facet_docs
+from ._decorators import _deprecate_positional_args
 
 
 __all__ = ["lmplot", "regplot", "residplot"]

--- a/seaborn/regression.py
+++ b/seaborn/regression.py
@@ -558,9 +558,9 @@ _regression_docs.update(_facet_docs)
 
 @_deprecate_positional_args
 def lmplot(
-    x=None, y=None,
-    *, data=None,
-    hue=None, col=None, row=None,
+    x=None, y=None, *,
+    data=None,
+    hue=None, col=None, row=None,  # TODO move before data once * is enforced
     palette=None, col_wrap=None, height=5, aspect=1, markers="o",
     sharex=True, sharey=True, hue_order=None, col_order=None, row_order=None,
     legend=True, legend_out=True, x_estimator=None, x_bins=None,
@@ -802,8 +802,8 @@ lmplot.__doc__ = dedent("""\
 
 @_deprecate_positional_args
 def regplot(
-    x=None, y=None,
-    *, data=None,
+    x=None, y=None, *,
+    data=None,
     x_estimator=None, x_bins=None, x_ci="ci",
     scatter=True, fit_reg=True, ci=95, n_boot=1000, units=None,
     seed=None, order=1, logistic=False, lowess=False, robust=False,
@@ -1000,8 +1000,8 @@ regplot.__doc__ = dedent("""\
 
 @_deprecate_positional_args
 def residplot(
-    x=None, y=None,
-    *, data=None,
+    x=None, y=None, *,
+    data=None,
     lowess=False, x_partial=None, y_partial=None,
     order=1, robust=False, dropna=True, label=None, color=None,
     scatter_kws=None, line_kws=None, ax=None

--- a/seaborn/relational.py
+++ b/seaborn/relational.py
@@ -9,7 +9,8 @@ import matplotlib.pyplot as plt
 
 from . import utils
 from .utils import (categorical_order, get_color_cycle, ci_to_errsize,
-                    remove_na, locator_to_legend_entries)
+                    remove_na, locator_to_legend_entries,
+                    _deprecate_positional_args)
 from .algorithms import bootstrap
 from .palettes import (color_palette, cubehelix_palette,
                        _parse_cubehelix_args, QUAL_PALETTES)
@@ -1109,6 +1110,7 @@ _relational_docs = dict(
 _relational_docs.update(_facet_docs)
 
 
+@_deprecate_positional_args
 def lineplot(
     x=None, y=None, hue=None, size=None, style=None,
     *, data=None,
@@ -1381,6 +1383,7 @@ lineplot.__doc__ = dedent("""\
     """).format(**_relational_docs)
 
 
+@_deprecate_positional_args
 def scatterplot(
     x=None, y=None, hue=None, style=None, size=None,
     *, data=None,
@@ -1626,6 +1629,7 @@ scatterplot.__doc__ = dedent("""\
     """).format(**_relational_docs)
 
 
+@_deprecate_positional_args
 def relplot(
     x=None, y=None, hue=None, size=None, style=None,
     *, data=None,

--- a/seaborn/relational.py
+++ b/seaborn/relational.py
@@ -1109,13 +1109,16 @@ _relational_docs = dict(
 _relational_docs.update(_facet_docs)
 
 
-def lineplot(x=None, y=None, hue=None, size=None, style=None, data=None,
-             palette=None, hue_order=None, hue_norm=None,
-             sizes=None, size_order=None, size_norm=None,
-             dashes=True, markers=None, style_order=None,
-             units=None, estimator="mean", ci=95, n_boot=1000, seed=None,
-             sort=True, err_style="band", err_kws=None,
-             legend="brief", ax=None, **kwargs):
+def lineplot(
+    x=None, y=None, hue=None, size=None, style=None,
+    *, data=None,
+    palette=None, hue_order=None, hue_norm=None,
+    sizes=None, size_order=None, size_norm=None,
+    dashes=True, markers=None, style_order=None,
+    units=None, estimator="mean", ci=95, n_boot=1000, seed=None,
+    sort=True, err_style="band", err_kws=None,
+    legend="brief", ax=None, **kwargs
+):
 
     p = _LinePlotter(
         x=x, y=y, hue=hue, size=size, style=style, data=data,
@@ -1378,14 +1381,17 @@ lineplot.__doc__ = dedent("""\
     """).format(**_relational_docs)
 
 
-def scatterplot(x=None, y=None, hue=None, style=None, size=None, data=None,
-                palette=None, hue_order=None, hue_norm=None,
-                sizes=None, size_order=None, size_norm=None,
-                markers=True, style_order=None,
-                x_bins=None, y_bins=None,
-                units=None, estimator=None, ci=95, n_boot=1000,
-                alpha="auto", x_jitter=None, y_jitter=None,
-                legend="brief", ax=None, **kwargs):
+def scatterplot(
+    x=None, y=None, hue=None, style=None, size=None,
+    *, data=None,
+    palette=None, hue_order=None, hue_norm=None,
+    sizes=None, size_order=None, size_norm=None,
+    markers=True, style_order=None,
+    x_bins=None, y_bins=None,
+    units=None, estimator=None, ci=95, n_boot=1000,
+    alpha="auto", x_jitter=None, y_jitter=None,
+    legend="brief", ax=None, **kwargs
+):
 
     p = _ScatterPlotter(
         x=x, y=y, hue=hue, style=style, size=size, data=data,
@@ -1620,13 +1626,18 @@ scatterplot.__doc__ = dedent("""\
     """).format(**_relational_docs)
 
 
-def relplot(x=None, y=None, hue=None, size=None, style=None, data=None,
-            row=None, col=None, col_wrap=None, row_order=None, col_order=None,
-            palette=None, hue_order=None, hue_norm=None,
-            sizes=None, size_order=None, size_norm=None,
-            markers=None, dashes=None, style_order=None,
-            legend="brief", kind="scatter",
-            height=5, aspect=1, facet_kws=None, **kwargs):
+def relplot(
+    x=None, y=None, hue=None, size=None, style=None,
+    *, data=None,
+    row=None, col=None,
+    col_wrap=None, row_order=None, col_order=None,
+    palette=None, hue_order=None, hue_norm=None,
+    sizes=None, size_order=None, size_norm=None,
+    markers=None, dashes=None, style_order=None,
+    legend="brief", kind="scatter",
+    height=5, aspect=1, facet_kws=None,
+    **kwargs
+):
 
     if kind == "scatter":
 

--- a/seaborn/relational.py
+++ b/seaborn/relational.py
@@ -1112,8 +1112,9 @@ _relational_docs.update(_facet_docs)
 
 @_deprecate_positional_args
 def lineplot(
-    x=None, y=None, hue=None, size=None, style=None,
-    *, data=None,
+    x=None, y=None, *,
+    hue=None, size=None, style=None,
+    data=None,
     palette=None, hue_order=None, hue_norm=None,
     sizes=None, size_order=None, size_norm=None,
     dashes=True, markers=None, style_order=None,
@@ -1385,8 +1386,8 @@ lineplot.__doc__ = dedent("""\
 
 @_deprecate_positional_args
 def scatterplot(
-    x=None, y=None, hue=None, style=None, size=None,
-    *, data=None,
+    x=None, y=None, *,
+    hue=None, style=None, size=None, data=None,
     palette=None, hue_order=None, hue_norm=None,
     sizes=None, size_order=None, size_norm=None,
     markers=True, style_order=None,
@@ -1631,9 +1632,9 @@ scatterplot.__doc__ = dedent("""\
 
 @_deprecate_positional_args
 def relplot(
-    x=None, y=None, hue=None, size=None, style=None,
-    *, data=None,
-    row=None, col=None,
+    x=None, y=None, *,
+    hue=None, size=None, style=None, data=None,
+    row=None, col=None,  # TODO move in front of data when * is enforced
     col_wrap=None, row_order=None, col_order=None,
     palette=None, hue_order=None, hue_norm=None,
     sizes=None, size_order=None, size_norm=None,

--- a/seaborn/relational.py
+++ b/seaborn/relational.py
@@ -9,12 +9,12 @@ import matplotlib.pyplot as plt
 
 from . import utils
 from .utils import (categorical_order, get_color_cycle, ci_to_errsize,
-                    remove_na, locator_to_legend_entries,
-                    _deprecate_positional_args)
+                    remove_na, locator_to_legend_entries)
 from .algorithms import bootstrap
 from .palettes import (color_palette, cubehelix_palette,
                        _parse_cubehelix_args, QUAL_PALETTES)
 from .axisgrid import FacetGrid, _facet_docs
+from ._decorators import _deprecate_positional_args
 
 
 __all__ = ["relplot", "scatterplot", "lineplot"]

--- a/seaborn/tests/test_axisgrid.py
+++ b/seaborn/tests/test_axisgrid.py
@@ -766,7 +766,7 @@ class TestPairGrid(object):
                 npt.assert_array_equal(x_in, x_out)
                 npt.assert_array_equal(y_in, y_out)
 
-        g2 = ag.PairGrid(self.df, "a")
+        g2 = ag.PairGrid(self.df, hue="a")
         g2.map(plt.scatter)
 
         for i, axes_i in enumerate(g2.axes):
@@ -1098,7 +1098,7 @@ class TestPairGrid(object):
                 npt.assert_array_equal(x_in, x_out)
                 npt.assert_array_equal(y_in, y_out)
 
-        g2 = ag.PairGrid(df, "a")
+        g2 = ag.PairGrid(df, hue="a")
         g2.map(plt.scatter)
 
         for i, axes_i in enumerate(g2.axes):
@@ -1280,7 +1280,7 @@ class TestJointGrid(object):
     def test_margin_grid_from_dataframe_bad_variable(self):
 
         with nt.assert_raises(ValueError):
-            ag.JointGrid("x", "bad_column", self.data)
+            ag.JointGrid("x", "bad_column", data=self.data)
 
     def test_margin_grid_axis_labels(self):
 
@@ -1297,10 +1297,10 @@ class TestJointGrid(object):
 
     def test_dropna(self):
 
-        g = ag.JointGrid("x_na", "y", self.data, dropna=False)
+        g = ag.JointGrid("x_na", "y", data=self.data, dropna=False)
         nt.assert_equal(len(g.x), len(self.x_na))
 
-        g = ag.JointGrid("x_na", "y", self.data, dropna=True)
+        g = ag.JointGrid("x_na", "y", data=self.data, dropna=True)
         nt.assert_equal(len(g.x), pd.notnull(self.x_na).sum())
 
     def test_axlims(self):
@@ -1331,7 +1331,7 @@ class TestJointGrid(object):
 
     def test_univariate_plot(self):
 
-        g = ag.JointGrid("x", "x", self.data)
+        g = ag.JointGrid("x", "x", data=self.data)
         g.plot_marginals(kdeplot)
 
         _, y1 = g.ax_marg_x.lines[0].get_xydata().T
@@ -1340,7 +1340,7 @@ class TestJointGrid(object):
 
     def test_plot(self):
 
-        g = ag.JointGrid("x", "x", self.data)
+        g = ag.JointGrid("x", "x", data=self.data)
         g.plot(plt.plot, kdeplot)
 
         x, y = g.ax_joint.lines[0].get_xydata().T

--- a/seaborn/tests/test_axisgrid.py
+++ b/seaborn/tests/test_axisgrid.py
@@ -1273,7 +1273,7 @@ class TestJointGrid(object):
 
     def test_margin_grid_from_dataframe(self):
 
-        g = ag.JointGrid("x", "y", self.data)
+        g = ag.JointGrid("x", "y", data=self.data)
         npt.assert_array_equal(g.x, self.x)
         npt.assert_array_equal(g.y, self.y)
 
@@ -1284,7 +1284,7 @@ class TestJointGrid(object):
 
     def test_margin_grid_axis_labels(self):
 
-        g = ag.JointGrid("x", "y", self.data)
+        g = ag.JointGrid("x", "y", data=self.data)
 
         xlabel, ylabel = g.ax_joint.get_xlabel(), g.ax_joint.get_ylabel()
         nt.assert_equal(xlabel, "x")
@@ -1306,7 +1306,7 @@ class TestJointGrid(object):
     def test_axlims(self):
 
         lim = (-3, 3)
-        g = ag.JointGrid("x", "y", self.data, xlim=lim, ylim=lim)
+        g = ag.JointGrid("x", "y", data=self.data, xlim=lim, ylim=lim)
 
         nt.assert_equal(g.ax_joint.get_xlim(), lim)
         nt.assert_equal(g.ax_joint.get_ylim(), lim)
@@ -1316,13 +1316,13 @@ class TestJointGrid(object):
 
     def test_marginal_ticks(self):
 
-        g = ag.JointGrid("x", "y", self.data)
+        g = ag.JointGrid("x", "y", data=self.data)
         nt.assert_true(~len(g.ax_marg_x.get_xticks()))
         nt.assert_true(~len(g.ax_marg_y.get_yticks()))
 
     def test_bivariate_plot(self):
 
-        g = ag.JointGrid("x", "y", self.data)
+        g = ag.JointGrid("x", "y", data=self.data)
         g.plot_joint(plt.plot)
 
         x, y = g.ax_joint.lines[0].get_xydata().T
@@ -1353,7 +1353,7 @@ class TestJointGrid(object):
 
     def test_annotate(self):
 
-        g = ag.JointGrid("x", "y", self.data)
+        g = ag.JointGrid("x", "y", data=self.data)
         rp = stats.pearsonr(self.x, self.y)
 
         with pytest.warns(UserWarning):
@@ -1384,7 +1384,7 @@ class TestJointGrid(object):
 
     def test_space(self):
 
-        g = ag.JointGrid("x", "y", self.data, space=0)
+        g = ag.JointGrid("x", "y", data=self.data, space=0)
 
         joint_bounds = g.ax_joint.bbox.bounds
         marg_x_bounds = g.ax_marg_x.bbox.bounds
@@ -1403,7 +1403,7 @@ class TestJointPlot(object):
 
     def test_scatter(self):
 
-        g = ag.jointplot("x", "y", self.data)
+        g = ag.jointplot("x", "y", data=self.data)
         nt.assert_equal(len(g.ax_joint.collections), 1)
 
         x, y = g.ax_joint.collections[0].get_offsets().T
@@ -1418,7 +1418,7 @@ class TestJointPlot(object):
 
     def test_reg(self):
 
-        g = ag.jointplot("x", "y", self.data, kind="reg")
+        g = ag.jointplot("x", "y", data=self.data, kind="reg")
         nt.assert_equal(len(g.ax_joint.collections), 2)
 
         x, y = g.ax_joint.collections[0].get_offsets().T
@@ -1437,7 +1437,7 @@ class TestJointPlot(object):
 
     def test_resid(self):
 
-        g = ag.jointplot("x", "y", self.data, kind="resid")
+        g = ag.jointplot("x", "y", data=self.data, kind="resid")
         nt.assert_equal(len(g.ax_joint.collections), 1)
         nt.assert_equal(len(g.ax_joint.lines), 1)
         nt.assert_equal(len(g.ax_marg_x.lines), 0)
@@ -1445,7 +1445,7 @@ class TestJointPlot(object):
 
     def test_hex(self):
 
-        g = ag.jointplot("x", "y", self.data, kind="hex")
+        g = ag.jointplot("x", "y", data=self.data, kind="hex")
         nt.assert_equal(len(g.ax_joint.collections), 1)
 
         x_bins = _freedman_diaconis_bins(self.x)
@@ -1456,7 +1456,7 @@ class TestJointPlot(object):
 
     def test_kde(self):
 
-        g = ag.jointplot("x", "y", self.data, kind="kde")
+        g = ag.jointplot("x", "y", data=self.data, kind="kde")
 
         nt.assert_true(len(g.ax_joint.collections) > 0)
         nt.assert_equal(len(g.ax_marg_x.collections), 1)
@@ -1467,7 +1467,7 @@ class TestJointPlot(object):
 
     def test_color(self):
 
-        g = ag.jointplot("x", "y", self.data, color="purple")
+        g = ag.jointplot("x", "y", data=self.data, color="purple")
 
         purple = mpl.colors.colorConverter.to_rgb("purple")
         scatter_color = g.ax_joint.collections[0].get_facecolor()[0, :3]
@@ -1479,16 +1479,17 @@ class TestJointPlot(object):
     def test_annotation(self):
 
         with pytest.warns(UserWarning):
-            g = ag.jointplot("x", "y", self.data, stat_func=stats.pearsonr)
+            g = ag.jointplot("x", "y", data=self.data,
+                             stat_func=stats.pearsonr)
         nt.assert_equal(len(g.ax_joint.legend_.get_texts()), 1)
 
-        g = ag.jointplot("x", "y", self.data, stat_func=None)
+        g = ag.jointplot("x", "y", data=self.data, stat_func=None)
         nt.assert_is(g.ax_joint.legend_, None)
 
     def test_hex_customise(self):
 
         # test that default gridsize can be overridden
-        g = ag.jointplot("x", "y", self.data, kind="hex",
+        g = ag.jointplot("x", "y", data=self.data, kind="hex",
                          joint_kws=dict(gridsize=5))
         nt.assert_equal(len(g.ax_joint.collections), 1)
         a = g.ax_joint.collections[0].get_array()
@@ -1497,7 +1498,7 @@ class TestJointPlot(object):
     def test_bad_kind(self):
 
         with nt.assert_raises(ValueError):
-            ag.jointplot("x", "y", self.data, kind="not_a_kind")
+            ag.jointplot("x", "y", data=self.data, kind="not_a_kind")
 
     def test_leaky_dict(self):
         # Validate input dicts are unchanged by jointplot plotting function
@@ -1505,6 +1506,6 @@ class TestJointPlot(object):
         for kwarg in ("joint_kws", "marginal_kws", "annot_kws"):
             for kind in ("hex", "kde", "resid", "reg", "scatter"):
                 empty_dict = {}
-                ag.jointplot("x", "y", self.data, kind=kind,
+                ag.jointplot("x", "y", data=self.data, kind=kind,
                              **{kwarg: empty_dict})
                 assert empty_dict == {}

--- a/seaborn/tests/test_categorical.py
+++ b/seaborn/tests/test_categorical.py
@@ -196,7 +196,7 @@ class TestCategoricalPlotter(CategoricalFixture):
         p = cat._CategoricalPlotter()
 
         # Test a vertically oriented grouped and nested plot
-        p.establish_variables("g", "y", "h", data=self.df)
+        p.establish_variables("g", "y", hue="h", data=self.df)
         nt.assert_equal(len(p.plot_data), 3)
         nt.assert_equal(len(p.plot_hues), 3)
         nt.assert_equal(p.orient, "v")
@@ -229,7 +229,7 @@ class TestCategoricalPlotter(CategoricalFixture):
         df.g = df.g.astype("category")
 
         # Test that horizontal orientation is automatically detected
-        p.establish_variables("y", "g", "h", data=df)
+        p.establish_variables("y", "g", hue="h", data=df)
         nt.assert_equal(len(p.plot_data), 3)
         nt.assert_equal(len(p.plot_hues), 3)
         nt.assert_equal(p.orient, "h")
@@ -245,7 +245,7 @@ class TestCategoricalPlotter(CategoricalFixture):
 
         # Test grouped data that matches on index
         p1 = cat._CategoricalPlotter()
-        p1.establish_variables(self.g, self.y, self.h)
+        p1.establish_variables(self.g, self.y, hue=self.h)
         p2 = cat._CategoricalPlotter()
         p2.establish_variables(self.g, self.y[::-1], self.h)
         for i, (d1, d2) in enumerate(zip(p1.plot_data, p2.plot_data)):
@@ -311,11 +311,11 @@ class TestCategoricalPlotter(CategoricalFixture):
         p = cat._CategoricalPlotter()
 
         # Test inferred hue order
-        p.establish_variables("g", "y", "h", data=self.df)
+        p.establish_variables("g", "y", hue="h", data=self.df)
         nt.assert_equal(p.hue_names, ["m", "n"])
 
         # Test specified hue order
-        p.establish_variables("g", "y", "h", data=self.df,
+        p.establish_variables("g", "y", hue="h", data=self.df,
                               hue_order=["n", "m"])
         nt.assert_equal(p.hue_names, ["n", "m"])
 
@@ -323,21 +323,21 @@ class TestCategoricalPlotter(CategoricalFixture):
         df = self.df.copy()
         df.h = df.h.astype("category")
         df.h = df.h.cat.reorder_categories(["n", "m"])
-        p.establish_variables("g", "y", "h", data=df)
+        p.establish_variables("g", "y", hue="h", data=df)
         nt.assert_equal(p.hue_names, ["n", "m"])
 
         df.h = (df.h.cat.add_categories("o")
                     .cat.reorder_categories(["o", "m", "n"]))
-        p.establish_variables("g", "y", "h", data=df)
+        p.establish_variables("g", "y", hue="h", data=df)
         nt.assert_equal(p.hue_names, ["o", "m", "n"])
 
     def test_plot_units(self):
 
         p = cat._CategoricalPlotter()
-        p.establish_variables("g", "y", "h", data=self.df)
+        p.establish_variables("g", "y", hue="h", data=self.df)
         nt.assert_is(p.plot_units, None)
 
-        p.establish_variables("g", "y", "h", data=self.df, units="u")
+        p.establish_variables("g", "y", hue="h", data=self.df, units="u")
         for group, units in zip(["a", "b", "c"], p.plot_units):
             npt.assert_array_equal(units, self.u[self.g == group])
 
@@ -375,7 +375,7 @@ class TestCategoricalPlotter(CategoricalFixture):
         nt.assert_equal(p.colors, palettes.color_palette(n_colors=3))
 
         # Test palette mapping the hue position
-        p.establish_variables("g", "y", "h", data=self.df)
+        p.establish_variables("g", "y", hue="h", data=self.df)
         p.establish_colors(None, None, 1)
         nt.assert_equal(p.colors, palettes.color_palette(n_colors=2))
 
@@ -399,7 +399,7 @@ class TestCategoricalPlotter(CategoricalFixture):
         nt.assert_equal(p.colors, [blue_rgb] * 3)
 
         # Test a color-based blend for the hue mapping
-        p.establish_variables("g", "y", "h", data=self.df)
+        p.establish_variables("g", "y", hue="h", data=self.df)
         p.establish_colors("#ff0022", None, 1)
         rgba_array = np.array(palettes.light_palette("#ff0022", 2))
         npt.assert_array_almost_equal(p.colors,
@@ -415,7 +415,7 @@ class TestCategoricalPlotter(CategoricalFixture):
         nt.assert_equal(p.colors, palettes.color_palette("dark", 3))
 
         # Test that non-None `color` and `hue` raises an error
-        p.establish_variables("g", "y", "h", data=self.df)
+        p.establish_variables("g", "y", hue="h", data=self.df)
         p.establish_colors(None, "muted", 1)
         nt.assert_equal(p.colors, palettes.color_palette("muted", 2))
 
@@ -428,7 +428,7 @@ class TestCategoricalPlotter(CategoricalFixture):
     def test_dict_as_palette(self):
 
         p = cat._CategoricalPlotter()
-        p.establish_variables("g", "y", "h", data=self.df)
+        p.establish_variables("g", "y", hue="h", data=self.df)
         pal = {"m": (0, 0, 1), "n": (1, 0, 0)}
         p.establish_colors(None, pal, 1)
         nt.assert_equal(p.colors, [(0, 0, 1), (1, 0, 0)])
@@ -455,7 +455,7 @@ class TestCategoricalStatPlotter(CategoricalFixture):
         p.estimate_statistic(np.mean, None, 100, None)
         npt.assert_array_equal(p.confint, np.array([]))
 
-        p.establish_variables("g", "y", "h", data=self.df)
+        p.establish_variables("g", "y", hue="h", data=self.df)
         p.estimate_statistic(np.mean, None, 100, None)
         npt.assert_array_equal(p.confint, np.array([[], [], []]))
 
@@ -763,31 +763,31 @@ class TestBoxPlotter(CategoricalFixture):
 
         kws = self.default_kws.copy()
         p = cat._BoxPlotter(**kws)
-        p.establish_variables("g", "y", "h", data=self.df)
+        p.establish_variables("g", "y", hue="h", data=self.df)
         nt.assert_equal(p.nested_width, .4 * .98)
 
         kws = self.default_kws.copy()
         kws["width"] = .6
         p = cat._BoxPlotter(**kws)
-        p.establish_variables("g", "y", "h", data=self.df)
+        p.establish_variables("g", "y", hue="h", data=self.df)
         nt.assert_equal(p.nested_width, .3 * .98)
 
         kws = self.default_kws.copy()
         kws["dodge"] = False
         p = cat._BoxPlotter(**kws)
-        p.establish_variables("g", "y", "h", data=self.df)
+        p.establish_variables("g", "y", hue="h", data=self.df)
         nt.assert_equal(p.nested_width, .8)
 
     def test_hue_offsets(self):
 
         p = cat._BoxPlotter(**self.default_kws)
-        p.establish_variables("g", "y", "h", data=self.df)
+        p.establish_variables("g", "y", hue="h", data=self.df)
         npt.assert_array_equal(p.hue_offsets, [-.2, .2])
 
         kws = self.default_kws.copy()
         kws["width"] = .6
         p = cat._BoxPlotter(**kws)
-        p.establish_variables("g", "y", "h", data=self.df)
+        p.establish_variables("g", "y", hue="h", data=self.df)
         npt.assert_array_equal(p.hue_offsets, [-.15, .15])
 
         p = cat._BoxPlotter(**kws)
@@ -801,7 +801,7 @@ class TestBoxPlotter(CategoricalFixture):
 
         plt.close("all")
 
-        ax = cat.boxplot("g", "y", "h", data=self.df)
+        ax = cat.boxplot("g", "y", hue="h", data=self.df)
         nt.assert_equal(len(ax.artists), 6)
 
         plt.close("all")
@@ -815,7 +815,7 @@ class TestBoxPlotter(CategoricalFixture):
 
         plt.close("all")
 
-        ax = cat.boxplot("g", "y", "h", data=self.df, saturation=1)
+        ax = cat.boxplot("g", "y", hue="h", data=self.df, saturation=1)
         pal = palettes.color_palette(n_colors=2)
         for patch, color in zip(ax.artists, pal * 2):
             nt.assert_equal(patch.get_facecolor()[:3], color)
@@ -841,7 +841,7 @@ class TestBoxPlotter(CategoricalFixture):
         plt.close("all")
 
         y[-1] = 0
-        ax = cat.boxplot(x, y, h)
+        ax = cat.boxplot(x, y, hue=h)
         nt.assert_equal(len(ax.artists), 7)
 
         plt.close("all")
@@ -856,8 +856,8 @@ class TestBoxPlotter(CategoricalFixture):
 
         f, (ax1, ax2) = plt.subplots(2)
         hue_order = self.h.unique()
-        cat.boxplot(self.g, self.y, self.h, hue_order=hue_order, ax=ax1)
-        cat.boxplot(self.g, self.y_perm, self.h,
+        cat.boxplot(self.g, self.y, hue=self.h, hue_order=hue_order, ax=ax1)
+        cat.boxplot(self.g, self.y_perm, hue=self.h,
                     hue_order=hue_order, ax=ax2)
         for l1, l2 in zip(ax1.lines, ax2.lines):
             assert np.array_equal(l1.get_xydata(), l2.get_xydata())
@@ -878,16 +878,16 @@ class TestBoxPlotter(CategoricalFixture):
         cat.boxplot("y", "g", data=self.df, orient="h")
         plt.close("all")
 
-        cat.boxplot("g", "y", "h", data=self.df)
+        cat.boxplot("g", "y", hue="h", data=self.df)
         plt.close("all")
 
-        cat.boxplot("g", "y", "h", order=list("nabc"), data=self.df)
+        cat.boxplot("g", "y", hue="h", order=list("nabc"), data=self.df)
         plt.close("all")
 
-        cat.boxplot("g", "y", "h", hue_order=list("omn"), data=self.df)
+        cat.boxplot("g", "y", hue="h", hue_order=list("omn"), data=self.df)
         plt.close("all")
 
-        cat.boxplot("y", "g", "h", data=self.df, orient="h")
+        cat.boxplot("y", "g", hue="h", data=self.df, orient="h")
         plt.close("all")
 
     def test_axes_annotation(self):
@@ -902,7 +902,7 @@ class TestBoxPlotter(CategoricalFixture):
 
         plt.close("all")
 
-        ax = cat.boxplot("g", "y", "h", data=self.df)
+        ax = cat.boxplot("g", "y", hue="h", data=self.df)
         nt.assert_equal(ax.get_xlabel(), "g")
         nt.assert_equal(ax.get_ylabel(), "y")
         npt.assert_array_equal(ax.get_xticks(), [0, 1, 2])
@@ -966,7 +966,7 @@ class TestViolinPlotter(CategoricalFixture):
         y = self.rs.randn(6)
         h = ["m", "n"] * 2 + ["m"] * 2
 
-        p.establish_variables(x, y, h)
+        p.establish_variables(x, y, hue=h)
         p.estimate_densities("scott", 2, "area", True, 20)
 
         nt.assert_equal(len(p.support[1][0]), 20)
@@ -1004,7 +1004,7 @@ class TestViolinPlotter(CategoricalFixture):
         y = self.rs.randn(7)
         h = (["m", "n"] * 4)[:-1]
 
-        p.establish_variables(x, y, h)
+        p.establish_variables(x, y, hue=h)
         p.estimate_densities("scott", 2, "area", True, 20)
 
         nt.assert_equal(len(p.support[1][0]), 20)
@@ -1502,26 +1502,26 @@ class TestViolinPlotter(CategoricalFixture):
         cat.violinplot("y", "g", data=self.df, orient="h")
         plt.close("all")
 
-        cat.violinplot("g", "y", "h", data=self.df)
+        cat.violinplot("g", "y", hue="h", data=self.df)
         plt.close("all")
 
-        cat.violinplot("g", "y", "h", order=list("nabc"), data=self.df)
+        cat.violinplot("g", "y", hue="h", order=list("nabc"), data=self.df)
         plt.close("all")
 
-        cat.violinplot("g", "y", "h", hue_order=list("omn"), data=self.df)
+        cat.violinplot("g", "y", hue="h", hue_order=list("omn"), data=self.df)
         plt.close("all")
 
-        cat.violinplot("y", "g", "h", data=self.df, orient="h")
+        cat.violinplot("y", "g", hue="h", data=self.df, orient="h")
         plt.close("all")
 
         for inner in ["box", "quart", "point", "stick", None]:
             cat.violinplot("g", "y", data=self.df, inner=inner)
             plt.close("all")
 
-            cat.violinplot("g", "y", "h", data=self.df, inner=inner)
+            cat.violinplot("g", "y", hue="h", data=self.df, inner=inner)
             plt.close("all")
 
-            cat.violinplot("g", "y", "h", data=self.df,
+            cat.violinplot("g", "y", hue="h", data=self.df,
                            inner=inner, split=True)
             plt.close("all")
 
@@ -1633,7 +1633,7 @@ class TestStripPlotter(CategoricalFixture):
 
         pal = palettes.color_palette()
 
-        ax = cat.stripplot("g", "y", "h", data=self.df,
+        ax = cat.stripplot("g", "y", hue="h", data=self.df,
                            jitter=False, dodge=True)
         for i, (_, group_vals) in enumerate(self.y.groupby(self.g)):
             for j, (_, vals) in enumerate(group_vals.groupby(self.h)):
@@ -1651,7 +1651,7 @@ class TestStripPlotter(CategoricalFixture):
         df = self.df.copy()
         df.g = df.g.astype("category")
 
-        ax = cat.stripplot("y", "g", "h", data=df,
+        ax = cat.stripplot("y", "g", hue="h", data=df,
                            jitter=False, dodge=True)
         for i, (_, group_vals) in enumerate(self.y.groupby(self.g)):
             for j, (_, vals) in enumerate(group_vals.groupby(self.h)):
@@ -1664,7 +1664,7 @@ class TestStripPlotter(CategoricalFixture):
     def test_nested_stripplot_vertical(self):
 
         # Test a simple vertical strip plot
-        ax = cat.stripplot("g", "y", "h", data=self.df,
+        ax = cat.stripplot("g", "y", hue="h", data=self.df,
                            jitter=False, dodge=False)
         for i, (_, group_vals) in enumerate(self.y.groupby(self.g)):
 
@@ -1678,7 +1678,7 @@ class TestStripPlotter(CategoricalFixture):
         df = self.df.copy()
         df.g = df.g.astype("category")
 
-        ax = cat.stripplot("y", "g", "h", data=df,
+        ax = cat.stripplot("y", "g", hue="h", data=df,
                            jitter=False, dodge=False)
         for i, (_, group_vals) in enumerate(self.y.groupby(self.g)):
 
@@ -1708,9 +1708,9 @@ class TestStripPlotter(CategoricalFixture):
 
         f, (ax1, ax2) = plt.subplots(2)
         hue_order = self.h.unique()
-        cat.stripplot(self.g, self.y, self.h,
+        cat.stripplot(self.g, self.y, hue=self.h,
                       hue_order=hue_order, ax=ax1)
-        cat.stripplot(self.g, self.y_perm, self.h,
+        cat.stripplot(self.g, self.y_perm, hue=self.h,
                       hue_order=hue_order, ax=ax2)
         for p1, p2 in zip(ax1.collections, ax2.collections):
             y1, y2 = p1.get_offsets()[:, 1], p2.get_offsets()[:, 1]
@@ -1720,9 +1720,9 @@ class TestStripPlotter(CategoricalFixture):
 
         f, (ax1, ax2) = plt.subplots(2)
         hue_order = self.h.unique()
-        cat.stripplot(self.g, self.y, self.h,
+        cat.stripplot(self.g, self.y, hue=self.h,
                       dodge=True, hue_order=hue_order, ax=ax1)
-        cat.stripplot(self.g, self.y_perm, self.h,
+        cat.stripplot(self.g, self.y_perm, hue=self.h,
                       dodge=True, hue_order=hue_order, ax=ax2)
         for p1, p2 in zip(ax1.collections, ax2.collections):
             y1, y2 = p1.get_offsets()[:, 1], p2.get_offsets()[:, 1]
@@ -1820,7 +1820,7 @@ class TestSwarmPlotter(CategoricalFixture):
 
         pal = palettes.color_palette()
 
-        ax = cat.swarmplot("g", "y", "h", data=self.df, dodge=True)
+        ax = cat.swarmplot("g", "y", hue="h", data=self.df, dodge=True)
         for i, (_, group_vals) in enumerate(self.y.groupby(self.g)):
             for j, (_, vals) in enumerate(group_vals.groupby(self.h)):
 
@@ -1834,7 +1834,8 @@ class TestSwarmPlotter(CategoricalFixture):
 
         pal = palettes.color_palette()
 
-        ax = cat.swarmplot("y", "g", "h", data=self.df, orient="h", dodge=True)
+        ax = cat.swarmplot("y", "g", hue="h", data=self.df,
+                           orient="h", dodge=True)
         for i, (_, group_vals) in enumerate(self.y.groupby(self.g)):
             for j, (_, vals) in enumerate(group_vals.groupby(self.h)):
 
@@ -1846,7 +1847,7 @@ class TestSwarmPlotter(CategoricalFixture):
 
     def test_nested_swarmplot_vertical(self):
 
-        ax = cat.swarmplot("g", "y", "h", data=self.df)
+        ax = cat.swarmplot("g", "y", hue="h", data=self.df)
 
         pal = palettes.color_palette()
         hue_names = self.h.unique().tolist()
@@ -1867,7 +1868,7 @@ class TestSwarmPlotter(CategoricalFixture):
 
     def test_nested_swarmplot_horizontal(self):
 
-        ax = cat.swarmplot("y", "g", "h", data=self.df, orient="h")
+        ax = cat.swarmplot("y", "g", hue="h", data=self.df, orient="h")
 
         pal = palettes.color_palette()
         hue_names = self.h.unique().tolist()
@@ -1899,9 +1900,9 @@ class TestSwarmPlotter(CategoricalFixture):
 
         f, (ax1, ax2) = plt.subplots(2)
         hue_order = self.h.unique()
-        cat.swarmplot(self.g, self.y, self.h,
+        cat.swarmplot(self.g, self.y, hue=self.h,
                       hue_order=hue_order, ax=ax1)
-        cat.swarmplot(self.g, self.y_perm, self.h,
+        cat.swarmplot(self.g, self.y_perm, hue=self.h,
                       hue_order=hue_order, ax=ax2)
         for p1, p2 in zip(ax1.collections, ax2.collections):
             assert np.allclose(p1.get_offsets()[:, 1],
@@ -1911,9 +1912,9 @@ class TestSwarmPlotter(CategoricalFixture):
 
         f, (ax1, ax2) = plt.subplots(2)
         hue_order = self.h.unique()
-        cat.swarmplot(self.g, self.y, self.h,
+        cat.swarmplot(self.g, self.y, hue=self.h,
                       dodge=True, hue_order=hue_order, ax=ax1)
-        cat.swarmplot(self.g, self.y_perm, self.h,
+        cat.swarmplot(self.g, self.y_perm, hue=self.h,
                       dodge=True, hue_order=hue_order, ax=ax2)
         for p1, p2 in zip(ax1.collections, ax2.collections):
             assert np.allclose(p1.get_offsets()[:, 1],
@@ -1938,7 +1939,7 @@ class TestBarPlotter(CategoricalFixture):
         kws = self.default_kws.copy()
 
         p = cat._BarPlotter(**kws)
-        p.establish_variables("g", "y", "h", data=self.df)
+        p.establish_variables("g", "y", hue="h", data=self.df)
         nt.assert_equal(p.nested_width, .8 / 2)
 
         p = cat._BarPlotter(**kws)
@@ -2090,9 +2091,9 @@ class TestBarPlotter(CategoricalFixture):
 
         f, (ax1, ax2) = plt.subplots(2)
         hue_order = self.h.unique()
-        cat.barplot(self.g, self.y, self.h, hue_order=hue_order, ci="sd",
+        cat.barplot(self.g, self.y, hue=self.h, hue_order=hue_order, ci="sd",
                     ax=ax1)
-        cat.barplot(self.g, self.y_perm, self.h,
+        cat.barplot(self.g, self.y_perm, hue=self.h,
                     hue_order=hue_order, ci="sd", ax=ax2)
         for l1, l2 in zip(ax1.lines, ax2.lines):
             assert pytest.approx(l1.get_xydata()) == l2.get_xydata()
@@ -2164,14 +2165,14 @@ class TestBarPlotter(CategoricalFixture):
         nt.assert_equal(ax.get_ylabel(), "g")
         plt.close("all")
 
-        ax = cat.barplot("g", "y", "h", data=self.df)
+        ax = cat.barplot("g", "y", hue="h", data=self.df)
         nt.assert_equal(len(ax.patches),
                         len(self.g.unique()) * len(self.h.unique()))
         nt.assert_equal(ax.get_xlabel(), "g")
         nt.assert_equal(ax.get_ylabel(), "y")
         plt.close("all")
 
-        ax = cat.barplot("y", "g", "h", orient="h", data=self.df)
+        ax = cat.barplot("y", "g", hue="h", orient="h", data=self.df)
         nt.assert_equal(len(ax.patches),
                         len(self.g.unique()) * len(self.h.unique()))
         nt.assert_equal(ax.get_xlabel(), "y")
@@ -2345,9 +2346,9 @@ class TestPointPlotter(CategoricalFixture):
 
         f, (ax1, ax2) = plt.subplots(2)
         hue_order = self.h.unique()
-        cat.pointplot(self.g, self.y, self.h,
+        cat.pointplot(self.g, self.y, hue=self.h,
                       hue_order=hue_order, ci="sd", ax=ax1)
-        cat.pointplot(self.g, self.y_perm, self.h,
+        cat.pointplot(self.g, self.y_perm, hue=self.h,
                       hue_order=hue_order, ci="sd", ax=ax2)
         for l1, l2 in zip(ax1.lines, ax2.lines):
             assert pytest.approx(l1.get_xydata()) == l2.get_xydata()
@@ -2427,7 +2428,7 @@ class TestPointPlotter(CategoricalFixture):
         nt.assert_equal(ax.get_ylabel(), "g")
         plt.close("all")
 
-        ax = cat.pointplot("g", "y", "h", data=self.df)
+        ax = cat.pointplot("g", "y", hue="h", data=self.df)
         nt.assert_equal(len(ax.collections), len(self.h.unique()))
         nt.assert_equal(len(ax.lines),
                         (len(self.g.unique()) *
@@ -2437,7 +2438,7 @@ class TestPointPlotter(CategoricalFixture):
         nt.assert_equal(ax.get_ylabel(), "y")
         plt.close("all")
 
-        ax = cat.pointplot("y", "g", "h", orient="h", data=self.df)
+        ax = cat.pointplot("y", "g", hue="h", orient="h", data=self.df)
         nt.assert_equal(len(ax.collections), len(self.h.unique()))
         nt.assert_equal(len(ax.lines),
                         (len(self.g.unique()) *
@@ -2510,7 +2511,7 @@ class TestCatPlot(CategoricalFixture):
         want_lines = self.g.unique().size + 1
         nt.assert_equal(len(g.ax.lines), want_lines)
 
-        g = cat.catplot("g", "y", "h", data=self.df, kind="point")
+        g = cat.catplot("g", "y", hue="h", data=self.df, kind="point")
         want_collections = self.h.unique().size
         nt.assert_equal(len(g.ax.collections), want_collections)
         want_lines = (self.g.unique().size + 1) * self.h.unique().size
@@ -2521,7 +2522,7 @@ class TestCatPlot(CategoricalFixture):
         nt.assert_equal(len(g.ax.patches), want_elements)
         nt.assert_equal(len(g.ax.lines), want_elements)
 
-        g = cat.catplot("g", "y", "h", data=self.df, kind="bar")
+        g = cat.catplot("g", "y", hue="h", data=self.df, kind="bar")
         want_elements = self.g.unique().size * self.h.unique().size
         nt.assert_equal(len(g.ax.patches), want_elements)
         nt.assert_equal(len(g.ax.lines), want_elements)
@@ -2540,7 +2541,7 @@ class TestCatPlot(CategoricalFixture):
         want_artists = self.g.unique().size
         nt.assert_equal(len(g.ax.artists), want_artists)
 
-        g = cat.catplot("g", "y", "h", data=self.df, kind="box")
+        g = cat.catplot("g", "y", hue="h", data=self.df, kind="box")
         want_artists = self.g.unique().size * self.h.unique().size
         nt.assert_equal(len(g.ax.artists), want_artists)
 
@@ -2549,7 +2550,7 @@ class TestCatPlot(CategoricalFixture):
         want_elements = self.g.unique().size
         nt.assert_equal(len(g.ax.collections), want_elements)
 
-        g = cat.catplot("g", "y", "h", data=self.df,
+        g = cat.catplot("g", "y", hue="h", data=self.df,
                         kind="violin", inner=None)
         want_elements = self.g.unique().size * self.h.unique().size
         nt.assert_equal(len(g.ax.collections), want_elements)
@@ -2558,7 +2559,7 @@ class TestCatPlot(CategoricalFixture):
         want_elements = self.g.unique().size
         nt.assert_equal(len(g.ax.collections), want_elements)
 
-        g = cat.catplot("g", "y", "h", data=self.df, kind="strip")
+        g = cat.catplot("g", "y", hue="h", data=self.df, kind="strip")
         want_elements = self.g.unique().size + self.h.unique().size
         nt.assert_equal(len(g.ax.collections), want_elements)
 
@@ -2729,13 +2730,13 @@ class TestBoxenPlotter(CategoricalFixture):
     def test_hue_offsets(self):
 
         p = cat._LVPlotter(**self.default_kws)
-        p.establish_variables("g", "y", "h", data=self.df)
+        p.establish_variables("g", "y", hue="h", data=self.df)
         npt.assert_array_equal(p.hue_offsets, [-.2, .2])
 
         kws = self.default_kws.copy()
         kws["width"] = .6
         p = cat._LVPlotter(**kws)
-        p.establish_variables("g", "y", "h", data=self.df)
+        p.establish_variables("g", "y", hue="h", data=self.df)
         npt.assert_array_equal(p.hue_offsets, [-.15, .15])
 
         p = cat._LVPlotter(**kws)
@@ -2750,7 +2751,7 @@ class TestBoxenPlotter(CategoricalFixture):
 
         plt.close("all")
 
-        ax = cat.boxenplot("g", "y", "h", data=self.df)
+        ax = cat.boxenplot("g", "y", hue="h", data=self.df)
         patches = filter(self.ispatch, ax.collections)
         nt.assert_equal(len(list(patches)), 6)
 
@@ -2765,7 +2766,7 @@ class TestBoxenPlotter(CategoricalFixture):
 
         plt.close("all")
 
-        ax = cat.boxenplot("g", "y", "h", data=self.df, saturation=1)
+        ax = cat.boxenplot("g", "y", hue="h", data=self.df, saturation=1)
         pal = palettes.color_palette(n_colors=2)
         for patch, color in zip(ax.artists, pal * 2):
             nt.assert_equal(patch.get_facecolor()[:3], color)
@@ -2791,8 +2792,8 @@ class TestBoxenPlotter(CategoricalFixture):
 
         f, (ax1, ax2) = plt.subplots(2)
         hue_order = self.h.unique()
-        cat.boxenplot(self.g, self.y, self.h, hue_order=hue_order, ax=ax1)
-        cat.boxenplot(self.g, self.y_perm, self.h,
+        cat.boxenplot(self.g, self.y, hue=self.h, hue_order=hue_order, ax=ax1)
+        cat.boxenplot(self.g, self.y_perm, hue=self.h,
                       hue_order=hue_order, ax=ax2)
         for l1, l2 in zip(ax1.lines, ax2.lines):
             assert np.array_equal(l1.get_xydata(), l2.get_xydata())
@@ -2810,7 +2811,7 @@ class TestBoxenPlotter(CategoricalFixture):
         plt.close("all")
 
         y[-1] = 0
-        ax = cat.boxenplot(x, y, h)
+        ax = cat.boxenplot(x, y, hue=h)
         nt.assert_equal(len(ax.lines), 7)
 
         plt.close("all")
@@ -2831,22 +2832,23 @@ class TestBoxenPlotter(CategoricalFixture):
         cat.boxenplot("y", "g", data=self.df, orient="h")
         plt.close("all")
 
-        cat.boxenplot("g", "y", "h", data=self.df)
+        cat.boxenplot("g", "y", hue="h", data=self.df)
         plt.close("all")
 
-        cat.boxenplot("g", "y", "h", order=list("nabc"), data=self.df)
+        cat.boxenplot("g", "y", hue="h", order=list("nabc"), data=self.df)
         plt.close("all")
 
-        cat.boxenplot("g", "y", "h", hue_order=list("omn"), data=self.df)
+        cat.boxenplot("g", "y", hue="h", hue_order=list("omn"), data=self.df)
         plt.close("all")
 
-        cat.boxenplot("y", "g", "h", data=self.df, orient="h")
+        cat.boxenplot("y", "g", hue="h", data=self.df, orient="h")
         plt.close("all")
 
-        cat.boxenplot("y", "g", "h", data=self.df, orient="h", palette="Set2")
+        cat.boxenplot("y", "g", hue="h", data=self.df, orient="h",
+                      palette="Set2")
         plt.close("all")
 
-        cat.boxenplot("y", "g", "h", data=self.df, orient="h", color="b")
+        cat.boxenplot("y", "g", hue="h", data=self.df, orient="h", color="b")
         plt.close("all")
 
     def test_axes_annotation(self):
@@ -2861,7 +2863,7 @@ class TestBoxenPlotter(CategoricalFixture):
 
         plt.close("all")
 
-        ax = cat.boxenplot("g", "y", "h", data=self.df)
+        ax = cat.boxenplot("g", "y", hue="h", data=self.df)
         nt.assert_equal(ax.get_xlabel(), "g")
         nt.assert_equal(ax.get_ylabel(), "y")
         npt.assert_array_equal(ax.get_xticks(), [0, 1, 2])
@@ -2894,7 +2896,7 @@ class TestBoxenPlotter(CategoricalFixture):
         exp = mpl.font_manager.FontProperties(size=size).get_size()
 
         with plt.rc_context(rc=rc_ctx):
-            ax = cat.boxenplot("g", "y", "h", data=self.df)
+            ax = cat.boxenplot("g", "y", hue="h", data=self.df)
             obs = ax.get_legend().get_title().get_fontproperties().get_size()
             assert obs == exp
 

--- a/seaborn/tests/test_decorators.py
+++ b/seaborn/tests/test_decorators.py
@@ -1,0 +1,65 @@
+import pytest
+from .._decorators import _deprecate_positional_args
+
+
+# This test was adapted from scikit-learn
+# github.com/scikit-learn/scikit-learn/blob/master/sklearn/utils/tests/test_validation.py
+def test_deprecate_positional_args_warns_for_function():
+
+    @_deprecate_positional_args
+    def f1(a, b, *, c=1, d=1):
+        return a, b, c, d
+
+    with pytest.warns(FutureWarning,
+                      match=r"Pass c=3 as keyword arg\."):
+        assert f1(1, 2, 3) == (1, 2, 3, 1)
+
+    with pytest.warns(FutureWarning,
+                      match=r"Pass c=3, d=4 as keyword args\."):
+        assert f1(1, 2, 3, 4) == (1, 2, 3, 4)
+
+    @_deprecate_positional_args
+    def f2(a=1, *, b=1, c=1, d=1):
+        return a, b, c, d
+
+    with pytest.warns(FutureWarning,
+                      match=r"Pass b=2 as keyword arg\."):
+        assert f2(1, 2) == (1, 2, 1, 1)
+
+    # The * is placed before a keyword only argument without a default value
+    @_deprecate_positional_args
+    def f3(a, *, b, c=1, d=1):
+        return a, b, c, d
+
+    with pytest.warns(FutureWarning,
+                      match=r"Pass b=2 as keyword arg\."):
+        assert f3(1, 2) == (1, 2, 1, 1)
+
+
+def test_deprecate_positional_args_warns_for_class():
+
+    class A1:
+        @_deprecate_positional_args
+        def __init__(self, a, b, *, c=1, d=1):
+            self.a = a, b, c, d
+
+    with pytest.warns(FutureWarning,
+                      match=r"Pass c=3 as keyword arg\."):
+        assert A1(1, 2, 3).a == (1, 2, 3, 1)
+
+    with pytest.warns(FutureWarning,
+                      match=r"Pass c=3, d=4 as keyword args\."):
+        assert A1(1, 2, 3, 4).a == (1, 2, 3, 4)
+
+    class A2:
+        @_deprecate_positional_args
+        def __init__(self, a=1, b=1, *, c=1, d=1):
+            self.a = a, b, c, d
+
+    with pytest.warns(FutureWarning,
+                      match=r"Pass c=3 as keyword arg\."):
+        assert A2(1, 2, 3).a == (1, 2, 3, 1)
+
+    with pytest.warns(FutureWarning,
+                      match=r"Pass c=3, d=4 as keyword args\."):
+        assert A2(1, 2, 3, 4).a == (1, 2, 3, 4)

--- a/seaborn/tests/test_distributions.py
+++ b/seaborn/tests/test_distributions.py
@@ -168,7 +168,7 @@ class TestKDE(object):
     def test_kde_cummulative_2d(self):
         """Check error if args indicate bivariate KDE and cumulative."""
         with npt.assert_raises(TypeError):
-            dist.kdeplot(self.x, data2=self.y, cumulative=True)
+            dist.kdeplot(self.x, self.y, cumulative=True)
 
     def test_kde_singular(self):
 
@@ -299,7 +299,7 @@ class TestRugPlot(object):
         for data in [list_data, array_data, series_data]:
 
             f, ax = plt.subplots()
-            dist.rugplot(data, h)
+            dist.rugplot(data, height=h)
             rug, = ax.collections
             segments = np.array(rug.get_segments())
 
@@ -312,7 +312,7 @@ class TestRugPlot(object):
             plt.close(f)
 
             f, ax = plt.subplots()
-            dist.rugplot(data, h, axis="y")
+            dist.rugplot(data, height=h, axis="y")
             rug, = ax.collections
             segments = np.array(rug.get_segments())
 

--- a/seaborn/tests/test_regression.py
+++ b/seaborn/tests/test_regression.py
@@ -469,7 +469,7 @@ class TestRegressionPlots(object):
     def test_regplot_basic(self):
 
         f, ax = plt.subplots()
-        lm.regplot("x", "y", self.df)
+        lm.regplot(x="x", y="y", data=self.df)
         nt.assert_equal(len(ax.lines), 1)
         nt.assert_equal(len(ax.collections), 2)
 
@@ -480,19 +480,19 @@ class TestRegressionPlots(object):
     def test_regplot_selective(self):
 
         f, ax = plt.subplots()
-        ax = lm.regplot("x", "y", self.df, scatter=False, ax=ax)
+        ax = lm.regplot("x", "y", data=self.df, scatter=False, ax=ax)
         nt.assert_equal(len(ax.lines), 1)
         nt.assert_equal(len(ax.collections), 1)
         ax.clear()
 
         f, ax = plt.subplots()
-        ax = lm.regplot("x", "y", self.df, fit_reg=False)
+        ax = lm.regplot("x", "y", data=self.df, fit_reg=False)
         nt.assert_equal(len(ax.lines), 0)
         nt.assert_equal(len(ax.collections), 1)
         ax.clear()
 
         f, ax = plt.subplots()
-        ax = lm.regplot("x", "y", self.df, ci=None)
+        ax = lm.regplot("x", "y", data=self.df, ci=None)
         nt.assert_equal(len(ax.lines), 1)
         nt.assert_equal(len(ax.collections), 1)
         ax.clear()
@@ -501,35 +501,35 @@ class TestRegressionPlots(object):
 
         f, ax = plt.subplots()
         color = np.array([[0.3, 0.8, 0.5, 0.5]])
-        ax = lm.regplot("x", "y", self.df, scatter_kws={'color': color})
+        ax = lm.regplot("x", "y", data=self.df, scatter_kws={'color': color})
         nt.assert_is(ax.collections[0]._alpha, None)
         nt.assert_equal(ax.collections[0]._facecolors[0, 3], 0.5)
 
         f, ax = plt.subplots()
         color = np.array([[0.3, 0.8, 0.5]])
-        ax = lm.regplot("x", "y", self.df, scatter_kws={'color': color})
+        ax = lm.regplot("x", "y", data=self.df, scatter_kws={'color': color})
         nt.assert_equal(ax.collections[0]._alpha, 0.8)
 
         f, ax = plt.subplots()
         color = np.array([[0.3, 0.8, 0.5]])
-        ax = lm.regplot("x", "y", self.df, scatter_kws={'color': color,
-                                                        'alpha': 0.4})
+        ax = lm.regplot("x", "y", data=self.df,
+                        scatter_kws={'color': color, 'alpha': 0.4})
         nt.assert_equal(ax.collections[0]._alpha, 0.4)
 
         f, ax = plt.subplots()
         color = 'r'
-        ax = lm.regplot("x", "y", self.df, scatter_kws={'color': color})
+        ax = lm.regplot("x", "y", data=self.df, scatter_kws={'color': color})
         nt.assert_equal(ax.collections[0]._alpha, 0.8)
 
     def test_regplot_binned(self):
 
-        ax = lm.regplot("x", "y", self.df, x_bins=5)
+        ax = lm.regplot("x", "y", data=self.df, x_bins=5)
         nt.assert_equal(len(ax.lines), 6)
         nt.assert_equal(len(ax.collections), 2)
 
     def test_lmplot_basic(self):
 
-        g = lm.lmplot("x", "y", self.df)
+        g = lm.lmplot("x", "y", data=self.df)
         ax = g.axes[0, 0]
         nt.assert_equal(len(ax.lines), 1)
         nt.assert_equal(len(ax.collections), 2)
@@ -604,7 +604,7 @@ class TestRegressionPlots(object):
     @pytest.mark.skipif(_no_statsmodels, reason="no statsmodels")
     def test_residplot_lowess(self):
 
-        ax = lm.residplot("x", "y", self.df, lowess=True)
+        ax = lm.residplot("x", "y", data=self.df, lowess=True)
         nt.assert_equal(len(ax.lines), 2)
 
         x, y = ax.lines[1].get_xydata().T

--- a/seaborn/tests/test_utils.py
+++ b/seaborn/tests/test_utils.py
@@ -29,7 +29,6 @@ from ..utils import (
     get_dataset_names,
     load_dataset,
     _network,
-    _deprecate_positional_args
 )
 
 
@@ -503,41 +502,3 @@ def test_remove_na():
     a_series = pd.Series([1, 2, np.nan, 3])
     a_series_rm = utils.remove_na(a_series)
     pdt.assert_series_equal(a_series_rm, pd.Series([1., 2, 3], [0, 1, 3]))
-
-
-# This test was adapted from scikit-learn
-# github.com/scikit-learn/scikit-learn/blob/master/sklearn/utils/tests/test_validation.py
-def test_deprecate_positional_args_warns_for_function():
-
-    @_deprecate_positional_args
-    def f1(a, b, *, c=1, d=1):
-        return a, b, c, d
-
-    with pytest.warns(FutureWarning,
-                      match=r"Pass c=3 as keyword arg\."):
-        out = f1(1, 2, 3)
-        assert out == (1, 2, 3, 1)
-
-    with pytest.warns(FutureWarning,
-                      match=r"Pass c=3, d=4 as keyword args\."):
-        out = f1(1, 2, 3, 4)
-        assert out == (1, 2, 3, 4)
-
-    @_deprecate_positional_args
-    def f2(a=1, *, b=1, c=1, d=1):
-        return a, b, c, d
-
-    with pytest.warns(FutureWarning,
-                      match=r"Pass b=2 as keyword arg\."):
-        out = f2(1, 2)
-        assert out == (1, 2, 1, 1)
-
-    # The * is placed before a keyword only argument without a default value
-    @_deprecate_positional_args
-    def f3(a, *, b, c=1, d=1):
-        return a, b, c, d
-
-    with pytest.warns(FutureWarning,
-                      match=r"Pass b=2 as keyword arg\."):
-        out = f3(1, 2)
-        assert out == (1, 2, 1, 1)

--- a/seaborn/utils.py
+++ b/seaborn/utils.py
@@ -1,6 +1,11 @@
-"""Small plotting-related utility functions."""
-import colorsys
+"""Utility functions, mostly for internal use."""
 import os
+import colorsys
+import warnings
+from urllib.request import urlopen, urlretrieve
+from http.client import HTTPException
+from inspect import signature, Parameter
+from functools import wraps
 
 import numpy as np
 from scipy import stats
@@ -8,10 +13,6 @@ import pandas as pd
 import matplotlib as mpl
 import matplotlib.colors as mplcol
 import matplotlib.pyplot as plt
-
-import warnings
-from urllib.request import urlopen, urlretrieve
-from http.client import HTTPException
 
 
 __all__ = ["desaturate", "saturate", "set_hls_values",
@@ -672,3 +673,46 @@ def _network(t=None, url='https://google.com'):
             f.close()
             return t(*args, **kwargs)
     return wrapper
+
+
+# This function was adapted from scikit-learn
+# github.com/scikit-learn/scikit-learn/blob/master/sklearn/utils/validation.py
+def _deprecate_positional_args(f):
+    """Decorator for methods that issues warnings for positional arguments.
+
+    Using the keyword-only argument syntax in pep 3102, arguments after the
+    * will issue a warning when passed as a positional argument.
+
+    Parameters
+    ----------
+    f : function
+        function to check arguments on
+
+    """
+    sig = signature(f)
+    kwonly_args = []
+    all_args = []
+
+    for name, param in sig.parameters.items():
+        if param.kind == Parameter.POSITIONAL_OR_KEYWORD:
+            all_args.append(name)
+        elif param.kind == Parameter.KEYWORD_ONLY:
+            kwonly_args.append(name)
+
+    @wraps(f)
+    def inner_f(*args, **kwargs):
+        extra_args = len(args) - len(all_args)
+        if extra_args > 0:
+            # ignore first 'self' argument for instance methods
+            args_msg = ['{}={}'.format(name, arg)
+                        for name, arg in zip(kwonly_args[:extra_args],
+                                             args[-extra_args:])]
+            plural = "s" if len(args_msg) > 1 else ""
+            warnings.warn("Pass {} as keyword arg{}. From version 0.12, "
+                          "passing these as positional arguments will "
+                          "result in an error"
+                          .format(", ".join(args_msg), plural),
+                          FutureWarning)
+        kwargs.update({k: arg for k, arg in zip(sig.parameters, args)})
+        return f(**kwargs)
+    return inner_f

--- a/seaborn/utils.py
+++ b/seaborn/utils.py
@@ -4,8 +4,6 @@ import colorsys
 import warnings
 from urllib.request import urlopen, urlretrieve
 from http.client import HTTPException
-from inspect import signature, Parameter
-from functools import wraps
 
 import numpy as np
 from scipy import stats
@@ -673,46 +671,3 @@ def _network(t=None, url='https://google.com'):
             f.close()
             return t(*args, **kwargs)
     return wrapper
-
-
-# This function was adapted from scikit-learn
-# github.com/scikit-learn/scikit-learn/blob/master/sklearn/utils/validation.py
-def _deprecate_positional_args(f):
-    """Decorator for methods that issues warnings for positional arguments.
-
-    Using the keyword-only argument syntax in pep 3102, arguments after the
-    * will issue a warning when passed as a positional argument.
-
-    Parameters
-    ----------
-    f : function
-        function to check arguments on
-
-    """
-    sig = signature(f)
-    kwonly_args = []
-    all_args = []
-
-    for name, param in sig.parameters.items():
-        if param.kind == Parameter.POSITIONAL_OR_KEYWORD:
-            all_args.append(name)
-        elif param.kind == Parameter.KEYWORD_ONLY:
-            kwonly_args.append(name)
-
-    @wraps(f)
-    def inner_f(*args, **kwargs):
-        extra_args = len(args) - len(all_args)
-        if extra_args > 0:
-            # ignore first 'self' argument for instance methods
-            args_msg = ['{}={}'.format(name, arg)
-                        for name, arg in zip(kwonly_args[:extra_args],
-                                             args[-extra_args:])]
-            plural = "s" if len(args_msg) > 1 else ""
-            warnings.warn("Pass {} as keyword arg{}. From version 0.12, "
-                          "passing these as positional arguments will "
-                          "result in an error"
-                          .format(", ".join(args_msg), plural),
-                          FutureWarning)
-        kwargs.update({k: arg for k, arg in zip(sig.parameters, args)})
-        return f(**kwargs)
-    return inner_f


### PR DESCRIPTION
This PR is a major and long-desired change that leverages Python 3 functionality to require most parameters to be defined with keyword arguments.

Most of the functions in the seaborn plotting API have a signature that looks roughly like:

```python
def plot(x, y, [semantic_vars, ...], data=None, [other_params, ...], **passthrough_kwargs):
    ...
```

Where `semantic_vars` are `hue`, `style`, etc.

This PR will enforce that ~~`data` and all subsequent params~~ most parameters, aside from those that specify data positions, be specified with explicit keyword arguments.

The motivation for requiring keyword arguments is that, when functions have long signatures, one would like to order the parameters in ways that are more meaningful than chronology. This is very much the case in seaborn, where a single function call has subsets of parameters that, e.g., control statistical aggregation or change the aesthetics of the plot.  In theory, inserting new parameters or reordering existing ones to achieve this has the potential to break user code, potentially in damaging ways (i.e., an argument might get passed to a parameter it is technically valid for but that produces an incorrect plot).

Seaborn has in the past sometimes inserted new parameters towards the end of the `other_params` under the sincere hope that people are not writing out 10+ positional arguments; this change will let us do that more safely in the future. But the real benefit of this change is the ability to define new `semantic_vars` while making it obvious what arguments can or cannot be used to extract values from the ``data`` object.

With this change, we will be able to

- standardize the signatures of the oldest functions that predated this convention (e.g., `lmplot`, where `hue` comes after `data`)
- add core semantics to older functions (i.e, `hue` or `style` for `kdeplot` or `regplot`)
- add new semantics going forward (e.g., `style` in categorical plots).

## Outstanding questions

- Should there be a grace period with a deprecation warning? scikit-learn has taken that approach and, we could borrow [their decorator](https://github.com/scikit-learn/scikit-learn/pull/13311/files) to do so. **A: Yes. 0.11 will warn; 0.12 will error.**

- Where should the `*` go? **A: For vector-oriented function, it goes after `x, y` (so before semantic variables and data. For multi-axes grid and matrix-oriented plotting functions, it goes after `data`).**

- What should the signature for the `*map` functions (`heatmap` and `clustermap` be?). **A: It will remain `func(data, ...)`, but this change will make it easy to add both location and semantic arguments to these functions (i.e. to pass long-form data with arguments to pivot into a matrix; #2054 ).** 

- What should the signature be for the `*Grid` objects? These are naturally long-form but don't have "leading semantics".  **A: ``data, ...``**.

- Are there other places we want to enforce keyword arguments? Maybe in `palettes.py`? **A: Perhaps, but this can be deferred**.