### PR TITLE
Programmatically define arbitrarily large style mappings

### DIFF
--- a/doc/releases/v0.11.0.txt
+++ b/doc/releases/v0.11.0.txt
@@ -2,9 +2,13 @@
 v0.11.0 (Unreleased)
 --------------------
 
+- TODO stub for explaining improvements to variable specificiation. Make this good!
+
 - Enforced keyword-only arguments for most parameters of most functions and classes.
 
 - Standardized the parameter names for the oldest functions (:func:`distplot`, :func:`kdeplot`, and :func:`rugplot`) to be `x` and `y`, as in other functions. Using the old names will warn now and break in the future.
+
+- Plots with a ``style`` semantic can now generate an infinite number of default dashes and/or markers. Prevously, an error would be raised if the ``style`` variable had more levels than could be mapped using the default lists. The existing defaults were slightly modified as part of this change; if you need to exactly reproduce plots from earlier versions, refer to the `old defaults <https://github.com/mwaskom/seaborn/blob/v0.10.1/seaborn/relational.py#L24>`_.
 
 - Added a ``tight_layout`` method to :class:`FacetGrid` and :class:`PairGrid`, which runs the :func:`matplotlib.pyplot.tight_layout` algorithm without interference from the external legend.
 

--- a/doc/releases/v0.11.0.txt
+++ b/doc/releases/v0.11.0.txt
@@ -8,7 +8,7 @@ v0.11.0 (Unreleased)
 
 - Standardized the parameter names for the oldest functions (:func:`distplot`, :func:`kdeplot`, and :func:`rugplot`) to be `x` and `y`, as in other functions. Using the old names will warn now and break in the future.
 
-- Plots with a ``style`` semantic can now generate an infinite number of default dashes and/or markers. Prevously, an error would be raised if the ``style`` variable had more levels than could be mapped using the default lists. The existing defaults were slightly modified as part of this change; if you need to exactly reproduce plots from earlier versions, refer to the `old defaults <https://github.com/mwaskom/seaborn/blob/v0.10.1/seaborn/relational.py#L24>`_.
+- Plots with a ``style`` semantic can now generate an infinite number of unique dashes and/or markers by default. Prevously, an error would be raised if the ``style`` variable had more levels than could be mapped using the default lists. The existing defaults were slightly modified as part of this change; if you need to exactly reproduce plots from earlier versions, refer to the `old defaults <https://github.com/mwaskom/seaborn/blob/v0.10.1/seaborn/relational.py#L24>`_.
 
 - Added a ``tight_layout`` method to :class:`FacetGrid` and :class:`PairGrid`, which runs the :func:`matplotlib.pyplot.tight_layout` algorithm without interference from the external legend.
 

--- a/doc/releases/v0.11.0.txt
+++ b/doc/releases/v0.11.0.txt
@@ -2,18 +2,18 @@
 v0.11.0 (Unreleased)
 --------------------
 
-- TODO stub for explaining improvements to variable specificiation. Make this good!
+- TODO stub for explaining improvements to variable specificiation. Make this good!  GH2017
 
-- Enforced keyword-only arguments for most parameters of most functions and classes.
+- Enforced keyword-only arguments for most parameters of most functions and classes.  GH2052
 
-- Standardized the parameter names for the oldest functions (:func:`distplot`, :func:`kdeplot`, and :func:`rugplot`) to be `x` and `y`, as in other functions. Using the old names will warn now and break in the future.
+- Standardized the parameter names for the oldest functions (:func:`distplot`, :func:`kdeplot`, and :func:`rugplot`) to be `x` and `y`, as in other functions. Using the old names will warn now and break in the future.  GH2060
 
-- Plots with a ``style`` semantic can now generate an infinite number of unique dashes and/or markers by default. Prevously, an error would be raised if the ``style`` variable had more levels than could be mapped using the default lists. The existing defaults were slightly modified as part of this change; if you need to exactly reproduce plots from earlier versions, refer to the `old defaults <https://github.com/mwaskom/seaborn/blob/v0.10.1/seaborn/relational.py#L24>`_.
+- Plots with a ``style`` semantic can now generate an infinite number of unique dashes and/or markers by default. Prevously, an error would be raised if the ``style`` variable had more levels than could be mapped using the default lists. The existing defaults were slightly modified as part of this change; if you need to exactly reproduce plots from earlier versions, refer to the `old defaults <https://github.com/mwaskom/seaborn/blob/v0.10.1/seaborn/relational.py#L24>`_. GH2075
 
