### PR TITLE
TST: Increase testing speed by utilizing multiple cores

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ install:
   - source activate testenv
   # Conda's matplotlib package pulls qt but this is not required for
   # non-interactive tests; use the compact matplotlib-base instead
-  - if [ $MPLBACKEND == "qtagg" ];
+  - if [ $MPLBACKEND == "qt5agg" ];
     then cat ci/deps_${DEPS}.txt ci/utils.txt > deps.txt;
     else cat ci/deps_${DEPS}.txt ci/utils.txt | sed 's/matplotlib$/matplotlib-base/' > deps.txt;
     fi
@@ -43,11 +43,6 @@ install:
 
 
 before_script:
-  - if [ $MPLBACKEND == "qtagg" ]; then
-    export DISPLAY=:99.0;
-    sh -e /etc/init.d/xvfb start;
-    sleep 3;
-    fi
   - python ci/cache_test_datasets.py
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,12 @@ before_install:
 install:
   - conda create -n testenv pip python=$PYTHON
   - source activate testenv
-  - cat ci/deps_${DEPS}.txt ci/utils.txt > deps.txt
+  # Conda's matplotlib package pulls qt but this is not required for
+  # non-interactive tests; use the compact matplotlib-base instead
+  - if [ $MPLBACKEND == "qtagg" ];
+    then cat ci/deps_${DEPS}.txt ci/utils.txt > deps.txt;
+    else cat ci/deps_${DEPS}.txt ci/utils.txt | sed 's/matplotlib$/matplotlib-base/' > deps.txt;
+    fi
   - conda install --file deps.txt
   - pip install .
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,7 @@ before_script:
     sh -e /etc/init.d/xvfb start;
     sleep 3;
     fi
+  - python ci/cache_test_datasets.py
 
 
 script:

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
 export SHELL := /bin/bash
 
 test:
-	pytest --doctest-modules seaborn
+	pytest -n auto --doctest-modules seaborn
 
 unittests:
-	pytest seaborn
+	pytest -n auto seaborn
 
 coverage:
-	pytest --doctest-modules --cov=seaborn --cov-config=.coveragerc seaborn
+	pytest -n auto --doctest-modules --cov=seaborn --cov-config=.coveragerc seaborn
 
 lint:
 	flake8 seaborn

--- a/ci/cache_test_datasets.py
+++ b/ci/cache_test_datasets.py
@@ -1,0 +1,19 @@
+"""
+Cache test datasets before running test suites to avoid
+race conditions to due tests parallelization
+"""
+import seaborn as sns
+
+datasets = (
+    "anscombe",
+    "attention",
+    "dots",
+    "exercise",
+    "flights",
+    "fmri",
+    "iris",
+    "planets",
+    "tips",
+    "titanic"
+)
+list(map(sns.load_dataset, datasets))

--- a/ci/utils.txt
+++ b/ci/utils.txt
@@ -1,4 +1,5 @@
 pytest!=5.3.4
 pytest-cov
+pytest-xdist
 flake8
 nose


### PR DESCRIPTION
pytest is capable of running multiple CPUs in parallel if `pytest-xdist` plugin is installed. This should improve tests speed on multi-core systems. Each Travis-CI process has 2 CPUs available and currently only one is utilized. This PR introduces multi-core testing, hopefully improving local and CI tests speed. On my 6-core system, the full test suit is completed in less than 60 seconds, compared to ~330 seconds using a single core.

To overcome race conditions on datasets pulls, I added a script to cache test datasets before actual running test suits. 

I also removed unnecessary qt pulls from non-interactive travis builds; this reduced ~1m from such travis builds. 