### PR TITLE
Add ecdfplot function

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -45,6 +45,7 @@ Distribution plots
 
     distplot
     histplot
+    ecdfplot
     kdeplot
     rugplot
 

--- a/doc/docstrings/ecdfplot.ipynb
+++ b/doc/docstrings/ecdfplot.ipynb
@@ -1,0 +1,130 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Plot a univariate distribution along the x axis:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import seaborn as sns; sns.set()\n",
+    "penguins = sns.load_dataset(\"penguins\")\n",
+    "sns.ecdfplot(data=penguins, x=\"flipper_length_mm\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Flip the plot by assigning the data variable to the y axis:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sns.ecdfplot(data=penguins, y=\"flipper_length_mm\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If neither `x` nor `y` is assigned, the dataset is treated as wide-form, and a histogram is drawn for each numeric column:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sns.ecdfplot(data=penguins.filter(like=\"culmen_\", axis=\"columns\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can also draw multiple histograms from a long-form dataset with hue mapping:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sns.ecdfplot(data=penguins, x=\"culmen_length_mm\", hue=\"species\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The default distribution statistic is normalized to show a proportion, but you can show absolute counts instead:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sns.ecdfplot(data=penguins, x=\"culmen_length_mm\", hue=\"species\", stat=\"count\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "It's also possible to plot the empirical complementary CDF (1 - CDF):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sns.ecdfplot(data=penguins, x=\"culmen_length_mm\", hue=\"species\", complementary=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "seaborn-refactor (py38)",
+   "language": "python",
+   "name": "seaborn-refactor"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/doc/docstrings/histplot.ipynb
+++ b/doc/docstrings/histplot.ipynb
@@ -103,7 +103,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You can also draw multiple histograms from a long-form dataset with hue mapping:"
+    "You can otherwise draw multiple histograms from a long-form dataset with hue mapping:"
    ]
   },
   {

--- a/doc/releases/v0.11.0.txt
+++ b/doc/releases/v0.11.0.txt
@@ -9,13 +9,17 @@ v0.11.0 (Unreleased)
 Modernization of distribution functions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-First, a new function, :func:`histplot` has been added. :func:`histplot` draws univariate or bivariate histograms with a number of features, including:
+First, two new functions, :func:`histplot` and :func:`ecdfplot` has been added.
+
+:func:`histplot` draws univariate or bivariate histograms with a number of features, including:
 
 - mapping multiple distributions with a ``hue`` semantic
 - normalization to show density, probability, or frequency statistics
 - flexible parameterization of bin size, including proper bins for discrete variables
 - adding a KDE fit to show a smoothed distribution over all bin statistics
 - experimental support for histograms over categorical and datetime variables. GH2125
+
+:func:`ecdfplot` draws univariate empirical cumulative distribution functions, using a similar interface.
 
 Second, the existing functions :func:`kdeplot` and :func:`rugplot` have been completely overhauled. Two of the oldest functions in the library, these lacked aspects of the otherwise-common seaborn API, such as the ability to assign variables by name from a ``data`` object; they had no capacity for semantic mapping; and they had numerous other inconsistencies and smaller issues.
 

--- a/seaborn/_docstrings.py
+++ b/seaborn/_docstrings.py
@@ -117,6 +117,9 @@ histplot : Plot a histogram of binned counts with optional normalization or smoo
     kdeplot="""
 kdeplot : Plot univariate or bivariate distributions using kernel density estimation.
     """,
+    ecdfplot="""
+ecdfplot : Plot empirical cumulative distribution functions.
+    """,
     rugplot="""
 rugplot : Plot a tick at each observation value along the x and/or y axes.
     """,

--- a/seaborn/_statistics.py
+++ b/seaborn/_statistics.py
@@ -1,3 +1,29 @@
+"""Statistical transformations for visualization.
+
+This module is currently private, but is being written to eventually form part
+of the public API.
+
+The classes should behave roughly in the style of scikit-learn.
+
+- All data-independent parameters should be passed to the class constructor.
+- Each class should impelment a default transformation that is exposed through
+  __call__. These are currently written for vector arguements, but I think
+  consuming a whole `plot_data` DataFrame and return it with transformed
+  variables would make more sense.
+- Some class have data-dependent preprocessing that should be cached and used
+  multiple times (think defining histogram bins off all data and then counting
+  observations within each bin multiple times per data subsets). These currently
+  have unique names, but it would be good to have a common name. Not quite
+  `fit`, but something similar.
+- Alternatively, the transform interface could take some information about grouping
+  variables and do a groupby internally.
+- Some classes should define alternate transforms that might make the most sense
+  with a different function. For example, KDE usually evaluates the distribution
+  on a regular grid, but it would be useful for it to transform at the actual
+  datapoints. Then again, this could be controlled by a parameter at  the time of
+  class instantiation.
+
+"""
 from distutils.version import LooseVersion
 from numbers import Number
 import numpy as np
@@ -348,9 +374,17 @@ class Histogram:
 
 
 class ECDF:
-
+    """Univariate empirical cumulative distribution estimator."""
     def __init__(self, stat="proportion"):
+        """Initialize the class with its paramters
 
+        Parameters
+        ----------
+        stat : {{"proportion", "count"}}
+            Distribution statistic to compute.
+
+        """
+        # TODO add remove_duplicates
         _check_argument("stat", ["count", "proportion"], stat)
         self.stat = stat
 

--- a/seaborn/_statistics.py
+++ b/seaborn/_statistics.py
@@ -375,18 +375,20 @@ class Histogram:
 
 class ECDF:
     """Univariate empirical cumulative distribution estimator."""
-    def __init__(self, stat="proportion"):
+    def __init__(self, stat="proportion", complementary=False):
         """Initialize the class with its paramters
 
         Parameters
         ----------
         stat : {{"proportion", "count"}}
             Distribution statistic to compute.
+        complementary : bool
+            If True, use the complementary CDF (1 - CDF)
 
         """
-        # TODO add remove_duplicates
         _check_argument("stat", ["count", "proportion"], stat)
         self.stat = stat
+        self.complementary = complementary
 
     # Do we need bivariate ECDF?
 
@@ -395,7 +397,6 @@ class ECDF:
         sorter = x.argsort()
         x = x[sorter]
         weights = weights[sorter]
-
         y = weights.cumsum()
 
         if self.stat == "proportion":
@@ -403,6 +404,9 @@ class ECDF:
 
         x = np.r_[-np.inf, x]
         y = np.r_[0, y]
+
+        if self.complementary:
+            y = y.max() - y
 
         return y, x
 

--- a/seaborn/_statistics.py
+++ b/seaborn/_statistics.py
@@ -392,7 +392,7 @@ class ECDF:
 
     def _eval_bivariate(self, x1, x2, weights):
         """Inner function for ECDF of two variables."""
-        raise NotImplementedError
+        raise NotImplementedError("Bivariate ECDF is not implemented")
 
     def _eval_univariate(self, x, weights):
         """Inner function for ECDF of one variable."""

--- a/seaborn/_statistics.py
+++ b/seaborn/_statistics.py
@@ -390,7 +390,9 @@ class ECDF:
         self.stat = stat
         self.complementary = complementary
 
-    # Do we need bivariate ECDF?
+    def _eval_bivariate(self, x1, x2, weights):
+        """Inner function for ECDF of two variables."""
+        raise NotImplementedError
 
     def _eval_univariate(self, x, weights):
         """Inner function for ECDF of one variable."""
@@ -410,7 +412,7 @@ class ECDF:
 
         return y, x
 
-    def __call__(self, x1, weights=None):
+    def __call__(self, x1, x2=None, weights=None):
         """Return proportion or count of observations below each sorted datapoint."""
         x1 = np.asarray(x1)
         if weights is None:
@@ -418,4 +420,7 @@ class ECDF:
         else:
             weights = np.asarray(weights)
 
-        return self._eval_univariate(x1, weights)
+        if x2 is None:
+            return self._eval_univariate(x1, weights)
+        else:
+            return self._eval_bivariate(x1, x2, weights)

--- a/seaborn/_statistics.py
+++ b/seaborn/_statistics.py
@@ -357,8 +357,8 @@ class ECDF:
     # Do we need bivariate ECDF?
 
     def _eval_univariate(self, x, weights):
-
-        sorter = np.argsort(x)
+        """Inner function for ECDF of one variable."""
+        sorter = x.argsort()
         x = x[sorter]
         weights = weights[sorter]
 
@@ -373,7 +373,7 @@ class ECDF:
         return y, x
 
     def __call__(self, x1, weights=None):
-
+        """Return proportion or count of observations below each sorted datapoint."""
         x1 = np.asarray(x1)
         if weights is None:
             weights = np.ones_like(x1)

--- a/seaborn/_statistics.py
+++ b/seaborn/_statistics.py
@@ -345,3 +345,39 @@ class Histogram:
             return self._eval_univariate(x1, weights)
         else:
             return self._eval_bivariate(x1, x2, weights)
+
+
+class ECDF:
+
+    def __init__(self, stat="proportion"):
+
+        _check_argument("stat", ["count", "proportion"], stat)
+        self.stat = stat
+
+    # Do we need bivariate ECDF?
+
+    def _eval_univariate(self, x, weights):
+
+        sorter = np.argsort(x)
+        x = x[sorter]
+        weights = weights[sorter]
+
+        y = weights.cumsum()
+
+        if self.stat == "proportion":
+            y = y / y.max()
+
+        x = np.r_[-np.inf, x]
+        y = np.r_[0, y]
+
+        return y, x
+
+    def __call__(self, x1, weights=None):
+
+        x1 = np.asarray(x1)
+        if weights is None:
+            weights = np.ones_like(x1)
+        else:
+            weights = np.asarray(weights)
+
+        return self._eval_univariate(x1, weights)

--- a/seaborn/distributions.py
+++ b/seaborn/distributions.py
@@ -1164,10 +1164,15 @@ class _DistributionPlotter(VectorPlotter):
                 plot_args = stat, vals
                 stat_variable = "x"
 
+            if estimator.stat == "count":
+                top_edge = len(observations)
+            else:
+                top_edge = 1
+
             # Draw the line for this subset
             artist, = ax.plot(*plot_args, **artist_kws)
             sticky_edges = getattr(artist.sticky_edges, stat_variable)
-            sticky_edges[:] = 0, 1
+            sticky_edges[:] = 0, top_edge
 
         # --- Finalize the plot ----
         stat = estimator.stat.capitalize()

--- a/seaborn/distributions.py
+++ b/seaborn/distributions.py
@@ -1146,8 +1146,11 @@ class _DistributionPlotter(VectorPlotter):
             "hue", reverse=True, from_comp_data=True,
         ):
 
