### PR TITLE
Fix object-typed numeric hue/size input to relational plots

### DIFF
--- a/seaborn/conftest.py
+++ b/seaborn/conftest.py
@@ -196,6 +196,15 @@ def missing_df(rng, long_df):
 
 
 @pytest.fixture
+def object_df(rng, long_df):
+
+    df = long_df.copy()
+    # objectify numeric columns
+    for col in ["c", "s", "f"]:
+        df[col] = df[col].astype(object)
+    return df
+
+@pytest.fixture
 def null_series():
 
     return pd.Series(index=np.arange(20), dtype='float64')

--- a/seaborn/relational.py
+++ b/seaborn/relational.py
@@ -70,7 +70,7 @@ class _RelationalPlotter(VectorPlotter):
                 locator = mpl.ticker.MaxNLocator(nbins=3)
             limits = min(self._hue_map.levels), max(self._hue_map.levels)
             hue_levels, hue_formatted_levels = locator_to_legend_entries(
-                locator, limits, self.plot_data["hue"].dtype
+                locator, limits, self.plot_data["hue"].infer_objects().dtype
             )
         elif self._hue_map.levels is None:
             hue_levels = hue_formatted_levels = []
@@ -99,7 +99,7 @@ class _RelationalPlotter(VectorPlotter):
             # Define the min/max data values
             limits = min(self._size_map.levels), max(self._size_map.levels)
             size_levels, size_formatted_levels = locator_to_legend_entries(
-                locator, limits, self.plot_data["size"].dtype
+                locator, limits, self.plot_data["size"].infer_objects().dtype
             )
         elif self._size_map.levels is None:
             size_levels = size_formatted_levels = []

--- a/seaborn/tests/test_relational.py
+++ b/seaborn/tests/test_relational.py
@@ -1241,7 +1241,7 @@ class TestLinePlotter(Helpers):
         wide_df, wide_array,
         wide_list_of_series, wide_list_of_arrays, wide_list_of_lists,
         flat_array, flat_series, flat_list,
-        long_df, missing_df
+        long_df, missing_df, object_df
     ):
 
         f, ax = plt.subplots()
@@ -1313,6 +1313,15 @@ class TestLinePlotter(Helpers):
         ax.clear()
 
         lineplot(x="x", y="y", hue="a", size="s", data=missing_df)
+        ax.clear()
+
+        lineplot(x="x", y="y", hue="f", data=object_df)
+        ax.clear()
+
+        lineplot(x="x", y="y", hue="c", size="f", data=object_df)
+        ax.clear()
+
+        lineplot(x="x", y="y", hue="f", size="s", data=object_df)
         ax.clear()
 
 
@@ -1678,7 +1687,7 @@ class TestScatterPlotter(Helpers):
         wide_df, wide_array,
         flat_series, flat_array, flat_list,
         wide_list_of_series, wide_list_of_arrays, wide_list_of_lists,
-        long_df, missing_df
+        long_df, missing_df, object_df
     ):
 
         f, ax = plt.subplots()
@@ -1747,4 +1756,13 @@ class TestScatterPlotter(Helpers):
         ax.clear()
 
         scatterplot(x="x", y="y", hue="a", size="s", data=missing_df)
+        ax.clear()
+
+        scatterplot(x="x", y="y", hue="f", data=object_df)
+        ax.clear()
+
+        scatterplot(x="x", y="y", hue="c", size="f", data=object_df)
+        ax.clear()
+
+        scatterplot(x="x", y="y", hue="f", size="s", data=object_df)
         ax.clear()


### PR DESCRIPTION
Fixes #2101 by inferring the underlying numeric data type using pandas' `infer_objects()`.