### PR TITLE
Standardize parameter names in distributions module

### DIFF
--- a/doc/releases/v0.11.0.txt
+++ b/doc/releases/v0.11.0.txt
@@ -4,6 +4,8 @@ v0.11.0 (Unreleased)
 
 - Enforced keyword-only arguments for most parameters of most functions and classes.
 
+- Standardized the parameter names for the oldest functions (:func:`distplot`, :func:`kdeplot`, and :func:`rugplot`) to be `x` and `y`, as in other functions. Using the old names will warn now and break in the future.
+
 - Added an explicit warning in :func:`swarmplot` when more than 2% of the points are overlap in the "gutters" of the swarm.
 
 - Added the ``axes_dict`` attribute to :class:`FacetGrid` for named access to the component axes.

--- a/seaborn/distributions.py
+++ b/seaborn/distributions.py
@@ -38,12 +38,11 @@ def _freedman_diaconis_bins(a):
 
 @_deprecate_positional_args
 def distplot(
-    a,
-    *,
+    x=None, *,
     bins=None, hist=True, kde=True, rug=False, fit=None,
     hist_kws=None, kde_kws=None, rug_kws=None, fit_kws=None,
     color=None, vertical=False, norm_hist=False, axlabel=None,
-    label=None, ax=None
+    label=None, ax=None, a=None,
 ):
     """Flexibly plot a univariate distribution of observations.
 
@@ -55,7 +54,7 @@ def distplot(
     Parameters
     ----------
 
-    a : Series, 1d-array, or list.
+    x : Series, 1d-array, or list.
         Observed data. If this is a Series object with a ``name`` attribute,
         the name will be used to label the data axis.
     bins : argument for matplotlib hist(), or None, optional
@@ -169,6 +168,14 @@ def distplot(
         ...                             "alpha": 1, "color": "g"})
 
     """
+    # Handle deprecation of ``a```
+    if a is not None:
+        msg = "The `a` parameter is now called `x`. Please update your code."
+        warnings.warn(msg)
+    else:
+        a = x  # TODO refactor
+
+    # Default to drawing on the currently-active axes
     if ax is None:
         ax = plt.gca()
 
@@ -509,21 +516,21 @@ def _scipy_bivariate_kde(x, y, bw, gridsize, cut, clip):
 
 @_deprecate_positional_args
 def kdeplot(
-    data, data2=None,
-    *,
+    x=None, y=None, *,
     shade=False, vertical=False, kernel="gau",
     bw="scott", gridsize=100, cut=3, clip=None, legend=True,
     cumulative=False, shade_lowest=True, cbar=False, cbar_ax=None,
     cbar_kws=None, ax=None,
+    data=None, data2=None,  # TODO move data once * is enforced
     **kwargs,
 ):
     """Fit and plot a univariate or bivariate kernel density estimate.
 
     Parameters
     ----------
-    data : 1d array-like
+    x : 1d array-like
         Input data.
-    data2: 1d array-like, optional
+    y: 1d array-like, optional
         Second input data. If present, a bivariate KDE will be estimated.
     shade : bool, optional
         If True, shade in the area under the KDE curve (or draw with filled
@@ -664,52 +671,44 @@ def kdeplot(
         ...                  cmap="Blues", shade=True, shade_lowest=False)
 
     """
-    if ax is None:
-        ax = plt.gca()
-
-    if isinstance(data, list):
-        data = np.asarray(data)
-
-    if len(data) == 0:
-        return ax
-
-    data = data.astype(np.float64)
-    if data2 is not None:
-        if isinstance(data2, list):
-            data2 = np.asarray(data2)
-        data2 = data2.astype(np.float64)
-
-    warn = False
-    bivariate = False
-    if isinstance(data, np.ndarray) and np.ndim(data) > 1:
-        warn = True
-        bivariate = True
-        x, y = data.T
-    elif isinstance(data, pd.DataFrame) and np.ndim(data) > 1:
-        warn = True
-        bivariate = True
-        x = data.iloc[:, 0].values
-        y = data.iloc[:, 1].values
-    elif data2 is not None:
-        bivariate = True
+    # Handle deprecation of `data` as name for x variable
+    # TODO this can be removed once refactored to do centralized preprocessing
+    # of input variables, because a vector input to `data` will be treated like
+    # an input to `x`. Warning is probably not necessary.
+    x_passed_as_data = (
+        x is None
+        and data is not None
+        and np.ndim(data) == 1
+    )
+    if x_passed_as_data:
         x = data
+
+    # Handle deprecation of `data2` as name for y variable
+    if data2 is not None:
+        msg = "The `data2` param is now named `y`; please update your code."
+        warnings.warn(msg)
         y = data2
 
-    if warn:
-        warn_msg = ("Passing a 2D dataset for a bivariate plot is deprecated "
-                    "in favor of kdeplot(x, y), and it will cause an error in "
-                    "future versions. Please update your code.")
-        warnings.warn(warn_msg, UserWarning)
+    # TODO replace this preprocessing with central refactoring
+    if isinstance(x, list):
+        x = np.asarray(x)
+    if isinstance(y, list):
+        y = np.asarray(y)
 
