### PR TITLE
DOC: small fixes

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -289,7 +289,7 @@ def setup(app):
 # -- Intersphinx ------------------------------------------------
 
 intersphinx_mapping = {
-    'numpy': ('https://docs.scipy.org/doc/numpy/', None),
+    'numpy': ('https://numpy.org/doc/stable/', None),
     'scipy': ('https://docs.scipy.org/doc/scipy/reference/', None),
     'matplotlib': ('https://matplotlib.org/', None),
     'pandas': ('https://pandas.pydata.org/pandas-docs/stable/', None),

--- a/examples/multiple_joint_kde.py
+++ b/examples/multiple_joint_kde.py
@@ -19,9 +19,9 @@ f, ax = plt.subplots(figsize=(8, 8))
 ax.set_aspect("equal")
 
 # Draw the two density plots
-ax = sns.kdeplot(setosa.sepal_width, setosa.sepal_length,
+ax = sns.kdeplot(x=setosa.sepal_width, y=setosa.sepal_length,
                  cmap="Reds", shade=True, shade_lowest=False)
-ax = sns.kdeplot(virginica.sepal_width, virginica.sepal_length,
+ax = sns.kdeplot(x=virginica.sepal_width, y=virginica.sepal_length,
                  cmap="Blues", shade=True, shade_lowest=False)
 
 # Add labels to the plot


### PR DESCRIPTION
This PR contains two small fixes to seaborn docs:
* Update kdeplot example to use keyword-only arguments, avoiding a warning
* Update intersphinx path to new numpy docs location