### PR TITLE
remove magic number in examples

### DIFF
--- a/examples/faceted_lineplot.py
+++ b/examples/faceted_lineplot.py
@@ -13,7 +13,7 @@ dots = sns.load_dataset("dots")
 # Define a palette to ensure that colors will be
 # shared across the facets
 palette = dict(zip(dots.coherence.unique(),
-                   sns.color_palette("rocket_r", 6)))
+                   sns.color_palette("rocket_r", len(dots.coherence.unique()))))
 
 # Plot the lines on two facets
 sns.relplot(x="time", y="firing_rate",


### PR DESCRIPTION
in the faceted lineplot example, the number of lines used for palette definition should not be a magic number. Instead, it should be derived from from the dataset itself via len(). This makes it easier to understand the example without knowledge of the underlying dataset.