### PR TITLE
Scale the default scatterplot edge width by the point radius

### DIFF
--- a/doc/releases/v0.11.0.txt
+++ b/doc/releases/v0.11.0.txt
@@ -12,6 +12,8 @@ v0.11.0 (Unreleased)
 
 - Added a ``tight_layout`` method to :class:`FacetGrid` and :class:`PairGrid`, which runs the :func:`matplotlib.pyplot.tight_layout` algorithm without interference from the external legend. GH2073
 
+- Changed how :func:`scatterplot` sets the default linewidth for the edges of the scatter points to scale with the point size themselves (on a plot-wise, not point-wise basis). This change also slightly reduces the default width when point sizes are not varied. Set ``linewidth=0.75`` to repoduce the previous behavior.
+
 - Added an explicit warning in :func:`swarmplot` when more than 2% of the points are overlap in the "gutters" of the swarm. GH2045
 
 - Added the ``axes_dict`` attribute to :class:`FacetGrid` for named access to the component axes.  GH2046

--- a/doc/releases/v0.11.0.txt
+++ b/doc/releases/v0.11.0.txt
@@ -12,7 +12,7 @@ v0.11.0 (Unreleased)
 
 - Added a ``tight_layout`` method to :class:`FacetGrid` and :class:`PairGrid`, which runs the :func:`matplotlib.pyplot.tight_layout` algorithm without interference from the external legend. GH2073
 
-- Changed how :func:`scatterplot` sets the default linewidth for the edges of the scatter points to scale with the point size themselves (on a plot-wise, not point-wise basis). This change also slightly reduces the default width when point sizes are not varied. Set ``linewidth=0.75`` to repoduce the previous behavior.
+- Changed how :func:`scatterplot` sets the default linewidth for the edges of the scatter points to scale with the point size themselves (on a plot-wise, not point-wise basis). This change also slightly reduces the default width when point sizes are not varied. Set ``linewidth=0.75`` to repoduce the previous behavior. GH2078
 
 - Added an explicit warning in :func:`swarmplot` when more than 2% of the points are overlap in the "gutters" of the swarm. GH2045
 

--- a/seaborn/relational.py
+++ b/seaborn/relational.py
@@ -774,7 +774,12 @@ class _ScatterPlotter(_RelationalPlotter):
 
         kws.pop("color", None)  # TODO is this optimal?
 
-        kws.setdefault("linewidth", .75)  # TODO scale with marker size?
+        if self.sizes:
+            size_ref = np.percentile(list(self.sizes.values()), 10)
+        else:
+            size_ref = np.percentile(s, 10)
+
+        kws.setdefault("linewidth", .05 * np.sqrt(size_ref))
         kws.setdefault("edgecolor", "w")
 
         if self.markers:

--- a/seaborn/tests/test_relational.py
+++ b/seaborn/tests/test_relational.py
@@ -2062,6 +2062,42 @@ class TestScatterPlotter(Helpers):
         ax = scatterplot(data=wide_df, ax=ax1)
         assert ax is ax1
 
+    def test_scatterplot_linewidths(self, long_df):
+
+        f, ax = plt.subplots()
+
+        scatterplot(data=long_df, x="x", y="y", s=10)
+        scatterplot(data=long_df, x="x", y="y", s=20)
+        points1, points2 = ax.collections
+        assert (
+            points1.get_linewidths().item() < points2.get_linewidths().item()
+        )
+
+        # These tests don't work because changes in matplotlib casue an error
+        # when we draw the scount with non-scalar s or c
+        """
+        ax.clear()
+        scatterplot(data=long_df, x="x", y="y", s=long_df["x"])
+        scatterplot(data=long_df, x="x", y="y", s=long_df["x"] * 2)
+        points1, points2 = ax.collections
+        assert (
+            points1.get_linewidths().item() < points2.get_linewidths().item()
+        )
+        """
+
+        ax.clear()
+        scatterplot(data=long_df, x="x", y="y", size=long_df["x"])
+        scatterplot(data=long_df, x="x", y="y", size=long_df["x"] * 2)
+        points1, points2, *_ = ax.collections
+        assert (
+            points1.get_linewidths().item() < points2.get_linewidths().item()
+        )
+
+        ax.clear()
+        lw = 2
+        scatterplot(data=long_df, x="x", y="y", linewidth=lw)
+        assert ax.collections[0].get_linewidths().item() == lw
+
     def test_scatterplot_smoke(
         self,
         wide_df, wide_array,

--- a/seaborn/tests/test_relational.py
+++ b/seaborn/tests/test_relational.py
@@ -2062,7 +2062,7 @@ class TestScatterPlotter(Helpers):
         ax = scatterplot(data=wide_df, ax=ax1)
         assert ax is ax1
 
-    def test_scatterplot_linewidths(self, long_df):
+    def test_linewidths(self, long_df):
 
         f, ax = plt.subplots()
 


### PR DESCRIPTION
`scatterplot` defaults to a thin white edge around each point; but for small points, this can dominate the points themselves.

This PR changes the default behavior to scale the line widths based on the actual sizes of the points that are drawn.

Here's an example using `diamonds`:

<details><summary>Open to see code</summary>

```python
import numpy as np
import pandas as pd
import seaborn as sns; sns.set()
import matplotlib as mpl
import matplotlib.pyplot as plt

diamonds = sns.load_dataset("diamonds")

f, ax = plt.subplots(figsize=(6.5, 6.5))
clarity_ranking = ["I1", "SI2", "SI1", "VS2", "VS1", "VVS2", "VVS1", "IF"]
sns.scatterplot(x="carat", y="price",
                hue="clarity", size="depth",
                palette="ch:r=-.2,d=.3_r",
                hue_order=clarity_ranking,
                sizes=(1, 8),
                rasterized=True,
                data=diamonds, ax=ax)
```

</details>



Old behavior:

![image](https://user-images.githubusercontent.com/315810/82130833-f0457e80-979c-11ea-8ec5-2d2951021e12.png)

New behavior:

![image](https://user-images.githubusercontent.com/315810/82153851-06ece380-9838-11ea-9035-f5fc47d0f596.png)

At the same time, "bubble" plots still have nicely-defined edges:

<details><summary>Open to see code</summary>

```python
import seaborn as sns
sns.set(style="white")

# Load the example mpg dataset
mpg = sns.load_dataset("mpg")

# Plot miles per gallon against horsepower with other semantics
sns.relplot(x="horsepower", y="mpg", hue="origin", size="weight",
            sizes=(40, 400), alpha=.6, palette="muted",
            height=6, data=mpg)
```

</details>

![image](https://user-images.githubusercontent.com/315810/82153763-8332f700-9837-11ea-8399-f30a26f36374.png)

It also has the effect of slightly reducing the width of the default edge. 

The exact values used (percentile and scaling constant) are subject to revision as I get a sense for how this looks across a range of applications.

It may also be wise to parameterize. For example, we could define `linewidth` in the function signature and accept a string like `"10%"` to scale the linewidth by 0.1 of the radius. But maybe that's too fussy.