-- Added a ``tight_layout`` method to :class:`FacetGrid` and :class:`PairGrid`, which runs the :func:`matplotlib.pyplot.tight_layout` algorithm without interference from the external legend.
+- Added a ``tight_layout`` method to :class:`FacetGrid` and :class:`PairGrid`, which runs the :func:`matplotlib.pyplot.tight_layout` algorithm without interference from the external legend. GH2073
 
-- Added an explicit warning in :func:`swarmplot` when more than 2% of the points are overlap in the "gutters" of the swarm.
+- Added an explicit warning in :func:`swarmplot` when more than 2% of the points are overlap in the "gutters" of the swarm. GH2045
 
-- Added the ``axes_dict`` attribute to :class:`FacetGrid` for named access to the component axes.
+- Added the ``axes_dict`` attribute to :class:`FacetGrid` for named access to the component axes.  GH2046
 
-- Made :meth:`FacetGrid.set_axis_labels` clear labels from "interior" axes.
+- Made :meth:`FacetGrid.set_axis_labels` clear labels from "interior" axes.  GH2046

--- a/seaborn/core.py
+++ b/seaborn/core.py
@@ -1,7 +1,9 @@
 import itertools
 from collections.abc import Iterable, Sequence, Mapping
+
 import numpy as np
 import pandas as pd
+import matplotlib as mpl
 
 
 class _VectorPlotter:
@@ -238,17 +240,17 @@ def unique_dashes(n):
     ----------
     n : int
         Number of unique dash specs to generate.
+
     Returns
     -------
