### PR TITLE
Clarified documentation of despine

### DIFF
--- a/seaborn/utils.py
+++ b/seaborn/utils.py
@@ -219,9 +219,10 @@ def despine(fig=None, ax=None, top=True, right=True, left=False,
     """Remove the top and right spines from plot(s).
 
     fig : matplotlib figure, optional
-        Figure to despine all axes of, default uses current figure.
+        Figure to despine all axes of, defaults to current figure.
     ax : matplotlib axes, optional
-        Specific axes object to despine.
+        Specific axes object to despine when a figure is not
+        specified, ignored otherwise.
     top, right, left, bottom : boolean, optional
         If True, remove that spine.
     offset : int or dict, optional

--- a/seaborn/utils.py
+++ b/seaborn/utils.py
@@ -219,10 +219,9 @@ def despine(fig=None, ax=None, top=True, right=True, left=False,
     """Remove the top and right spines from plot(s).
 
     fig : matplotlib figure, optional
-        Figure to despine all axes of, defaults to current figure.
+        Figure to despine all axes of, defaults to the current figure.
     ax : matplotlib axes, optional
-        Specific axes object to despine when a figure is not
-        specified, ignored otherwise.
+        Specific axes object to despine. Ignored if fig is provided.
     top, right, left, bottom : boolean, optional
         If True, remove that spine.
     offset : int or dict, optional


### PR DESCRIPTION
When `fig` and `ax` are both specified, `ax` is ignored and all axes in `fig` are despined. Took me a while to figure out, so I clarified the documentation.

I think in this case it would be better to despine `ax` and ignore `fig`, but I realize this is undesirable as it might break some code out there.

I also thought of adding an explicit warning, would this be excessive? For example:

```
    elif fig is not None:
        axes = fig.axes
        if ax is not None:
            warnings.warn('ax parameter ignored when fig is specified')
```