### PR TITLE
DOC: enable Sphinx rules for linking to GitHub issues, PRs and users

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -13,8 +13,6 @@
 
 import sys, os
 import sphinx_bootstrap_theme
-import matplotlib as mpl
-mpl.use("Agg")
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -39,7 +39,11 @@ extensions = [
     'matplotlib.sphinxext.plot_directive',
     'gallery_generator',
     'numpydoc',
+    'sphinx_issues',
 ]
+
+# Sphinx-issues configuration
+issues_github_path = 'mwaskom/seaborn'
 
 # Generate the API documentation when building
 autosummary_generate = True

--- a/doc/releases/v0.11.0.txt
+++ b/doc/releases/v0.11.0.txt
@@ -2,14 +2,14 @@
 v0.11.0 (Unreleased)
 --------------------
 
-- TODO stub for explaining improvements to variable specificiation. Make this good!  GH2017
+- TODO stub for explaining improvements to variable specificiation. Make this good! (:issue:`2052`).
 
-- TODO stub for enforced keyword-only arguments for most parameters of most functions and classes.  GH2052, GH2081
+- TODO stub for enforced keyword-only arguments for most parameters of most functions and classes (:issue:`2052,2081`).
 
 Modernization of distribution functions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-First, two new functions, :func:`histplot` and :func:`ecdfplot` has been added.
+First, two new functions, :func:`histplot` and :func:`ecdfplot` has been added (:pr:`2125`).
 
 :func:`histplot` draws univariate or bivariate histograms with a number of features, including:
 
@@ -17,13 +17,13 @@ First, two new functions, :func:`histplot` and :func:`ecdfplot` has been added.
 - normalization to show density, probability, or frequency statistics
 - flexible parameterization of bin size, including proper bins for discrete variables
 - adding a KDE fit to show a smoothed distribution over all bin statistics
-- experimental support for histograms over categorical and datetime variables. GH2125
+- experimental support for histograms over categorical and datetime variables. 
 
 :func:`ecdfplot` draws univariate empirical cumulative distribution functions, using a similar interface.
 
-Second, the existing functions :func:`kdeplot` and :func:`rugplot` have been completely overhauled. Two of the oldest functions in the library, these lacked aspects of the otherwise-common seaborn API, such as the ability to assign variables by name from a ``data`` object; they had no capacity for semantic mapping; and they had numerous other inconsistencies and smaller issues.
+Second, the existing functions :func:`kdeplot` and :func:`rugplot` have been completely overhauled (see :pr:`2060,2104`). Two of the oldest functions in the library, these lacked aspects of the otherwise-common seaborn API, such as the ability to assign variables by name from a ``data`` object; they had no capacity for semantic mapping; and they had numerous other inconsistencies and smaller issues.
 
-The overhauled functions now share a common API with the rest of seaborn, they can show conditional distributions by mapping a third variable with a ``hue`` semantic, and have been improved in numerous other ways. The `github pull request (GH2104) <https://github.com/mwaskom/seaborn/pull/2104>`_ has a longer explanation of the changes and the motivation behind them.
+The overhauled functions now share a common API with the rest of seaborn, they can show conditional distributions by mapping a third variable with a ``hue`` semantic, and have been improved in numerous other ways. The github pull request (:pr:`2104`) has a longer explanation of the changes and the motivation behind them.
 
 This is a necessarily API-breaking change. The parameter names for the positional variables
 are now ``x`` and ``y``, and the old names have been deprecated. Efforts were made to handle and warn when using the deprecated API, but it is strongly suggested to check your plots carefully.
@@ -39,34 +39,34 @@ Other new features include:
 - log-space density estimation (using the new ``log_scale`` parameter, or by scaling the data axis before plotting)
 - "bivariate" rug plots with a single function call (by assigning both ``x`` and ``y``)
 
-GH2060, GH2104
+
 
 Other
 ~~~~~
 
-- Changed how functions that use different representations for numeric and categorical data handle vectors with an `object` data type. Previously, data was considered numeric if it could be coerced to a float representation without error. Now, object-typed vectors are considered numeric only when their contents are themselves numeric. As a consequence, numbers that are encoded as strings will now be treated as categorical data.  GH2084
+- Changed how functions that use different representations for numeric and categorical data handle vectors with an `object` data type (:pr:`2084`). Previously, data was considered numeric if it could be coerced to a float representation without error. Now, object-typed vectors are considered numeric only when their contents are themselves numeric. As a consequence, numbers that are encoded as strings will now be treated as categorical data. 
 
-- Plots with a ``style`` semantic can now generate an infinite number of unique dashes and/or markers by default. Prevously, an error would be raised if the ``style`` variable had more levels than could be mapped using the default lists. The existing defaults were slightly modified as part of this change; if you need to exactly reproduce plots from earlier versions, refer to the `old defaults <https://github.com/mwaskom/seaborn/blob/v0.10.1/seaborn/relational.py#L24>`_. GH2075
+- Plots with a ``style`` semantic can now generate an infinite number of unique dashes and/or markers by default (:pr:`2075`). Prevously, an error would be raised if the ``style`` variable had more levels than could be mapped using the default lists. The existing defaults were slightly modified as part of this change; if you need to exactly reproduce plots from earlier versions, refer to the `old defaults <https://github.com/mwaskom/seaborn/blob/v0.10.1/seaborn/relational.py#L24>`_.
 