-    dashes : list of tuples
+    dashes : list of strings or tuples
         Valid arguments for the ``dashes`` parameter on
         :class:`matplotlib.lines.Line2D`. The first spec is a solid
         line (``""``), the remainder are sequences of long and short
         dashes.
 
     """
-
-    # Start with 5 dash specs that are well distinguishable
+    # Start with dash specs that are well distinguishable
     dashes = [
         "",
         (4, 1.5),
@@ -258,12 +260,12 @@ def unique_dashes(n):
     ]
 
     # Now programatically build as many as we need
-    q = 3
+    p = 3
     while len(dashes) < n:
 
         # Take combinations of long and short dashes
-        a = itertools.combinations_with_replacement([3, 1.5], q)
-        b = itertools.combinations_with_replacement([4, 1], q)
+        a = itertools.combinations_with_replacement([3, 1.25], p)
+        b = itertools.combinations_with_replacement([4, 1], p)
 
         # Interleave the combinations, reversing one of the streams
         segment_list = itertools.chain(*zip(
@@ -271,12 +273,57 @@ def unique_dashes(n):
             list(b)[1:-1]
         ))
 
-        # Now insert the "off" segments
+        # Now insert the gaps
         for segments in segment_list:
-            off = min(segments)
-            spec = tuple(itertools.chain(*((on, off) for on in segments)))
+            gap = min(segments)
+            spec = tuple(itertools.chain(*((seg, gap) for seg in segments)))
             dashes.append(spec)
 
-        q += 1
+        p += 1
 
     return dashes[:n]
+
+
+def unique_markers(n):
+    """Build an arbitrarily long list of unique marker styles for points.
+
+    Parameters
+    ----------
+    n : int
+        Number of unique marker specs to generate.
+
+    Returns
+    -------
+    markers : list of :class:`matplotlib.markers.MarkerStyle` objects
+        All markers will be filled.
+
+    """
+    # Start with marker specs that are well distinguishable
+    markers = [
+        "o",
+        "X",
+        (4, 0, 45),
+        "P",
+        (4, 0, 0),
+        (4, 1, 0),
+        "^",
+        (4, 1, 45),
+        "v",
+    ]
+
+    # Now generate more from regular polygons of increasing order
+    s = 5
+    while len(markers) < n:
+        a = 360 / (s + 1) / 2
+        markers.extend([
+            (s + 1, 1, a),
+            (s + 1, 0, a),
+            (s, 1, 0),
+            (s, 0, 0),
+        ])
+        s += 1
+
+    # Convert to MarkerStyle object, using only exactly what we need
+    markers = [mpl.markers.MarkerStyle(m) for m in markers[:n]]
+
+    return markers

--- a/seaborn/core.py
+++ b/seaborn/core.py
@@ -1,3 +1,4 @@
+import itertools
 from collections.abc import Iterable, Sequence, Mapping
 import numpy as np
 import pandas as pd
@@ -228,3 +229,54 @@ class _VectorPlotter:
         }
 
         return plot_data, variables
+
+
+def unique_dashes(n):
+    """Build an arbitrarily long list of unique dash styles for lines.
+
+    Parameters
+    ----------
+    n : int
+        Number of unique dash specs to generate.
+    Returns
+    -------
+    dashes : list of tuples
+        Valid arguments for the ``dashes`` parameter on
+        :class:`matplotlib.lines.Line2D`. The first spec is a solid
+        line (``""``), the remainder are sequences of long and short
+        dashes.
+
+    """
+
+    # Start with 5 dash specs that are well distinguishable
+    dashes = [
+        "",
+        (4, 1.5),
+        (1, 1),
+        (3, 1.25, 1.5, 1.25),
+        (5, 1, 1, 1),
+    ]
+
+    # Now programatically build as many as we need
+    q = 3
+    while len(dashes) < n:
+
+        # Take combinations of long and short dashes
+        a = itertools.combinations_with_replacement([3, 1.5], q)
+        b = itertools.combinations_with_replacement([4, 1], q)
+
+        # Interleave the combinations, reversing one of the streams
+        segment_list = itertools.chain(*zip(
+            list(a)[1:-1][::-1],
+            list(b)[1:-1]
+        ))
+
+        # Now insert the "off" segments
+        for segments in segment_list:
+            off = min(segments)
+            spec = tuple(itertools.chain(*((on, off) for on in segments)))
+            dashes.append(spec)
+
+        q += 1
+
+    return dashes[:n]

--- a/seaborn/core.py
+++ b/seaborn/core.py
@@ -324,6 +324,6 @@ def unique_markers(n):
         s += 1
 
     # Convert to MarkerStyle object, using only exactly what we need
-    markers = [mpl.markers.MarkerStyle(m) for m in markers[:n]]
+    # markers = [mpl.markers.MarkerStyle(m) for m in markers[:n]]
 
-    return markers
+    return markers[:n]

--- a/seaborn/core.py
+++ b/seaborn/core.py
@@ -3,7 +3,6 @@ from collections.abc import Iterable, Sequence, Mapping
 
 import numpy as np
 import pandas as pd
-import matplotlib as mpl
 
 
 class _VectorPlotter:
@@ -294,7 +293,8 @@ def unique_markers(n):
 
     Returns
     -------
-    markers : list of :class:`matplotlib.markers.MarkerStyle` objects
+    markers : list of string or tuples
+        Values for defining :class:`matplotlib.markers.MarkerStyle` objects.
         All markers will be filled.
 
     """

--- a/seaborn/relational.py
+++ b/seaborn/relational.py
@@ -7,7 +7,7 @@ import pandas as pd
 import matplotlib as mpl
 import matplotlib.pyplot as plt
 
-from .core import (_VectorPlotter, unique_dashes)
+from .core import (_VectorPlotter, unique_dashes, unique_markers)
 from .utils import (categorical_order, get_color_cycle, ci_to_errsize,
                     remove_na, locator_to_legend_entries,
                     ci as ci_func)
@@ -35,9 +35,6 @@ class _RelationalPlotter(_VectorPlotter):
     # Defaults for size semantic
     # TODO this should match style of other defaults
     _default_size_range = 0, 1
-
-    # Defaults for style semantic
-    default_markers = ["o", "X", "s", "P", "D", "^", "v", "p"]
 
     def categorical_to_palette(self, data, order, palette):
         """Determine colors when the hue variable is qualitative."""
