### PR TITLE
Require keyword arguments almost everywhere

### DIFF
--- a/doc/releases/v0.11.0.txt
+++ b/doc/releases/v0.11.0.txt
@@ -4,7 +4,7 @@ v0.11.0 (Unreleased)
 
 - TODO stub for explaining improvements to variable specificiation. Make this good!  GH2017
 
-- Enforced keyword-only arguments for most parameters of most functions and classes.  GH2052
+- TODO stub for enforced keyword-only arguments for most parameters of most functions and classes.  GH2052, GH2080
 
 - Standardized the parameter names for the oldest functions (:func:`distplot`, :func:`kdeplot`, and :func:`rugplot`) to be `x` and `y`, as in other functions. Using the old names will warn now and break in the future.  GH2060
 

--- a/doc/releases/v0.11.0.txt
+++ b/doc/releases/v0.11.0.txt
@@ -4,7 +4,7 @@ v0.11.0 (Unreleased)
 
 - TODO stub for explaining improvements to variable specificiation. Make this good!  GH2017
 
-- TODO stub for enforced keyword-only arguments for most parameters of most functions and classes.  GH2052, GH2080
+- TODO stub for enforced keyword-only arguments for most parameters of most functions and classes.  GH2052, GH2081
 
 - Standardized the parameter names for the oldest functions (:func:`distplot`, :func:`kdeplot`, and :func:`rugplot`) to be `x` and `y`, as in other functions. Using the old names will warn now and break in the future.  GH2060
 

--- a/doc/tutorial/axis_grids.ipynb
+++ b/doc/tutorial/axis_grids.ipynb
@@ -170,7 +170,7 @@
    "outputs": [],
    "source": [
     "g = sns.FacetGrid(tips, col=\"day\", height=4, aspect=.5)\n",
-    "g.map(sns.barplot, \"sex\", \"total_bill\");"
+    "g.map(sns.barplot, \"sex\", \"total_bill\", order=[\"Male\", \"Female\"]);"
    ]
   },
   {

--- a/doc/tutorial/categorical.ipynb
+++ b/doc/tutorial/categorical.ipynb
@@ -155,8 +155,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.catplot(x=\"size\", y=\"total_bill\", kind=\"swarm\",\n",
-    "            data=tips.query(\"size != 3\"));"
+    "sns.catplot(x=\"size\", y=\"total_bill\", data=tips);"
    ]
   },
   {
@@ -526,7 +525,7 @@
    "outputs": [],
    "source": [
     "sns.catplot(x=\"day\", y=\"total_bill\", hue=\"smoker\",\n",
-    "            col=\"time\", aspect=.6,\n",
+    "            col=\"time\", aspect=.7,\n",
     "            kind=\"swarm\", data=tips);"
    ]
   },
@@ -562,7 +561,7 @@
  "metadata": {
   "celltoolbar": "Tags",
   "kernelspec": {
-   "display_name": "Python 3.6  (seaborn-py37-latest)",
+   "display_name": "seaborn-py37-latest",
    "language": "python",
    "name": "seaborn-py37-latest"
   },
@@ -580,5 +579,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }

--- a/doc/tutorial/color_palettes.ipynb
+++ b/doc/tutorial/color_palettes.ipynb
@@ -459,7 +459,7 @@
    "source": [
     "x, y = np.random.multivariate_normal([0, 0], [[1, -.5], [-.5, 1]], size=300).T\n",
     "cmap = sns.cubehelix_palette(light=1, as_cmap=True)\n",
-    "sns.kdeplot(x, y, cmap=cmap, shade=True);"
+    "sns.kdeplot(x=x, y=y, cmap=cmap, shade=True);"
    ]
   },
   {
@@ -527,7 +527,7 @@
    "outputs": [],
    "source": [
     "pal = sns.dark_palette(\"palegreen\", as_cmap=True)\n",
-    "sns.kdeplot(x, y, cmap=pal);"
+    "sns.kdeplot(x=x, y=y, cmap=pal);"
    ]
   },
   {
@@ -738,7 +738,7 @@
  "metadata": {
   "celltoolbar": "Tags",
   "kernelspec": {
-   "display_name": "Python 3.6  (seaborn-py37-latest)",
+   "display_name": "seaborn-py37-latest",
    "language": "python",
    "name": "seaborn-py37-latest"
   },
@@ -756,5 +756,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }

--- a/doc/tutorial/distributions.ipynb
+++ b/doc/tutorial/distributions.ipynb
@@ -81,7 +81,7 @@
    "outputs": [],
    "source": [
     "x = np.random.normal(size=100)\n",
-    "sns.distplot(x);"
+    "sns.distplot(x=x);"
    ]
   },
   {
@@ -102,7 +102,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.distplot(x, kde=False, rug=True);"
+    "sns.distplot(x=x, kde=False, rug=True);"
    ]
   },
   {
@@ -118,7 +118,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.distplot(x, bins=20, kde=False, rug=True);"
+    "sns.distplot(x=x, bins=20, kde=False, rug=True);"
    ]
   },
   {
@@ -137,7 +137,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.distplot(x, hist=False, rug=True);"
+    "sns.distplot(x=x, hist=False, rug=True);"
    ]
   },
   {
@@ -164,7 +164,7 @@
     "    kernels.append(kernel)\n",
     "    plt.plot(support, kernel, color=\"r\")\n",
     "\n",
-    "sns.rugplot(x, color=\".2\", linewidth=3);"
+    "sns.rugplot(x=x, color=\".2\", linewidth=3);"
    ]
   },
   {
@@ -199,7 +199,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.kdeplot(x, shade=True);"
+    "sns.kdeplot(x=x, shade=True);"
    ]
   },
   {
@@ -215,9 +215,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.kdeplot(x)\n",
-    "sns.kdeplot(x, bw=.2, label=\"bw: 0.2\")\n",
-    "sns.kdeplot(x, bw=2, label=\"bw: 2\")\n",
+    "sns.kdeplot(x=x)\n",
+    "sns.kdeplot(x=x, bw=.2, label=\"bw: 0.2\")\n",
+    "sns.kdeplot(x=x, bw=2, label=\"bw: 2\")\n",
     "plt.legend();"
    ]
   },
