### PR TITLE
Centralize and modify variable type inference

### DIFF
--- a/doc/installing.rst
+++ b/doc/installing.rst
@@ -34,18 +34,18 @@ Dependencies
 Mandatory dependencies
 ^^^^^^^^^^^^^^^^^^^^^^
 
--  `numpy <https://numpy.org/>`__ (>= 1.13.3)
+-  `numpy <https://numpy.org/>`__
 
--  `scipy <https://www.scipy.org/>`__ (>= 1.0.1)
+-  `scipy <https://www.scipy.org/>`__
 
--  `pandas <https://pandas.pydata.org/>`__ (>= 0.22.0)
+-  `pandas <https://pandas.pydata.org/>`__
 
--  `matplotlib <https://matplotlib.org>`__ (>= 2.1.2)
+-  `matplotlib <https://matplotlib.org>`__
 
 Recommended dependencies
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
--  `statsmodels <https://www.statsmodels.org/>`__ (>= 0.8.0)
+-  `statsmodels <https://www.statsmodels.org/>`__
 
 Bugs
 ~~~~

--- a/doc/releases/v0.11.0.txt
+++ b/doc/releases/v0.11.0.txt
@@ -23,3 +23,5 @@ v0.11.0 (Unreleased)
 - Made :meth:`FacetGrid.set_axis_labels` clear labels from "interior" axes.  GH2046
 
 - Improved :meth:`FacetGrid.set_titles` with `margin titles=True`, such that texts representing the original row titles are removed before adding new ones. GH2083
+
+- Changed how functions that use different representations for numeric and categorical data handle vectors with an `object` data type. Previously, data was considered numeric if it could be coerced to a float representation without error. Now, object-typed vectors are considered numeric only when their contents are themselves numeric. This change means that numbers that are encoded as strings will now be treated as categorical data.

--- a/doc/releases/v0.11.0.txt
+++ b/doc/releases/v0.11.0.txt
@@ -24,4 +24,6 @@ v0.11.0 (Unreleased)
 
 - Improved :meth:`FacetGrid.set_titles` with `margin titles=True`, such that texts representing the original row titles are removed before adding new ones. GH2083
 
-- Changed how functions that use different representations for numeric and categorical data handle vectors with an `object` data type. Previously, data was considered numeric if it could be coerced to a float representation without error. Now, object-typed vectors are considered numeric only when their contents are themselves numeric. This change means that numbers that are encoded as strings will now be treated as categorical data.
+- Changed how functions that use different representations for numeric and categorical data handle vectors with an `object` data type. Previously, data was considered numeric if it could be coerced to a float representation without error. Now, object-typed vectors are considered numeric only when their contents are themselves numeric. This change means that numbers that are encoded as strings will now be treated as categorical data.  GH2084
+
+- Improved the error messages produced when categorical plots process the orientation parameter.

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -10,6 +10,7 @@ import matplotlib as mpl
 import matplotlib.pyplot as plt
 
 from . import utils
+from .core import variable_type
 from .palettes import color_palette, blend_palette
 from .distributions import distplot, kdeplot, _freedman_diaconis_bins
 from ._decorators import _deprecate_positional_args
@@ -1611,15 +1612,10 @@ class PairGrid(Grid):
 
     def _find_numeric_cols(self, data):
         """Find which variables in a DataFrame are numeric."""
-        # This can't be the best way to do this, but  I do not
-        # know what the best way might be, so this seems ok
         numeric_cols = []
         for col in data:
-            try:
-                data[col].astype(np.float)
+            if variable_type(data[col]) == "numeric":
                 numeric_cols.append(col)
-            except (ValueError, TypeError):
-                pass
         return numeric_cols
 
 

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -31,7 +31,7 @@ class _CategoricalPlotter(object):
 
     width = .8
     default_palette = "light"
