### PR TITLE
Fix ordering bug by maintaining category metadata

### DIFF
--- a/seaborn/_core.py
+++ b/seaborn/_core.py
@@ -113,18 +113,23 @@ class HueMapping(SemanticMapping):
 
             # --- Option 2: categorical mapping using seaborn palette
 
-            else:
+            elif map_type == "categorial":
 
+                cmap = norm = None
+                levels, lookup_table = self.categorical_mapping(
+                    data, palette, order,
+                )
+
+            # --- Option 3: datetime mapping
+
+            else:
+                # TODO this needs actual implementation
                 cmap = norm = None
                 levels, lookup_table = self.categorical_mapping(
                     # Casting data to list to handle differences in the way
                     # pandas and numpy represent datetime64 data
                     list(data), palette, order,
                 )
-
-            # --- Option 3: datetime mapping
-
-            # TODO this needs implementation; currently uses categorical
 
             self.map_type = map_type
             self.lookup_table = lookup_table
@@ -166,10 +171,7 @@ class HueMapping(SemanticMapping):
         """Determine colors when the hue mapping is categorical."""
         # -- Identify the order and name of the levels
 
-        if order is None:
-            levels = categorical_order(data)
-        else:
-            levels = order
+        levels = categorical_order(data, order)
         n_colors = len(levels)
 
         # -- Identify the set of colors to use
@@ -289,7 +291,7 @@ class SizeMapping(SemanticMapping):
 
             # --- Option 2: categorical mapping
 
-            else:
+            elif map_type == "categorical":
 
                 levels, lookup_table = self.categorical_mapping(
                     data, sizes, order,
@@ -297,7 +299,14 @@ class SizeMapping(SemanticMapping):
 
             # --- Option 3: datetime mapping
 
-            # TODO this needs implementation; currently uses categorical
+            # TODO this needs an actual implementation
+            else:
+
+                levels, lookup_table = self.categorical_mapping(
+                    # Casting data to list to handle differences in the way
+                    # pandas and numpy represent datetime64 data
+                    list(data), sizes, order,
+                )
 
             self.map_type = map_type
             self.levels = levels
@@ -490,9 +499,12 @@ class StyleMapping(SemanticMapping):
 
         if data.notna().any():
 
-            # Find ordered unique values
             # Cast to list to handle numpy/pandas datetime quirks
-            levels = categorical_order(list(data), order)
+            if variable_type(data) == "datetime":
+                data = list(data)
+
+            # Find ordered unique values
+            levels = categorical_order(data, order)
 
             markers = self._map_attributes(
                 markers, levels, unique_markers(len(levels)), "markers",
@@ -1131,14 +1143,14 @@ def unique_markers(n):
     return markers[:n]
 
 
-def categorical_order(values, order=None):
+def categorical_order(vector, order=None):
     """Return a list of unique data values.
 
     Determine an ordered list of levels in ``values``.
 
     Parameters
     ----------
-    values : list, array, Categorical, or Series
+    vector : list, array, Categorical, or Series
         Vector of "categorical" values
     order : list-like, optional
         Desired order of category levels to override the order determined
@@ -1151,19 +1163,19 @@ def categorical_order(values, order=None):
 
     """
     if order is None:
-        if hasattr(values, "categories"):
-            order = values.categories
+        if hasattr(vector, "categories"):
+            order = vector.categories
         else:
             try:
-                order = values.cat.categories
+                order = vector.cat.categories
             except (TypeError, AttributeError):
 
                 try:
-                    order = values.unique()
+                    order = vector.unique()
                 except AttributeError:
-                    order = pd.unique(values)
+                    order = pd.unique(vector)
 
-                if variable_type(values) == "numeric":
+                if variable_type(vector) == "numeric":
                     order = np.sort(order)
 
         order = filter(pd.notnull, order)

--- a/seaborn/conftest.py
+++ b/seaborn/conftest.py
@@ -142,6 +142,9 @@ def long_df(rng):
         s=rng.choice([2, 4, 8], n),
         f=rng.choice([0.2, 0.3], n),
     ))
+    df["a_cat"] = df["a"].astype("category")
+    new_order = df["a_cat"].cat.categories[[1, 2, 0]]
+    df["a_cat"] = df["a_cat"].cat.reorder_categories(new_order)
     df["s_cat"] = df["s"].astype("category")
     df["s_str"] = df["s"].astype(str)
     return df

--- a/seaborn/tests/test_core.py
+++ b/seaborn/tests/test_core.py
@@ -181,6 +181,12 @@ class TestHueMapping:
         assert m.levels == [pd.Timestamp('2005-02-25')]
         assert m.map_type == "datetime"
 
+        # Test excplicit categories
+        p = VectorPlotter(data=long_df, variables=dict(x="x", hue="a_cat"))
+        m = HueMapping(p)
+        assert m.levels == long_df["a_cat"].cat.categories.tolist()
+        assert m.map_type == "categorical"
+
         # Test numeric data with category type
         p = VectorPlotter(
             data=long_df,
@@ -408,6 +414,12 @@ class TestSizeMapping:
         m = SizeMapping(p, sizes=sizes)
         assert m.lookup_table == sizes
 
+        # Test excplicit categories
+        p = VectorPlotter(data=long_df, variables=dict(x="x", size="a_cat"))
+        m = SizeMapping(p)
+        assert m.levels == long_df["a_cat"].cat.categories.tolist()
+        assert m.map_type == "categorical"
+
         # Test sizes list with wrong length
         sizes = list(np.random.rand(len(levels) + 1))
         with pytest.raises(ValueError):
@@ -510,6 +522,11 @@ class TestStyleMapping:
         for key in m.levels:
             assert m(key, "marker") == markers[key]
             assert m(key, "dashes") == dashes[key]
+
+        # Test excplicit categories
+        p = VectorPlotter(data=long_df, variables=dict(x="x", style="a_cat"))
+        m = StyleMapping(p)
+        assert m.levels == long_df["a_cat"].cat.categories.tolist()
 
         # Test style order with defaults
         order = p.plot_data["style"].unique()[[1, 2, 0]]


### PR DESCRIPTION
#1695 converted data vectors to lists before semantic mapping to avoid errors related to datetime dtypes, but it  introduced a bug in that it stripped pandas category metadata, which is used for default ordering of categorical semantic maps.

Fortunately, this is now easy to work around.