### PR TITLE
Handle matplotlib==3.3 deprecations

### DIFF
--- a/seaborn/_core.py
+++ b/seaborn/_core.py
@@ -5,6 +5,7 @@ from functools import partial
 from collections.abc import Iterable, Sequence, Mapping
 from numbers import Number
 from datetime import datetime
+from distutils.version import LooseVersion
 
 import numpy as np
 import pandas as pd
@@ -1006,7 +1007,10 @@ class VectorPlotter:
                     if scale is True:
                         set_scale("log")
                     else:
-                        set_scale("log", **{f"base{axis}": scale})
+                        if LooseVersion(mpl.__version__) >= "3.3":
+                            set_scale("log", **{"base": scale})
+                        else:
+                            set_scale("log", **{f"base{axis}": scale})
 
         self.ax = ax
 

--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -298,9 +298,14 @@ class _HeatMapper(object):
         # Remove all the Axes spines
         despine(ax=ax, left=True, bottom=True)
 
+        # setting vmin/vmax in addition to norm is deprecated
+        # so avoid setting if norm is set
+        if "norm" not in kws:
+            kws.setdefault("vmin", self.vmin)
+            kws.setdefault("vmax", self.vmax)
+
         # Draw the heatmap
-        mesh = ax.pcolormesh(self.plot_data, vmin=self.vmin, vmax=self.vmax,
-                             cmap=self.cmap, **kws)
+        mesh = ax.pcolormesh(self.plot_data, cmap=self.cmap, **kws)
 
         # Set the axis limits
         ax.set(xlim=(0, self.data.shape[1]), ylim=(0, self.data.shape[0]))


### PR DESCRIPTION
* Adapts to a recent change in matplotlib where `basex/basey` parameters of `axis.set_scale` are now just `base`.
* Adapts to another change affecting `heatmap` where passing `norm` to `ax.pcolormesh` accompanied with `vmin/vmax` is deprecated. `norm` is not a `heatmap` parameter, so this PR avoids setting `vmin/vmax` if `norm` is given as a kwarg.