-    require_numeric_dv = True
+    require_numeric = True
 
     def establish_variables(self, x=None, y=None, hue=None, data=None,
                             orient=None, order=None, hue_order=None,
@@ -153,7 +153,7 @@ class _CategoricalPlotter(object):
 
             # Figure out the plotting orientation
             orient = infer_orient(
-                x, y, orient, require_numeric_dv=self.require_numeric_dv
+                x, y, orient, require_numeric=self.require_numeric
             )
 
             # Option 2a:
@@ -1044,7 +1044,7 @@ class _ViolinPlotter(_CategoricalPlotter):
 class _CategoricalScatterPlotter(_CategoricalPlotter):
 
     default_palette = "dark"
-    require_numeric_dv = False
+    require_numeric = False
 
     @property
     def point_colors(self):
@@ -1421,7 +1421,7 @@ class _SwarmPlotter(_CategoricalScatterPlotter):
 
 class _CategoricalStatPlotter(_CategoricalPlotter):
 
-    require_numeric_dv = True
+    require_numeric = True
 
     @property
     def nested_width(self):
@@ -1787,7 +1787,7 @@ class _PointPlotter(_CategoricalStatPlotter):
 
 
 class _CountPlotter(_BarPlotter):
-    require_numeric_dv = False
+    require_numeric = False
 
 
 class _LVPlotter(_CategoricalPlotter):
@@ -3774,7 +3774,7 @@ def catplot(
         "count": _CountPlotter,
     }[kind]
     p = _CategoricalPlotter()
-    p.require_numeric_dv = plotter_class.require_numeric_dv
+    p.require_numeric = plotter_class.require_numeric
     p.establish_variables(x_, y_, hue, data, orient, order, hue_order)
     order = p.group_names
     hue_order = p.hue_names

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -11,7 +11,7 @@ import warnings
 from distutils.version import LooseVersion
 
 from . import utils
-from .core import variable_type
+from .core import variable_type, infer_orient
 from .utils import iqr, categorical_order, remove_na
 from .algorithms import bootstrap
 from .palettes import color_palette, husl_palette, light_palette, dark_palette
@@ -151,7 +151,7 @@ class _CategoricalPlotter(object):
                     raise ValueError(err)
 
             # Figure out the plotting orientation
-            orient = self.infer_orient(x, y, orient)
+            orient = infer_orient(x, y, orient)
 
             # Option 2a:
             # We are plotting a single set of data
@@ -318,31 +318,6 @@ class _CategoricalPlotter(object):
         # Assign object attributes
         self.colors = rgb_colors
         self.gray = gray
-
-    def infer_orient(self, x, y, orient=None):
-        """Determine how the plot should be oriented based on the data."""
-        orient = str(orient)
-
-        x_type = None if x is None else variable_type(x)
-        y_type = None if y is None else variable_type(y)
-
-        if orient.startswith("v"):
-            return "v"
-        elif orient.startswith("h"):
-            return "h"
-        elif x is None:
-            return "v"
-        elif y is None:
-            return "h"
-        elif x_type != "numeric" and y_type == "numeric":
-            return "v"
-        elif x_type == "numeric" and y_type != "numeric":
-            return "h"
-        elif x_type != "numeric" and y_type != "numeric":
-            err = "Neither the `x` nor `y` variable appears to be numeric."
-            raise ValueError(err)
-        else:
-            return "v"
 
     @property
     def hue_offsets(self):

--- a/seaborn/conftest.py
+++ b/seaborn/conftest.py
@@ -143,6 +143,7 @@ def long_df(rng):
         f=rng.choice([0.2, 0.3], n),
     ))
     df["s_cat"] = df["s"].astype("category")
+    df["s_str"] = df["s"].astype(str)
     return df
 
 

--- a/seaborn/core.py
+++ b/seaborn/core.py
@@ -310,7 +310,7 @@ def infer_orient(x=None, y=None, orient=None, require_numeric=True):
 
     For historical reasons, the convention is to call a plot "horizontally"
     or "vertically" oriented based on the axis representing its dependent
