### PR TITLE
Add tight_layout method on FacetGrid and PairGrid

### DIFF
--- a/doc/releases/v0.11.0.txt
+++ b/doc/releases/v0.11.0.txt
@@ -6,6 +6,8 @@ v0.11.0 (Unreleased)
 
 - Standardized the parameter names for the oldest functions (:func:`distplot`, :func:`kdeplot`, and :func:`rugplot`) to be `x` and `y`, as in other functions. Using the old names will warn now and break in the future.
 
+- Added a ``tight_layout`` method to :class:`FacetGrid` and :class:`PairGrid`, which runs the :func:`matplotlib.pyplot.tight_layout` algorithm without interference from the external legend.
+
 - Added an explicit warning in :func:`swarmplot` when more than 2% of the points are overlap in the "gutters" of the swarm.
 
 - Added the ``axes_dict`` attribute to :class:`FacetGrid` for named access to the component axes.

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,4 +1,5 @@
 sphinx==2.3.1
 sphinx_bootstrap_theme==0.6.5  # Later versions mess up the css somehow
+numpydoc
 nbconvert
 ipykernel

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -23,6 +23,10 @@ class Grid(object):
     _margin_titles = False
     _legend_out = True
 
+    def __init__(self):
+
+        self._tight_layout_rect = [0, 0, 1, 1]
+
     def set(self, **kwargs):
         """Set attributes on each subplot Axes."""
         for ax in self.axes.flat:
@@ -34,6 +38,12 @@ class Grid(object):
         kwargs = kwargs.copy()
         kwargs.setdefault("bbox_inches", "tight")
         self.fig.savefig(*args, **kwargs)
+
+    def tight_layout(self, *args, **kwargs):
+        """Call fig.tight_layout within rect that exclude the legend."""
+        kwargs = kwargs.copy()
+        kwargs.setdefault("rect", self._tight_layout_rect)
+        self.fig.tight_layout(*args, **kwargs)
 
     def add_legend(self, legend_data=None, title=None, label_order=None,
                    **kwargs):
@@ -125,6 +135,7 @@ class Grid(object):
 
             # Place the subplot axes to give space for the legend
             self.fig.subplots_adjust(right=right)
+            self._tight_layout_rect[2] = right
 
         else:
             # Draw a legend in the first axis
@@ -239,6 +250,8 @@ class FacetGrid(Grid):
         margin_titles=False, xlim=None, ylim=None, subplot_kws=None,
         gridspec_kws=None, size=None
     ):
+
+        super(FacetGrid, self).__init__()
 
         # Handle deprecations
         if size is not None:
@@ -1284,6 +1297,8 @@ class PairGrid(Grid):
             >>> g = g.add_legend()
 
         """
+
+        super(PairGrid, self).__init__()
 
         # Handle deprecations
         if size is not None:

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -398,7 +398,7 @@ class FacetGrid(Grid):
 
         # --- Make the axes look good
 
-        fig.tight_layout()
+        self.tight_layout()
         if despine:
             self.despine()
 
@@ -884,7 +884,7 @@ class FacetGrid(Grid):
         """Finalize the annotations and layout."""
         self.set_axis_labels(*axlabels)
         self.set_titles()
-        self.fig.tight_layout()
+        self.tight_layout()
 
     def facet_axis(self, row_i, col_j):
         """Make the axis identified by these indices active and return it."""
@@ -1388,7 +1388,7 @@ class PairGrid(Grid):
         if despine:
             self._despine = True
             utils.despine(fig=fig)
-        fig.tight_layout(pad=layout_pad)
+        self.tight_layout(pad=layout_pad)
 
     def map(self, func, **kwargs):
         """Plot with the same function in every subplot.

--- a/seaborn/tests/test_axisgrid.py
+++ b/seaborn/tests/test_axisgrid.py
@@ -306,6 +306,18 @@ class TestFacetGrid(object):
         g.map(plt.plot, "x", "y", linewidth=3)
         g.add_legend()
 
+    def test_legend_tight_layout(self):
+
+        g = ag.FacetGrid(self.df, hue='b')
+        g.map(plt.plot, "x", "y", linewidth=3)
+        g.add_legend()
+        g.tight_layout()
+
+        axes_right_edge = g.ax.get_window_extent().xmax
+        legend_left_edge = g._legend.get_window_extent().xmin
+
+        assert axes_right_edge < legend_left_edge
+
     def test_subplot_kws(self):
 
         g = ag.FacetGrid(self.df, despine=False,


### PR DESCRIPTION
The matplotlib `tight_layout` algorithm ignores figure-level legends, which causes problems with `FacetGrid` and `PairGrid` if you need to tighten the layout after adding the legend:

```python
mpg = sns.load_dataset("mpg")
g = sns.relplot(
    x="horsepower",
    y="mpg",
    size="weight",
    sizes=(40, 400),
    alpha=0.5,
    height=6,
    data=mpg,
)
g.fig.tight_layout()
```
![image](https://user-images.githubusercontent.com/315810/81965380-fba27980-95e5-11ea-82d6-bec37c99cb7f.png)

This PR adds a `tight_layout` method on the `Grid` class that keeps the axes from overlapping with the legend:

```python
g = sns.relplot(
    x="horsepower",
    y="mpg",
    size="weight",
    sizes=(40, 400),
    alpha=0.5,
    height=6,
    data=mpg,
)
g.tight_layout()
```
![image](https://user-images.githubusercontent.com/315810/81965429-0b21c280-95e6-11ea-96ef-72cbb77d04c6.png)
