### PR TITLE
Address various warnings raised within the tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,7 @@
 [pytest]
 filterwarnings =
-;   Warnings raised from within pytest itself
+;   Warnings raised from within patsy imports
     ignore:Using or importing the ABCs:DeprecationWarning
+;   Warnings raised from nose utils (can be removed after nose is dropped)
     ignore:the imp module is deprecated in favour of importlib
 junit_family=xunit1

--- a/seaborn/_core.py
+++ b/seaborn/_core.py
@@ -723,7 +723,7 @@ class VectorPlotter:
         if isinstance(data, dict):
             values = data.values()
         else:
-            values = np.atleast_1d(data)
+            values = np.atleast_1d(np.asarray(data, dtype=object))
         flat = not any(
             isinstance(v, Iterable) and not isinstance(v, (str, bytes))
             for v in values

--- a/seaborn/_core.py
+++ b/seaborn/_core.py
@@ -1012,14 +1012,18 @@ class VectorPlotter:
         if not hasattr(self, "ax"):
             # Probably a good idea, but will need a bunch of tests updated
             # Most of these tests should just use the external interface
-            # Then this can be reeneabled.
+            # Then this can be re-enabled.
             # raise AttributeError("No Axes attached to plotter")
             return self.plot_data
 
         if not hasattr(self, "_comp_data"):
 
-            comp_data = self.plot_data.copy(deep=False)
-            for var in "xy":
+            comp_data = (
+                self.plot_data
+                .copy(deep=False)
+                .drop(["x", "y"], axis=1, errors="ignore")
+            )
+            for var in "yx":
                 if var not in self.variables:
                     continue
 
@@ -1038,7 +1042,7 @@ class VectorPlotter:
                 comp_var = axis.convert_units(self.plot_data[var])
                 if axis.get_scale() == "log":
                     comp_var = np.log10(comp_var)
-                comp_data[var] = comp_var
+                comp_data.insert(0, var, comp_var)
 
             self._comp_data = comp_data
 

--- a/seaborn/algorithms.py
+++ b/seaborn/algorithms.py
@@ -96,11 +96,10 @@ def _structured_bootstrap(args, n_boot, units, func, func_kwargs, integers):
     boot_dist = []
     for i in range(int(n_boot)):
         resampler = integers(0, n_units, n_units, dtype=np.intp)
-        sample = [np.take(a, resampler, axis=0) for a in args]
+        sample = [[a[i] for i in resampler] for a in args]
         lengths = map(len, sample[0])
         resampler = [integers(0, n, n, dtype=np.intp) for n in lengths]
-        sample = [[c.take(r, axis=0) for c, r in zip(a, resampler)]
-                  for a in sample]
+        sample = [[c.take(r, axis=0) for c, r in zip(a, resampler)] for a in sample]
         sample = list(map(np.concatenate, sample))
         boot_dist.append(func(*sample, **func_kwargs))
     return np.array(boot_dist)

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -960,6 +960,8 @@ class FacetGrid(Grid):
     def set_xticklabels(self, labels=None, step=None, **kwargs):
         """Set x axis tick labels of the grid."""
         for ax in self.axes.flat:
+            curr_ticks = ax.get_xticks()
+            ax.set_xticks(curr_ticks)
             if labels is None:
                 curr_labels = [l.get_text() for l in ax.get_xticklabels()]
                 if step is not None:
@@ -974,6 +976,8 @@ class FacetGrid(Grid):
     def set_yticklabels(self, labels=None, **kwargs):
         """Set y axis tick labels on the left column of the grid."""
         for ax in self.axes.flat:
+            curr_ticks = ax.get_yticks()
+            ax.set_yticks(curr_ticks)
             if labels is None:
                 curr_labels = [l.get_text() for l in ax.get_yticklabels()]
                 ax.set_yticklabels(curr_labels, **kwargs)

--- a/seaborn/tests/test_axisgrid.py
+++ b/seaborn/tests/test_axisgrid.py
@@ -496,12 +496,14 @@ class TestFacetGrid(object):
 
         g = ag.FacetGrid(self.df, row="a", col="b")
         g.map(plt.plot, "x", "y")
-        xlab = [l.get_text() + "h" for l in g.axes[1, 0].get_xticklabels()]
-        ylab = [l.get_text() for l in g.axes[1, 0].get_yticklabels()]
+
+        ax = g.axes[-1, 0]
+        xlab = [l.get_text() + "h" for l in ax.get_xticklabels()]
+        ylab = [l.get_text() + "i" for l in ax.get_yticklabels()]
 
         g.set_xticklabels(xlab)
         g.set_yticklabels(ylab)
-        got_x = [l.get_text() for l in g.axes[1, 1].get_xticklabels()]
+        got_x = [l.get_text() for l in g.axes[-1, 1].get_xticklabels()]
         got_y = [l.get_text() for l in g.axes[0, 0].get_yticklabels()]
         npt.assert_array_equal(got_x, xlab)
         npt.assert_array_equal(got_y, ylab)

--- a/seaborn/tests/test_categorical.py
+++ b/seaborn/tests/test_categorical.py
@@ -78,7 +78,8 @@ class TestCategoricalPlotter(CategoricalFixture):
 
         # Test an object array that looks 1D but isn't
         x_notreally_1d = np.array([self.x.ravel(),
-                                   self.x.ravel()[:int(self.n_total / 2)]])
+                                   self.x.ravel()[:int(self.n_total / 2)]],
+                                  dtype=object)
         p.establish_variables(data=x_notreally_1d)
         nt.assert_equal(len(p.plot_data), 2)
         nt.assert_equal(len(p.plot_data[0]), self.n_total)