-    variable. Practically, this is used for determining the axis for
+    variable. Practically, this is used when determining the axis for
     numerical aggregation.
 
     Paramters
@@ -320,7 +320,7 @@ def infer_orient(x=None, y=None, orient=None, require_numeric=True):
     orient : string or None
         Specified orientation, which must start with "v" or "h" if not None.
     require_numeric : bool
-        If set, raise if the implied dependent variable is not numeric.
+        If set, raise when the implied dependent variable is not numeric.
 
     Returns
     -------
@@ -329,7 +329,7 @@ def infer_orient(x=None, y=None, orient=None, require_numeric=True):
     Raises
     ------
     ValueError: When `orient` is not None and does not start with "h" or "v"
-    TypeError: When dep. variable is not numeric, with `require_numeric`
+    TypeError: When dependant variable is not numeric, with `require_numeric`
 
     """
 

--- a/seaborn/core.py
+++ b/seaborn/core.py
@@ -305,7 +305,7 @@ def variable_type(vector, boolean_type="numeric"):
     return "categorical"
 
 
-def infer_orient(x=None, y=None, orient=None, require_numeric_dv=True):
+def infer_orient(x=None, y=None, orient=None, require_numeric=True):
     """Determine how the plot should be oriented based on the data.
 
     For historical reasons, the convention is to call a plot "horizontally"
@@ -319,7 +319,7 @@ def infer_orient(x=None, y=None, orient=None, require_numeric_dv=True):
         Positional data vectors for the plot.
     orient : string or None
         Specified orientation, which must start with "v" or "h" if not None.
-    require_numeric_dv : True
+    require_numeric : bool
         If set, raise if the implied dependent variable is not numeric.
 
     Returns
@@ -329,7 +329,7 @@ def infer_orient(x=None, y=None, orient=None, require_numeric_dv=True):
     Raises
     ------
     ValueError: When `orient` is not None and does not start with "h" or "v"
-    TypeError: When dep. variable is not numeric, with `require_numeric_dv`
+    TypeError: When dep. variable is not numeric, with `require_numeric`
 
     """
 
@@ -342,24 +342,24 @@ def infer_orient(x=None, y=None, orient=None, require_numeric_dv=True):
     if x is None:
         if str(orient).startswith("h"):
             warnings.warn(single_var_warning.format("Horizontal", "y"))
-        if require_numeric_dv and y_type != "numeric":
+        if require_numeric and y_type != "numeric":
             raise TypeError(nonnumeric_dv_error.format("Vertical", "y"))
         return "v"
 
     elif y is None:
         if str(orient).startswith("v"):
             warnings.warn(single_var_warning.format("Vertical", "x"))
-        if require_numeric_dv and x_type != "numeric":
+        if require_numeric and x_type != "numeric":
             raise TypeError(nonnumeric_dv_error.format("Horizontal", "x"))
         return "h"
 
     elif str(orient).startswith("v"):
-        if require_numeric_dv and y_type != "numeric":
+        if require_numeric and y_type != "numeric":
             raise TypeError(nonnumeric_dv_error.format("Vertical", "y"))
         return "v"
 
     elif str(orient).startswith("h"):
-        if require_numeric_dv and x_type != "numeric":
+        if require_numeric and x_type != "numeric":
             raise TypeError(nonnumeric_dv_error.format("Horizontal", "x"))
         return "h"
 
@@ -372,7 +372,7 @@ def infer_orient(x=None, y=None, orient=None, require_numeric_dv=True):
     elif x_type == "numeric" and y_type != "numeric":
         return "h"
 
-    elif require_numeric_dv and "numeric" not in (x_type, y_type):
+    elif require_numeric and "numeric" not in (x_type, y_type):
         err = "Neither the `x` nor `y` variable appears to be numeric."
         raise TypeError(err)
 

--- a/seaborn/core.py
+++ b/seaborn/core.py
@@ -262,7 +262,7 @@ def variable_type(vector, boolean_type="numeric"):
     if pd.isna(vector).all():
         return "numeric"
 
-    # Special-case binary/boolean data, which is always "categorical"
+    # Special-case binary/boolean data, allow caller to determine
     if np.isin(vector, [0, 1, np.nan]).all():
         return boolean_type
 

--- a/seaborn/core.py
+++ b/seaborn/core.py
@@ -235,7 +235,7 @@ class _VectorPlotter:
         return plot_data, variables
 
 
-def variable_type(vector):
+def variable_type(vector, boolean_type="numeric"):
     """Determine whether a vector contains numeric, categorical, or dateime data.
 
     This function differs from the pandas typing API in two ways:
