### PR TITLE
MNT: fix some failures with matplotlib=3.3.0rc1

### DIFF
--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -357,12 +357,16 @@ class _CategoricalPlotter(object):
         if ylabel is not None:
             ax.set_ylabel(ylabel)
 
+        group_names = self.group_names
+        if not group_names:
+            group_names = ["" for _ in range(len(self.plot_data))]
+
         if self.orient == "v":
             ax.set_xticks(np.arange(len(self.plot_data)))
-            ax.set_xticklabels(self.group_names)
+            ax.set_xticklabels(group_names)
         else:
             ax.set_yticks(np.arange(len(self.plot_data)))
-            ax.set_yticklabels(self.group_names)
+            ax.set_yticklabels(group_names)
 
         if self.orient == "v":
             ax.xaxis.grid(False)

--- a/seaborn/miscplot.py
+++ b/seaborn/miscplot.py
@@ -1,7 +1,7 @@
 import numpy as np
 import matplotlib as mpl
 import matplotlib.pyplot as plt
-
+import matplotlib.ticker as ticker
 
 __all__ = ["palplot", "dogplot"]
 
@@ -24,8 +24,10 @@ def palplot(pal, size=1):
               interpolation="nearest", aspect="auto")
     ax.set_xticks(np.arange(n) - .5)
     ax.set_yticks([-.5, .5])
-    ax.set_xticklabels([])
-    ax.set_yticklabels([])
+    # Ensure nice border between colors
+    ax.set_xticklabels(["" for _ in range(n)])
+    # The proper way to set no ticks
+    ax.yaxis.set_major_locator(ticker.NullLocator())
 
 
 def dogplot(*_, **__):

--- a/seaborn/tests/test_matrix.py
+++ b/seaborn/tests/test_matrix.py
@@ -422,7 +422,10 @@ class TestHeatmap(object):
     def test_square_aspect(self):
 
         ax = mat.heatmap(self.df_norm, square=True)
-        nt.assert_equal(ax.get_aspect(), "equal")
+        obs_aspect = ax.get_aspect()
+        # mpl>3.3 returns 1 for setting "equal" aspect
+        # so test for the two possible equal outcomes
+        assert obs_aspect == "equal" or obs_aspect == 1
 
     def test_mask_validation(self):
 


### PR DESCRIPTION
Matplotlib 3.3.0rc1 has been released and results with several failing tests. This PR addresses some of them:

* FixedLocator now requires that `set_ticklabels()` inputs are equal to the number of ticks ([https://github.com/matplotlib/matplotlib/pull/17266](https://github.com/matplotlib/matplotlib/pull/17266)). This is an issue for `palplot` as well as categorical plots using unnamed groups, and fails several smoke tests and documentation examples. The proposed changes pass empty ticklabels in such cases (e.g. `[""]` instead of `[]`).

* `ax.get_aspect()` now returns `1` instead of `"equal"` when aspect was set to `"equal"` ([https://github.com/matplotlib/matplotlib/pull/16012](https://github.com/matplotlib/matplotlib/pull/16012)). "equal" aspect input is still valid. This affects matrix tests. The proposed change involves testing for both `"equal"` and `"1"` aspect values. 

Two remaining test failures are under investigation. While still unclear, these may not require seaborn code changes so I didn't include them here.