-            # "Compute" the ECDF
+            # Compute the ECDF
             sub_data = sub_data[cols].dropna()
+            if sub_data.empty:
+                continue
+
             observations = sub_data[self.data_variable]
             weights = sub_data.get("weights", None)
             stat, vals = estimator(observations, weights)
@@ -1927,6 +1930,11 @@ See Also
 {seealso.kdeplot}
 {seealso.rugplot}
 distplot
+
+Examples
+--------
+
+.. include:: ../docstrings/ecdfplot.rst
 
 """.format(
     params=_param_docs,

--- a/seaborn/distributions.py
+++ b/seaborn/distributions.py
@@ -76,6 +76,7 @@ _param_docs = DocstringComponents.from_nested_components(
     dist=DocstringComponents(_dist_params),
     kde=DocstringComponents.from_function_params(KDE.__init__),
     hist=DocstringComponents.from_function_params(Histogram.__init__),
+    ecdf=DocstringComponents.from_function_params(ECDF.__init__),
 )
 
 
@@ -1904,11 +1905,7 @@ Parameters
 {params.core.data}
 {params.core.xy}
 {params.core.hue}
-weights : vector or key in ``data``
-    If provided, weight the contribution of the corresponding data points
-    towards the distribution by these factors.
-stat : {{"proportion", "count"}}
-    Distribution statistic to compute.
+{params.ecdf.stat}
 {params.core.palette}
 {params.core.hue_order}
 {params.core.hue_norm}

--- a/seaborn/distributions.py
+++ b/seaborn/distributions.py
@@ -1840,7 +1840,7 @@ def ecdfplot(
     # Vector variables
     x=None, y=None, hue=None, weights=None,
     # Computation parameters
-    stat="proportion",
+    stat="proportion", complementary=False,
     # Hue mapping parameters
     palette=None, hue_order=None, hue_norm=None,
     # Axes information
@@ -1874,6 +1874,7 @@ def ecdfplot(
 
     estimate_kws = dict(
         stat=stat,
+        complementary=complementary,
     )
 
     p.plot_univariate_ecdf(
@@ -1906,6 +1907,7 @@ Parameters
 {params.core.xy}
 {params.core.hue}
 {params.ecdf.stat}
+{params.ecdf.complementary}
 {params.core.palette}
 {params.core.hue_order}
 {params.core.hue_norm}

--- a/seaborn/distributions.py
+++ b/seaborn/distributions.py
@@ -1475,6 +1475,7 @@ See Also
 --------
 {seealso.kdeplot}
 {seealso.rugplot}
+{seealso.ecdfplot}
 {seealso.jointplot}
 distplot
 
@@ -1781,9 +1782,10 @@ Returns
 
 See Also
 --------
-{seealso.histplot}
-{seealso.rugplot}
 {seealso.violinplot}
+{seealso.histplot}
+{seealso.ecdfplot}
+{seealso.rugplot}
 {seealso.jointplot}
 distplot
 
@@ -1839,7 +1841,7 @@ def ecdfplot(
     # Computation parameters
     stat="proportion",
     # Hue mapping parameters
-    palette=None, hue_order=None, hue_norm=None, color=None,
+    palette=None, hue_order=None, hue_norm=None,
     # Axes information
     log_scale=None, legend=True, ax=None,
     # Other appearance keywords
@@ -1881,6 +1883,57 @@ def ecdfplot(
     )
 
     return ax
+
+
+ecdfplot.__doc__ = """\
+Plot empirical cumulative distribution functions.
+
+An ECDF represents the proportion or count of observations falling below each
+unique value in a dataset. Compared to a histogram or density plot, it has the
+advantage that each observation is visualized directly, meaning that there are
+no binning or smoothing parameters that need to be adjusted. It also aids direct
+comparisons between multiple distributions. A downside is that the relationship
+between the appearance of the plot and the basic properties of the distribution
+(such as its central tendency, variance, and the presence of any bimodality)
+may not be as intuitive.
+
+More information is provided in the :ref:`user guide <userguide_ecdf>`.
+
+Parameters
+----------
+{params.core.data}
+{params.core.xy}
+{params.core.hue}
+weights : vector or key in ``data``
+    If provided, weight the contribution of the corresponding data points
+    towards the distribution by these factors.
+stat : {{"proportion", "count"}}
+    Distribution statistic to compute.
+{params.core.palette}
+{params.core.hue_order}
+{params.core.hue_norm}
+{params.dist.log_scale}
+{params.dist.legend}
+{params.core.ax}
+kwargs
+    Other keyword arguments are passed to :meth:`matplotlib.axes.Axes.plot`.
+
+Returns
+-------
+{returns.ax}
+
+See Also
+--------
+{seealso.histplot}
+{seealso.kdeplot}
+{seealso.rugplot}
+distplot
+
+""".format(
+    params=_param_docs,
+    returns=_core_docs["returns"],
+    seealso=_core_docs["seealso"],
+)
 
 
 @_deprecate_positional_args

--- a/seaborn/distributions.py
+++ b/seaborn/distributions.py
@@ -1137,6 +1137,9 @@ class _DistributionPlotter(VectorPlotter):
         # TODO maybe have an option for joint start/end?
         estimator = ECDF(**estimate_kws)
 
+        # Allow other drawstyles (I'm not sure why you'd want them)
+        plot_kws.setdefault("drawstyle", "steps-post")
+
         # Loop through the subsets, transform and plot the data
         for sub_vars, sub_data in self._semantic_subsets(
             "hue", reverse=True, from_comp_data=True,
@@ -1162,7 +1165,7 @@ class _DistributionPlotter(VectorPlotter):
                 stat_variable = "x"
 
             # Draw the line for this subset
-            artist, = ax.plot(*plot_args, drawstyle="steps-post", **artist_kws)
+            artist, = ax.plot(*plot_args, **artist_kws)
             sticky_edges = getattr(artist.sticky_edges, stat_variable)
             sticky_edges[:] = 0, 1
 

--- a/seaborn/distributions.py
+++ b/seaborn/distributions.py
@@ -1139,7 +1139,6 @@ class _DistributionPlotter(VectorPlotter):
         # TODO see notes elsewhere about GH2135
         cols = list(self.variables)
 
-        # TODO maybe have an option for joint start/end?
         estimator = ECDF(**estimate_kws)
 
         # Set the draw style to step the right way for the data varible

--- a/seaborn/distributions.py
+++ b/seaborn/distributions.py
@@ -540,8 +540,12 @@ class _DistributionPlotter(VectorPlotter):
                     y = np.append(hist["heights"], final["heights"])
                     b = np.append(bottom, bottom[-1])
 
-                    step = "post"
-                    drawstyle = "steps-post"
+                    if self.data_variable == "x":
+                        step = "post"
+                        drawstyle = "steps-post"
+                    else:
+                        step = "post"  # fillbetweenx handles mapping internally
+                        drawstyle = "steps-pre"
 
                 elif element == "poly":
 
@@ -1138,8 +1142,9 @@ class _DistributionPlotter(VectorPlotter):
         # TODO maybe have an option for joint start/end?
         estimator = ECDF(**estimate_kws)
 
-        # Allow other drawstyles (I'm not sure why you'd want them)
-        plot_kws.setdefault("drawstyle", "steps-post")
+        # Set the draw style to step the right way for the data varible
+        drawstyles = dict(x="steps-post", y="steps-pre")
+        plot_kws["drawstyle"] = drawstyles[self.data_variable]
 
         # Loop through the subsets, transform and plot the data
         for sub_vars, sub_data in self._semantic_subsets(

--- a/seaborn/tests/test_distributions.py
+++ b/seaborn/tests/test_distributions.py
@@ -1837,6 +1837,13 @@ class TestECDFPlotUnivariate:
             assert line.get_linestyle() == ls
             assert line.get_linewidth() == lw
 
+    @pytest.mark.parametrize("data_var", ["x", "y"])
+    def test_drawstyle(self, flat_series, data_var):
+
+        ax = ecdfplot(**{data_var: flat_series})
+        drawstyles = dict(x="steps-post", y="steps-pre")
+        assert ax.lines[0].get_drawstyle() == drawstyles[data_var]
+
     @pytest.mark.parametrize(
         "data_var,stat_var", [["x", "y"], ["y", "x"]],
     )

--- a/seaborn/tests/test_distributions.py
+++ b/seaborn/tests/test_distributions.py
@@ -1852,6 +1852,18 @@ class TestECDFPlotUnivariate:
     @pytest.mark.parametrize(
         "data_var,stat_var", [["x", "y"], ["y", "x"]],
     )
+    def test_proportion_limits_complementary(self, flat_series, data_var, stat_var):
+
+        ax = ecdfplot(**{data_var: flat_series}, complementary=True)
+        data = getattr(ax.lines[0], f"get_{stat_var}data")()
+        assert data[0] == 1
+        assert data[-1] == 0
+        sticky_edges = getattr(ax.lines[0].sticky_edges, stat_var)
+        assert sticky_edges[:] == [0, 1]
+
+    @pytest.mark.parametrize(
+        "data_var,stat_var", [["x", "y"], ["y", "x"]],
+    )
     def test_proportion_count(self, flat_series, data_var, stat_var):
 
         n = len(flat_series)

--- a/seaborn/tests/test_distributions.py
+++ b/seaborn/tests/test_distributions.py
@@ -1833,7 +1833,7 @@ class TestECDFPlotUnivariate:
         ax = ecdfplot(long_df, x="x", color=color, ls=ls, lw=lw)
 
         for line in ax.lines:
-            assert line.get_color() == to_rgb(color)
+            assert to_rgb(line.get_color()) == to_rgb(color)
             assert line.get_linestyle() == ls
             assert line.get_linewidth() == lw
 

--- a/seaborn/tests/test_distributions.py
+++ b/seaborn/tests/test_distributions.py
@@ -26,8 +26,9 @@ from .._statistics import (
 from ..distributions import (
     _DistributionPlotter,
     histplot,
-    rugplot,
+    ecdfplot,
     kdeplot,
+    rugplot,
 )
 
 
@@ -1793,3 +1794,73 @@ class TestHistPlotBivariate:
         f, (ax, cax) = plt.subplots(2)
         histplot(long_df, x="x", y="y", cbar=True, cbar_ax=cax, ax=ax)
         assert len(ax.figure.axes) == 2
+
+
+class TestECDFPlotUnivariate:
+
+    @pytest.mark.parametrize("variable", ["x", "y"])
+    def test_long_vectors(self, long_df, variable):
+
+        vector = long_df[variable]
+        vectors = [
+            variable, vector, np.asarray(vector), vector.tolist(),
+        ]
+
+        f, ax = plt.subplots()
+        for vector in vectors:
+            ecdfplot(data=long_df, ax=ax, **{variable: vector})
+
+        xdata = [l.get_xdata() for l in ax.lines]
+        for a, b in itertools.product(xdata, xdata):
+            assert_array_equal(a, b)
+
+        ydata = [l.get_ydata() for l in ax.lines]
+        for a, b in itertools.product(ydata, ydata):
+            assert_array_equal(a, b)
+
+    def test_hue(self, long_df):
+
+        ax = ecdfplot(long_df, x="x", hue="a")
+
+        for line, color in zip(ax.lines[::-1], color_palette()):
+            assert line.get_color() == color
+
+    def test_line_kwargs(self, long_df):
+
+        ls = "--"
+        lw = 3
+        ax = ecdfplot(long_df, x="x", hue="a", ls=ls, lw=lw)
+
+        for line in ax.lines:
+            assert line.get_linestyle() == ls
+            assert line.get_linewidth() == lw
+
+    @pytest.mark.parametrize(
+        "data_var,stat_var", [["x", "y"], ["y", "x"]],
+    )
+    def test_proportion_limits(self, flat_series, data_var, stat_var):
+
+        ax = ecdfplot(**{data_var: flat_series})
+        data = getattr(ax.lines[0], f"get_{stat_var}data")()
+        assert data[0] == 0
+        assert data[-1] == 1
+        sticky_edges = getattr(ax.lines[0].sticky_edges, stat_var)
+        assert sticky_edges[:] == [0, 1]
+
+    @pytest.mark.parametrize(
+        "data_var,stat_var", [["x", "y"], ["y", "x"]],
+    )
+    def test_proportion_count(self, flat_series, data_var, stat_var):
+
+        n = len(flat_series)
+        ax = ecdfplot(**{data_var: flat_series}, stat="count")
+        data = getattr(ax.lines[0], f"get_{stat_var}data")()
+        assert data[0] == 0
+        assert data[-1] == n
+        sticky_edges = getattr(ax.lines[0].sticky_edges, stat_var)
+        assert sticky_edges[:] == [0, n]
+
+    def test_bivariate_error(self, long_df):
+
+        with pytest.raises(NotImplementedError, match="Bivariate ECDF plots"):
+            ecdfplot(data=long_df, x="x", y="y")

--- a/seaborn/tests/test_distributions.py
+++ b/seaborn/tests/test_distributions.py
@@ -1827,11 +1827,13 @@ class TestECDFPlotUnivariate:
 
     def test_line_kwargs(self, long_df):
 
+        color = "r"
         ls = "--"
         lw = 3
-        ax = ecdfplot(long_df, x="x", hue="a", ls=ls, lw=lw)
+        ax = ecdfplot(long_df, x="x", color=color, ls=ls, lw=lw)
 
         for line in ax.lines:
+            assert line.get_color() == to_rgb(color)
             assert line.get_linestyle() == ls
             assert line.get_linewidth() == lw
 

--- a/seaborn/tests/test_statistics.py
+++ b/seaborn/tests/test_statistics.py
@@ -433,12 +433,17 @@ class TestECDF(DistributionFixtures):
     @pytest.mark.skipif(smdist is None, reason="Requires statsmodels")
     def test_against_statsmodels(self, x):
 
+        sm_ecdf = smdist.empirical_distribution.ECDF(x)
+
         ecdf = ECDF()
         stat, vals = ecdf(x)
-
-        sm_ecdf = smdist.empirical_distribution.ECDF(x)
         assert_array_equal(vals, sm_ecdf.x)
         assert_array_almost_equal(stat, sm_ecdf.y)
+
+        ecdf = ECDF(complementary=True)
+        stat, vals = ecdf(x)
+        assert_array_equal(vals, sm_ecdf.x)
+        assert_array_almost_equal(stat, sm_ecdf.y[::-1])
 
     def test_invalid_stat(self, x):
 

--- a/seaborn/tests/test_statistics.py
+++ b/seaborn/tests/test_statistics.py
@@ -1,13 +1,34 @@
 import numpy as np
 from scipy import integrate
 
+try:
+    import statsmodels.distributions as smdist
+except ImportError:
+    smdist = None
+
 import pytest
-from numpy.testing import assert_array_equal
+from numpy.testing import assert_array_equal, assert_array_almost_equal
 
 from .._statistics import (
     KDE,
     Histogram,
+    ECDF,
 )
+
+
+class DistributionFixtures:
+
+    @pytest.fixture
+    def x(self, rng):
+        return rng.normal(0, 1, 100)
+
+    @pytest.fixture
+    def y(self, rng):
+        return rng.normal(0, 5, 100)
+
+    @pytest.fixture
+    def weights(self, rng):
+        return rng.uniform(0, 5, 100)
 
 
 class TestKDE:
@@ -127,15 +148,7 @@ class TestKDE:
         assert density[-1, -1] == pytest.approx(1, abs=1e-2)
 
 
-class TestHistogram:
-
-    @pytest.fixture
-    def x(self, rng):
-        return rng.normal(0, 1, 100)
-
-    @pytest.fixture
-    def y(self, rng):
-        return rng.normal(0, 5, 100)
+class TestHistogram(DistributionFixtures):
 
     def test_string_bins(self, x):
 
@@ -379,3 +392,54 @@ class TestHistogram:
 
         with pytest.raises(ValueError):
             Histogram(stat="invalid")
+
+
+class TestECDF(DistributionFixtures):
+
+    def test_univariate_proportion(self, x):
+
+        ecdf = ECDF()
+        stat, vals = ecdf(x)
+        assert_array_equal(vals[1:], np.sort(x))
+        assert_array_almost_equal(stat[1:], np.linspace(0, 1, len(x) + 1)[1:])
+        assert stat[0] == 0
+
+    def test_univariate_count(self, x):
+
+        ecdf = ECDF(stat="count")
+        stat, vals = ecdf(x)
+
+        assert_array_equal(vals[1:], np.sort(x))
+        assert_array_almost_equal(stat[1:], np.arange(len(x)) + 1)
+        assert stat[0] == 0
+
+    def test_univariate_proportion_weights(self, x, weights):
+
+        ecdf = ECDF()
+        stat, vals = ecdf(x, weights=weights)
+        assert_array_equal(vals[1:], np.sort(x))
+        assert_array_almost_equal(stat[1:], weights[x.argsort()].cumsum() / weights.sum())
+        assert stat[0] == 0
+
+    def test_univariate_count_weights(self, x, weights):
+
+        ecdf = ECDF(stat="count")
+        stat, vals = ecdf(x, weights=weights)
+        assert_array_equal(vals[1:], np.sort(x))
+        assert_array_almost_equal(stat[1:], weights[x.argsort()].cumsum())
+        assert stat[0] == 0
+
+    @pytest.mark.skipif(smdist is None, reason="Requires statsmodels")
+    def test_against_statsmodels(self, x):
+
+        ecdf = ECDF()
+        stat, vals = ecdf(x)
+
+        sm_ecdf = smdist.empirical_distribution.ECDF(x)
+        assert_array_equal(vals, sm_ecdf.x)
+        assert_array_almost_equal(stat, sm_ecdf.y)
+
+    def test_invalid_stat(self, x):
+
+        with pytest.raises(ValueError, match="`stat` must be one of"):
+            ECDF(stat="density")

--- a/seaborn/tests/test_statistics.py
+++ b/seaborn/tests/test_statistics.py
@@ -418,7 +418,8 @@ class TestECDF(DistributionFixtures):
         ecdf = ECDF()
         stat, vals = ecdf(x, weights=weights)
         assert_array_equal(vals[1:], np.sort(x))
-        assert_array_almost_equal(stat[1:], weights[x.argsort()].cumsum() / weights.sum())
+        expected_stats = weights[x.argsort()].cumsum() / weights.sum()
+        assert_array_almost_equal(stat[1:], expected_stats)
         assert stat[0] == 0
 
     def test_univariate_count_weights(self, x, weights):

--- a/seaborn/tests/test_statistics.py
+++ b/seaborn/tests/test_statistics.py
@@ -449,3 +449,9 @@ class TestECDF(DistributionFixtures):
 
         with pytest.raises(ValueError, match="`stat` must be one of"):
             ECDF(stat="density")
+
+    def test_bivariate_error(self, x, y):
+
+        with pytest.raises(NotImplementedError, match="Bivariate ECDF"):
+            ecdf = ECDF()
+            ecdf(x, y)


### PR DESCRIPTION
This PR adds a new function in the distributions module, `ecdfplot`.

Simple example:

```python
sns.ecdfplot(diamonds, x="price", hue="cut")
```
![ecdf](https://user-images.githubusercontent.com/315810/84705271-26efef80-af29-11ea-94c5-252e4c1504db.png)

There's some motivation for it in #1536 
There was an initial attempt in #1621, but the overhaul to the distributions module made it unfortunately impossible to pull those commits into the history

There's really not too much to the implementation.

We could add more semantics than just `hue` fairly easily, but because the other distribution plots don't support them well, I have deferred for the moment. They can always be added later.

We could also do a bivariate ECDF plot. But I am not sure this is very useful. The main advantage of the ECDF over histogram/kde is that it lends itself better to comparing distributions. But that is less true in the bivariate case. Still nothing here blocks it from being added later.

## To do:

- [x] Unit tests for `ECDF` estimator
- [x] Unit tests for `ecdfplot` function
- [x] Docstring content
- [x] API examples
- [x] Release notes