### PR TITLE
FIX: don't fail on heatmap with int data and mask

### DIFF
--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -196,7 +196,7 @@ class _HeatMapper(object):
         """Use some heuristics to set good defaults for colorbar and range."""
 
         # plot_data is a np.ma.array instance
-        calc_data = plot_data.filled(np.nan)
+        calc_data = plot_data.astype(np.float).filled(np.nan)
         if vmin is None:
             if robust:
                 vmin = np.nanpercentile(calc_data, 2)

--- a/seaborn/tests/test_matrix.py
+++ b/seaborn/tests/test_matrix.py
@@ -87,13 +87,15 @@ class TestHeatmap(object):
         npt.assert_array_equal(p.xticklabels, combined_tick_labels)
         nt.assert_equal(p.xlabel, "letter-number")
 
-    def test_mask_input(self):
+    @pytest.mark.parametrize("dtype", [np.float, np.int64, np.object])
+    def test_mask_input(self, dtype):
         kws = self.default_kws.copy()
 
         mask = self.x_norm > 0
         kws['mask'] = mask
-        p = mat._HeatMapper(self.x_norm, **kws)
-        plot_data = np.ma.masked_where(mask, self.x_norm)
+        data = self.x_norm.astype(dtype)
+        p = mat._HeatMapper(data, **kws)
+        plot_data = np.ma.masked_where(mask, data)
 
         npt.assert_array_equal(p.plot_data, plot_data)
 


### PR DESCRIPTION
`heatmap` on integer data and a mask fails when calculating cmap limits (#2102). This bug was introduced by #1956 so should work on any version prior to 0.10.1 (I tested on 0.9.0 and it works there). This PR fixes the issue by casting the data input to float before filling with `np.nan`.

Fixes #2102