@@ -249,6 +249,8 @@ def variable_type(vector):
     ----------
     vector : :func:`pandas.Series`, :func:`numpy.ndarray`, or Python sequence
         Input data to test.
+    binary_type : 'numeric' or 'categorical'
+        Type to use for vectors containing only 0s and 1s (and NAs).
 
     Returns
     -------
@@ -262,7 +264,7 @@ def variable_type(vector):
 
     # Special-case binary/boolean data, which is always "categorical"
     if np.isin(vector, [0, 1, np.nan]).all():
-        return "categorical"
+        return boolean_type
 
     # Defer to positive pandas tests
     if pd.api.types.is_numeric_dtype(vector):

--- a/seaborn/relational.py
+++ b/seaborn/relational.py
@@ -222,7 +222,6 @@ class _RelationalPlotter(_VectorPlotter):
             if var_type == "numeric":
 
                 data = pd.to_numeric(data)
-
                 levels, palette, cmap, norm = self.numeric_to_palette(
                     data, order, palette, norm
                 )
@@ -406,7 +405,7 @@ class _RelationalPlotter(_VectorPlotter):
         if self.input_format == "wide":
             return "categorical"
         else:
-            return variable_type(data)
+            return variable_type(data, boolean_type="categorical")
 
     def label_axes(self, ax):
         """Set x and y labels with visibility that matches the ticklabels."""

--- a/seaborn/tests/test_categorical.py
+++ b/seaborn/tests/test_categorical.py
@@ -341,30 +341,6 @@ class TestCategoricalPlotter(CategoricalFixture):
         for group, units in zip(["a", "b", "c"], p.plot_units):
             npt.assert_array_equal(units, self.u[self.g == group])
 
-    def test_infer_orient(self):
-
-        p = cat._CategoricalPlotter()
-
-        cats = pd.Series(["a", "b", "c"] * 10)
-        nums = pd.Series(self.rs.randn(30))
-
-        nt.assert_equal(p.infer_orient(cats, nums), "v")
-        nt.assert_equal(p.infer_orient(nums, cats), "h")
-        nt.assert_equal(p.infer_orient(nums, None), "h")
-        nt.assert_equal(p.infer_orient(None, nums), "v")
-        nt.assert_equal(p.infer_orient(nums, nums, "vert"), "v")
-        nt.assert_equal(p.infer_orient(nums, nums, "hori"), "h")
-
-        with nt.assert_raises(ValueError):
-            p.infer_orient(cats, cats)
-
-        cats = pd.Series([0, 1, 2] * 10, dtype="category")
-        nt.assert_equal(p.infer_orient(cats, nums), "v")
-        nt.assert_equal(p.infer_orient(nums, cats), "h")
-
-        with nt.assert_raises(ValueError):
-            p.infer_orient(cats, cats)
-
     def test_default_palettes(self):
 
         p = cat._CategoricalPlotter()

--- a/seaborn/tests/test_categorical.py
+++ b/seaborn/tests/test_categorical.py
@@ -2460,10 +2460,7 @@ class TestCountPlot(CategoricalFixture):
 
     def test_input_error(self):
 
