### PR TITLE
Allow vectors for c= or s= in scatterplot

### DIFF
--- a/doc/releases/v0.11.0.txt
+++ b/doc/releases/v0.11.0.txt
@@ -14,6 +14,8 @@ v0.11.0 (Unreleased)
 
 - Changed how :func:`scatterplot` sets the default linewidth for the edges of the scatter points to scale with the point size themselves (on a plot-wise, not point-wise basis). This change also slightly reduces the default width when point sizes are not varied. Set ``linewidth=0.75`` to repoduce the previous behavior. GH2078
 
+- Adapted to a change in matploltib that prevented passing vectors of literal values to ``c`` and ``s`` in :func:`scatterplot`.  GH2079
+
 - Added an explicit warning in :func:`swarmplot` when more than 2% of the points are overlap in the "gutters" of the swarm. GH2045
 
 - Added the ``axes_dict`` attribute to :class:`FacetGrid` for named access to the component axes.  GH2046

--- a/doc/releases/v0.11.0.txt
+++ b/doc/releases/v0.11.0.txt
@@ -12,9 +12,9 @@ v0.11.0 (Unreleased)
 
 - Added a ``tight_layout`` method to :class:`FacetGrid` and :class:`PairGrid`, which runs the :func:`matplotlib.pyplot.tight_layout` algorithm without interference from the external legend. GH2073
 
-- Changed how :func:`scatterplot` sets the default linewidth for the edges of the scatter points to scale with the point size themselves (on a plot-wise, not point-wise basis). This change also slightly reduces the default width when point sizes are not varied. Set ``linewidth=0.75`` to repoduce the previous behavior. GH2078
+- Changed how :func:`scatterplot` sets the default linewidth for the edges of the scatter points. New behaviot is to scale with the point sizes themselves (on a plot-wise, not point-wise basis). This change also slightly reduces the default width when point sizes are not varied. Set ``linewidth=0.75`` to repoduce the previous behavior. GH2078
 
-- Adapted to a change in matploltib that prevented passing vectors of literal values to ``c`` and ``s`` in :func:`scatterplot`.  GH2079
+- Adapted to a change in matplotlib that prevented passing vectors of literal values to ``c`` and ``s`` in :func:`scatterplot`.  GH2079
 
 - Added an explicit warning in :func:`swarmplot` when more than 2% of the points are overlap in the "gutters" of the swarm. GH2045
 

--- a/seaborn/relational.py
+++ b/seaborn/relational.py
@@ -767,7 +767,12 @@ class _ScatterPlotter(_RelationalPlotter):
         # gotten from the corresponding matplotlib function, and calling the
         # function will advance the axes property cycle.
 
-        scout = ax.scatter([], [], **kws)
+        scout_size = max(
+            np.atleast_1d(kws.get("s", [])).shape[0],
+            np.atleast_1d(kws.get("c", [])).shape[0],
+        )
+        scout_x = scout_y = np.full(scout_size, np.nan)
+        scout = ax.scatter(scout_x, scout_y, **kws)
         s = kws.pop("s", scout.get_sizes())
         c = kws.pop("c", scout.get_facecolors())
         scout.remove()
@@ -1254,7 +1259,7 @@ def scatterplot(
     markers=True, style_order=None,
     x_bins=None, y_bins=None,
     units=None, estimator=None, ci=95, n_boot=1000,
-    alpha="auto", x_jitter=None, y_jitter=None,
+    alpha=None, x_jitter=None, y_jitter=None,
     legend="brief", ax=None, **kwargs
 ):
 

--- a/seaborn/tests/test_relational.py
+++ b/seaborn/tests/test_relational.py
@@ -2062,6 +2062,21 @@ class TestScatterPlotter(Helpers):
         ax = scatterplot(data=wide_df, ax=ax1)
         assert ax is ax1
 
+    def test_literal_attribute_vectors(self):
+
+        f, ax = plt.subplots()
+
+        x = y = [1, 2, 3]
+        s = [5, 10, 15]
+        c = [(1, 1, 0, 1), (1, 0, 1, .5), (.5, 1, 0, 1)]
+
+        scatterplot(x=x, y=y, c=c, s=s, ax=ax)
+
+        points, = ax.collections
+
+        assert_array_equal(points.get_sizes().squeeze(), s)
+        assert_array_equal(points.get_facecolors(), c)
+
     def test_linewidths(self, long_df):
 
         f, ax = plt.subplots()
@@ -2073,9 +2088,6 @@ class TestScatterPlotter(Helpers):
             points1.get_linewidths().item() < points2.get_linewidths().item()
         )
 
-        # These tests don't work because changes in matplotlib casue an error
-        # when we draw the scount with non-scalar s or c
-        """
         ax.clear()
         scatterplot(data=long_df, x="x", y="y", s=long_df["x"])
         scatterplot(data=long_df, x="x", y="y", s=long_df["x"] * 2)
@@ -2083,7 +2095,6 @@ class TestScatterPlotter(Helpers):
         assert (
             points1.get_linewidths().item() < points2.get_linewidths().item()
         )
-        """
 
         ax.clear()
         scatterplot(data=long_df, x="x", y="y", size=long_df["x"])


### PR DESCRIPTION
Stricter input checks in matplotlib caused this to start failing; now it should work again.

```python
import seaborn as sns
x = y = [1, 2, 3]
s = [100, 200, 300]
c = sns.color_palette("bright", 3)
style = "a", "b", "c"
sns.scatterplot(x=x, y=y, s=s, c=c, style=style)
```

![image](https://user-images.githubusercontent.com/315810/82155258-83d08b00-9841-11ea-8ef6-b80d3a573b1e.png)
