### PR TITLE
adding option for parametric (t-based) confidence intervals

### DIFF
--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -1483,8 +1483,9 @@ class _CategoricalStatPlotter(_CategoricalPlotter):
 
                     elif type(ci) == tuple and ci[0] == "parametric":
 
-                        confint.append(stats.t.interval(ci[1]/100, len(stat_data)-1,
-                            loc=estimator(stat_data), scale=stats.sem(stat_data)))
+                        confint.append(stats.t.interval(ci[1] / 100, len(stat_data) - 1,
+                                                        loc=estimator(stat_data),
+                                                        scale=stats.sem(stat_data)))
 
                     else:
 
@@ -1539,8 +1540,10 @@ class _CategoricalStatPlotter(_CategoricalPlotter):
 
                         elif type(ci) == tuple and ci[0] == "parametric":
 
-                            confint[i].append(stats.t.interval(ci[1]/100, len(stat_data)-1,
-                                loc=estimator(stat_data), scale=stats.sem(stat_data)))
+                            confint[i].append(stats.t.interval(ci[1] / 100,
+                                              len(stat_data) - 1,
+                                              loc=estimator(stat_data),
+                                              scale=stats.sem(stat_data)))
 
                         else:
 
@@ -2123,9 +2126,10 @@ _categorical_docs = dict(
         Size of confidence intervals to draw around estimated values.  If
         "sd", skip bootstrapping and draw the standard deviation of the
         observations. If ``None``, no bootstrapping will be performed, and
-        error bars will not be drawn. If 2-element tuple with first element "parametric",
-        then skip bootstrapping and draw a parametric sample confidence interval based on
-        Student's T distribution. Size of the interval is determined by ``ci[1]`` in that case.
+        error bars will not be drawn. If 2-element tuple with first element
+        "parametric", then skip bootstrapping and draw a parametric sample
+        confidence interval based on Student's T distribution. Size of the interval
+        is determined by ``ci[1]`` in that case.
     n_boot : int, optional
         Number of bootstrap iterations to use when computing confidence
         intervals.

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -2119,11 +2119,13 @@ _categorical_docs = dict(
     stat_api_params=dedent("""\
     estimator : callable that maps vector -> scalar, optional
         Statistical function to estimate within each categorical bin.
-    ci : float or "sd" or None, optional
+    ci : float or "sd" or tuple ("parametric", ci_val<float>) or None, optional
         Size of confidence intervals to draw around estimated values.  If
         "sd", skip bootstrapping and draw the standard deviation of the
         observations. If ``None``, no bootstrapping will be performed, and
-        error bars will not be drawn.
+        error bars will not be drawn. If 2-element tuple with first element "parametric",
+        then skip bootstrapping and draw a parametric sample confidence interval based on
+        Student's T distribution. Size of the interval is determined by ``ci[1]`` in that case.
     n_boot : int, optional
         Number of bootstrap iterations to use when computing confidence
         intervals.

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -1481,6 +1481,11 @@ class _CategoricalStatPlotter(_CategoricalPlotter):
                         sd = np.std(stat_data)
                         confint.append((estimate - sd, estimate + sd))
 
+                    elif type(ci) == tuple and ci[0] == "parametric":
+
+                        confint.append(stats.t.interval(ci[1]/100, len(stat_data)-1,
+                            loc=estimator(stat_data), scale=stats.sem(stat_data)))
+
                     else:
 
                         boots = bootstrap(stat_data, func=estimator,
@@ -1531,6 +1536,11 @@ class _CategoricalStatPlotter(_CategoricalPlotter):
                             estimate = estimator(stat_data)
                             sd = np.std(stat_data)
                             confint[i].append((estimate - sd, estimate + sd))
+
+                        elif type(ci) == tuple and ci[0] == "parametric":
+
+                            confint[i].append(stats.t.interval(ci[1]/100, len(stat_data)-1,
+                                loc=estimator(stat_data), scale=stats.sem(stat_data)))
 
                         else:
 


### PR DESCRIPTION
In some common cases (e.g. for comparison with other statistics and plots) it is desirable to display parametric confidence intervals, typically based on a T-distribution. Usually, these will be very similar to the bootstrapped CI, but I think it's good to have the option for exact parametric intervals as well. This PR adds this functionality.

Currently there is no option for `ci_estimator` or so, and I thought implementing such a thing would be too big an API overhaul without discussing. I think the following is a lightweight enough option that it might be useful to many:

```python

sns.pointplot(data, ci=("parametric", 95))
```

for a parametric CI. This is how the current PR exposes the functionality.