-        with nt.assert_raises(TypeError):
-            cat.countplot()
-
-        with nt.assert_raises(TypeError):
+        with nt.assert_raises(ValueError):
             cat.countplot(x="g", y="h", data=self.df)
 
 

--- a/seaborn/tests/test_core.py
+++ b/seaborn/tests/test_core.py
@@ -121,20 +121,20 @@ class TestCoreFunc:
         with pytest.warns(UserWarning, match="Horizontal .+ `y`"):
             assert infer_orient(None, nums, "h") == "v"
 
-        infer_orient(cats, None, require_numeric_dv=False) == "h"
+        infer_orient(cats, None, require_numeric=False) == "h"
         with pytest.raises(TypeError, match="Horizontal .+ `x`"):
             infer_orient(cats, None)
 
-        infer_orient(cats, None, require_numeric_dv=False) == "v"
+        infer_orient(cats, None, require_numeric=False) == "v"
         with pytest.raises(TypeError, match="Vertical .+ `y`"):
             infer_orient(None, cats)
 
         assert infer_orient(nums, nums, "vert") == "v"
         assert infer_orient(nums, nums, "hori") == "h"
 
-        assert infer_orient(cats, cats, "h", require_numeric_dv=False) == "h"
-        assert infer_orient(cats, cats, "v", require_numeric_dv=False) == "v"
-        assert infer_orient(cats, cats, require_numeric_dv=False) == "v"
+        assert infer_orient(cats, cats, "h", require_numeric=False) == "h"
+        assert infer_orient(cats, cats, "v", require_numeric=False) == "v"
+        assert infer_orient(cats, cats, require_numeric=False) == "v"
 
         with pytest.raises(TypeError, match="Vertical .+ `y`"):
             infer_orient(cats, cats, "v")

--- a/seaborn/tests/test_core.py
+++ b/seaborn/tests/test_core.py
@@ -89,7 +89,8 @@ class TestCoreFunc:
         assert variable_type(s.tolist()) == "categorical"
 
         s = pd.Series([True, False, False])
-        assert variable_type(s) == "categorical"
+        assert variable_type(s) == "numeric"
+        assert variable_type(s, boolean_type="categorical") == "categorical"
 
         s = pd.Series([pd.Timestamp(1), pd.Timestamp(2)])
         assert variable_type(s) == "datetime"

--- a/seaborn/tests/test_core.py
+++ b/seaborn/tests/test_core.py
@@ -1,10 +1,12 @@
 import numpy as np
+import pandas as pd
 import matplotlib as mpl
 
 from numpy.testing import assert_array_equal
 
 from ..core import (
     _VectorPlotter,
+    variable_type,
     unique_dashes,
     unique_markers,
 )
@@ -63,3 +65,36 @@ class TestCoreFunc:
         assert len(set(markers)) == n
         for m in markers:
             assert mpl.markers.MarkerStyle(m).is_filled()
+
+    def test_variable_type(vector):
+
+        s = pd.Series([1., 2., 3.])
+
+        assert variable_type(s) == "numeric"
+        assert variable_type(s.astype(int)) == "numeric"
+        assert variable_type(s.astype(object)) == "numeric"
+        # assert variable_type(s.to_numpy()) == "numeric"
+        assert variable_type(s.values) == "numeric"
+        # assert variable_type(s.to_list()) == "numeric"
+        assert variable_type(s.tolist()) == "numeric"
+
+        s = pd.Series([1, 2, 3, np.nan], dtype=object)
+        assert variable_type(s) == "numeric"
+
+        s = pd.Series(["1", "2", "3"])
+        assert variable_type(s) == "categorical"
+        # assert variable_type(s.to_numpy()) == "categorical"
+        assert variable_type(s.values) == "categorical"
+        # assert variable_type(s.to_list()) == "categorical"
+        assert variable_type(s.tolist()) == "categorical"
+
+        s = pd.Series([True, False, False])
+        assert variable_type(s) == "categorical"
+
+        s = pd.Series([pd.Timestamp(1), pd.Timestamp(2)])
+        assert variable_type(s) == "datetime"
+        assert variable_type(s.astype(object)) == "datetime"
+        # assert variable_type(s.to_numpy()) == "datetime"
+        assert variable_type(s.values) == "datetime"
+        # assert variable_type(s.to_list()) == "datetime"
+        assert variable_type(s.tolist()) == "datetime"