@@ -372,7 +369,7 @@ class _RelationalPlotter(_VectorPlotter):
                 levels = order
 
             markers = self.style_to_attributes(
-                levels, markers, self.default_markers, "markers"
+                levels, markers, unique_markers(len(levels)), "markers"
             )
 
             dashes = self.style_to_attributes(

--- a/seaborn/tests/test_core.py
+++ b/seaborn/tests/test_core.py
@@ -1,10 +1,12 @@
 import numpy as np
+import matplotlib as mpl
 
 from numpy.testing import assert_array_equal
 
 from ..core import (
     _VectorPlotter,
     unique_dashes,
+    unique_markers,
 )
 
 
@@ -44,8 +46,21 @@ class TestCoreFunc:
 
         n = 24
         dashes = unique_dashes(n)
-        assert len(set(dashes)) == n
 
+        assert len(dashes) == n
+        assert len(set(dashes)) == n
         assert dashes[0] == ""
         for spec in dashes[1:]:
             assert isinstance(spec, tuple)
+            assert not len(spec) % 2
+
+    def test_unique_markers(self):
+
+        n = 24
+        markers = unique_markers(n)
+
+        assert len(markers) == n
+        assert len(set(markers)) == n
+        for m in markers:
+            assert isinstance(m, mpl.markers.MarkerStyle)
+            assert m.is_filled()

--- a/seaborn/tests/test_core.py
+++ b/seaborn/tests/test_core.py
@@ -2,7 +2,10 @@ import numpy as np
 
 from numpy.testing import assert_array_equal
 
-from ..core import _VectorPlotter
+from ..core import (
+    _VectorPlotter,
+    unique_dashes,
+)
 
 
 class TestVectorPlotter:
@@ -33,3 +36,16 @@ class TestVectorPlotter:
 
         assert p.variables["x"] == expected_x_name
         assert p.variables["y"] == expected_y_name
+
+
+class TestCoreFunc:
+
+    def test_unique_dashes(self):
+
+        n = 24
+        dashes = unique_dashes(n)
+        assert len(set(dashes)) == n
+
+        assert dashes[0] == ""
+        for spec in dashes[1:]:
+            assert isinstance(spec, tuple)

--- a/seaborn/tests/test_core.py
+++ b/seaborn/tests/test_core.py
@@ -62,5 +62,4 @@ class TestCoreFunc:
         assert len(markers) == n
         assert len(set(markers)) == n
         for m in markers:
-            assert isinstance(m, mpl.markers.MarkerStyle)
-            assert m.is_filled()
+            assert mpl.markers.MarkerStyle(m).is_filled()

--- a/seaborn/tests/test_relational.py
+++ b/seaborn/tests/test_relational.py
@@ -870,10 +870,12 @@ class TestRelationalPlotter(Helpers):
         assert p.dashes == dict(zip(p.style_levels, unique_dashes(n)))
 
         actual_marker_paths = {
-            k: m.get_path() for k, m in p.markers.items()
+            k: mpl.markers.MarkerStyle(m).get_path()
+            for k, m in p.markers.items()
         }
         expected_marker_paths = {
-            k: m.get_path() for k, m in zip(p.style_levels, unique_markers(n))
+            k: mpl.markers.MarkerStyle(m).get_path()
+            for k, m in zip(p.style_levels, unique_markers(n))
         }
         assert actual_marker_paths == expected_marker_paths
 
@@ -899,10 +901,12 @@ class TestRelationalPlotter(Helpers):
         assert p.dashes == dict(zip(style_order, unique_dashes(n)))
 
         actual_marker_paths = {
-            k: m.get_path() for k, m in p.markers.items()
+            k: mpl.markers.MarkerStyle(m).get_path()
+            for k, m in p.markers.items()
         }
         expected_marker_paths = {
-            k: m.get_path() for k, m in zip(style_order, unique_markers(n))
+            k: mpl.markers.MarkerStyle(m).get_path()
+            for k, m in zip(style_order, unique_markers(n))
         }
         assert actual_marker_paths == expected_marker_paths
 

--- a/seaborn/tests/test_relational.py
+++ b/seaborn/tests/test_relational.py
@@ -11,6 +11,11 @@ from numpy.testing import assert_array_equal
 from ..palettes import color_palette
 from ..utils import categorical_order
 
+from ..core import (
+    unique_dashes,
+    unique_markers,
+)
+
 from ..relational import (
     _RelationalPlotter,
     _LinePlotter,
@@ -860,8 +865,17 @@ class TestRelationalPlotter(Helpers):
         # Test defaults
         markers, dashes = True, True
         p.parse_style(p.plot_data["style"], markers, dashes)
-        assert p.markers == dict(zip(p.style_levels, p.default_markers))
-        assert p.dashes == dict(zip(p.style_levels, p.default_dashes))
+
+        n = len(p.style_levels)
+        assert p.dashes == dict(zip(p.style_levels, unique_dashes(n)))
+
+        actual_marker_paths = {
+            k: m.get_path() for k, m in p.markers.items()
+        }
+        expected_marker_paths = {
+            k: m.get_path() for k, m in zip(p.style_levels, unique_markers(n))
+        }
+        assert actual_marker_paths == expected_marker_paths
 
         # Test lists
         markers, dashes = ["o", "s", "d"], [(1, 0), (1, 1), (2, 1, 3, 1)]
@@ -880,8 +894,17 @@ class TestRelationalPlotter(Helpers):
         style_order = np.take(p.style_levels, [1, 2, 0])
         markers = dashes = True
         p.parse_style(p.plot_data["style"], markers, dashes, style_order)
-        assert p.markers == dict(zip(style_order, p.default_markers))
-        assert p.dashes == dict(zip(style_order, p.default_dashes))
+
+        n = len(style_order)
+        assert p.dashes == dict(zip(style_order, unique_dashes(n)))
+
+        actual_marker_paths = {
+            k: m.get_path() for k, m in p.markers.items()
+        }
+        expected_marker_paths = {
+            k: m.get_path() for k, m in zip(style_order, unique_markers(n))
+        }
+        assert actual_marker_paths == expected_marker_paths
 
         # Test too many levels with style lists
         markers, dashes = ["o", "s"], False


### PR DESCRIPTION
The relational plots raise an error when the number of levels on the `style` semantic exceeds the number of dash or marker styles provided. There are only 8 default markers and 6 default dashes.

This is especially surprising with wide-form data, where the style semantic is used implicitly.

See https://github.com/mwaskom/seaborn/issues/1513 for more discussion.

The challenge is that there is no idea approach. Either you a) error, b) cycle, or c) generate markers/dashes that are difficult to visually discriminate.

