### PR TITLE
Improve variable assignment feedback

### DIFF
--- a/seaborn/_core.py
+++ b/seaborn/_core.py
@@ -708,10 +708,15 @@ class VectorPlotter:
             the inputs (or None when no name can be determined).
 
         """
-        # TODO raise here if any kwarg values are not None,
-        # # if we decide for "structure-only" wide API
+        # Raise if semantic or other variables are assigned in wide-form mode
+        assigned = [k for k, v in kwargs.items() if v is not None]
+        if any(assigned):
+            s = "s" if len(assigned) > 1 else ""
+            err = f"The following variable{s} cannot be assigned with wide-form data: "
+            err += ", ".join(f"`{v}`" for v in assigned)
+            raise ValueError(err)
 
-        # First, determine if the data object actually has any data in it
+        # Determine if the data object actually has any data in it
         empty = data is None or not len(data)
 
         # Then, determine if we have "flat" data (a single vector)

--- a/seaborn/_core.py
+++ b/seaborn/_core.py
@@ -889,14 +889,26 @@ class VectorPlotter:
                     variables[key] = val
                 else:
                     # We don't know what this name means
-                    err = f"Could not interpret input '{val}'"
+                    err = f"Could not interpret value `{val}` for parameter `{key}`"
                     raise ValueError(err)
 
             else:
 
                 # Otherwise, assume the value is itself a vector of data
-                # TODO check for 1D here or let pd.DataFrame raise?
+
+                # Raise when data is present and a vector can't be combined with it
+                if isinstance(data, pd.DataFrame) and not isinstance(val, pd.Series):
+                    if val is not None and len(data) != len(val):
+                        val_cls = val.__class__.__name__
+                        err = (
+                            f"Length of {val_cls} vectors must match length of `data`"
+                            f" when both are used, but `data` has length {len(data)}"
+                            f" and the vector passed to `{key}` has length {len(val)}."
+                        )
+                        raise ValueError(err)
+
                 plot_data[key] = val
+
                 # Try to infer the name of the variable
                 variables[key] = getattr(val, "name", None)
 

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -45,7 +45,7 @@ class _CategoricalPlotter(object):
 
             # Do a sanity check on the inputs
             if hue is not None:
-                error = "Cannot use `hue` without `x` or `y`"
+                error = "Cannot use `hue` without `x` and `y`"
                 raise ValueError(error)
 
             # No hue grouping with wide inputs

--- a/seaborn/conftest.py
+++ b/seaborn/conftest.py
@@ -197,6 +197,6 @@ def missing_df(rng, long_df):
 
 
 @pytest.fixture
-def null_series():
+def null_series(flat_series):
 
-    return pd.Series(index=np.arange(20), dtype='float64')
+    return pd.Series(index=flat_series.index, dtype='float64')

--- a/seaborn/tests/test_core.py
+++ b/seaborn/tests/test_core.py
@@ -599,6 +599,12 @@ class TestVectorPlotter:
     # TODO note that most of the other tests that excercise the core
     # variable assignment code still live in test_relational
 
+    def test_wide_semantic_error(self, wide_df):
+
+        err = "The following variable cannot be assigned with wide-form data: `hue`"
+        with pytest.raises(ValueError, match=err):
+            VectorPlotter(data=wide_df, variables={"hue": "a"})
+
     def test_wide_categorical_columns(self, wide_df):
 
         wide_df.columns = pd.CategoricalIndex(wide_df.columns)

--- a/seaborn/tests/test_core.py
+++ b/seaborn/tests/test_core.py
@@ -78,9 +78,9 @@ class TestHueMapping:
         assert p._hue_map.palette == palette
         assert p._hue_map.levels == hue_order
 
-    def test_hue_map_null(self, long_df, null_series):
+    def test_hue_map_null(self, flat_series, null_series):
 
-        p = VectorPlotter(variables=dict(hue=null_series))
+        p = VectorPlotter(variables=dict(x=flat_series, hue=null_series))
         m = HueMapping(p)
         assert m.levels is None
         assert m.map_type is None
@@ -341,9 +341,9 @@ class TestSizeMapping:
         assert p._size_map.lookup_table == dict(zip(size_order, sizes))
         assert p._size_map.levels == size_order
 
-    def test_size_map_null(self, long_df, null_series):
+    def test_size_map_null(self, flat_series, null_series):
 
-        p = VectorPlotter(variables=dict(size=null_series))
+        p = VectorPlotter(variables=dict(x=flat_series, size=null_series))
         m = HueMapping(p)
         assert m.levels is None
         assert m.map_type is None
@@ -482,9 +482,9 @@ class TestStyleMapping:
         assert p._style_map.levels == style_order
         assert p._style_map(style_order, "marker") == markers
 
-    def test_style_map_null(self, long_df, null_series):
+    def test_style_map_null(self, flat_series, null_series):
 
-        p = VectorPlotter(variables=dict(style=null_series))
+        p = VectorPlotter(variables=dict(x=flat_series, style=null_series))
         m = HueMapping(p)
         assert m.levels is None
         assert m.map_type is None

--- a/seaborn/tests/test_core.py
+++ b/seaborn/tests/test_core.py
@@ -596,7 +596,7 @@ class TestVectorPlotter:
         assert p.variables["x"] == expected_x_name
         assert p.variables["y"] == expected_y_name
 
-    # TODO note that most of the other tests that excercise the core
+    # TODO note that most of the other tests that exercise the core
     # variable assignment code still live in test_relational
 
     def test_wide_semantic_error(self, wide_df):
@@ -604,6 +604,18 @@ class TestVectorPlotter:
         err = "The following variable cannot be assigned with wide-form data: `hue`"
         with pytest.raises(ValueError, match=err):
             VectorPlotter(data=wide_df, variables={"hue": "a"})
+
+    def test_long_unknown_error(self, long_df):
+
+        err = "Could not interpret value `what` for parameter `hue`"
+        with pytest.raises(ValueError, match=err):
+            VectorPlotter(data=long_df, variables={"x": "x", "hue": "what"})
+
+    def test_long_unmatched_size_error(self, long_df, flat_array):
+
+        err = "Length of ndarray vectors must match length of `data`"
+        with pytest.raises(ValueError, match=err):
+            VectorPlotter(data=long_df, variables={"x": "x", "hue": flat_array})
 
     def test_wide_categorical_columns(self, wide_df):
 

--- a/seaborn/tests/test_distributions.py
+++ b/seaborn/tests/test_distributions.py
@@ -2018,9 +2018,10 @@ class TestDisPlot:
         if ax.legend_ is not None:
             self.assert_legends_equal(ax.legend_, g._legend)
 
-        long_df["_"] = "_"
-        g2 = displot(long_df, col="_", **kwargs)
-        self.assert_plots_equal(ax, g2.ax)
+        if kwargs:
+            long_df["_"] = "_"
+            g2 = displot(long_df, col="_", **kwargs)
+            self.assert_plots_equal(ax, g2.ax)
 
     @pytest.mark.parametrize(
         "kwargs", [
@@ -2050,9 +2051,10 @@ class TestDisPlot:
         if ax.legend_ is not None:
             self.assert_legends_equal(ax.legend_, g._legend)
 
-        long_df["_"] = "_"
-        g2 = displot(long_df, kind="kde", col="_", **kwargs)
-        self.assert_plots_equal(ax, g2.ax)
+        if kwargs:
+            long_df["_"] = "_"
+            g2 = displot(long_df, kind="kde", col="_", **kwargs)
+            self.assert_plots_equal(ax, g2.ax)
 
     @pytest.mark.parametrize(
         "kwargs", [
@@ -2077,9 +2079,10 @@ class TestDisPlot:
         if ax.legend_ is not None:
             self.assert_legends_equal(ax.legend_, g._legend)
 
-        long_df["_"] = "_"
-        g2 = displot(long_df, kind="ecdf", col="_", **kwargs)
-        self.assert_plots_equal(ax, g2.ax)
+        if kwargs:
+            long_df["_"] = "_"
+            g2 = displot(long_df, kind="ecdf", col="_", **kwargs)
+            self.assert_plots_equal(ax, g2.ax)
 
     @pytest.mark.parametrize(
         "kwargs", [


### PR DESCRIPTION
- Adds an error message when assigning semantics with wide-form data
- Improves the error message when mixing a `DataFrame` and non-`Series` vector and the lengths don't match
- Improves the error message when a key cannot be parsed with long-form data


Closes #2082