--- a/seaborn/tests/test_core.py
+++ b/seaborn/tests/test_core.py
@@ -2,11 +2,13 @@ import numpy as np
 import pandas as pd
 import matplotlib as mpl
 
+import pytest
 from numpy.testing import assert_array_equal
 
 from ..core import (
     _VectorPlotter,
     variable_type,
+    infer_orient,
     unique_dashes,
     unique_markers,
 )
@@ -66,7 +68,7 @@ class TestCoreFunc:
         for m in markers:
             assert mpl.markers.MarkerStyle(m).is_filled()
 
-    def test_variable_type(vector):
+    def test_variable_type(self):
 
         s = pd.Series([1., 2., 3.])
         assert variable_type(s) == "numeric"
@@ -102,3 +104,41 @@ class TestCoreFunc:
         assert variable_type(s.values) == "datetime"
         # assert variable_type(s.to_list()) == "datetime"
         assert variable_type(s.tolist()) == "datetime"
+
+    def test_infer_orient(self):
+
+        nums = pd.Series(np.arange(6))
+        cats = pd.Series(["a", "b"] * 3)
+
+        assert infer_orient(cats, nums) == "v"
+        assert infer_orient(nums, cats) == "h"
+
+        assert infer_orient(nums, None) == "h"
+        with pytest.warns(UserWarning, match="Vertical .+ `x`"):
+            assert infer_orient(nums, None, "v") == "h"
+
+        assert infer_orient(None, nums) == "v"
+        with pytest.warns(UserWarning, match="Horizontal .+ `y`"):
+            assert infer_orient(None, nums, "h") == "v"
+
+        infer_orient(cats, None, require_numeric_dv=False) == "h"
+        with pytest.raises(TypeError, match="Horizontal .+ `x`"):
+            infer_orient(cats, None)
+
+        infer_orient(cats, None, require_numeric_dv=False) == "v"
+        with pytest.raises(TypeError, match="Vertical .+ `y`"):
+            infer_orient(None, cats)
+
+        assert infer_orient(nums, nums, "vert") == "v"
+        assert infer_orient(nums, nums, "hori") == "h"
+
+        assert infer_orient(cats, cats, "h", require_numeric_dv=False) == "h"
+        assert infer_orient(cats, cats, "v", require_numeric_dv=False) == "v"
+        assert infer_orient(cats, cats, require_numeric_dv=False) == "v"
+
+        with pytest.raises(TypeError, match="Vertical .+ `y`"):
+            infer_orient(cats, cats, "v")
+        with pytest.raises(TypeError, match="Horizontal .+ `x`"):
+            infer_orient(cats, cats, "h")
+        with pytest.raises(TypeError, match="Neither"):
+            infer_orient(cats, cats)

--- a/seaborn/tests/test_core.py
+++ b/seaborn/tests/test_core.py
@@ -69,7 +69,6 @@ class TestCoreFunc:
     def test_variable_type(vector):
 
         s = pd.Series([1., 2., 3.])
-
         assert variable_type(s) == "numeric"
         assert variable_type(s.astype(int)) == "numeric"
         assert variable_type(s.astype(object)) == "numeric"
@@ -79,6 +78,10 @@ class TestCoreFunc:
         assert variable_type(s.tolist()) == "numeric"
 
         s = pd.Series([1, 2, 3, np.nan], dtype=object)