The errors are annoying, and in some situations, perplexing. I am opposed to having semantic attributes cycle; I don't believe that happens anywhere in seaborn. So we have to do our best to generate discriminable mappings.

This PR implements programatic generation of arbitrarily large numbers of dash and marker specs. Although these will be difficult to visually discriminate beyond a specific point, some thought has gone into making them reasonably distinct. I am also open to future improvements to the algorithm.

The first 16 dashes look like this:

![image](https://user-images.githubusercontent.com/315810/82125454-0a1e9b80-9774-11ea-82f2-0b84fd980d9b.png)

<details><summary>Code to generate</summary>

```python
n = 16
lw = 3
with sns.axes_style("dark"):
    f, ax = plt.subplots(figsize=(9, n / 3))
f.subplots_adjust(0, 0, 1, 1)
ax.set(xticks=[], yticks=[])
ax.invert_yaxis()
for i, dashes in enumerate(sns.core.unique_dashes(n)):
    ax.axhline(i, dashes=dashes, color=".2", lw=lw)
```

</details>

The first 18 markers look like this:

![image](https://user-images.githubusercontent.com/315810/82126197-0ccfbf80-9779-11ea-845b-072cfa7fe3e6.png)

<details><summary>Code to generate</summary>

```python
n = 18
w = 9
s = 300
linewidth = .05 * np.sqrt(s)
f, ax = plt.subplots(figsize=(w, n // w))
f.subplots_adjust(0, 0, 1, 1)
ax.set(xticks=[], yticks=[])
ax.margins(y=.5, x=.1)
ax.invert_yaxis()
for i, marker in enumerate(sns.core.unique_markers(n)):
    ax.scatter([i % w], [i // w], marker=marker, c=".2", linewidth=linewidth, edgecolor="w", s=s, clip_on=False)
```

</details>

---

Closes https://github.com/mwaskom/seaborn/issues/1513 