@@ -2632,12 +2633,15 @@ class TestBoxenPlotter(CategoricalFixture):
         return np.percentile(data, q)
 
     def test_box_ends_finite(self):
+
         p = cat._LVPlotter(**self.default_kws)
         p.establish_variables("g", "y", data=self.df)
-        box_k = np.asarray([[b, k]
-                           for b, k in map(p._lv_box_ends, p.plot_data)])
-        box_ends = box_k[:, 0]
-        k_vals = box_k[:, 1]
+        box_ends = []
+        k_vals = []
+        for s in p.plot_data:
+            b, k = p._lv_box_ends(s)
+            box_ends.append(b)
+            k_vals.append(k)
 
         # Check that all the box ends are finite and are within
         # the bounds of the data

--- a/seaborn/tests/test_core.py
+++ b/seaborn/tests/test_core.py
@@ -1001,7 +1001,7 @@ class TestVectorPlotter:
 
     def test_comp_data_log(self, long_df):
 
-        p = VectorPlotter(data=long_df, variables={"x": "x", "y": "y"})
+        p = VectorPlotter(data=long_df, variables={"x": "z", "y": "y"})
         _, ax = plt.subplots()
         p._attach(ax, log_scale=(True, False))
 

--- a/seaborn/tests/test_distributions.py
+++ b/seaborn/tests/test_distributions.py
@@ -889,6 +889,9 @@ class TestKDEPlotBivariate:
     )
     def test_weights(self, rng):
 
+        import warnings
+        warnings.simplefilter("error", np.VisibleDeprecationWarning)
+
         n = 100
         x, y = rng.multivariate_normal([1, 3], [(.2, .5), (.5, 2)], n).T
         hue = np.repeat([0, 1], n // 2)
@@ -899,8 +902,10 @@ class TestKDEPlotBivariate:
         kdeplot(x=x, y=y, hue=hue, weights=weights, ax=ax2)
 
         for c1, c2 in zip(ax1.collections, ax2.collections):
-            if c1.get_segments():
-                assert not np.array_equal(c1.get_segments(), c2.get_segments())
+            if c1.get_segments() and c2.get_segments():
+                seg1 = np.concatenate(c1.get_segments(), axis=0)
+                seg2 = np.concatenate(c2.get_segments(), axis=0)
+                assert not np.array_equal(seg1, seg2)
 
     def test_hue_ignores_cmap(self, long_df):
 


### PR DESCRIPTION
Mostly related to changes in numpy (warning on creating a ragged array without explicit object dtype) and matplotlib (warning on setting ticklabels without setting ticks).