### PR TITLE
Change 'culmen' to 'bill' in all examples using penguins

### DIFF
--- a/doc/docstrings/JointGrid.ipynb
+++ b/doc/docstrings/JointGrid.ipynb
@@ -28,7 +28,7 @@
    "outputs": [],
    "source": [
     "penguins = sns.load_dataset(\"penguins\")\n",
-    "sns.JointGrid(data=penguins, x=\"culmen_length_mm\", y=\"culmen_depth_mm\")"
+    "sns.JointGrid(data=penguins, x=\"bill_length_mm\", y=\"bill_depth_mm\")"
    ]
   },
   {
@@ -44,7 +44,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "g = sns.JointGrid(data=penguins, x=\"culmen_length_mm\", y=\"culmen_depth_mm\")\n",
+    "g = sns.JointGrid(data=penguins, x=\"bill_length_mm\", y=\"bill_depth_mm\")\n",
     "g.plot(sns.scatterplot, sns.histplot)"
    ]
   },
@@ -61,7 +61,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "g = sns.JointGrid(data=penguins, x=\"culmen_length_mm\", y=\"culmen_depth_mm\")\n",
+    "g = sns.JointGrid(data=penguins, x=\"bill_length_mm\", y=\"bill_depth_mm\")\n",
     "g.plot(sns.scatterplot, sns.histplot, alpha=.7, edgecolor=\".2\", linewidth=.5)"
    ]
   },
@@ -78,7 +78,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "g = sns.JointGrid(data=penguins, x=\"culmen_length_mm\", y=\"culmen_depth_mm\")\n",
+    "g = sns.JointGrid(data=penguins, x=\"bill_length_mm\", y=\"bill_depth_mm\")\n",
     "g.plot_joint(sns.scatterplot, s=100, alpha=.5)\n",
     "g.plot_marginals(sns.histplot, kde=True)"
    ]
@@ -113,7 +113,7 @@
    "outputs": [],
    "source": [
     "g = sns.JointGrid()\n",
-    "x, y = penguins[\"culmen_length_mm\"], penguins[\"culmen_depth_mm\"]\n",
+    "x, y = penguins[\"bill_length_mm\"], penguins[\"bill_depth_mm\"]\n",
     "sns.scatterplot(x=x, y=y, ec=\"b\", fc=\"none\", s=100, linewidth=1.5, ax=g.ax_joint)\n",
     "sns.histplot(x=x, fill=False, linewidth=2, ax=g.ax_marg_x)\n",
     "sns.kdeplot(y=y, linewidth=2, ax=g.ax_marg_y)"
@@ -132,7 +132,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "g = sns.JointGrid(data=penguins, x=\"culmen_length_mm\", y=\"culmen_depth_mm\")\n",
+    "g = sns.JointGrid(data=penguins, x=\"bill_length_mm\", y=\"bill_depth_mm\")\n",
     "g.plot(sns.regplot, sns.boxplot)"
    ]
   },
@@ -149,7 +149,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "g = sns.JointGrid(data=penguins, x=\"culmen_length_mm\", y=\"culmen_depth_mm\", hue=\"species\")\n",
+    "g = sns.JointGrid(data=penguins, x=\"bill_length_mm\", y=\"bill_depth_mm\", hue=\"species\")\n",
     "g.plot(sns.scatterplot, sns.histplot)"
    ]
   },