+        assert variable_type(s) == "numeric"
+
+        s = pd.Series([np.nan, np.nan])
+        # s = pd.Series([pd.NA, pd.NA])
         assert variable_type(s) == "numeric"
 
         s = pd.Series(["1", "2", "3"])

--- a/seaborn/tests/test_relational.py
+++ b/seaborn/tests/test_relational.py
@@ -668,7 +668,7 @@ class TestRelationalPlotter(Helpers):
         p.establish_variables(data=long_df, x="x", y="y", hue="t")
         p.parse_hue(p.plot_data["hue"])
         assert p.hue_levels == [pd.Timestamp('2005-02-25')]
-        assert p.hue_type == "categorical"
+        assert p.hue_type == "datetime"
 
         # Test numeric data with category type
         p = _RelationalPlotter()

--- a/seaborn/utils.py
+++ b/seaborn/utils.py
@@ -12,6 +12,8 @@ import matplotlib as mpl
 import matplotlib.colors as mplcol
 import matplotlib.pyplot as plt
 
+from .core import variable_type
+
 
 __all__ = ["desaturate", "saturate", "set_hls_values",
            "despine", "get_dataset_names", "get_data_home", "load_dataset"]
@@ -542,15 +544,15 @@ def categorical_order(values, order=None):
             try:
                 order = values.cat.categories
             except (TypeError, AttributeError):
+
                 try:
                     order = values.unique()
                 except AttributeError:
                     order = pd.unique(values)
-                try:
-                    np.asarray(values).astype(np.float)
+
+                if variable_type(values) == "numeric":
                     order = np.sort(order)
-                except (ValueError, TypeError):
-                    order = order
+
         order = filter(pd.notnull, order)
     return list(order)
 

--- a/setup.py
+++ b/setup.py
@@ -30,10 +30,10 @@ VERSION = '0.11.0.dev0'
 PYTHON_REQUIRES = ">=3.6"
 
 INSTALL_REQUIRES = [
-    'numpy>=1.13.3',
-    'scipy>=1.0.1',
-    'pandas>=0.22.0',
-    'matplotlib>=2.1.2',
+    'numpy>=1.13',
+    'scipy>=1.0',
+    'pandas>=0.23',
+    'matplotlib>=2.1',
 ]
 
 

--- a/testing/deps_pinned.txt
+++ b/testing/deps_pinned.txt
@@ -1,5 +1,5 @@
-numpy=1.13.3
-scipy=1.0.1
-pandas=0.22.0
-matplotlib=2.1.2
-statsmodels=0.8.0
+numpy=1.13
+scipy=1.0
+pandas=0.23
+matplotlib=2.1
+statsmodels=0.8


### PR DESCRIPTION
This PR refactors the code that infers the type of a variable in `plot_data`. It also changes the way that seaborn handles object-typed data.

Seaborn has traditionally distinguished between two variable types: numeric and categorical. The standard way of discriminating was to ask whether a vector could be coerced to a float dtype without error.

The idea is that seaborn is trying to duck-type here: we don't care about data storage, just what we can do with the data (for instance, whether we can use a quantitative color map). The typing API in pandas treats object-typed data (including Python lists) as non-numeric, but it's not uncommon to end up with a Series that has an object dtype despite being full of numbers.

One consequence of this approach is that numbers explicitly represented as strings would be treated as numeric. This was surprising to some, and lead to downstream errors (#1515 ) that were fixed with a hack (#1905).

The new approach is to introspect object-typed vectors and consider them numeric only when their contents are actually numbers.

The PR also adds explicit identification of datetime data, although we do not yet do anything specific to handle them and they are generally treated as "not numeric" in the current codebase. This does affect the behavior identified in #2056; now categorical plots raise if they get one categorical and one datetime variable and would otherwise fail (but the categorical scatter plots do not).

Finally, the PR improves the error messages that one sees related to specifying the orientation of a categorical plot.