+    bivariate = x is not None and y is not None
     if bivariate and cumulative:
         raise TypeError("Cumulative distribution plots are not"
                         "supported for bivariate distributions.")
+
+    if ax is None:
+        ax = plt.gca()
+
     if bivariate:
         ax = _bivariate_kdeplot(x, y, shade, shade_lowest,
                                 kernel, bw, gridsize, cut, clip, legend,
                                 cbar, cbar_ax, cbar_kws, ax, **kwargs)
     else:
-        ax = _univariate_kdeplot(data, shade, vertical, kernel, bw,
+        ax = _univariate_kdeplot(x, shade, vertical, kernel, bw,
                                  gridsize, cut, clip, legend, ax,
                                  cumulative=cumulative, **kwargs)
 
@@ -718,16 +717,16 @@ def kdeplot(
 
 @_deprecate_positional_args
 def rugplot(
-    a,
-    *,
+    x=None, *,
     height=.05, axis="x", ax=None,
+    a=None,
     **kwargs
 ):
     """Plot datapoints in an array as sticks on an axis.
 
     Parameters
     ----------
-    a : vector
+    x : vector
         1D array of observations.
     height : scalar, optional
         Height of ticks as proportion of the axis.
@@ -744,6 +743,14 @@ def rugplot(
         The Axes object with the plot on it.
 
     """
+    # Handle deprecation of ``a```
+    if a is not None:
+        msg = "The `a` parameter is now called `x`. Please update your code."
+        warnings.warn(msg)
+    else:
+        a = x  # TODO refactor
+
+    # Default to drawing on the currently active axes
     if ax is None:
         ax = plt.gca()
     a = np.asarray(a)

--- a/seaborn/distributions.py
+++ b/seaborn/distributions.py
@@ -370,6 +370,9 @@ def _univariate_kdeplot(data, shade, vertical, kernel, bw, gridsize, cut,
 def _statsmodels_univariate_kde(data, kernel, bw, gridsize, cut, clip,
                                 cumulative=False):
     """Compute a univariate kernel density estimate using statsmodels."""
+    # statsmodels 0.8 fails on int type data
+    data = data.astype(np.float64)
+
     fft = kernel == "gau"
     kde = smnp.KDEUnivariate(data)
 
@@ -471,6 +474,10 @@ def _bivariate_kdeplot(x, y, filled, fill_lowest,
 
 def _statsmodels_bivariate_kde(x, y, bw, gridsize, cut, clip):
     """Compute a bivariate kde using statsmodels."""
+    # statsmodels 0.8 fails on int type data
+    x = x.astype(np.float64)
+    y = y.astype(np.float64)
+
     if isinstance(bw, str):
         bw_func = getattr(smnp.bandwidths, "bw_" + bw)
         x_bw = bw_func(x)

--- a/seaborn/tests/test_distributions.py
+++ b/seaborn/tests/test_distributions.py
@@ -1,3 +1,4 @@
+import itertools
 import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
@@ -103,6 +104,38 @@ class TestKDE(object):
     gridsize = 128
     clip = (-np.inf, np.inf)
     cut = 3
+
+    def test_kde_1d_input_output(self):
+        """Test that array/series/list inputs give the same output."""
+        f, ax = plt.subplots()
+
+        dist.kdeplot(x=self.x)
+        dist.kdeplot(x=pd.Series(self.x))
+        dist.kdeplot(x=self.x.tolist())
+        dist.kdeplot(data=self.x)
+
+        supports = [l.get_xdata() for l in ax.lines]
+        for a, b in itertools.product(supports, supports):
+            assert np.array_equal(a, b)
+
+        densities = [l.get_ydata() for l in ax.lines]
+        for a, b in itertools.product(densities, densities):
+            assert np.array_equal(a, b)
+
+    def test_kde_2d_input_output(self):
+        """Test that array/series/list inputs give the same output."""
+        f, ax = plt.subplots()
+
+        dist.kdeplot(x=self.x, y=self.y)
+        dist.kdeplot(x=pd.Series(self.x), y=pd.Series(self.y))
+        dist.kdeplot(x=self.x.tolist(), y=self.y.tolist())
+
+        contours = ax.collections
+        n = len(contours) // 3
+
+        for i in range(n):
+            for a, b in itertools.product(contours[i::n], contours[i::n]):
+                assert np.array_equal(a.get_offsets(), b.get_offsets())
 
     def test_scipy_univariate_kde(self):
         """Test the univariate KDE estimation with scipy."""


### PR DESCRIPTION
The distribution plots (`distplot`, `kdeplot`, and `rugplot`) are the oldest functions in seaborn and predated the common API, so their input parameters had unusual names.

This PR deprecates the old names and replaces them with `x` and `y` like in other functions.

Ultimately, there will be a full refactoring of these functions to accept input data like all the other seaborn plotters, either as vectors or names that index into a data object. This is the first step of that process.