--- a/doc/docstrings/displot.ipynb
+++ b/doc/docstrings/displot.ipynb
@@ -91,7 +91,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.displot(data=penguins, x=\"flipper_length_mm\", y=\"culmen_length_mm\")"
+    "sns.displot(data=penguins, x=\"flipper_length_mm\", y=\"bill_length_mm\")"
    ]
   },
   {
@@ -107,7 +107,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.displot(data=penguins, x=\"flipper_length_mm\", y=\"culmen_length_mm\", kind=\"kde\")"
+    "sns.displot(data=penguins, x=\"flipper_length_mm\", y=\"bill_length_mm\", kind=\"kde\")"
    ]
   },
   {
@@ -123,7 +123,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "g = sns.displot(data=penguins, x=\"flipper_length_mm\", y=\"culmen_length_mm\", kind=\"kde\", rug=True)"
+    "g = sns.displot(data=penguins, x=\"flipper_length_mm\", y=\"bill_length_mm\", kind=\"kde\", rug=True)"
    ]
   },
   {

--- a/doc/docstrings/ecdfplot.ipynb
+++ b/doc/docstrings/ecdfplot.ipynb
@@ -59,7 +59,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.ecdfplot(data=penguins.filter(like=\"culmen_\", axis=\"columns\"))"
+    "sns.ecdfplot(data=penguins.filter(like=\"bill_\", axis=\"columns\"))"
    ]
   },
   {
@@ -75,7 +75,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.ecdfplot(data=penguins, x=\"culmen_length_mm\", hue=\"species\")"
+    "sns.ecdfplot(data=penguins, x=\"bill_length_mm\", hue=\"species\")"
    ]
   },
   {
@@ -91,7 +91,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.ecdfplot(data=penguins, x=\"culmen_length_mm\", hue=\"species\", stat=\"count\")"
+    "sns.ecdfplot(data=penguins, x=\"bill_length_mm\", hue=\"species\", stat=\"count\")"
    ]
   },
   {
@@ -107,7 +107,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.ecdfplot(data=penguins, x=\"culmen_length_mm\", hue=\"species\", complementary=True)"
+    "sns.ecdfplot(data=penguins, x=\"bill_length_mm\", hue=\"species\", complementary=True)"
    ]
   },
   {

--- a/doc/docstrings/histplot.ipynb
+++ b/doc/docstrings/histplot.ipynb
@@ -189,7 +189,7 @@
    "outputs": [],
    "source": [
     "sns.histplot(\n",
-    "    penguins, x=\"culmen_length_mm\", hue=\"island\", element=\"step\",\n",
+    "    penguins, x=\"bill_length_mm\", hue=\"island\", element=\"step\",\n",
     "    stat=\"density\", common_norm=False,\n",
     ")"
    ]
@@ -342,7 +342,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.histplot(penguins, x=\"culmen_depth_mm\", y=\"body_mass_g\")"
+    "sns.histplot(penguins, x=\"bill_depth_mm\", y=\"body_mass_g\")"
    ]
   },
   {
@@ -358,7 +358,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.histplot(penguins, x=\"culmen_depth_mm\", y=\"body_mass_g\", hue=\"species\")"
+    "sns.histplot(penguins, x=\"bill_depth_mm\", y=\"body_mass_g\", hue=\"species\")"
    ]
   },
   {
@@ -375,7 +375,7 @@
    "outputs": [],
    "source": [
     "sns.histplot(\n",
-    "    penguins, x=\"culmen_depth_mm\", y=\"species\", hue=\"species\", legend=False\n",
+    "    penguins, x=\"bill_depth_mm\", y=\"species\", hue=\"species\", legend=False\n",
     ")"
    ]
   },

--- a/doc/docstrings/jointplot.ipynb
+++ b/doc/docstrings/jointplot.ipynb
@@ -28,7 +28,7 @@
    "outputs": [],
    "source": [
     "penguins = sns.load_dataset(\"penguins\")\n",
-    "sns.jointplot(data=penguins, x=\"culmen_length_mm\", y=\"culmen_depth_mm\")"
+    "sns.jointplot(data=penguins, x=\"bill_length_mm\", y=\"bill_depth_mm\")"
    ]
   },
   {
@@ -44,7 +44,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.jointplot(data=penguins, x=\"culmen_length_mm\", y=\"culmen_depth_mm\", hue=\"species\")"
+    "sns.jointplot(data=penguins, x=\"bill_length_mm\", y=\"bill_depth_mm\", hue=\"species\")"
    ]
   },
   {
@@ -60,7 +60,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.jointplot(data=penguins, x=\"culmen_length_mm\", y=\"culmen_depth_mm\", hue=\"species\", kind=\"kde\")"
+    "sns.jointplot(data=penguins, x=\"bill_length_mm\", y=\"bill_depth_mm\", hue=\"species\", kind=\"kde\")"
    ]
   },
   {
@@ -76,7 +76,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.jointplot(data=penguins, x=\"culmen_length_mm\", y=\"culmen_depth_mm\", kind=\"reg\")"
+    "sns.jointplot(data=penguins, x=\"bill_length_mm\", y=\"bill_depth_mm\", kind=\"reg\")"
    ]
   },
   {
@@ -92,7 +92,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.jointplot(data=penguins, x=\"culmen_length_mm\", y=\"culmen_depth_mm\", kind=\"hist\")"
+    "sns.jointplot(data=penguins, x=\"bill_length_mm\", y=\"bill_depth_mm\", kind=\"hist\")"
    ]
   },
   {
@@ -108,7 +108,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.jointplot(data=penguins, x=\"culmen_length_mm\", y=\"culmen_depth_mm\", kind=\"hex\")"
+    "sns.jointplot(data=penguins, x=\"bill_length_mm\", y=\"bill_depth_mm\", kind=\"hex\")"
    ]
   },
   {
@@ -125,7 +125,7 @@
    "outputs": [],
    "source": [
     "sns.jointplot(\n",
-    "    data=penguins, x=\"culmen_length_mm\", y=\"culmen_depth_mm\",\n",
+    "    data=penguins, x=\"bill_length_mm\", y=\"bill_depth_mm\",\n",
     "    marker=\"+\", s=100, marginal_kws=dict(bins=25, fill=False),\n",
     ")"
    ]
@@ -143,7 +143,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.jointplot(data=penguins, x=\"culmen_length_mm\", y=\"culmen_depth_mm\", height=5, ratio=2, marginal_ticks=True)"
+    "sns.jointplot(data=penguins, x=\"bill_length_mm\", y=\"bill_depth_mm\", height=5, ratio=2, marginal_ticks=True)"
    ]
   },
   {
@@ -159,7 +159,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "g = sns.jointplot(data=penguins, x=\"culmen_length_mm\", y=\"culmen_depth_mm\")\n",
+    "g = sns.jointplot(data=penguins, x=\"bill_length_mm\", y=\"bill_depth_mm\")\n",
     "g.plot_joint(sns.kdeplot, color=\"r\", zorder=0, levels=6)\n",
     "g.plot_marginals(sns.rugplot, color=\"r\", height=-.15, clip_on=False)"
    ]

