### PR TITLE
Support wide data with categorical columns

### DIFF
--- a/seaborn/distributions.py
+++ b/seaborn/distributions.py
@@ -95,8 +95,8 @@ class _DistributionPlotter(VectorPlotter):
 
     semantics = "x", "y", "hue", "weights"
 
-    wide_structure = {"x": "values", "hue": "columns"}
-    flat_structure = {"x": "values"}
+    wide_structure = {"x": "@values", "hue": "@columns"}
+    flat_structure = {"x": "@values"}
 
     def __init__(
         self,

--- a/seaborn/relational.py
+++ b/seaborn/relational.py
@@ -184,7 +184,7 @@ _param_docs = DocstringComponents.from_nested_components(
 class _RelationalPlotter(VectorPlotter):
 
     wide_structure = {
-        "x": "index", "y": "values", "hue": "columns", "style": "columns",
+        "x": "@index", "y": "@values", "hue": "@columns", "style": "@columns",
     }
 
     # TODO where best to define default parameters?

--- a/seaborn/tests/test_core.py
+++ b/seaborn/tests/test_core.py
@@ -599,6 +599,12 @@ class TestVectorPlotter:
     # TODO note that most of the other tests that excercise the core
     # variable assignment code still live in test_relational
 
+    def test_wide_categorical_columns(self, wide_df):
+
+        wide_df.columns = pd.CategoricalIndex(wide_df.columns)
+        p = VectorPlotter(data=wide_df)
+        assert_array_equal(p.plot_data["hue"].unique(), ["a", "b", "c"])
+
     def test_iter_data_quantitites(self, long_df):
 
         p = VectorPlotter(


### PR DESCRIPTION
Previously this would fail:

```python
flights = sns.load_dataset("flights")
flights_wide = flights.pivot("year", "month", "passengers")
sns.lineplot(data=flights_wide)
```
![image](https://user-images.githubusercontent.com/315810/90537198-058aca00-e14b-11ea-9365-278b9b322f9f.png)

Also changes the (internal) wide structure spec to use `@columns`, `@index`, `@values` to decrease chance of collisions with actual dataframe keys.