@@ -234,8 +234,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.kdeplot(x, shade=True, cut=0)\n",
-    "sns.rugplot(x);"
+    "sns.kdeplot(x=x, shade=True, cut=0)\n",
+    "sns.rugplot(x=x);"
    ]
   },
   {
@@ -255,7 +255,7 @@
    "outputs": [],
    "source": [
     "x = np.random.gamma(6, size=200)\n",
-    "sns.distplot(x, kde=False, fit=stats.gamma);"
+    "sns.distplot(x=x, kde=False, fit=stats.gamma);"
    ]
   },
   {
@@ -352,9 +352,9 @@
    "outputs": [],
    "source": [
     "f, ax = plt.subplots(figsize=(6, 6))\n",
-    "sns.kdeplot(df.x, df.y, ax=ax)\n",
-    "sns.rugplot(df.x, color=\"g\", ax=ax)\n",
-    "sns.rugplot(df.y, vertical=True, ax=ax);"
+    "sns.kdeplot(x=df.x, y=df.y, ax=ax)\n",
+    "sns.rugplot(x=df.x, color=\"g\", ax=ax)\n",
+    "sns.rugplot(x=df.y, vertical=True, ax=ax);"
    ]
   },
   {
@@ -372,7 +372,7 @@
    "source": [
     "f, ax = plt.subplots(figsize=(6, 6))\n",
     "cmap = sns.cubehelix_palette(as_cmap=True, dark=0, light=1, reverse=True)\n",
-    "sns.kdeplot(df.x, df.y, cmap=cmap, n_levels=60, shade=True);"
+    "sns.kdeplot(x=df.x, y=df.y, cmap=cmap, n_levels=60, shade=True);"
    ]
   },
   {
@@ -461,7 +461,7 @@
  "metadata": {
   "celltoolbar": "Tags",
   "kernelspec": {
-   "display_name": "Python 3.6  (seaborn-py37-latest)",
+   "display_name": "seaborn-py37-latest",
    "language": "python",
    "name": "seaborn-py37-latest"
   },
@@ -479,5 +479,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }

--- a/doc/tutorial/regression.ipynb
+++ b/doc/tutorial/regression.ipynb
@@ -201,9 +201,7 @@
   },
   {
    "cell_type": "raw",
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "source": [
     "In the presence of these kind of higher-order relationships, :func:`lmplot` and :func:`regplot` can fit a polynomial regression model to explore simple kinds of nonlinear trends in the dataset:"
    ]
@@ -517,7 +515,7 @@
  "metadata": {
   "celltoolbar": "Tags",
   "kernelspec": {
-   "display_name": "Python 3.6  (seaborn-py37-latest)",
+   "display_name": "seaborn-py37-latest",
    "language": "python",
    "name": "seaborn-py37-latest"
   },
@@ -535,5 +533,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }

--- a/doc/tutorial/relational.ipynb
+++ b/doc/tutorial/relational.ipynb
@@ -404,9 +404,7 @@
   },
   {
    "cell_type": "raw",
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "source": [
     "The default colormap and handling of the legend in :func:`lineplot` also depends on whether the hue semantic is categorical or numeric:"
    ]
@@ -616,7 +614,7 @@
  "metadata": {
   "celltoolbar": "Tags",
   "kernelspec": {
-   "display_name": "Python 3.6  (seaborn-py37-latest)",
+   "display_name": "seaborn-py37-latest",
    "language": "python",
    "name": "seaborn-py37-latest"
   },
@@ -634,5 +632,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/examples/cubehelix_palette.py
+++ b/examples/cubehelix_palette.py
@@ -22,7 +22,7 @@ for ax, s in zip(axes.flat, np.linspace(0, 3, 10)):
 
     # Generate and plot a random bivariate dataset
     x, y = rs.randn(2, 50)
-    sns.kdeplot(x, y, cmap=cmap, shade=True, cut=5, ax=ax)
+    sns.kdeplot(x=x, y=y, cmap=cmap, shade=True, cut=5, ax=ax)
     ax.set(xlim=(-3, 3), ylim=(-3, 3))
 
 f.tight_layout()

--- a/examples/distplot_options.py
+++ b/examples/distplot_options.py
@@ -15,19 +15,20 @@ f, axes = plt.subplots(2, 2, figsize=(7, 7), sharex=True)
 sns.despine(left=True)
 
 # Generate a random univariate dataset
-d = rs.normal(size=100)
+x = rs.normal(size=100)
 
 # Plot a simple histogram with binsize determined automatically
-sns.distplot(d, kde=False, color="b", ax=axes[0, 0])
+sns.distplot(x=x, kde=False, color="b", ax=axes[0, 0])
 
 # Plot a kernel density estimate and rug plot
-sns.distplot(d, hist=False, rug=True, color="r", ax=axes[0, 1])
+sns.distplot(x=x, hist=False, rug=True, color="r", ax=axes[0, 1])
 
 # Plot a filled kernel density estimate
-sns.distplot(d, hist=False, color="g", kde_kws={"shade": True}, ax=axes[1, 0])
+sns.distplot(x=x, hist=False, color="g",
+             kde_kws={"shade": True}, ax=axes[1, 0])
 
 # Plot a histogram and kernel density estimate
-sns.distplot(d, color="m", ax=axes[1, 1])
+sns.distplot(x=x, color="m", ax=axes[1, 1])
 
 plt.setp(axes, yticks=[])
-plt.tight_layout()
+f.tight_layout()

--- a/examples/hexbin_marginals.py
+++ b/examples/hexbin_marginals.py
@@ -12,4 +12,4 @@ rs = np.random.RandomState(11)
 x = rs.gamma(2, size=1000)
 y = -.5 * x + rs.normal(size=1000)
 
-sns.jointplot(x, y, kind="hex", color="#4CB391")
+sns.jointplot(x=x, y=y, kind="hex", color="#4CB391")

--- a/examples/joint_kde.py
+++ b/examples/joint_kde.py
@@ -18,4 +18,4 @@ x1 = pd.Series(x1, name="$X_1$")
 x2 = pd.Series(x2, name="$X_2$")
 
 # Show the joint distribution using kernel density estimation
-g = sns.jointplot(x1, x2, kind="kde", height=7, space=0)
+g = sns.jointplot(x=x1, y=x2, kind="kde", height=7, space=0)

--- a/examples/marginal_ticks.py
+++ b/examples/marginal_ticks.py
@@ -15,6 +15,6 @@ cov = [(1, 0), (0, 2)]
 x, y = rs.multivariate_normal(mean, cov, 100).T
 
 # Use JointGrid directly to draw a custom plot
-grid = sns.JointGrid(x, y, space=0, height=6, ratio=20)
+grid = sns.JointGrid(x=x, y=y, space=0, height=6, ratio=20)
 grid.plot_joint(sns.scatterplot, color="g")
 grid.plot_marginals(sns.rugplot, height=1, color="g")

--- a/examples/regression_marginals.py
+++ b/examples/regression_marginals.py
@@ -8,7 +8,7 @@ import seaborn as sns
 sns.set(style="darkgrid")
 
 tips = sns.load_dataset("tips")
-g = sns.jointplot("total_bill", "tip", data=tips,
+g = sns.jointplot(x="total_bill", y="tip", data=tips,
                   kind="reg", truncate=False,
                   xlim=(0, 60), ylim=(0, 12),
                   color="m", height=7)

--- a/examples/residplot.py
+++ b/examples/residplot.py
@@ -13,4 +13,4 @@ x = rs.normal(2, 1, 75)
 y = 2 + 1.5 * x + rs.normal(0, 2, 75)
 
 # Plot the residuals after fitting a linear model
-sns.residplot(x, y, lowess=True, color="g")
+sns.residplot(x=x, y=y, lowess=True, color="g")

--- a/seaborn/_decorators.py
+++ b/seaborn/_decorators.py
@@ -31,16 +31,16 @@ def _deprecate_positional_args(f):
     def inner_f(*args, **kwargs):
         extra_args = len(args) - len(all_args)
         if extra_args > 0:
-            # ignore first 'self' argument for instance methods
-            args_msg = ['{}={}'.format(name, arg)
-                        for name, arg in zip(kwonly_args[:extra_args],
-                                             args[-extra_args:])]
-            plural = "s" if len(args_msg) > 1 else ""
-            warnings.warn("Pass {} as keyword arg{}. From version 0.12, "
-                          "passing these as positional arguments will "
-                          "result in an error"
-                          .format(", ".join(args_msg), plural),
-                          FutureWarning)
+            plural = "s" if extra_args > 1 else ""
+            article = "" if plural else "a "
+            warnings.warn(
+                "Pass the following variable{} as {}keyword arg{}: {}. "
+                "From version 0.12, passing positional arguments "
+                "will result in an error or misinterpreted input."
+                .format(plural, article, plural,
+                        ", ".join(kwonly_args[:extra_args])),
+                FutureWarning
+            )
         kwargs.update({k: arg for k, arg in zip(sig.parameters, args)})
         return f(**kwargs)
     return inner_f

--- a/seaborn/_decorators.py
+++ b/seaborn/_decorators.py
@@ -35,8 +35,9 @@ def _deprecate_positional_args(f):
             article = "" if plural else "a "
             warnings.warn(
                 "Pass the following variable{} as {}keyword arg{}: {}. "
-                "From version 0.12, passing positional arguments "
-                "will result in an error or misinterpreted input."
+                "From version 0.12, the only valid positional argument "
+                "will be `data`, and passing other arguments without an "
+                "explcit keyword will result in an error or misinterpretation."
                 .format(plural, article, plural,
                         ", ".join(kwonly_args[:extra_args])),
                 FutureWarning

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -874,7 +874,7 @@ class FacetGrid(Grid):
     def _facet_plot(self, func, ax, plot_args, plot_kwargs):
 
         # Draw the plot
-        if func.__module__.startswith("seaborn"):
+        if str(func.__module__).startswith("seaborn"):
             plot_kwargs = plot_kwargs.copy()
             semantics = ["x", "y", "hue", "size", "style"]
             for key, val in zip(semantics, plot_args):
@@ -1534,7 +1534,7 @@ class PairGrid(Grid):
                 if self._dropna:
                     data_k = utils.remove_na(data_k)
 
-                if func.__module__.startswith("seaborn"):
+                if str(func.__module__).startswith("seaborn"):
                     func(x=data_k, label=label_k, color=color, **kwargs)
                 else:
                     func(data_k, label=label_k, color=color, **kwargs)
@@ -1583,7 +1583,7 @@ class PairGrid(Grid):
                 kwargs[kw] = val_list[k]
             color = self.palette[k] if kw_color is None else kw_color
 
-            if func.__module__.startswith("seaborn"):
+            if str(func.__module__).startswith("seaborn"):
                 func(x=x, y=y, label=label_k, color=color, **kwargs)
             else:
                 func(x, y, label=label_k, color=color, **kwargs)
@@ -1842,7 +1842,7 @@ class JointGrid(object):
         """
         plt.sca(self.ax_joint)
 
-        if func.__module__.startswith("seaborn"):
+        if str(func.__module__).startswith("seaborn"):
             func(x=self.x, y=self.y, **kwargs)
         else:
             func(self.x, self.y, **kwargs)
@@ -1870,14 +1870,14 @@ class JointGrid(object):
         """
         kwargs["vertical"] = False
         plt.sca(self.ax_marg_x)
-        if func.__module__.startswith("seaborn"):
+        if str(func.__module__).startswith("seaborn"):
             func(x=self.x, **kwargs)
         else:
             func(self.x, **kwargs)
 
         kwargs["vertical"] = True
         plt.sca(self.ax_marg_y)
-        if func.__module__.startswith("seaborn"):
+        if str(func.__module__).startswith("seaborn"):
             func(x=self.y, **kwargs)
         else:
             func(self.y, **kwargs)

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -1607,7 +1607,8 @@ class JointGrid(object):
 
     @_deprecate_positional_args
     def __init__(
-        self, x, y, *,
+        self, *,
+        x=None, y=None,
         data=None,
         height=6, ratio=5, space=.2,
         dropna=True, xlim=None, ylim=None, size=None
@@ -2192,7 +2193,8 @@ def pairplot(
 
 @_deprecate_positional_args
 def jointplot(
-    x=None, y=None, *,
+    *,
+    x=None, y=None,
     data=None,
     kind="scatter", stat_func=None,
     color=None, height=6, ratio=5, space=.2,

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -2239,7 +2239,8 @@ _categorical_docs.update(_facet_docs)
 
 @_deprecate_positional_args
 def boxplot(
-    x=None, y=None, *,
+    *,
+    x=None, y=None,
     hue=None, data=None,
     order=None, hue_order=None,
     orient=None, color=None, palette=None, saturation=.75,
@@ -2395,7 +2396,8 @@ boxplot.__doc__ = dedent("""\
 
 @_deprecate_positional_args
 def violinplot(
-    x=None, y=None, *,
+    *,
+    x=None, y=None,
     hue=None, data=None,
     order=None, hue_order=None,
     bw="scott", cut=2, scale="area", scale_hue=True, gridsize=100,
@@ -2640,7 +2642,8 @@ def lvplot(*args, **kwargs):
 
 @_deprecate_positional_args
 def boxenplot(
-    x=None, y=None, *,
+    *,
+    x=None, y=None,
     hue=None, data=None,
     order=None, hue_order=None,
     orient=None, color=None, palette=None, saturation=.75,
@@ -2801,7 +2804,8 @@ boxenplot.__doc__ = dedent("""\
 
 @_deprecate_positional_args
 def stripplot(
-    x=None, y=None, *,
+    *,
+    x=None, y=None,
     hue=None, data=None,
     order=None, hue_order=None,
     jitter=True, dodge=False, orient=None, color=None, palette=None,
@@ -2997,7 +3001,8 @@ stripplot.__doc__ = dedent("""\
 
 @_deprecate_positional_args
 def swarmplot(
-    x=None, y=None, *,
+    *,
+    x=None, y=None,
     hue=None, data=None,
     order=None, hue_order=None,
     dodge=False, orient=None, color=None, palette=None,
@@ -3177,7 +3182,8 @@ swarmplot.__doc__ = dedent("""\
 
 @_deprecate_positional_args
 def barplot(
-    x=None, y=None, *,
+    *,
+    x=None, y=None,
     hue=None, data=None,
     order=None, hue_order=None,
     estimator=np.mean, ci=95, n_boot=1000, units=None, seed=None,
@@ -3369,7 +3375,8 @@ barplot.__doc__ = dedent("""\
 
 @_deprecate_positional_args
 def pointplot(
-    x=None, y=None, *,
+    *,
+    x=None, y=None,
     hue=None, data=None,
     order=None, hue_order=None,
     estimator=np.mean, ci=95, n_boot=1000, units=None, seed=None,
@@ -3576,7 +3583,8 @@ pointplot.__doc__ = dedent("""\
 
 @_deprecate_positional_args
 def countplot(
-    x=None, y=None, *,
+    *,
+    x=None, y=None,
     hue=None, data=None,
     order=None, hue_order=None,
     orient=None, color=None, palette=None, saturation=.75,
@@ -3735,7 +3743,8 @@ def factorplot(*args, **kwargs):
 
 @_deprecate_positional_args
 def catplot(
-    x=None, y=None, *,
+    *,
+    x=None, y=None,
     hue=None, data=None,
     row=None, col=None,  # TODO move in front of data when * is enforced
     col_wrap=None, estimator=np.mean, ci=95, n_boot=1000,

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -3328,7 +3328,7 @@ barplot.__doc__ = dedent("""\
     .. plot::
         :context: close-figs
 
-        >>> ax = sns.barplot("size", y="total_bill", data=tips,
+        >>> ax = sns.barplot(x="size", y="total_bill", data=tips,
         ...                  palette="Blues_d")
 
     Use ``hue`` without changing bar position or width:
@@ -3345,7 +3345,7 @@ barplot.__doc__ = dedent("""\
     .. plot::
         :context: close-figs
 
-        >>> ax = sns.barplot("size", y="total_bill", data=tips,
+        >>> ax = sns.barplot(x="size", y="total_bill", data=tips,
         ...                  color="salmon", saturation=.5)
 
     Use :meth:`matplotlib.axes.Axes.bar` parameters to control the style.
@@ -3353,7 +3353,7 @@ barplot.__doc__ = dedent("""\
     .. plot::
         :context: close-figs
 
-        >>> ax = sns.barplot("day", "total_bill", data=tips,
+        >>> ax = sns.barplot(x="day", y="total_bill", data=tips,
         ...                  linewidth=2.5, facecolor=(1, 1, 1, 0),
         ...                  errcolor=".2", edgecolor=".2")
 
@@ -3516,7 +3516,7 @@ pointplot.__doc__ = dedent("""\
     .. plot::
         :context: close-figs
 
-        >>> ax = sns.pointplot("time", y="total_bill", data=tips,
+        >>> ax = sns.pointplot(x="time", y="total_bill", data=tips,
         ...                    color="#bb3f3f")
 
     Use a different color palette for the points:
@@ -3831,7 +3831,12 @@ def catplot(
     g = FacetGrid(**facet_kws)
 
     # Draw the plot onto the facets
-    g.map_dataframe(plot_func, x, y, hue=hue, **plot_kws)
+    g.map_dataframe(plot_func, x=x, y=y, hue=hue, **plot_kws)
+
+    if p.orient == "h":
+        g.set_axis_labels(p.value_label, p.group_label)
+    else:
+        g.set_axis_labels(p.group_label, p.value_label)
 
     # Special case axis labels for a count type plot
     if kind == "count":
@@ -3973,7 +3978,7 @@ catplot.__doc__ = dedent("""\
         :context: close-figs
 
         >>> titanic = sns.load_dataset("titanic")
-        >>> g = sns.catplot("alive", col="deck", col_wrap=4,
+        >>> g = sns.catplot(x="alive", col="deck", col_wrap=4,
         ...                 data=titanic[titanic.deck.notnull()],
         ...                 kind="count", height=2.5, aspect=.8)
 

--- a/seaborn/distributions.py
+++ b/seaborn/distributions.py
@@ -38,7 +38,8 @@ def _freedman_diaconis_bins(a):
 
 @_deprecate_positional_args
 def distplot(
-    x=None, *,
+    *,
+    x=None,
     bins=None, hist=True, kde=True, rug=False, fit=None,
     hist_kws=None, kde_kws=None, rug_kws=None, fit_kws=None,
     color=None, vertical=False, norm_hist=False, axlabel=None,
@@ -523,7 +524,8 @@ def _scipy_bivariate_kde(x, y, bw, gridsize, cut, clip):
 
 @_deprecate_positional_args
 def kdeplot(
-    x=None, y=None, *,
+    *,
+    x=None, y=None,
     shade=False, vertical=False, kernel="gau",
     bw="scott", gridsize=100, cut=3, clip=None, legend=True,
     cumulative=False, shade_lowest=True, cbar=False, cbar_ax=None,
@@ -724,7 +726,8 @@ def kdeplot(
 
 @_deprecate_positional_args
 def rugplot(
-    x=None, *,
+    *,
+    x=None,
     height=.05, axis="x", ax=None,
     a=None,
     **kwargs

--- a/seaborn/distributions.py
+++ b/seaborn/distributions.py
@@ -116,7 +116,7 @@ def distplot(
         >>> import seaborn as sns, numpy as np
         >>> sns.set(); np.random.seed(0)
         >>> x = np.random.randn(100)
-        >>> ax = sns.distplot(x)
+        >>> ax = sns.distplot(x=x)
 
     Use Pandas objects to get an informative axis label:
 
@@ -125,14 +125,14 @@ def distplot(
 
         >>> import pandas as pd
         >>> x = pd.Series(x, name="x variable")
-        >>> ax = sns.distplot(x)
+        >>> ax = sns.distplot(x=x)
 
     Plot the distribution with a kernel density estimate and rug plot:
 
     .. plot::
         :context: close-figs
 
-        >>> ax = sns.distplot(x, rug=True, hist=False)
+        >>> ax = sns.distplot(x=x, rug=True, hist=False)
 
     Plot the distribution with a histogram and maximum likelihood gaussian
     distribution fit:
@@ -141,14 +141,14 @@ def distplot(
         :context: close-figs
 
         >>> from scipy.stats import norm
-        >>> ax = sns.distplot(x, fit=norm, kde=False)
+        >>> ax = sns.distplot(x=x, fit=norm, kde=False)
 
     Plot the distribution on the vertical axis:
 
     .. plot::
         :context: close-figs
 
-        >>> ax = sns.distplot(x, vertical=True)
+        >>> ax = sns.distplot(x=x, vertical=True)
 
     Change the color of all the plot elements:
 
@@ -156,14 +156,14 @@ def distplot(
         :context: close-figs
 
         >>> sns.set_color_codes()
-        >>> ax = sns.distplot(x, color="y")
+        >>> ax = sns.distplot(x=x, color="y")
 
     Pass specific parameters to the underlying plot functions:
 
     .. plot::
         :context: close-figs
 
-        >>> ax = sns.distplot(x, rug=True, rug_kws={"color": "g"},
+        >>> ax = sns.distplot(x=x, rug=True, rug_kws={"color": "g"},
         ...                   kde_kws={"color": "k", "lw": 3, "label": "KDE"},
         ...                   hist_kws={"histtype": "step", "linewidth": 3,
         ...                             "alpha": 1, "color": "g"})
@@ -239,14 +239,14 @@ def distplot(
 
     if kde:
         kde_color = kde_kws.pop("color", color)
-        kdeplot(a, vertical=vertical, ax=ax, color=kde_color, **kde_kws)
+        kdeplot(x=a, vertical=vertical, ax=ax, color=kde_color, **kde_kws)
         if kde_color != color:
             kde_kws["color"] = kde_color
 
     if rug:
         rug_color = rug_kws.pop("color", color)
         axis = "y" if vertical else "x"
-        rugplot(a, axis=axis, ax=ax, color=rug_color, **rug_kws)
+        rugplot(x=a, axis=axis, ax=ax, color=rug_color, **rug_kws)
         if rug_color != color:
             rug_kws["color"] = rug_color
 
@@ -608,63 +608,63 @@ def kdeplot(
         >>> import seaborn as sns; sns.set(color_codes=True)
         >>> mean, cov = [0, 2], [(1, .5), (.5, 1)]
         >>> x, y = np.random.multivariate_normal(mean, cov, size=50).T
-        >>> ax = sns.kdeplot(x)
+        >>> ax = sns.kdeplot(x=x)
 
     Shade under the density curve and use a different color:
 
     .. plot::
         :context: close-figs
 
-        >>> ax = sns.kdeplot(x, shade=True, color="r")
+        >>> ax = sns.kdeplot(x=x, shade=True, color="r")
 
     Plot a bivariate density:
 
     .. plot::
         :context: close-figs
 
-        >>> ax = sns.kdeplot(x, y)
+        >>> ax = sns.kdeplot(x=x, y=y)
 
     Use filled contours:
 
     .. plot::
         :context: close-figs
 
-        >>> ax = sns.kdeplot(x, y, shade=True)
+        >>> ax = sns.kdeplot(x=x, y=y, shade=True)
 
     Use more contour levels and a different color palette:
 
     .. plot::
         :context: close-figs
 
-        >>> ax = sns.kdeplot(x, y, n_levels=30, cmap="Purples_d")
+        >>> ax = sns.kdeplot(x=x, y=y, n_levels=30, cmap="Purples_d")
 
     Use a narrower bandwith:
 
     .. plot::
         :context: close-figs
 
-        >>> ax = sns.kdeplot(x, bw=.15)
+        >>> ax = sns.kdeplot(x=x, bw=.15)
 
     Plot the density on the vertical axis:
 
     .. plot::
         :context: close-figs
 
-        >>> ax = sns.kdeplot(y, vertical=True)
+        >>> ax = sns.kdeplot(x=y, vertical=True)
 
     Limit the density curve within the range of the data:
 
     .. plot::
         :context: close-figs
 
-        >>> ax = sns.kdeplot(x, cut=0)
+        >>> ax = sns.kdeplot(x=x, cut=0)
 
     Add a colorbar for the contours:
 
     .. plot::
         :context: close-figs
 
-        >>> ax = sns.kdeplot(x, y, cbar=True)
+        >>> ax = sns.kdeplot(x=x, y=y, cbar=True)
 
     Plot two shaded bivariate densities:
 
@@ -674,9 +674,9 @@ def kdeplot(
         >>> iris = sns.load_dataset("iris")
         >>> setosa = iris.loc[iris.species == "setosa"]
         >>> virginica = iris.loc[iris.species == "virginica"]
-        >>> ax = sns.kdeplot(setosa.sepal_width, setosa.sepal_length,
+        >>> ax = sns.kdeplot(x=setosa.sepal_width, y=setosa.sepal_length,
         ...                  cmap="Reds", shade=True, shade_lowest=False)
-        >>> ax = sns.kdeplot(virginica.sepal_width, virginica.sepal_length,
+        >>> ax = sns.kdeplot(x=virginica.sepal_width, y=virginica.sepal_length,
         ...                  cmap="Blues", shade=True, shade_lowest=False)
 
     """

--- a/seaborn/regression.py
+++ b/seaborn/regression.py
@@ -558,7 +558,8 @@ _regression_docs.update(_facet_docs)
 
 @_deprecate_positional_args
 def lmplot(
-    x=None, y=None, *,
+    *,
+    x=None, y=None,
     data=None,
     hue=None, col=None, row=None,  # TODO move before data once * is enforced
     palette=None, col_wrap=None, height=5, aspect=1, markers="o",
@@ -804,7 +805,8 @@ lmplot.__doc__ = dedent("""\
 
 @_deprecate_positional_args
 def regplot(
-    x=None, y=None, *,
+    *,
+    x=None, y=None,
     data=None,
     x_estimator=None, x_bins=None, x_ci="ci",
     scatter=True, fit_reg=True, ci=95, n_boot=1000, units=None,
@@ -1002,7 +1004,8 @@ regplot.__doc__ = dedent("""\
 
 @_deprecate_positional_args
 def residplot(
-    x=None, y=None, *,
+    *,
+    x=None, y=None,
     data=None,
     lowess=False, x_partial=None, y_partial=None,
     order=1, robust=False, dropna=True, label=None, color=None,

--- a/seaborn/regression.py
+++ b/seaborn/regression.py
@@ -622,7 +622,10 @@ def lmplot(
         truncate=truncate, x_jitter=x_jitter, y_jitter=y_jitter,
         scatter_kws=scatter_kws, line_kws=line_kws,
     )
-    facets.map_dataframe(regplot, x, y, **regplot_kws)
+    facets.map_dataframe(regplot, x=x, y=y, **regplot_kws)
+
+    # TODO this will need to change when we relax string requirement
+    facets.set_axis_labels(x, y)
 
     # Add a legend
     if legend and (hue is not None) and (hue not in [col, row]):

--- a/seaborn/relational.py
+++ b/seaborn/relational.py
@@ -978,7 +978,8 @@ _relational_docs.update(_facet_docs)
 
 @_deprecate_positional_args
 def lineplot(
-    x=None, y=None, *,
+    *,
+    x=None, y=None,
     hue=None, size=None, style=None,
     data=None,
     palette=None, hue_order=None, hue_norm=None,
@@ -1252,7 +1253,8 @@ lineplot.__doc__ = dedent("""\
 
 @_deprecate_positional_args
 def scatterplot(
-    x=None, y=None, *,
+    *,
+    x=None, y=None,
     hue=None, style=None, size=None, data=None,
     palette=None, hue_order=None, hue_norm=None,
     sizes=None, size_order=None, size_norm=None,
@@ -1498,7 +1500,8 @@ scatterplot.__doc__ = dedent("""\
 
 @_deprecate_positional_args
 def relplot(
-    x=None, y=None, *,
+    *,
+    x=None, y=None,
     hue=None, size=None, style=None, data=None,
     row=None, col=None,  # TODO move in front of data when * is enforced
     col_wrap=None, row_order=None, col_order=None,

--- a/seaborn/tests/test_axisgrid.py
+++ b/seaborn/tests/test_axisgrid.py
@@ -503,7 +503,7 @@ class TestFacetGrid(object):
 
         x, y = np.arange(10), np.arange(10)
         df = pd.DataFrame(np.c_[x, y], columns=["x", "y"])
-        g = ag.FacetGrid(df).map(pointplot, "x", "y", order=x)
+        g = ag.FacetGrid(df).map_dataframe(pointplot, x="x", y="y", order=x)
         g.set_xticklabels(step=2)
         got_x = [int(l.get_text()) for l in g.axes[0, 0].get_xticklabels()]
         npt.assert_array_equal(x[::2], got_x)
@@ -1267,36 +1267,36 @@ class TestJointGrid(object):
 
     def test_margin_grid_from_lists(self):
 
-        g = ag.JointGrid(self.x.tolist(), self.y.tolist())
+        g = ag.JointGrid(x=self.x.tolist(), y=self.y.tolist())
         npt.assert_array_equal(g.x, self.x)
         npt.assert_array_equal(g.y, self.y)
 
     def test_margin_grid_from_arrays(self):
 
-        g = ag.JointGrid(self.x, self.y)
+        g = ag.JointGrid(x=self.x, y=self.y)
         npt.assert_array_equal(g.x, self.x)
         npt.assert_array_equal(g.y, self.y)
 
     def test_margin_grid_from_series(self):
 
-        g = ag.JointGrid(self.data.x, self.data.y)
+        g = ag.JointGrid(x=self.data.x, y=self.data.y)
         npt.assert_array_equal(g.x, self.x)
         npt.assert_array_equal(g.y, self.y)
 
     def test_margin_grid_from_dataframe(self):
 
-        g = ag.JointGrid("x", "y", data=self.data)
+        g = ag.JointGrid(x="x", y="y", data=self.data)
         npt.assert_array_equal(g.x, self.x)
         npt.assert_array_equal(g.y, self.y)
 
     def test_margin_grid_from_dataframe_bad_variable(self):
 
         with nt.assert_raises(ValueError):
-            ag.JointGrid("x", "bad_column", data=self.data)
+            ag.JointGrid(x="x", y="bad_column", data=self.data)
 
     def test_margin_grid_axis_labels(self):
 
-        g = ag.JointGrid("x", "y", data=self.data)
+        g = ag.JointGrid(x="x", y="y", data=self.data)
 
         xlabel, ylabel = g.ax_joint.get_xlabel(), g.ax_joint.get_ylabel()
         nt.assert_equal(xlabel, "x")
@@ -1309,16 +1309,16 @@ class TestJointGrid(object):
 
     def test_dropna(self):
 
-        g = ag.JointGrid("x_na", "y", data=self.data, dropna=False)
+        g = ag.JointGrid(x="x_na", y="y", data=self.data, dropna=False)
         nt.assert_equal(len(g.x), len(self.x_na))
 
-        g = ag.JointGrid("x_na", "y", data=self.data, dropna=True)
+        g = ag.JointGrid(x="x_na", y="y", data=self.data, dropna=True)
         nt.assert_equal(len(g.x), pd.notnull(self.x_na).sum())
 
     def test_axlims(self):
 
         lim = (-3, 3)
-        g = ag.JointGrid("x", "y", data=self.data, xlim=lim, ylim=lim)
+        g = ag.JointGrid(x="x", y="y", data=self.data, xlim=lim, ylim=lim)
 
         nt.assert_equal(g.ax_joint.get_xlim(), lim)
         nt.assert_equal(g.ax_joint.get_ylim(), lim)
@@ -1328,13 +1328,13 @@ class TestJointGrid(object):
 
     def test_marginal_ticks(self):
 
-        g = ag.JointGrid("x", "y", data=self.data)
+        g = ag.JointGrid(x="x", y="y", data=self.data)
         nt.assert_true(~len(g.ax_marg_x.get_xticks()))
         nt.assert_true(~len(g.ax_marg_y.get_yticks()))
 
     def test_bivariate_plot(self):
 
-        g = ag.JointGrid("x", "y", data=self.data)
+        g = ag.JointGrid(x="x", y="y", data=self.data)
         g.plot_joint(plt.plot)
 
         x, y = g.ax_joint.lines[0].get_xydata().T
@@ -1343,7 +1343,7 @@ class TestJointGrid(object):
 
     def test_univariate_plot(self):
 
-        g = ag.JointGrid("x", "x", data=self.data)
+        g = ag.JointGrid(x="x", y="x", data=self.data)
         g.plot_marginals(kdeplot)
 
         _, y1 = g.ax_marg_x.lines[0].get_xydata().T
@@ -1352,7 +1352,7 @@ class TestJointGrid(object):
 
     def test_plot(self):
 
-        g = ag.JointGrid("x", "x", data=self.data)
+        g = ag.JointGrid(x="x", y="x", data=self.data)
         g.plot(plt.plot, kdeplot)
 
         x, y = g.ax_joint.lines[0].get_xydata().T
@@ -1365,7 +1365,7 @@ class TestJointGrid(object):
 
     def test_annotate(self):
 
-        g = ag.JointGrid("x", "y", data=self.data)
+        g = ag.JointGrid(x="x", y="y", data=self.data)
         rp = stats.pearsonr(self.x, self.y)
 
         with pytest.warns(UserWarning):
@@ -1396,7 +1396,7 @@ class TestJointGrid(object):
 
     def test_space(self):
 
-        g = ag.JointGrid("x", "y", data=self.data, space=0)
+        g = ag.JointGrid(x="x", y="y", data=self.data, space=0)
 
         joint_bounds = g.ax_joint.bbox.bounds
         marg_x_bounds = g.ax_marg_x.bbox.bounds
@@ -1415,7 +1415,7 @@ class TestJointPlot(object):
 
     def test_scatter(self):
 
-        g = ag.jointplot("x", "y", data=self.data)
+        g = ag.jointplot(x="x", y="y", data=self.data)
         nt.assert_equal(len(g.ax_joint.collections), 1)
 
         x, y = g.ax_joint.collections[0].get_offsets().T
@@ -1430,7 +1430,7 @@ class TestJointPlot(object):
 
     def test_reg(self):
 
-        g = ag.jointplot("x", "y", data=self.data, kind="reg")
+        g = ag.jointplot(x="x", y="y", data=self.data, kind="reg")
         nt.assert_equal(len(g.ax_joint.collections), 2)
 
         x, y = g.ax_joint.collections[0].get_offsets().T
@@ -1449,7 +1449,7 @@ class TestJointPlot(object):
 
     def test_resid(self):
 
-        g = ag.jointplot("x", "y", data=self.data, kind="resid")
+        g = ag.jointplot(x="x", y="y", data=self.data, kind="resid")
         nt.assert_equal(len(g.ax_joint.collections), 1)
         nt.assert_equal(len(g.ax_joint.lines), 1)
         nt.assert_equal(len(g.ax_marg_x.lines), 0)
@@ -1457,7 +1457,7 @@ class TestJointPlot(object):
 
     def test_hex(self):
 
-        g = ag.jointplot("x", "y", data=self.data, kind="hex")
+        g = ag.jointplot(x="x", y="y", data=self.data, kind="hex")
         nt.assert_equal(len(g.ax_joint.collections), 1)
 
         x_bins = _freedman_diaconis_bins(self.x)
@@ -1468,7 +1468,7 @@ class TestJointPlot(object):
 
     def test_kde(self):
 
-        g = ag.jointplot("x", "y", data=self.data, kind="kde")
+        g = ag.jointplot(x="x", y="y", data=self.data, kind="kde")
 
         nt.assert_true(len(g.ax_joint.collections) > 0)
         nt.assert_equal(len(g.ax_marg_x.collections), 1)
@@ -1479,7 +1479,7 @@ class TestJointPlot(object):
 
     def test_color(self):
 
-        g = ag.jointplot("x", "y", data=self.data, color="purple")
+        g = ag.jointplot(x="x", y="y", data=self.data, color="purple")
 
         purple = mpl.colors.colorConverter.to_rgb("purple")
         scatter_color = g.ax_joint.collections[0].get_facecolor()[0, :3]
@@ -1491,17 +1491,17 @@ class TestJointPlot(object):
     def test_annotation(self):
 
         with pytest.warns(UserWarning):
-            g = ag.jointplot("x", "y", data=self.data,
+            g = ag.jointplot(x="x", y="y", data=self.data,
                              stat_func=stats.pearsonr)
         nt.assert_equal(len(g.ax_joint.legend_.get_texts()), 1)
 
-        g = ag.jointplot("x", "y", data=self.data, stat_func=None)
+        g = ag.jointplot(x="x", y="y", data=self.data, stat_func=None)
         nt.assert_is(g.ax_joint.legend_, None)
 
     def test_hex_customise(self):
 
         # test that default gridsize can be overridden
-        g = ag.jointplot("x", "y", data=self.data, kind="hex",
+        g = ag.jointplot(x="x", y="y", data=self.data, kind="hex",
                          joint_kws=dict(gridsize=5))
         nt.assert_equal(len(g.ax_joint.collections), 1)
         a = g.ax_joint.collections[0].get_array()
@@ -1510,7 +1510,7 @@ class TestJointPlot(object):
     def test_bad_kind(self):
 
         with nt.assert_raises(ValueError):
-            ag.jointplot("x", "y", data=self.data, kind="not_a_kind")
+            ag.jointplot(x="x", y="y", data=self.data, kind="not_a_kind")
 
     def test_leaky_dict(self):
         # Validate input dicts are unchanged by jointplot plotting function
@@ -1518,6 +1518,6 @@ class TestJointPlot(object):
         for kwarg in ("joint_kws", "marginal_kws", "annot_kws"):
             for kind in ("hex", "kde", "resid", "reg", "scatter"):
                 empty_dict = {}
-                ag.jointplot("x", "y", data=self.data, kind=kind,
+                ag.jointplot(x="x", y="y", data=self.data, kind=kind,
                              **{kwarg: empty_dict})
                 assert empty_dict == {}

--- a/seaborn/tests/test_categorical.py
+++ b/seaborn/tests/test_categorical.py
@@ -796,26 +796,26 @@ class TestBoxPlotter(CategoricalFixture):
 
     def test_axes_data(self):
 
-        ax = cat.boxplot("g", "y", data=self.df)
+        ax = cat.boxplot(x="g", y="y", data=self.df)
         nt.assert_equal(len(ax.artists), 3)
 
         plt.close("all")
 
-        ax = cat.boxplot("g", "y", hue="h", data=self.df)
+        ax = cat.boxplot(x="g", y="y", hue="h", data=self.df)
         nt.assert_equal(len(ax.artists), 6)
 
         plt.close("all")
 
     def test_box_colors(self):
 
-        ax = cat.boxplot("g", "y", data=self.df, saturation=1)
+        ax = cat.boxplot(x="g", y="y", data=self.df, saturation=1)
         pal = palettes.color_palette(n_colors=3)
         for patch, color in zip(ax.artists, pal):
             nt.assert_equal(patch.get_facecolor()[:3], color)
 
         plt.close("all")
 
-        ax = cat.boxplot("g", "y", hue="h", data=self.df, saturation=1)
+        ax = cat.boxplot(x="g", y="y", hue="h", data=self.df, saturation=1)
         pal = palettes.color_palette(n_colors=2)
         for patch, color in zip(ax.artists, pal * 2):
             nt.assert_equal(patch.get_facecolor()[:3], color)
@@ -824,7 +824,7 @@ class TestBoxPlotter(CategoricalFixture):
 
     def test_draw_missing_boxes(self):
 
-        ax = cat.boxplot("g", "y", data=self.df,
+        ax = cat.boxplot(x="g", y="y", data=self.df,
                          order=["a", "b", "c", "d"])
         nt.assert_equal(len(ax.artists), 3)
 
@@ -835,13 +835,13 @@ class TestBoxPlotter(CategoricalFixture):
         y = self.rs.randn(8)
         y[-2:] = np.nan
 
-        ax = cat.boxplot(x, y)
+        ax = cat.boxplot(x=x, y=y)
         nt.assert_equal(len(ax.artists), 3)
 
         plt.close("all")
 
         y[-1] = 0
-        ax = cat.boxplot(x, y, hue=h)
+        ax = cat.boxplot(x=x, y=y, hue=h)
         nt.assert_equal(len(ax.artists), 7)
 
         plt.close("all")
@@ -849,15 +849,16 @@ class TestBoxPlotter(CategoricalFixture):
     def test_unaligned_index(self):
 
         f, (ax1, ax2) = plt.subplots(2)
-        cat.boxplot(self.g, self.y, ax=ax1)
-        cat.boxplot(self.g, self.y_perm, ax=ax2)
+        cat.boxplot(x=self.g, y=self.y, ax=ax1)
+        cat.boxplot(x=self.g, y=self.y_perm, ax=ax2)
         for l1, l2 in zip(ax1.lines, ax2.lines):
             assert np.array_equal(l1.get_xydata(), l2.get_xydata())
 
         f, (ax1, ax2) = plt.subplots(2)
         hue_order = self.h.unique()
-        cat.boxplot(self.g, self.y, hue=self.h, hue_order=hue_order, ax=ax1)
-        cat.boxplot(self.g, self.y_perm, hue=self.h,
+        cat.boxplot(x=self.g, y=self.y, hue=self.h,
+                    hue_order=hue_order, ax=ax1)
+        cat.boxplot(x=self.g, y=self.y_perm, hue=self.h,
                     hue_order=hue_order, ax=ax2)
         for l1, l2 in zip(ax1.lines, ax2.lines):
             assert np.array_equal(l1.get_xydata(), l2.get_xydata())
@@ -866,33 +867,33 @@ class TestBoxPlotter(CategoricalFixture):
 
         # Smoke test the high level boxplot options
 
-        cat.boxplot("y", data=self.df)
+        cat.boxplot(x="y", data=self.df)
         plt.close("all")
 
         cat.boxplot(y="y", data=self.df)
         plt.close("all")
 
-        cat.boxplot("g", "y", data=self.df)
+        cat.boxplot(x="g", y="y", data=self.df)
         plt.close("all")
 
-        cat.boxplot("y", "g", data=self.df, orient="h")
+        cat.boxplot(x="y", y="g", data=self.df, orient="h")
         plt.close("all")
 
-        cat.boxplot("g", "y", hue="h", data=self.df)
+        cat.boxplot(x="g", y="y", hue="h", data=self.df)
         plt.close("all")
 
-        cat.boxplot("g", "y", hue="h", order=list("nabc"), data=self.df)
+        cat.boxplot(x="g", y="y", hue="h", order=list("nabc"), data=self.df)
         plt.close("all")
 
-        cat.boxplot("g", "y", hue="h", hue_order=list("omn"), data=self.df)
+        cat.boxplot(x="g", y="y", hue="h", hue_order=list("omn"), data=self.df)
         plt.close("all")
 
-        cat.boxplot("y", "g", hue="h", data=self.df, orient="h")
+        cat.boxplot(x="y", y="g", hue="h", data=self.df, orient="h")
         plt.close("all")
 
     def test_axes_annotation(self):
 
-        ax = cat.boxplot("g", "y", data=self.df)
+        ax = cat.boxplot(x="g", y="y", data=self.df)
         nt.assert_equal(ax.get_xlabel(), "g")
         nt.assert_equal(ax.get_ylabel(), "y")
         nt.assert_equal(ax.get_xlim(), (-.5, 2.5))
@@ -902,7 +903,7 @@ class TestBoxPlotter(CategoricalFixture):
 
         plt.close("all")
 
-        ax = cat.boxplot("g", "y", hue="h", data=self.df)
+        ax = cat.boxplot(x="g", y="y", hue="h", data=self.df)
         nt.assert_equal(ax.get_xlabel(), "g")
         nt.assert_equal(ax.get_ylabel(), "y")
         npt.assert_array_equal(ax.get_xticks(), [0, 1, 2])
@@ -913,7 +914,7 @@ class TestBoxPlotter(CategoricalFixture):
 
         plt.close("all")
 
-        ax = cat.boxplot("y", "g", data=self.df, orient="h")
+        ax = cat.boxplot(x="y", y="g", data=self.df, orient="h")
         nt.assert_equal(ax.get_xlabel(), "y")
         nt.assert_equal(ax.get_ylabel(), "g")
         nt.assert_equal(ax.get_ylim(), (2.5, -.5))
@@ -1490,38 +1491,40 @@ class TestViolinPlotter(CategoricalFixture):
 
         # Smoke test the high level violinplot options
 
-        cat.violinplot("y", data=self.df)
+        cat.violinplot(x="y", data=self.df)
         plt.close("all")
 
         cat.violinplot(y="y", data=self.df)
         plt.close("all")
 
-        cat.violinplot("g", "y", data=self.df)
+        cat.violinplot(x="g", y="y", data=self.df)
         plt.close("all")
 
-        cat.violinplot("y", "g", data=self.df, orient="h")
+        cat.violinplot(x="y", y="g", data=self.df, orient="h")
         plt.close("all")
 
-        cat.violinplot("g", "y", hue="h", data=self.df)
+        cat.violinplot(x="g", y="y", hue="h", data=self.df)
         plt.close("all")
 
-        cat.violinplot("g", "y", hue="h", order=list("nabc"), data=self.df)
+        order = list("nabc")
+        cat.violinplot(x="g", y="y", hue="h", order=order, data=self.df)
         plt.close("all")
 
-        cat.violinplot("g", "y", hue="h", hue_order=list("omn"), data=self.df)
+        order = list("omn")
+        cat.violinplot(x="g", y="y", hue="h", hue_order=order, data=self.df)
         plt.close("all")
 
-        cat.violinplot("y", "g", hue="h", data=self.df, orient="h")
+        cat.violinplot(x="y", y="g", hue="h", data=self.df, orient="h")
         plt.close("all")
 
         for inner in ["box", "quart", "point", "stick", None]:
-            cat.violinplot("g", "y", data=self.df, inner=inner)
+            cat.violinplot(x="g", y="y", data=self.df, inner=inner)
             plt.close("all")
 
-            cat.violinplot("g", "y", hue="h", data=self.df, inner=inner)
+            cat.violinplot(x="g", y="y", hue="h", data=self.df, inner=inner)
             plt.close("all")
 
-            cat.violinplot("g", "y", hue="h", data=self.df,
+            cat.violinplot(x="g", y="y", hue="h", data=self.df,
                            inner=inner, split=True)
             plt.close("all")
 
@@ -1591,7 +1594,7 @@ class TestStripPlotter(CategoricalFixture):
 
         pal = palettes.color_palette()
 
-        ax = cat.stripplot("g", "y", jitter=False, data=self.df)
+        ax = cat.stripplot(x="g", y="y", jitter=False, data=self.df)
         for i, (_, vals) in enumerate(self.y.groupby(self.g)):
 
             x, y = ax.collections[i].get_offsets().T
@@ -1606,7 +1609,7 @@ class TestStripPlotter(CategoricalFixture):
         df = self.df.copy()
         df.g = df.g.astype("category")
 
-        ax = cat.stripplot("y", "g", jitter=False, data=df)
+        ax = cat.stripplot(x="y", y="g", jitter=False, data=df)
         for i, (_, vals) in enumerate(self.y.groupby(self.g)):
 
             x, y = ax.collections[i].get_offsets().T
@@ -1618,7 +1621,7 @@ class TestStripPlotter(CategoricalFixture):
 
         pal = palettes.color_palette()
 
-        ax = cat.stripplot("g", "y", data=self.df, jitter=True)
+        ax = cat.stripplot(x="g", y="y", data=self.df, jitter=True)
         for i, (_, vals) in enumerate(self.y.groupby(self.g)):
 
             x, y = ax.collections[i].get_offsets().T
@@ -1633,7 +1636,7 @@ class TestStripPlotter(CategoricalFixture):
 
         pal = palettes.color_palette()
 
-        ax = cat.stripplot("g", "y", hue="h", data=self.df,
+        ax = cat.stripplot(x="g", y="y", hue="h", data=self.df,
                            jitter=False, dodge=True)
         for i, (_, group_vals) in enumerate(self.y.groupby(self.g)):
             for j, (_, vals) in enumerate(group_vals.groupby(self.h)):
@@ -1651,7 +1654,7 @@ class TestStripPlotter(CategoricalFixture):
         df = self.df.copy()
         df.g = df.g.astype("category")
 
-        ax = cat.stripplot("y", "g", hue="h", data=df,
+        ax = cat.stripplot(x="y", y="g", hue="h", data=df,
                            jitter=False, dodge=True)
         for i, (_, group_vals) in enumerate(self.y.groupby(self.g)):
             for j, (_, vals) in enumerate(group_vals.groupby(self.h)):
@@ -1664,7 +1667,7 @@ class TestStripPlotter(CategoricalFixture):
     def test_nested_stripplot_vertical(self):
 
         # Test a simple vertical strip plot
-        ax = cat.stripplot("g", "y", hue="h", data=self.df,
+        ax = cat.stripplot(x="g", y="y", hue="h", data=self.df,
                            jitter=False, dodge=False)
         for i, (_, group_vals) in enumerate(self.y.groupby(self.g)):
 
@@ -1678,7 +1681,7 @@ class TestStripPlotter(CategoricalFixture):
         df = self.df.copy()
         df.g = df.g.astype("category")
 
-        ax = cat.stripplot("y", "g", hue="h", data=df,
+        ax = cat.stripplot(x="y", y="g", hue="h", data=df,
                            jitter=False, dodge=False)
         for i, (_, group_vals) in enumerate(self.y.groupby(self.g)):
 
@@ -1698,8 +1701,8 @@ class TestStripPlotter(CategoricalFixture):
     def test_unaligned_index(self):
 
         f, (ax1, ax2) = plt.subplots(2)
-        cat.stripplot(self.g, self.y, ax=ax1)
-        cat.stripplot(self.g, self.y_perm, ax=ax2)
+        cat.stripplot(x=self.g, y=self.y, ax=ax1)
+        cat.stripplot(x=self.g, y=self.y_perm, ax=ax2)
         for p1, p2 in zip(ax1.collections, ax2.collections):
             y1, y2 = p1.get_offsets()[:, 1], p2.get_offsets()[:, 1]
             assert np.array_equal(np.sort(y1), np.sort(y2))
@@ -1708,9 +1711,9 @@ class TestStripPlotter(CategoricalFixture):
 
         f, (ax1, ax2) = plt.subplots(2)
         hue_order = self.h.unique()
-        cat.stripplot(self.g, self.y, hue=self.h,
+        cat.stripplot(x=self.g, y=self.y, hue=self.h,
                       hue_order=hue_order, ax=ax1)
-        cat.stripplot(self.g, self.y_perm, hue=self.h,
+        cat.stripplot(x=self.g, y=self.y_perm, hue=self.h,
                       hue_order=hue_order, ax=ax2)
         for p1, p2 in zip(ax1.collections, ax2.collections):
             y1, y2 = p1.get_offsets()[:, 1], p2.get_offsets()[:, 1]
@@ -1720,9 +1723,9 @@ class TestStripPlotter(CategoricalFixture):
 
         f, (ax1, ax2) = plt.subplots(2)
         hue_order = self.h.unique()
-        cat.stripplot(self.g, self.y, hue=self.h,
+        cat.stripplot(x=self.g, y=self.y, hue=self.h,
                       dodge=True, hue_order=hue_order, ax=ax1)
-        cat.stripplot(self.g, self.y_perm, hue=self.h,
+        cat.stripplot(x=self.g, y=self.y_perm, hue=self.h,
                       dodge=True, hue_order=hue_order, ax=ax2)
         for p1, p2 in zip(ax1.collections, ax2.collections):
             y1, y2 = p1.get_offsets()[:, 1], p2.get_offsets()[:, 1]
@@ -1794,7 +1797,7 @@ class TestSwarmPlotter(CategoricalFixture):
 
         pal = palettes.color_palette()
 
-        ax = cat.swarmplot("g", "y", data=self.df)
+        ax = cat.swarmplot(x="g", y="y", data=self.df)
         for i, (_, vals) in enumerate(self.y.groupby(self.g)):
 
             x, y = ax.collections[i].get_offsets().T
@@ -1807,7 +1810,7 @@ class TestSwarmPlotter(CategoricalFixture):
 
         pal = palettes.color_palette()
 
-        ax = cat.swarmplot("y", "g", data=self.df, orient="h")
+        ax = cat.swarmplot(x="y", y="g", data=self.df, orient="h")
         for i, (_, vals) in enumerate(self.y.groupby(self.g)):
 
             x, y = ax.collections[i].get_offsets().T
@@ -1820,7 +1823,7 @@ class TestSwarmPlotter(CategoricalFixture):
 
         pal = palettes.color_palette()
 
-        ax = cat.swarmplot("g", "y", hue="h", data=self.df, dodge=True)
+        ax = cat.swarmplot(x="g", y="y", hue="h", data=self.df, dodge=True)
         for i, (_, group_vals) in enumerate(self.y.groupby(self.g)):
             for j, (_, vals) in enumerate(group_vals.groupby(self.h)):
 
@@ -1834,7 +1837,7 @@ class TestSwarmPlotter(CategoricalFixture):
 
         pal = palettes.color_palette()
 
-        ax = cat.swarmplot("y", "g", hue="h", data=self.df,
+        ax = cat.swarmplot(x="y", y="g", hue="h", data=self.df,
                            orient="h", dodge=True)
         for i, (_, group_vals) in enumerate(self.y.groupby(self.g)):
             for j, (_, vals) in enumerate(group_vals.groupby(self.h)):
@@ -1847,7 +1850,7 @@ class TestSwarmPlotter(CategoricalFixture):
 
     def test_nested_swarmplot_vertical(self):
 
-        ax = cat.swarmplot("g", "y", hue="h", data=self.df)
+        ax = cat.swarmplot(x="g", y="y", hue="h", data=self.df)
 
         pal = palettes.color_palette()
         hue_names = self.h.unique().tolist()
@@ -1868,7 +1871,7 @@ class TestSwarmPlotter(CategoricalFixture):
 
     def test_nested_swarmplot_horizontal(self):
 
-        ax = cat.swarmplot("y", "g", hue="h", data=self.df, orient="h")
+        ax = cat.swarmplot(x="y", y="g", hue="h", data=self.df, orient="h")
 
         pal = palettes.color_palette()
         hue_names = self.h.unique().tolist()
@@ -1890,8 +1893,8 @@ class TestSwarmPlotter(CategoricalFixture):
     def test_unaligned_index(self):
 
         f, (ax1, ax2) = plt.subplots(2)
-        cat.swarmplot(self.g, self.y, ax=ax1)
-        cat.swarmplot(self.g, self.y_perm, ax=ax2)
+        cat.swarmplot(x=self.g, y=self.y, ax=ax1)
+        cat.swarmplot(x=self.g, y=self.y_perm, ax=ax2)
         for p1, p2 in zip(ax1.collections, ax2.collections):
             assert np.allclose(p1.get_offsets()[:, 1],
                                p2.get_offsets()[:, 1])
@@ -1900,9 +1903,9 @@ class TestSwarmPlotter(CategoricalFixture):
 
         f, (ax1, ax2) = plt.subplots(2)
         hue_order = self.h.unique()
-        cat.swarmplot(self.g, self.y, hue=self.h,
+        cat.swarmplot(x=self.g, y=self.y, hue=self.h,
                       hue_order=hue_order, ax=ax1)
-        cat.swarmplot(self.g, self.y_perm, hue=self.h,
+        cat.swarmplot(x=self.g, y=self.y_perm, hue=self.h,
                       hue_order=hue_order, ax=ax2)
         for p1, p2 in zip(ax1.collections, ax2.collections):
             assert np.allclose(p1.get_offsets()[:, 1],
@@ -1912,9 +1915,9 @@ class TestSwarmPlotter(CategoricalFixture):
 
         f, (ax1, ax2) = plt.subplots(2)
         hue_order = self.h.unique()
-        cat.swarmplot(self.g, self.y, hue=self.h,
+        cat.swarmplot(x=self.g, y=self.y, hue=self.h,
                       dodge=True, hue_order=hue_order, ax=ax1)
-        cat.swarmplot(self.g, self.y_perm, hue=self.h,
+        cat.swarmplot(x=self.g, y=self.y_perm, hue=self.h,
                       dodge=True, hue_order=hue_order, ax=ax2)
         for p1, p2 in zip(ax1.collections, ax2.collections):
             assert np.allclose(p1.get_offsets()[:, 1],
@@ -2080,8 +2083,8 @@ class TestBarPlotter(CategoricalFixture):
     def test_unaligned_index(self):
 
         f, (ax1, ax2) = plt.subplots(2)
-        cat.barplot(self.g, self.y, ci="sd", ax=ax1)
-        cat.barplot(self.g, self.y_perm, ci="sd", ax=ax2)
+        cat.barplot(x=self.g, y=self.y, ci="sd", ax=ax1)
+        cat.barplot(x=self.g, y=self.y_perm, ci="sd", ax=ax2)
         for l1, l2 in zip(ax1.lines, ax2.lines):
             assert pytest.approx(l1.get_xydata()) == l2.get_xydata()
         for p1, p2 in zip(ax1.patches, ax2.patches):
@@ -2091,9 +2094,9 @@ class TestBarPlotter(CategoricalFixture):
 
         f, (ax1, ax2) = plt.subplots(2)
         hue_order = self.h.unique()
-        cat.barplot(self.g, self.y, hue=self.h, hue_order=hue_order, ci="sd",
-                    ax=ax1)
-        cat.barplot(self.g, self.y_perm, hue=self.h,
+        cat.barplot(x=self.g, y=self.y, hue=self.h,
+                    hue_order=hue_order, ci="sd", ax=ax1)
+        cat.barplot(x=self.g, y=self.y_perm, hue=self.h,
                     hue_order=hue_order, ci="sd", ax=ax2)
         for l1, l2 in zip(ax1.lines, ax2.lines):
             assert pytest.approx(l1.get_xydata()) == l2.get_xydata()
@@ -2153,26 +2156,26 @@ class TestBarPlotter(CategoricalFixture):
 
     def test_simple_barplots(self):
 
-        ax = cat.barplot("g", "y", data=self.df)
+        ax = cat.barplot(x="g", y="y", data=self.df)
         nt.assert_equal(len(ax.patches), len(self.g.unique()))
         nt.assert_equal(ax.get_xlabel(), "g")
         nt.assert_equal(ax.get_ylabel(), "y")
         plt.close("all")
 
-        ax = cat.barplot("y", "g", orient="h", data=self.df)
+        ax = cat.barplot(x="y", y="g", orient="h", data=self.df)
         nt.assert_equal(len(ax.patches), len(self.g.unique()))
         nt.assert_equal(ax.get_xlabel(), "y")
         nt.assert_equal(ax.get_ylabel(), "g")
         plt.close("all")
 
-        ax = cat.barplot("g", "y", hue="h", data=self.df)
+        ax = cat.barplot(x="g", y="y", hue="h", data=self.df)
         nt.assert_equal(len(ax.patches),
                         len(self.g.unique()) * len(self.h.unique()))
         nt.assert_equal(ax.get_xlabel(), "g")
         nt.assert_equal(ax.get_ylabel(), "y")
         plt.close("all")
 
-        ax = cat.barplot("y", "g", hue="h", orient="h", data=self.df)
+        ax = cat.barplot(x="y", y="g", hue="h", orient="h", data=self.df)
         nt.assert_equal(len(ax.patches),
                         len(self.g.unique()) * len(self.h.unique()))
         nt.assert_equal(ax.get_xlabel(), "y")
@@ -2337,8 +2340,8 @@ class TestPointPlotter(CategoricalFixture):
     def test_unaligned_index(self):
 
         f, (ax1, ax2) = plt.subplots(2)
-        cat.pointplot(self.g, self.y, ci="sd", ax=ax1)
-        cat.pointplot(self.g, self.y_perm, ci="sd", ax=ax2)
+        cat.pointplot(x=self.g, y=self.y, ci="sd", ax=ax1)
+        cat.pointplot(x=self.g, y=self.y_perm, ci="sd", ax=ax2)
         for l1, l2 in zip(ax1.lines, ax2.lines):
             assert pytest.approx(l1.get_xydata()) == l2.get_xydata()
         for p1, p2 in zip(ax1.collections, ax2.collections):
@@ -2346,9 +2349,9 @@ class TestPointPlotter(CategoricalFixture):
 
         f, (ax1, ax2) = plt.subplots(2)
         hue_order = self.h.unique()
-        cat.pointplot(self.g, self.y, hue=self.h,
+        cat.pointplot(x=self.g, y=self.y, hue=self.h,
                       hue_order=hue_order, ci="sd", ax=ax1)
-        cat.pointplot(self.g, self.y_perm, hue=self.h,
+        cat.pointplot(x=self.g, y=self.y_perm, hue=self.h,
                       hue_order=hue_order, ci="sd", ax=ax2)
         for l1, l2 in zip(ax1.lines, ax2.lines):
             assert pytest.approx(l1.get_xydata()) == l2.get_xydata()
@@ -2414,21 +2417,21 @@ class TestPointPlotter(CategoricalFixture):
 
     def test_simple_pointplots(self):
 
-        ax = cat.pointplot("g", "y", data=self.df)
+        ax = cat.pointplot(x="g", y="y", data=self.df)
         nt.assert_equal(len(ax.collections), 1)
         nt.assert_equal(len(ax.lines), len(self.g.unique()) + 1)
         nt.assert_equal(ax.get_xlabel(), "g")
         nt.assert_equal(ax.get_ylabel(), "y")
         plt.close("all")
 
-        ax = cat.pointplot("y", "g", orient="h", data=self.df)
+        ax = cat.pointplot(x="y", y="g", orient="h", data=self.df)
         nt.assert_equal(len(ax.collections), 1)
         nt.assert_equal(len(ax.lines), len(self.g.unique()) + 1)
         nt.assert_equal(ax.get_xlabel(), "y")
         nt.assert_equal(ax.get_ylabel(), "g")
         plt.close("all")
 
-        ax = cat.pointplot("g", "y", hue="h", data=self.df)
+        ax = cat.pointplot(x="g", y="y", hue="h", data=self.df)
         nt.assert_equal(len(ax.collections), len(self.h.unique()))
         nt.assert_equal(len(ax.lines),
                         (len(self.g.unique())
@@ -2438,7 +2441,7 @@ class TestPointPlotter(CategoricalFixture):
         nt.assert_equal(ax.get_ylabel(), "y")
         plt.close("all")
 
-        ax = cat.pointplot("y", "g", hue="h", orient="h", data=self.df)
+        ax = cat.pointplot(x="y", y="g", hue="h", orient="h", data=self.df)
         nt.assert_equal(len(ax.collections), len(self.h.unique()))
         nt.assert_equal(len(ax.lines),
                         (len(self.g.unique())
@@ -2453,7 +2456,7 @@ class TestCountPlot(CategoricalFixture):
 
     def test_plot_elements(self):
 
-        ax = cat.countplot("g", data=self.df)
+        ax = cat.countplot(x="g", data=self.df)
         nt.assert_equal(len(ax.patches), self.g.unique().size)
         for p in ax.patches:
             nt.assert_equal(p.get_y(), 0)
@@ -2469,7 +2472,7 @@ class TestCountPlot(CategoricalFixture):
                             self.g.size / self.g.unique().size)
         plt.close("all")
 
-        ax = cat.countplot("g", hue="h", data=self.df)
+        ax = cat.countplot(x="g", hue="h", data=self.df)
         nt.assert_equal(len(ax.patches),
                         self.g.unique().size * self.h.unique().size)
         plt.close("all")
@@ -2492,123 +2495,123 @@ class TestCatPlot(CategoricalFixture):
 
     def test_facet_organization(self):
 
-        g = cat.catplot("g", "y", data=self.df)
+        g = cat.catplot(x="g", y="y", data=self.df)
         nt.assert_equal(g.axes.shape, (1, 1))
 
-        g = cat.catplot("g", "y", col="h", data=self.df)
+        g = cat.catplot(x="g", y="y", col="h", data=self.df)
         nt.assert_equal(g.axes.shape, (1, 2))
 
-        g = cat.catplot("g", "y", row="h", data=self.df)
+        g = cat.catplot(x="g", y="y", row="h", data=self.df)
         nt.assert_equal(g.axes.shape, (2, 1))
 
-        g = cat.catplot("g", "y", col="u", row="h", data=self.df)
+        g = cat.catplot(x="g", y="y", col="u", row="h", data=self.df)
         nt.assert_equal(g.axes.shape, (2, 3))
 
     def test_plot_elements(self):
 
-        g = cat.catplot("g", "y", data=self.df, kind="point")
+        g = cat.catplot(x="g", y="y", data=self.df, kind="point")
         nt.assert_equal(len(g.ax.collections), 1)
         want_lines = self.g.unique().size + 1
         nt.assert_equal(len(g.ax.lines), want_lines)
 
-        g = cat.catplot("g", "y", hue="h", data=self.df, kind="point")
+        g = cat.catplot(x="g", y="y", hue="h", data=self.df, kind="point")
         want_collections = self.h.unique().size
         nt.assert_equal(len(g.ax.collections), want_collections)
         want_lines = (self.g.unique().size + 1) * self.h.unique().size
         nt.assert_equal(len(g.ax.lines), want_lines)
 
-        g = cat.catplot("g", "y", data=self.df, kind="bar")
+        g = cat.catplot(x="g", y="y", data=self.df, kind="bar")
         want_elements = self.g.unique().size
         nt.assert_equal(len(g.ax.patches), want_elements)
         nt.assert_equal(len(g.ax.lines), want_elements)
 
-        g = cat.catplot("g", "y", hue="h", data=self.df, kind="bar")
+        g = cat.catplot(x="g", y="y", hue="h", data=self.df, kind="bar")
         want_elements = self.g.unique().size * self.h.unique().size
         nt.assert_equal(len(g.ax.patches), want_elements)
         nt.assert_equal(len(g.ax.lines), want_elements)
 
-        g = cat.catplot("g", data=self.df, kind="count")
+        g = cat.catplot(x="g", data=self.df, kind="count")
         want_elements = self.g.unique().size
         nt.assert_equal(len(g.ax.patches), want_elements)
         nt.assert_equal(len(g.ax.lines), 0)
 
-        g = cat.catplot("g", hue="h", data=self.df, kind="count")
+        g = cat.catplot(x="g", hue="h", data=self.df, kind="count")
         want_elements = self.g.unique().size * self.h.unique().size
         nt.assert_equal(len(g.ax.patches), want_elements)
         nt.assert_equal(len(g.ax.lines), 0)
 
-        g = cat.catplot("g", "y", data=self.df, kind="box")
+        g = cat.catplot(x="g", y="y", data=self.df, kind="box")
         want_artists = self.g.unique().size
         nt.assert_equal(len(g.ax.artists), want_artists)
 
-        g = cat.catplot("g", "y", hue="h", data=self.df, kind="box")
+        g = cat.catplot(x="g", y="y", hue="h", data=self.df, kind="box")
         want_artists = self.g.unique().size * self.h.unique().size
         nt.assert_equal(len(g.ax.artists), want_artists)
 
-        g = cat.catplot("g", "y", data=self.df,
+        g = cat.catplot(x="g", y="y", data=self.df,
                         kind="violin", inner=None)
         want_elements = self.g.unique().size
         nt.assert_equal(len(g.ax.collections), want_elements)
 
-        g = cat.catplot("g", "y", hue="h", data=self.df,
+        g = cat.catplot(x="g", y="y", hue="h", data=self.df,
                         kind="violin", inner=None)
         want_elements = self.g.unique().size * self.h.unique().size
         nt.assert_equal(len(g.ax.collections), want_elements)
 
-        g = cat.catplot("g", "y", data=self.df, kind="strip")
+        g = cat.catplot(x="g", y="y", data=self.df, kind="strip")
         want_elements = self.g.unique().size
         nt.assert_equal(len(g.ax.collections), want_elements)
 
-        g = cat.catplot("g", "y", hue="h", data=self.df, kind="strip")
+        g = cat.catplot(x="g", y="y", hue="h", data=self.df, kind="strip")
         want_elements = self.g.unique().size + self.h.unique().size
         nt.assert_equal(len(g.ax.collections), want_elements)
 
     def test_bad_plot_kind_error(self):
 
         with nt.assert_raises(ValueError):
-            cat.catplot("g", "y", data=self.df, kind="not_a_kind")
+            cat.catplot(x="g", y="y", data=self.df, kind="not_a_kind")
 
     def test_count_x_and_y(self):
 
         with nt.assert_raises(ValueError):
-            cat.catplot("g", "y", data=self.df, kind="count")
+            cat.catplot(x="g", y="y", data=self.df, kind="count")
 
     def test_plot_colors(self):
 
-        ax = cat.barplot("g", "y", data=self.df)
-        g = cat.catplot("g", "y", data=self.df, kind="bar")
+        ax = cat.barplot(x="g", y="y", data=self.df)
+        g = cat.catplot(x="g", y="y", data=self.df, kind="bar")
         for p1, p2 in zip(ax.patches, g.ax.patches):
             nt.assert_equal(p1.get_facecolor(), p2.get_facecolor())
         plt.close("all")
 
-        ax = cat.barplot("g", "y", data=self.df, color="purple")
-        g = cat.catplot("g", "y", data=self.df,
+        ax = cat.barplot(x="g", y="y", data=self.df, color="purple")
+        g = cat.catplot(x="g", y="y", data=self.df,
                         kind="bar", color="purple")
         for p1, p2 in zip(ax.patches, g.ax.patches):
             nt.assert_equal(p1.get_facecolor(), p2.get_facecolor())
         plt.close("all")
 
-        ax = cat.barplot("g", "y", data=self.df, palette="Set2")
-        g = cat.catplot("g", "y", data=self.df,
+        ax = cat.barplot(x="g", y="y", data=self.df, palette="Set2")
+        g = cat.catplot(x="g", y="y", data=self.df,
                         kind="bar", palette="Set2")
         for p1, p2 in zip(ax.patches, g.ax.patches):
             nt.assert_equal(p1.get_facecolor(), p2.get_facecolor())
         plt.close("all")
 
-        ax = cat.pointplot("g", "y", data=self.df)
-        g = cat.catplot("g", "y", data=self.df)
+        ax = cat.pointplot(x="g", y="y", data=self.df)
+        g = cat.catplot(x="g", y="y", data=self.df)
         for l1, l2 in zip(ax.lines, g.ax.lines):
             nt.assert_equal(l1.get_color(), l2.get_color())
         plt.close("all")
 
-        ax = cat.pointplot("g", "y", data=self.df, color="purple")
-        g = cat.catplot("g", "y", data=self.df, color="purple")
+        ax = cat.pointplot(x="g", y="y", data=self.df, color="purple")
+        g = cat.catplot(x="g", y="y", data=self.df, color="purple")
         for l1, l2 in zip(ax.lines, g.ax.lines):
             nt.assert_equal(l1.get_color(), l2.get_color())
         plt.close("all")
 
-        ax = cat.pointplot("g", "y", data=self.df, palette="Set2")
-        g = cat.catplot("g", "y", data=self.df, palette="Set2")
+        ax = cat.pointplot(x="g", y="y", data=self.df, palette="Set2")
+        g = cat.catplot(x="g", y="y", data=self.df, palette="Set2")
         for l1, l2 in zip(ax.lines, g.ax.lines):
             nt.assert_equal(l1.get_color(), l2.get_color())
         plt.close("all")
@@ -2617,14 +2620,14 @@ class TestCatPlot(CategoricalFixture):
 
         f, ax = plt.subplots()
         with pytest.warns(UserWarning):
-            g = cat.catplot("g", "y", data=self.df, ax=ax)
+            g = cat.catplot(x="g", y="y", data=self.df, ax=ax)
         assert len(ax.collections) == 0
         assert len(g.ax.collections) > 0
 
     def test_factorplot(self):
 
         with pytest.warns(UserWarning):
-            g = cat.factorplot("g", "y", data=self.df)
+            g = cat.factorplot(x="g", y="y", data=self.df)
 
         nt.assert_equal(len(g.ax.collections), 1)
         want_lines = self.g.unique().size + 1
@@ -2715,13 +2718,13 @@ class TestBoxenPlotter(CategoricalFixture):
 
     def test_showfliers(self):
 
-        ax = cat.boxenplot("g", "y", data=self.df)
+        ax = cat.boxenplot(x="g", y="y", data=self.df)
         for c in filter(self.ispath, ax.collections):
             assert len(c.get_offsets()) == 2
 
         plt.close("all")
 
-        ax = cat.boxenplot("g", "y", data=self.df, showfliers=False)
+        ax = cat.boxenplot(x="g", y="y", data=self.df, showfliers=False)
         for c in filter(self.ispath, ax.collections):
             assert len(c.get_offsets()) == 0
 
@@ -2745,13 +2748,13 @@ class TestBoxenPlotter(CategoricalFixture):
 
     def test_axes_data(self):
 
-        ax = cat.boxenplot("g", "y", data=self.df)
+        ax = cat.boxenplot(x="g", y="y", data=self.df)
         patches = filter(self.ispatch, ax.collections)
         nt.assert_equal(len(list(patches)), 3)
 
         plt.close("all")
 
-        ax = cat.boxenplot("g", "y", hue="h", data=self.df)
+        ax = cat.boxenplot(x="g", y="y", hue="h", data=self.df)
         patches = filter(self.ispatch, ax.collections)
         nt.assert_equal(len(list(patches)), 6)
 
@@ -2759,14 +2762,14 @@ class TestBoxenPlotter(CategoricalFixture):
 
     def test_box_colors(self):
 
-        ax = cat.boxenplot("g", "y", data=self.df, saturation=1)
+        ax = cat.boxenplot(x="g", y="y", data=self.df, saturation=1)
         pal = palettes.color_palette(n_colors=3)
         for patch, color in zip(ax.artists, pal):
             nt.assert_equal(patch.get_facecolor()[:3], color)
 
         plt.close("all")
 
-        ax = cat.boxenplot("g", "y", hue="h", data=self.df, saturation=1)
+        ax = cat.boxenplot(x="g", y="y", hue="h", data=self.df, saturation=1)
         pal = palettes.color_palette(n_colors=2)
         for patch, color in zip(ax.artists, pal * 2):
             nt.assert_equal(patch.get_facecolor()[:3], color)
@@ -2775,7 +2778,7 @@ class TestBoxenPlotter(CategoricalFixture):
 
     def test_draw_missing_boxes(self):
 
-        ax = cat.boxenplot("g", "y", data=self.df,
+        ax = cat.boxenplot(x="g", y="y", data=self.df,
                            order=["a", "b", "c", "d"])
 
         patches = filter(self.ispatch, ax.collections)
@@ -2785,15 +2788,16 @@ class TestBoxenPlotter(CategoricalFixture):
     def test_unaligned_index(self):
 
         f, (ax1, ax2) = plt.subplots(2)
-        cat.boxenplot(self.g, self.y, ax=ax1)
-        cat.boxenplot(self.g, self.y_perm, ax=ax2)
+        cat.boxenplot(x=self.g, y=self.y, ax=ax1)
+        cat.boxenplot(x=self.g, y=self.y_perm, ax=ax2)
         for l1, l2 in zip(ax1.lines, ax2.lines):
             assert np.array_equal(l1.get_xydata(), l2.get_xydata())
 
         f, (ax1, ax2) = plt.subplots(2)
         hue_order = self.h.unique()
-        cat.boxenplot(self.g, self.y, hue=self.h, hue_order=hue_order, ax=ax1)
-        cat.boxenplot(self.g, self.y_perm, hue=self.h,
+        cat.boxenplot(x=self.g, y=self.y, hue=self.h,
+                      hue_order=hue_order, ax=ax1)
+        cat.boxenplot(x=self.g, y=self.y_perm, hue=self.h,
                       hue_order=hue_order, ax=ax2)
         for l1, l2 in zip(ax1.lines, ax2.lines):
             assert np.array_equal(l1.get_xydata(), l2.get_xydata())
@@ -2805,13 +2809,13 @@ class TestBoxenPlotter(CategoricalFixture):
         y = self.rs.randn(8)
         y[-2:] = np.nan
 
-        ax = cat.boxenplot(x, y)
+        ax = cat.boxenplot(x=x, y=y)
         nt.assert_equal(len(ax.lines), 3)
 
         plt.close("all")
 
         y[-1] = 0
-        ax = cat.boxenplot(x, y, hue=h)
+        ax = cat.boxenplot(x=x, y=y, hue=h)
         nt.assert_equal(len(ax.lines), 7)
 
         plt.close("all")
@@ -2820,40 +2824,43 @@ class TestBoxenPlotter(CategoricalFixture):
 
         # Smoke test the high level boxenplot options
 
-        cat.boxenplot("y", data=self.df)
+        cat.boxenplot(x="y", data=self.df)
         plt.close("all")
 
         cat.boxenplot(y="y", data=self.df)
         plt.close("all")
 
-        cat.boxenplot("g", "y", data=self.df)
+        cat.boxenplot(x="g", y="y", data=self.df)
         plt.close("all")
 
-        cat.boxenplot("y", "g", data=self.df, orient="h")
+        cat.boxenplot(x="y", y="g", data=self.df, orient="h")
         plt.close("all")
 
-        cat.boxenplot("g", "y", hue="h", data=self.df)
+        cat.boxenplot(x="g", y="y", hue="h", data=self.df)
         plt.close("all")
 
-        cat.boxenplot("g", "y", hue="h", order=list("nabc"), data=self.df)
+        order = list("nabc")
+        cat.boxenplot(x="g", y="y", hue="h", order=order, data=self.df)
         plt.close("all")
 
-        cat.boxenplot("g", "y", hue="h", hue_order=list("omn"), data=self.df)
+        order = list("omn")
+        cat.boxenplot(x="g", y="y", hue="h", hue_order=order, data=self.df)
         plt.close("all")
 
-        cat.boxenplot("y", "g", hue="h", data=self.df, orient="h")
+        cat.boxenplot(x="y", y="g", hue="h", data=self.df, orient="h")
         plt.close("all")
 
-        cat.boxenplot("y", "g", hue="h", data=self.df, orient="h",
+        cat.boxenplot(x="y", y="g", hue="h", data=self.df, orient="h",
                       palette="Set2")
         plt.close("all")
 
-        cat.boxenplot("y", "g", hue="h", data=self.df, orient="h", color="b")
+        cat.boxenplot(x="y", y="g", hue="h", data=self.df,
+                      orient="h", color="b")
         plt.close("all")
 
     def test_axes_annotation(self):
 
-        ax = cat.boxenplot("g", "y", data=self.df)
+        ax = cat.boxenplot(x="g", y="y", data=self.df)
         nt.assert_equal(ax.get_xlabel(), "g")
         nt.assert_equal(ax.get_ylabel(), "y")
         nt.assert_equal(ax.get_xlim(), (-.5, 2.5))
@@ -2863,7 +2870,7 @@ class TestBoxenPlotter(CategoricalFixture):
 
         plt.close("all")
 
-        ax = cat.boxenplot("g", "y", hue="h", data=self.df)
+        ax = cat.boxenplot(x="g", y="y", hue="h", data=self.df)
         nt.assert_equal(ax.get_xlabel(), "g")
         nt.assert_equal(ax.get_ylabel(), "y")
         npt.assert_array_equal(ax.get_xticks(), [0, 1, 2])
@@ -2874,7 +2881,7 @@ class TestBoxenPlotter(CategoricalFixture):
 
         plt.close("all")
 
-        ax = cat.boxenplot("y", "g", data=self.df, orient="h")
+        ax = cat.boxenplot(x="y", y="g", data=self.df, orient="h")
         nt.assert_equal(ax.get_xlabel(), "y")
         nt.assert_equal(ax.get_ylabel(), "g")
         nt.assert_equal(ax.get_ylim(), (2.5, -.5))
@@ -2896,7 +2903,7 @@ class TestBoxenPlotter(CategoricalFixture):
         exp = mpl.font_manager.FontProperties(size=size).get_size()
 
         with plt.rc_context(rc=rc_ctx):
-            ax = cat.boxenplot("g", "y", hue="h", data=self.df)
+            ax = cat.boxenplot(x="g", y="y", hue="h", data=self.df)
             obs = ax.get_legend().get_title().get_fontproperties().get_size()
             assert obs == exp
 
@@ -2905,7 +2912,7 @@ class TestBoxenPlotter(CategoricalFixture):
     def test_lvplot(self):
 
         with pytest.warns(UserWarning):
-            ax = cat.lvplot("g", "y", data=self.df)
+            ax = cat.lvplot(x="g", y="y", data=self.df)
 
         patches = filter(self.ispatch, ax.collections)
         nt.assert_equal(len(list(patches)), 3)

--- a/seaborn/tests/test_decorators.py
+++ b/seaborn/tests/test_decorators.py
@@ -10,20 +10,26 @@ def test_deprecate_positional_args_warns_for_function():
     def f1(a, b, *, c=1, d=1):
         return a, b, c, d
 
-    with pytest.warns(FutureWarning,
-                      match=r"Pass c=3 as keyword arg\."):
+    with pytest.warns(
+        FutureWarning,
+        match=r"Pass the following variable as a keyword arg: c\."
+    ):
         assert f1(1, 2, 3) == (1, 2, 3, 1)
 
-    with pytest.warns(FutureWarning,
-                      match=r"Pass c=3, d=4 as keyword args\."):
+    with pytest.warns(
+        FutureWarning,
+        match=r"Pass the following variables as keyword args: c, d\."
+    ):
         assert f1(1, 2, 3, 4) == (1, 2, 3, 4)
 
     @_deprecate_positional_args
     def f2(a=1, *, b=1, c=1, d=1):
         return a, b, c, d
 
-    with pytest.warns(FutureWarning,
-                      match=r"Pass b=2 as keyword arg\."):
+    with pytest.warns(
+        FutureWarning,
+        match=r"Pass the following variable as a keyword arg: b\.",
+    ):
         assert f2(1, 2) == (1, 2, 1, 1)
 
     # The * is placed before a keyword only argument without a default value
@@ -31,8 +37,10 @@ def test_deprecate_positional_args_warns_for_function():
     def f3(a, *, b, c=1, d=1):
         return a, b, c, d
 
-    with pytest.warns(FutureWarning,
-                      match=r"Pass b=2 as keyword arg\."):
+    with pytest.warns(
+        FutureWarning,
+        match=r"Pass the following variable as a keyword arg: b\.",
+    ):
         assert f3(1, 2) == (1, 2, 1, 1)
 
 
@@ -43,12 +51,16 @@ def test_deprecate_positional_args_warns_for_class():
         def __init__(self, a, b, *, c=1, d=1):
             self.a = a, b, c, d
 
-    with pytest.warns(FutureWarning,
-                      match=r"Pass c=3 as keyword arg\."):
+    with pytest.warns(
+        FutureWarning,
+        match=r"Pass the following variable as a keyword arg: c\."
+    ):
         assert A1(1, 2, 3).a == (1, 2, 3, 1)
 
-    with pytest.warns(FutureWarning,
-                      match=r"Pass c=3, d=4 as keyword args\."):
+    with pytest.warns(
+        FutureWarning,
+        match=r"Pass the following variables as keyword args: c, d\."
+    ):
         assert A1(1, 2, 3, 4).a == (1, 2, 3, 4)
 
     class A2:
@@ -56,10 +68,14 @@ def test_deprecate_positional_args_warns_for_class():
         def __init__(self, a=1, b=1, *, c=1, d=1):
             self.a = a, b, c, d
 
-    with pytest.warns(FutureWarning,
-                      match=r"Pass c=3 as keyword arg\."):
+    with pytest.warns(
+        FutureWarning,
+        match=r"Pass the following variable as a keyword arg: c\.",
+    ):
         assert A2(1, 2, 3).a == (1, 2, 3, 1)
 
-    with pytest.warns(FutureWarning,
-                      match=r"Pass c=3, d=4 as keyword args\."):
+    with pytest.warns(
+        FutureWarning,
+        match=r"Pass the following variables as keyword args: c, d\.",
+    ):
         assert A2(1, 2, 3, 4).a == (1, 2, 3, 4)

--- a/seaborn/tests/test_distributions.py
+++ b/seaborn/tests/test_distributions.py
@@ -29,42 +29,42 @@ class TestDistPlot(object):
             fd_edges = np.histogram_bin_edges(self.x, "fd")
         except AttributeError:
             pytest.skip("Requires numpy >= 1.15")
-        ax = dist.distplot(self.x)
+        ax = dist.distplot(x=self.x)
         for edge, bar in zip(fd_edges, ax.patches):
             assert pytest.approx(edge) == bar.get_x()
 
         plt.close(ax.figure)
         n = 25
         n_edges = np.histogram_bin_edges(self.x, n)
-        ax = dist.distplot(self.x, bins=n)
+        ax = dist.distplot(x=self.x, bins=n)
         for edge, bar in zip(n_edges, ax.patches):
             assert pytest.approx(edge) == bar.get_x()
 
     def test_elements(self):
 
         n = 10
-        ax = dist.distplot(self.x, bins=n,
+        ax = dist.distplot(x=self.x, bins=n,
                            hist=True, kde=False, rug=False, fit=None)
         assert len(ax.patches) == 10
         assert len(ax.lines) == 0
         assert len(ax.collections) == 0
 
         plt.close(ax.figure)
-        ax = dist.distplot(self.x,
+        ax = dist.distplot(x=self.x,
                            hist=False, kde=True, rug=False, fit=None)
         assert len(ax.patches) == 0
         assert len(ax.lines) == 1
         assert len(ax.collections) == 0
 
         plt.close(ax.figure)
-        ax = dist.distplot(self.x,
+        ax = dist.distplot(x=self.x,
                            hist=False, kde=False, rug=True, fit=None)
         assert len(ax.patches) == 0
         assert len(ax.lines) == 0
         assert len(ax.collections) == 1
 
         plt.close(ax.figure)
-        ax = dist.distplot(self.x,
+        ax = dist.distplot(x=self.x,
                            hist=False, kde=False, rug=False, fit=stats.norm)
         assert len(ax.patches) == 0
         assert len(ax.lines) == 1
@@ -75,8 +75,8 @@ class TestDistPlot(object):
         f, (ax1, ax2) = plt.subplots(2)
         x_null = np.append(self.x, [np.nan])
 
-        dist.distplot(self.x, ax=ax1)
-        dist.distplot(x_null, ax=ax2)
+        dist.distplot(x=self.x, ax=ax1)
+        dist.distplot(x=x_null, ax=ax2)
 
         line1 = ax1.lines[0]
         line2 = ax2.lines[0]
@@ -205,7 +205,7 @@ class TestKDE(object):
     def test_kde_cummulative_2d(self):
         """Check error if args indicate bivariate KDE and cumulative."""
         with npt.assert_raises(TypeError):
-            dist.kdeplot(self.x, self.y, cumulative=True)
+            dist.kdeplot(x=self.x, y=self.y, cumulative=True)
 
     def test_kde_singular(self):
         """Check that kdeplot warns and skips on singular inputs."""
@@ -257,8 +257,8 @@ class TestKDE(object):
         x_missing = np.append(self.x, [np.nan, np.nan])
 
         f, ax = plt.subplots()
-        dist.kdeplot(self.x, cumulative=cumulative)
-        dist.kdeplot(x_missing, cumulative=cumulative)
+        dist.kdeplot(x=self.x, cumulative=cumulative)
+        dist.kdeplot(x=x_missing, cumulative=cumulative)
 
         line1, line2 = ax.lines
         assert np.array_equal(line1.get_xydata(), line2.get_xydata())
@@ -266,8 +266,8 @@ class TestKDE(object):
     def test_bivariate_kde_series(self):
         df = pd.DataFrame({'x': self.x, 'y': self.y})
 
-        ax_series = dist.kdeplot(df.x, df.y)
-        ax_values = dist.kdeplot(df.x.values, df.y.values)
+        ax_series = dist.kdeplot(x=df.x, y=df.y)
+        ax_values = dist.kdeplot(x=df.x.values, y=df.y.values)
 
         nt.assert_equal(len(ax_series.collections),
                         len(ax_values.collections))
@@ -277,7 +277,7 @@ class TestKDE(object):
     def test_bivariate_kde_colorbar(self):
 
         f, ax = plt.subplots()
-        dist.kdeplot(self.x, self.y,
+        dist.kdeplot(x=self.x, y=self.y,
                      cbar=True, cbar_kws=dict(label="density"),
                      ax=ax)
         nt.assert_equal(len(f.axes), 2)
@@ -286,12 +286,12 @@ class TestKDE(object):
     def test_legend(self):
 
         f, ax = plt.subplots()
-        dist.kdeplot(self.x, self.y, label="test1")
+        dist.kdeplot(x=self.x, y=self.y, label="test1")
         line = ax.lines[-1]
         assert line.get_label() == "test1"
 
         f, ax = plt.subplots()
-        dist.kdeplot(self.x, self.y, shade=True, label="test2")
+        dist.kdeplot(x=self.x, y=self.y, shade=True, label="test2")
         fill = ax.collections[-1]
         assert fill.get_label() == "test2"
 
@@ -300,7 +300,7 @@ class TestKDE(object):
         rgb = (.1, .5, .7)
         f, ax = plt.subplots()
 
-        dist.kdeplot(self.x, self.y, color=rgb)
+        dist.kdeplot(x=self.x, y=self.y, color=rgb)
         contour = ax.collections[-1]
         assert np.array_equal(contour.get_color()[0, :3], rgb)
         low = ax.collections[0].get_color().mean()
@@ -308,14 +308,14 @@ class TestKDE(object):
         assert low < high
 
         f, ax = plt.subplots()
-        dist.kdeplot(self.x, self.y, shade=True, color=rgb)
+        dist.kdeplot(x=self.x, y=self.y, shade=True, color=rgb)
         contour = ax.collections[-1]
         low = ax.collections[0].get_facecolor().mean()
         high = ax.collections[-1].get_facecolor().mean()
         assert low > high
 
         f, ax = plt.subplots()
-        dist.kdeplot(self.x, self.y, shade=True, colors=[rgb])
+        dist.kdeplot(x=self.x, y=self.y, shade=True, colors=[rgb])
         for level in ax.collections:
             level_rgb = tuple(level.get_facecolor().squeeze()[:3])
             assert level_rgb == rgb
@@ -339,45 +339,45 @@ class TestRugPlot(object):
 
         h = .1
 
-        for data in [list_data, array_data, series_data]:
+        for x in [list_data, array_data, series_data]:
 
             f, ax = plt.subplots()
-            dist.rugplot(data, height=h)
+            dist.rugplot(x=x, height=h)
             rug, = ax.collections
             segments = np.array(rug.get_segments())
 
-            assert len(segments) == len(data)
-            assert np.array_equal(segments[:, 0, 0], data)
-            assert np.array_equal(segments[:, 1, 0], data)
-            assert np.array_equal(segments[:, 0, 1], np.zeros_like(data))
-            assert np.array_equal(segments[:, 1, 1], np.ones_like(data) * h)
+            assert len(segments) == len(x)
+            assert np.array_equal(segments[:, 0, 0], x)
+            assert np.array_equal(segments[:, 1, 0], x)
+            assert np.array_equal(segments[:, 0, 1], np.zeros_like(x))
+            assert np.array_equal(segments[:, 1, 1], np.ones_like(x) * h)
 
             plt.close(f)
 
             f, ax = plt.subplots()
-            dist.rugplot(data, height=h, axis="y")
+            dist.rugplot(x=x, height=h, axis="y")
             rug, = ax.collections
             segments = np.array(rug.get_segments())
 
-            assert len(segments) == len(data)
-            assert np.array_equal(segments[:, 0, 1], data)
-            assert np.array_equal(segments[:, 1, 1], data)
-            assert np.array_equal(segments[:, 0, 0], np.zeros_like(data))
-            assert np.array_equal(segments[:, 1, 0], np.ones_like(data) * h)
+            assert len(segments) == len(x)
+            assert np.array_equal(segments[:, 0, 1], x)
+            assert np.array_equal(segments[:, 1, 1], x)
+            assert np.array_equal(segments[:, 0, 0], np.zeros_like(x))
+            assert np.array_equal(segments[:, 1, 0], np.ones_like(x) * h)
 
             plt.close(f)
 
         f, ax = plt.subplots()
-        dist.rugplot(data, axis="y")
-        dist.rugplot(data, vertical=True)
+        dist.rugplot(x=x, axis="y")
+        dist.rugplot(x=x, vertical=True)
         c1, c2 = ax.collections
         assert np.array_equal(c1.get_segments(), c2.get_segments())
         plt.close(f)
 
         f, ax = plt.subplots()
-        dist.rugplot(data)
-        dist.rugplot(data, lw=2)
-        dist.rugplot(data, linewidth=3, alpha=.5)
+        dist.rugplot(x=x)
+        dist.rugplot(x=x, lw=2)
+        dist.rugplot(x=x, linewidth=3, alpha=.5)
         for c, lw in zip(ax.collections, [1, 2, 3]):
             assert np.squeeze(c.get_linewidth()).item() == lw
         assert c.get_alpha() == .5

--- a/seaborn/tests/test_regression.py
+++ b/seaborn/tests/test_regression.py
@@ -480,19 +480,19 @@ class TestRegressionPlots(object):
     def test_regplot_selective(self):
 
         f, ax = plt.subplots()
-        ax = lm.regplot("x", "y", data=self.df, scatter=False, ax=ax)
+        ax = lm.regplot(x="x", y="y", data=self.df, scatter=False, ax=ax)
         nt.assert_equal(len(ax.lines), 1)
         nt.assert_equal(len(ax.collections), 1)
         ax.clear()
 
         f, ax = plt.subplots()
-        ax = lm.regplot("x", "y", data=self.df, fit_reg=False)
+        ax = lm.regplot(x="x", y="y", data=self.df, fit_reg=False)
         nt.assert_equal(len(ax.lines), 0)
         nt.assert_equal(len(ax.collections), 1)
         ax.clear()
 
         f, ax = plt.subplots()
-        ax = lm.regplot("x", "y", data=self.df, ci=None)
+        ax = lm.regplot(x="x", y="y", data=self.df, ci=None)
         nt.assert_equal(len(ax.lines), 1)
         nt.assert_equal(len(ax.collections), 1)
         ax.clear()
@@ -501,35 +501,38 @@ class TestRegressionPlots(object):
 
         f, ax = plt.subplots()
         color = np.array([[0.3, 0.8, 0.5, 0.5]])
-        ax = lm.regplot("x", "y", data=self.df, scatter_kws={'color': color})
+        ax = lm.regplot(x="x", y="y", data=self.df,
+                        scatter_kws={'color': color})
         nt.assert_is(ax.collections[0]._alpha, None)
         nt.assert_equal(ax.collections[0]._facecolors[0, 3], 0.5)
 
         f, ax = plt.subplots()
         color = np.array([[0.3, 0.8, 0.5]])
-        ax = lm.regplot("x", "y", data=self.df, scatter_kws={'color': color})
+        ax = lm.regplot(x="x", y="y", data=self.df,
+                        scatter_kws={'color': color})
         nt.assert_equal(ax.collections[0]._alpha, 0.8)
 
         f, ax = plt.subplots()
         color = np.array([[0.3, 0.8, 0.5]])
-        ax = lm.regplot("x", "y", data=self.df,
+        ax = lm.regplot(x="x", y="y", data=self.df,
                         scatter_kws={'color': color, 'alpha': 0.4})
         nt.assert_equal(ax.collections[0]._alpha, 0.4)
 
         f, ax = plt.subplots()
         color = 'r'
-        ax = lm.regplot("x", "y", data=self.df, scatter_kws={'color': color})
+        ax = lm.regplot(x="x", y="y", data=self.df,
+                        scatter_kws={'color': color})
         nt.assert_equal(ax.collections[0]._alpha, 0.8)
 
     def test_regplot_binned(self):
 
-        ax = lm.regplot("x", "y", data=self.df, x_bins=5)
+        ax = lm.regplot(x="x", y="y", data=self.df, x_bins=5)
         nt.assert_equal(len(ax.lines), 6)
         nt.assert_equal(len(ax.collections), 2)
 
     def test_lmplot_basic(self):
 
-        g = lm.lmplot("x", "y", data=self.df)
+        g = lm.lmplot(x="x", y="y", data=self.df)
         ax = g.axes[0, 0]
         nt.assert_equal(len(ax.lines), 1)
         nt.assert_equal(len(ax.collections), 2)
@@ -540,7 +543,7 @@ class TestRegressionPlots(object):
 
     def test_lmplot_hue(self):
 
-        g = lm.lmplot("x", "y", data=self.df, hue="h")
+        g = lm.lmplot(x="x", y="y", data=self.df, hue="h")
         ax = g.axes[0, 0]
 
         nt.assert_equal(len(ax.lines), 2)
@@ -548,18 +551,19 @@ class TestRegressionPlots(object):
 
     def test_lmplot_markers(self):
 
-        g1 = lm.lmplot("x", "y", data=self.df, hue="h", markers="s")
+        g1 = lm.lmplot(x="x", y="y", data=self.df, hue="h", markers="s")
         nt.assert_equal(g1.hue_kws, {"marker": ["s", "s"]})
 
-        g2 = lm.lmplot("x", "y", data=self.df, hue="h", markers=["o", "s"])
+        g2 = lm.lmplot(x="x", y="y", data=self.df, hue="h", markers=["o", "s"])
         nt.assert_equal(g2.hue_kws, {"marker": ["o", "s"]})
 
         with nt.assert_raises(ValueError):
-            lm.lmplot("x", "y", data=self.df, hue="h", markers=["o", "s", "d"])
+            lm.lmplot(x="x", y="y", data=self.df, hue="h",
+                      markers=["o", "s", "d"])
 
     def test_lmplot_marker_linewidths(self):
 
-        g = lm.lmplot("x", "y", data=self.df, hue="h",
+        g = lm.lmplot(x="x", y="y", data=self.df, hue="h",
                       fit_reg=False, markers=["o", "+"])
         c = g.axes[0, 0].collections
         nt.assert_equal(c[1].get_linewidths()[0],
@@ -567,23 +571,23 @@ class TestRegressionPlots(object):
 
     def test_lmplot_facets(self):
 
-        g = lm.lmplot("x", "y", data=self.df, row="g", col="h")
+        g = lm.lmplot(x="x", y="y", data=self.df, row="g", col="h")
         nt.assert_equal(g.axes.shape, (3, 2))
 
-        g = lm.lmplot("x", "y", data=self.df, col="u", col_wrap=4)
+        g = lm.lmplot(x="x", y="y", data=self.df, col="u", col_wrap=4)
         nt.assert_equal(g.axes.shape, (6,))
 
-        g = lm.lmplot("x", "y", data=self.df, hue="h", col="u")
+        g = lm.lmplot(x="x", y="y", data=self.df, hue="h", col="u")
         nt.assert_equal(g.axes.shape, (1, 6))
 
     def test_lmplot_hue_col_nolegend(self):
 
-        g = lm.lmplot("x", "y", data=self.df, col="h", hue="h")
+        g = lm.lmplot(x="x", y="y", data=self.df, col="h", hue="h")
         nt.assert_is(g._legend, None)
 
     def test_lmplot_scatter_kws(self):
 
-        g = lm.lmplot("x", "y", hue="h", data=self.df, ci=None)
+        g = lm.lmplot(x="x", y="y", hue="h", data=self.df, ci=None)
         red_scatter, blue_scatter = g.axes[0, 0].collections
 
         red, blue = color_palette(n_colors=2)
@@ -593,7 +597,7 @@ class TestRegressionPlots(object):
     def test_residplot(self):
 
         x, y = self.df.x, self.df.y
-        ax = lm.residplot(x, y)
+        ax = lm.residplot(x=x, y=y)
 
         resid = y - np.polyval(np.polyfit(x, y, 1), x)
         x_plot, y_plot = ax.collections[0].get_offsets().T
@@ -604,7 +608,7 @@ class TestRegressionPlots(object):
     @pytest.mark.skipif(_no_statsmodels, reason="no statsmodels")
     def test_residplot_lowess(self):
 
-        ax = lm.residplot("x", "y", data=self.df, lowess=True)
+        ax = lm.residplot(x="x", y="y", data=self.df, lowess=True)
         nt.assert_equal(len(ax.lines), 2)
 
         x, y = ax.lines[1].get_xydata().T
@@ -613,7 +617,7 @@ class TestRegressionPlots(object):
     def test_three_point_colors(self):
 
         x, y = np.random.randn(2, 3)
-        ax = lm.regplot(x, y, color=(1, 0, 0))
+        ax = lm.regplot(x=x, y=y, color=(1, 0, 0))
         color = ax.collections[0].get_facecolors()
         npt.assert_almost_equal(color[0, :3],
                                 (1, 0, 0))
@@ -622,7 +626,7 @@ class TestRegressionPlots(object):
 
         f, ax = plt.subplots()
         x, y1, y2 = np.random.randn(3, 50)
-        lm.regplot(x, y1, truncate=False)
-        lm.regplot(x, y2, truncate=False)
+        lm.regplot(x=x, y=y1, truncate=False)
+        lm.regplot(x=x, y=y2, truncate=False)
         line1, line2 = ax.lines
         assert np.array_equal(line1.get_xdata(), line2.get_xdata())

--- a/seaborn/tests/test_relational.py
+++ b/seaborn/tests/test_relational.py
@@ -1321,7 +1321,7 @@ class TestRelationalPlotter(Helpers):
 
         f, ax = plt.subplots()
         with pytest.warns(UserWarning):
-            g = relplot("x", "y", data=long_df, ax=ax)
+            g = relplot(x="x", y="y", data=long_df, ax=ax)
         assert len(ax.collections) == 0
         assert len(g.ax.collections) > 0
 
@@ -1746,7 +1746,7 @@ class TestLinePlotter(Helpers):
 
         f, ax = plt.subplots()
 
-        lineplot([], [])
+        lineplot(x=[], y=[])
         ax.clear()
 
         lineplot(data=wide_df)
@@ -2119,7 +2119,7 @@ class TestScatterPlotter(Helpers):
 
         f, ax = plt.subplots()
 
-        scatterplot([], [])
+        scatterplot(x=[], y=[])
         ax.clear()
 
         scatterplot(data=wide_df)


### PR DESCRIPTION
In #2052, a warning was added that keyword-only arguments would be enforced for all parameters except `x` and `y` (or `data`, for those functions where `data` is the first parameter).

Thinking further, and based on the work in #2071 to improve wide-form data handling, I think it makes sense to require explicit keywords arguments for *all* semantics. Then, the parameters can be rearranged so that `data` comes first in every function. This has several benefits:

- every function will have the same basic signature
- easier to pipe pandas dataframes into seaborn plots
- calling `func(data)` will do something useful for almost any kind of `data`, which is not true if `x` is the first parameter.

Fixes #2066