--- a/doc/tutorial/distributions.ipynb
+++ b/doc/tutorial/distributions.ipynb
@@ -552,7 +552,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.displot(penguins, x=\"culmen_length_mm\", y=\"culmen_depth_mm\")"
+    "sns.displot(penguins, x=\"bill_length_mm\", y=\"bill_depth_mm\")"
    ]
   },
   {
@@ -568,7 +568,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.displot(penguins, x=\"culmen_length_mm\", y=\"culmen_depth_mm\", kind=\"kde\")"
+    "sns.displot(penguins, x=\"bill_length_mm\", y=\"bill_depth_mm\", kind=\"kde\")"
    ]
   },
   {
@@ -584,7 +584,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.displot(penguins, x=\"culmen_length_mm\", y=\"culmen_depth_mm\", hue=\"species\")"
+    "sns.displot(penguins, x=\"bill_length_mm\", y=\"bill_depth_mm\", hue=\"species\")"
    ]
   },
   {
@@ -600,7 +600,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.displot(penguins, x=\"culmen_length_mm\", y=\"culmen_depth_mm\", hue=\"species\", kind=\"kde\")"
+    "sns.displot(penguins, x=\"bill_length_mm\", y=\"bill_depth_mm\", hue=\"species\", kind=\"kde\")"
    ]
   },
   {
@@ -616,7 +616,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.displot(penguins, x=\"culmen_length_mm\", y=\"culmen_depth_mm\", binwidth=(2, .5))"
+    "sns.displot(penguins, x=\"bill_length_mm\", y=\"bill_depth_mm\", binwidth=(2, .5))"
    ]
   },
   {
@@ -632,7 +632,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.displot(penguins, x=\"culmen_length_mm\", y=\"culmen_depth_mm\", binwidth=(2, .5), cbar=True)"
+    "sns.displot(penguins, x=\"bill_length_mm\", y=\"bill_depth_mm\", binwidth=(2, .5), cbar=True)"
    ]
   },
   {
@@ -648,7 +648,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.displot(penguins, x=\"culmen_length_mm\", y=\"culmen_depth_mm\", kind=\"kde\", thresh=.2, levels=4)"
+    "sns.displot(penguins, x=\"bill_length_mm\", y=\"bill_depth_mm\", kind=\"kde\", thresh=.2, levels=4)"
    ]
   },
   {
@@ -664,7 +664,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.displot(penguins, x=\"culmen_length_mm\", y=\"culmen_depth_mm\", kind=\"kde\", levels=[.01, .05, .1, .8])"
+    "sns.displot(penguins, x=\"bill_length_mm\", y=\"bill_depth_mm\", kind=\"kde\", levels=[.01, .05, .1, .8])"
    ]
   },
   {
@@ -721,7 +721,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.jointplot(data=penguins, x=\"culmen_length_mm\", y=\"culmen_depth_mm\")"
+    "sns.jointplot(data=penguins, x=\"bill_length_mm\", y=\"bill_depth_mm\")"
    ]
   },
   {
@@ -739,7 +739,7 @@
    "source": [
     "sns.jointplot(\n",
     "    data=penguins,\n",
-    "    x=\"culmen_length_mm\", y=\"culmen_depth_mm\", hue=\"species\",\n",
+    "    x=\"bill_length_mm\", y=\"bill_depth_mm\", hue=\"species\",\n",
     "    kind=\"kde\"\n",
     ")"
    ]
@@ -757,7 +757,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "g = sns.JointGrid(data=penguins, x=\"culmen_length_mm\", y=\"culmen_depth_mm\")\n",
+    "g = sns.JointGrid(data=penguins, x=\"bill_length_mm\", y=\"bill_depth_mm\")\n",
     "g.plot_joint(sns.histplot)\n",
     "g.plot_marginals(sns.boxplot)"
    ]
