### PR TITLE
Remove deprecated JointGrid annotation code

### DIFF
--- a/doc/releases/v0.11.0.txt
+++ b/doc/releases/v0.11.0.txt
@@ -116,3 +116,5 @@ TODO organize by module.
 - Deprecated the ``axlabel`` function; use ``ax.set(xlabel=, ylabel=)`` instead.
 
 - Deprecated the ``iqr`` function; use :func:`scipy.stats.iqr` instead.
+
+- Final removal of the ``annotate`` method on :class:`JointGrid` and related parameters, which was deprecated in the v0.9.0 release.

--- a/doc/releases/v0.9.0.txt
+++ b/doc/releases/v0.9.0.txt
@@ -52,7 +52,7 @@ A few functions have been renamed or have had changes to their default parameter
 
 - Renamed the ``size`` parameter to ``height`` in multi-plot grid objects (:class:`FacetGrid`, :class:`PairGrid`, and :class:`JointGrid`) along with functions that use them (``factorplot``, :func:`lmplot`, :func:`pairplot`, and :func:`jointplot`) to avoid conflicts with the ``size`` parameter that is used in ``scatterplot`` and ``lineplot`` (necessary to make :func:`relplot` work) and also makes the meaning of the parameter a bit more clear.
 
-- Changed the default diagonal plots in :func:`pairplot` to use `func`:kdeplot` when a ``"hue"`` dimension is used.
+- Changed the default diagonal plots in :func:`pairplot` to use func:`kdeplot` when a ``"hue"`` dimension is used.
 
 - Deprecated the statistical annotation component of :class:`JointGrid`. The method is still available but will be removed in a future version.
 

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -1754,7 +1754,7 @@ class JointGrid(object):
             if key in func_params:
                 kws.setdefault(key, val)
 
-    def plot(self, joint_func, marginal_func, annot_func=None, **kwargs):
+    def plot(self, joint_func, marginal_func, **kwargs):
         """Draw the plot by passing functions for joint and marginal axes.
 
         This method passes the ``kwargs`` dictionary to both functions. If you
@@ -1778,8 +1778,6 @@ class JointGrid(object):
         """
         self.plot_marginals(marginal_func, **kwargs)
         self.plot_joint(joint_func, **kwargs)
-        if annot_func is not None:
-            self.annotate(annot_func)
         return self
 
     def plot_joint(self, func, **kwargs):
@@ -1858,71 +1856,6 @@ class JointGrid(object):
 
         self.ax_marg_x.yaxis.get_label().set_visible(False)
         self.ax_marg_y.xaxis.get_label().set_visible(False)
-
-        return self
-
-    def annotate(self, func, template=None, stat=None, loc="best", **kwargs):
-        """Annotate the plot with a statistic about the relationship.
-
-        *Deprecated and will be removed in a future version*.
-
-        Parameters
-        ----------
-        func : callable
-            Statistical function that maps the x, y vectors either to (val, p)
-            or to val.
-        template : string format template
-            The template must have the format keys "stat" and "val";
-            if `func` returns a p value, it should also have the key "p".
-        stat : string
-            Name to use for the statistic in the annotation, by default it
-            uses the name of `func`.
-        loc : string or int
-            Matplotlib legend location code; used to place the annotation.
-        kwargs : key, value mappings
-            Other keyword arguments are passed to `ax.legend`, which formats
-            the annotation.
-
-        Returns
-        -------
-        self : JointGrid instance.
-            Returns `self`.
-
-        """
-        msg = ("JointGrid annotation is deprecated and will be removed "
-               "in a future release.")
-        warnings.warn(UserWarning(msg))
-
-        default_template = "{stat} = {val:.2g}; p = {p:.2g}"
-
-        # Call the function and determine the form of the return value(s)
-        out = func(self.x, self.y)
-        try:
-            val, p = out
-        except TypeError:
-            val, p = out, None
-            default_template, _ = default_template.split(";")
-
-        # Set the default template
-        if template is None:
-            template = default_template
-
-        # Default to name of the function
-        if stat is None:
-            stat = func.__name__
-
-        # Format the annotation
-        if p is None:
-            annotation = template.format(stat=stat, val=val)
-        else:
-            annotation = template.format(stat=stat, val=val, p=p)
-
-        # Draw an invisible plot and use the legend to draw the annotation
-        # This is a bit of a hack, but `loc=best` works nicely and is not
-        # easily abstracted.
-        phantom, = self.ax_joint.plot(self.x, self.y, linestyle="", alpha=0)
-        self.ax_joint.legend([phantom], [annotation], loc=loc, **kwargs)
-        phantom.remove()
 
         return self
 
@@ -2248,10 +2181,9 @@ def jointplot(
     *,
     x=None, y=None,
     data=None,
-    kind="scatter", stat_func=None,
-    color=None, height=6, ratio=5, space=.2,
+    kind="scatter", color=None, height=6, ratio=5, space=.2,
     dropna=False, xlim=None, ylim=None, marginal_ticks=False,
-    joint_kws=None, marginal_kws=None, annot_kws=None,
+    joint_kws=None, marginal_kws=None,
     hue=None, palette=None, hue_order=None, hue_norm=None,
     **kwargs
 ):
@@ -2271,7 +2203,6 @@ def jointplot(
     joint_kws = {} if joint_kws is None else joint_kws.copy()
     joint_kws.update(kwargs)
     marginal_kws = {} if marginal_kws is None else marginal_kws.copy()
-    annot_kws = {} if annot_kws is None else annot_kws.copy()
 
     # Handle deprecations of distplot-specific kwargs
     distplot_keys = [
@@ -2399,10 +2330,6 @@ def jointplot(
         marginal_kws.setdefault("color", color)
         histplot(x=x, hue=hue, ax=grid.ax_marg_x, **marginal_kws)
         histplot(y=y, hue=hue, ax=grid.ax_marg_y, **marginal_kws)
-        stat_func = None
-
-    if stat_func is not None:
-        grid.annotate(stat_func, **annot_kws)
 
     return grid
 
@@ -2421,8 +2348,6 @@ Parameters
 {params.core.data}
 kind : {{ "scatter" | "kde" | "hist" | "hex" | "reg" | "resid" }}
     Kind of plot to draw. See the examples for references to the underlying functions.
-stat_func : callable or None
-    *Deprecated*
 {params.core.color}
 height : numeric
     Size of the figure (it will be square).
@@ -2436,7 +2361,7 @@ dropna : bool
     Axis limits to set before plotting.
 marginal_ticks : bool
     If False, suppress ticks on the count/density axis of the marginal plots.
-{{joint, marginal, annot}}_kws : dicts
+{{joint, marginal}}_kws : dicts
     Additional keyword arguments for the plot components.
 {params.core.hue}
     Semantic variable that is mapped to determine the color of plot elements.

--- a/seaborn/tests/test_axisgrid.py
+++ b/seaborn/tests/test_axisgrid.py
@@ -2,7 +2,6 @@ import warnings
 
 import numpy as np
 import pandas as pd
-from scipy import stats
 import matplotlib as mpl
 import matplotlib.pyplot as plt
 
@@ -1383,37 +1382,6 @@ class TestJointGrid(object):
         y2, _ = g.ax_marg_y.lines[0].get_xydata().T
         npt.assert_array_equal(y1, y2)
 
-    def test_annotate(self):
-
-        g = ag.JointGrid(x="x", y="y", data=self.data)
-        rp = stats.pearsonr(self.x, self.y)
-
-        with pytest.warns(UserWarning):
-            g.annotate(stats.pearsonr)
-        annotation = g.ax_joint.legend_.texts[0].get_text()
-        nt.assert_equal(annotation, "pearsonr = %.2g; p = %.2g" % rp)
-
-        with pytest.warns(UserWarning):
-            g.annotate(stats.pearsonr, stat="correlation")
-        annotation = g.ax_joint.legend_.texts[0].get_text()
-        nt.assert_equal(annotation, "correlation = %.2g; p = %.2g" % rp)
-
-        def rsquared(x, y):
-            return stats.pearsonr(x, y)[0] ** 2
-
-        r2 = rsquared(self.x, self.y)
-        with pytest.warns(UserWarning):
-            g.annotate(rsquared)
-        annotation = g.ax_joint.legend_.texts[0].get_text()
-        nt.assert_equal(annotation, "rsquared = %.2g" % r2)
-
-        template = "{stat} = {val:.3g} (p = {p:.3g})"
-        with pytest.warns(UserWarning):
-            g.annotate(stats.pearsonr, template=template)
-        annotation = g.ax_joint.legend_.texts[0].get_text()
-        nt.assert_equal(annotation, template.format(stat="pearsonr",
-                                                    val=rp[0], p=rp[1]))
-
     def test_space(self):
 
         g = ag.JointGrid(x="x", y="y", data=self.data, space=0)
@@ -1586,16 +1554,6 @@ class TestJointPlot(object):
         assert_plots_equal(g1.ax_marg_x, g2.ax_marg_x, labels=False)
         assert_plots_equal(g1.ax_marg_y, g2.ax_marg_y, labels=False)
 
-    def test_annotation(self):
-
-        with pytest.warns(UserWarning):
-            g = ag.jointplot(x="x", y="y", data=self.data,
-                             stat_func=stats.pearsonr)
-        assert len(g.ax_joint.legend_.get_texts()) == 1
-
-        g = ag.jointplot(x="x", y="y", data=self.data, stat_func=None)
-        assert g.ax_joint.legend_ is None
-
     def test_hex_customise(self):
 
         # test that default gridsize can be overridden
@@ -1613,7 +1571,7 @@ class TestJointPlot(object):
     def test_leaky_dict(self):
         # Validate input dicts are unchanged by jointplot plotting function
 
-        for kwarg in ("joint_kws", "marginal_kws", "annot_kws"):
+        for kwarg in ("joint_kws", "marginal_kws"):
             for kind in ("hex", "kde", "resid", "reg", "scatter"):
                 empty_dict = {}
                 ag.jointplot(x="x", y="y", data=self.data, kind=kind,


### PR DESCRIPTION
Deprecated in 0.9 and removed now as it conflicts with the legend that ``hue`` mapping requires.