### PR TITLE
Improve support for datetime (and categorical) data in relational plots

### DIFF
--- a/doc/releases/v0.11.0.txt
+++ b/doc/releases/v0.11.0.txt
@@ -60,6 +60,8 @@ Other
 
 - Improved :meth:`FacetGrid.set_titles` with `margin titles=True`, such that texts representing the original row titles are removed before adding new ones. GH2083
 
+- Improved support for datetime variables in :func:`scatterplot` and :func:`lineplot`. GH2138
+
 - Fixed a bug where :func:`lineplot` did not pass the ``linestyle`` parameter down to matplotlib. GH2095
 
 - Improved the error messages produced when categorical plots process the orientation parameter.

--- a/seaborn/_core.py
+++ b/seaborn/_core.py
@@ -920,7 +920,11 @@ class VectorPlotter:
     def comp_data(self):
         """Dataframe with numeric x and y, after unit conversion and log scaling."""
         if not hasattr(self, "ax"):
-            raise AttributeError("No Axes attached to plotter")
+            # Probably a good idea, but will need a bunch of tests updated
+            # Most of these tests should just use the external interface
+            # Then this can be reeneabled.
+            # raise AttributeError("No Axes attached to plotter")
+            return self.plot_data
 
         if not hasattr(self, "_comp_data"):
 

--- a/seaborn/conftest.py
+++ b/seaborn/conftest.py
@@ -1,17 +1,22 @@
 import numpy as np
 import pandas as pd
+import datetime
+import matplotlib as mpl
 import matplotlib.pyplot as plt
 
 import pytest
 
 
 @pytest.fixture(scope="session", autouse=True)
-def disable_pandas_unit_conversion():
+def remove_pandas_unit_conversion():
     # Prior to pandas 1.0, it registered its own datetime converters,
     # but they are less powerful than what matplotlib added in 2.2,
     # and we rely on that functionality in seaborn.
     # https://github.com/matplotlib/matplotlib/pull/9779
-    pd.set_option("plotting.matplotlib.register_converters", False)
+    # https://github.com/pandas-dev/pandas/issues/27036
+    mpl.units.registry[np.datetime64] = mpl.dates.DateConverter()
+    mpl.units.registry[datetime.date] = mpl.dates.DateConverter()
+    mpl.units.registry[datetime.datetime] = mpl.dates.DateConverter()
 
 
 @pytest.fixture(autouse=True)

--- a/seaborn/conftest.py
+++ b/seaborn/conftest.py
@@ -5,6 +5,15 @@ import matplotlib.pyplot as plt
 import pytest
 
 
+@pytest.fixture(scope="session", autouse=True)
+def disable_pandas_unit_conversion():
+    # Prior to pandas 1.0, it registered its own datetime converters,
+    # but they are less powerful than what matplotlib added in 2.2,
+    # and we rely on that functionality in seaborn.
+    # https://github.com/matplotlib/matplotlib/pull/9779
+    pd.set_option("plotting.matplotlib.register_converters", False)
+
+
 @pytest.fixture(autouse=True)
 def close_figs():
     yield
@@ -138,7 +147,7 @@ def long_df(rng):
         a=rng.choice(list("abc"), n),
         b=rng.choice(list("mnop"), n),
         c=rng.choice([0, 1], n, [.3, .7]),
-        t=rng.choice(np.arange("2005-02-25", "2005-02-28", dtype="datetime64[D]"), n),
+        t=rng.choice(np.arange("2004-07-30", "2007-07-30", dtype="datetime64[Y]"), n),
         s=rng.choice([2, 4, 8], n),
         f=rng.choice([0.2, 0.3], n),
     ))

--- a/seaborn/relational.py
+++ b/seaborn/relational.py
@@ -288,7 +288,9 @@ class _LinePlotter(_RelationalPlotter):
 
         # Loop over the semantic subsets and add to the plot
         grouping_semantics = "hue", "size", "style"
-        for sub_vars, sub_data in self._semantic_subsets(grouping_semantics):
+        for sub_vars, sub_data in self._semantic_subsets(
+            grouping_semantics, from_comp_data=True
+        ):
 
             if self.sort:
                 sub_data = sub_data.sort_values(["units", "x", "y"])