@@ -776,7 +776,7 @@
    "outputs": [],
    "source": [
     "sns.displot(\n",
-    "    penguins, x=\"culmen_length_mm\", y=\"culmen_depth_mm\",\n",
+    "    penguins, x=\"bill_length_mm\", y=\"bill_depth_mm\",\n",
     "    kind=\"kde\", rug=True\n",
     ")"
    ]
@@ -794,8 +794,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.relplot(data=penguins, x=\"culmen_length_mm\", y=\"culmen_depth_mm\")\n",
-    "sns.rugplot(data=penguins, x=\"culmen_length_mm\", y=\"culmen_depth_mm\")"
+    "sns.relplot(data=penguins, x=\"bill_length_mm\", y=\"bill_depth_mm\")\n",
+    "sns.rugplot(data=penguins, x=\"bill_length_mm\", y=\"bill_depth_mm\")"
    ]
   },
   {

--- a/examples/joint_kde.py
+++ b/examples/joint_kde.py
@@ -13,6 +13,6 @@ penguins = sns.load_dataset("penguins")
 # Show the joint distribution using kernel density estimation
 g = sns.jointplot(
     data=penguins,
-    x="culmen_length_mm", y="culmen_depth_mm", hue="species",
+    x="bill_length_mm", y="bill_depth_mm", hue="species",
     kind="kde",
 )

--- a/examples/multiple_regression.py
+++ b/examples/multiple_regression.py
@@ -13,7 +13,7 @@ penguins = sns.load_dataset("penguins")
 # Plot sepal width as a function of sepal_length across days
 g = sns.lmplot(
     data=penguins,
-    x="culmen_length_mm", y="culmen_depth_mm", hue="species",
+    x="bill_length_mm", y="bill_depth_mm", hue="species",
     height=5
 )
 

--- a/examples/smooth_bivariate_kde.py
+++ b/examples/smooth_bivariate_kde.py
@@ -9,7 +9,7 @@ sns.set(style="white")
 
 df = sns.load_dataset("penguins")
 
-g = sns.JointGrid(data=df, x="body_mass_g", y="culmen_depth_mm", space=0)
+g = sns.JointGrid(data=df, x="body_mass_g", y="bill_depth_mm", space=0)
 g.plot_joint(sns.kdeplot,
              fill=True, clip=((2200, 6800), (10, 25)),
              thresh=0, levels=100, cmap="rocket")


### PR DESCRIPTION
Mirrors changes in the R penguins dataset, saves characters, and
it's easier to remember how to spell 'bill'

If you have the penguins data cached, you'll need to re-download it.