-- Fixed a few issues with :func:`boxenplot` regarding the way the number of boxes are calculated. `k_depth="tukey"` is now the default boxes calculation method as the previous default (`"proportion"`) produces too many boxes when datasets are small. Added the option to specify the desired number of boxes as a scalar (e.g. `k_depth=6`) or just plot boxes that will cover most of the data points (with `k_depth="full"`). Added a new parameter `trust_alpha` to control the number of boxes when `k_depth="trustworthy"`. Additionally, the visual appearance of :func:`boxenplot` now more closely resembles :func:`boxplot`, and thin boxes will remain visible when the edges are white. Finally, the ``lvplot`` function (the previously-deprecated name for :func:`boxenplot`) has been removed. GH2086
+- Fixed a few issues with :func:`boxenplot` regarding the way the number of boxes are calculated. `k_depth="tukey"` is now the default boxes calculation method as the previous default (`"proportion"`) produces too many boxes when datasets are small. Added the option to specify the desired number of boxes as a scalar (e.g. `k_depth=6`) or just plot boxes that will cover most of the data points (with `k_depth="full"`). Added a new parameter `trust_alpha` to control the number of boxes when `k_depth="trustworthy"`. Additionally, the visual appearance of :func:`boxenplot` now more closely resembles :func:`boxplot`, and thin boxes will remain visible when the edges are white. Finally, the ``lvplot`` function (the previously-deprecated name for :func:`boxenplot`) has been removed. For more information see :pr:`2086`.
 
-- Added a ``tight_layout`` method to :class:`FacetGrid` and :class:`PairGrid`, which runs the :func:`matplotlib.pyplot.tight_layout` algorithm without interference from the external legend. GH2073
+- Added a ``tight_layout`` method to :class:`FacetGrid` and :class:`PairGrid`, which runs the :func:`matplotlib.pyplot.tight_layout` algorithm without interference from the external legend (:pr:`2073`).
 
-- Changed how :func:`scatterplot` sets the default linewidth for the edges of the scatter points. New behaviot is to scale with the point sizes themselves (on a plot-wise, not point-wise basis). This change also slightly reduces the default width when point sizes are not varied. Set ``linewidth=0.75`` to repoduce the previous behavior. GH2078
+- Changed how :func:`scatterplot` sets the default linewidth for the edges of the scatter points (:pr:`2078`). New behaviot is to scale with the point sizes themselves (on a plot-wise, not point-wise basis). This change also slightly reduces the default width when point sizes are not varied. Set ``linewidth=0.75`` to repoduce the previous behavior.
 
-- Adapted to a change in matplotlib that prevented passing vectors of literal values to ``c`` and ``s`` in :func:`scatterplot`.  GH2079
+- Adapted to a change in matplotlib that prevented passing vectors of literal values to ``c`` and ``s`` in :func:`scatterplot` (:pr:`2079`).
 
-- Added an explicit warning in :func:`swarmplot` when more than 2% of the points overlap in the "gutters" of the swarm. GH2045
+- Added an explicit warning in :func:`swarmplot` when more than 2% of the points overlap in the "gutters" of the swarm (:pr:`2045`).
 
-- Added the ``axes_dict`` attribute to :class:`FacetGrid` for named access to the component axes.  GH2046
+- Added the ``axes_dict`` attribute to :class:`FacetGrid` for named access to the component axes (:pr:`2046`).
 
-- Made :meth:`FacetGrid.set_axis_labels` clear labels from "interior" axes.  GH2046
+- Made :meth:`FacetGrid.set_axis_labels` clear labels from "interior" axes (:pr:`2046`).
 
-- Improved :meth:`FacetGrid.set_titles` with `margin titles=True`, such that texts representing the original row titles are removed before adding new ones. GH2083
+- Improved :meth:`FacetGrid.set_titles` with `margin titles=True`, such that texts representing the original row titles are removed before adding new ones (:pr:`2083`).
 
-- Improved support for datetime variables in :func:`scatterplot` and :func:`lineplot`. GH2138
+- Improved support for datetime variables in :func:`scatterplot` and :func:`lineplot` (:pr:`2138`). 
 
-- Fixed a bug where :func:`lineplot` did not pass the ``linestyle`` parameter down to matplotlib. GH2095
+- Fixed a bug where :func:`lineplot` did not pass the ``linestyle`` parameter down to matplotlib (:pr:`2095`).
 
 - Improved the error messages produced when categorical plots process the orientation parameter.
 

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -3,3 +3,4 @@ sphinx_bootstrap_theme==0.6.5  # Later versions mess up the css somehow
 numpydoc
 nbconvert
 ipykernel
+sphinx-issues


### PR DESCRIPTION
This PR adds the ability to easily link to GitHub issues, PRs and users (e.g. for release notes), to easily provide broader context and credit. This is achieved by adding `sphinx-issues` extension (as done in scikit-learn, see [here](https://github.com/sloria/sphinx-issues)). Rules examples:
- ``:issue:`2062` `` links to #2062 
- ``:issue:`2052,2081` `` will link to both issues
- ``:pr:`2151` `` links to PR #2151
- ``:user:`MaozGelbart` `` links to user @MaozGelbart 

It can also link to other repos: ``:issue:`user/repo#12345` `` 

This PR also removes what seems like an unnecessary matplotlib import from sphinx conf file ('agg' is already the default backend in modern matplotlibs)

Closes #2062 