@@ -641,6 +643,8 @@ def lineplot(
     if ax is None:
         ax = plt.gca()
 
+    p._attach(ax)
+
     p.plot(ax, kwargs)
     return ax
 
@@ -919,6 +923,8 @@ def scatterplot(
 
     if ax is None:
         ax = plt.gca()
+
+    p._attach(ax)
 
     p.plot(ax, kwargs)
 

--- a/seaborn/tests/test_core.py
+++ b/seaborn/tests/test_core.py
@@ -897,8 +897,10 @@ class TestVectorPlotter:
 
         p = VectorPlotter(data=long_df, variables={"x": "x", "y": "t"})
 
-        with pytest.raises(AttributeError):
-            p.comp_data
+        # We have disabled this check for now, while it remains part of
+        # the internal API, because it will require updating a number of tests
+        # with pytest.raises(AttributeError):
+        #     p.comp_data
 
         _, ax = plt.subplots()
         p._attach(ax)

--- a/seaborn/tests/test_relational.py
+++ b/seaborn/tests/test_relational.py
@@ -1697,10 +1697,10 @@ class TestScatterPlotter(Helpers):
 
     def test_datetime_scale(self, long_df):
 
-        f, (ax1, ax2) = plt.subplots(2)
-        scatterplot(data=long_df, x="t", y="y", ax=ax1)
-        ax2.scatter(long_df["t"], long_df["y"])
-        assert ax1.get_xlim() == pytest.approx(ax2.get_xlim())
+        ax = scatterplot(data=long_df, x="t", y="y")
+        # Check that we avoid weird matplotlib default auto scaling
+        # https://github.com/matplotlib/matplotlib/issues/17586
+        ax.get_xlim()[0] > ax.xaxis.convert_units(np.datetime64("2002-01-01"))
 
     def test_scatterplot_vs_relplot(self, long_df, long_semantics):
 

--- a/seaborn/tests/test_relational.py
+++ b/seaborn/tests/test_relational.py
@@ -1326,6 +1326,9 @@ class TestLinePlotter(Helpers):
         lineplot(x="x", y=long_df.y.values, data=long_df)
         ax.clear()
 
+        lineplot(x="x", y="t", data=long_df)
+        ax.clear()
+
         lineplot(x="x", y="y", hue="a", data=long_df)
         ax.clear()
 
@@ -1691,6 +1694,13 @@ class TestScatterPlotter(Helpers):
         lw = 2
         scatterplot(data=long_df, x="x", y="y", linewidth=lw)
         assert ax.collections[0].get_linewidths().item() == lw
+
+    def test_datetime_scale(self, long_df):
+
+        f, (ax1, ax2) = plt.subplots(2)
+        scatterplot(data=long_df, x="t", y="y", ax=ax1)
+        ax2.scatter(long_df["t"], long_df["y"])
+        assert ax1.get_xlim() == pytest.approx(ax2.get_xlim())
 
     def test_scatterplot_vs_relplot(self, long_df, long_semantics):
 


### PR DESCRIPTION
Fixes #2130

Also addresses the `lineplot` example in https://github.com/mwaskom/seaborn/issues/2056; lineplot can now have a datetime (or categorical) `y` variable and aggregate across it.

Eventually, a similar approach can be used in all the categorical plots. (But it will take more refactoring).

This ran into some issues with an old conflict between pandas and matplotlib, summarized here and in various linked issues: https://github.com/matplotlib/matplotlib/issues/9610

Pre pandas 1.0 (I think?), they registered their own datetime converters, but those converters are less powerful than what matplotlib added in 2.2 (and what seaborn needs to make e.g. `comp_data` work).

I think seaborn wants to avoid mucking with the matplotlib converter registry, which unfortunately means that users on older versions of pandas won't get to take full advantage of the new features here unless they run

```python
pd.set_option("plotting.matplotlib.register_converters", False)
```

But disabling all of the pandas converters runs into: https://github.com/pandas-dev/pandas/issues/27036

So a better thing for seaborn to do is to add the pandas converters we need, but only when setting up the tests.

This is a mess ... but I don't think it's *our* mess.