### PR TITLE
Use core axis labeling method in relational plots

### DIFF
--- a/seaborn/_core.py
+++ b/seaborn/_core.py
@@ -1172,11 +1172,17 @@ class VectorPlotter:
         return any(log_scaled)
 
     def _add_axis_labels(self, ax, default_x="", default_y=""):
-        """Add axis labels from internal variable names if not already existing."""
+        """Add axis labels if not present, set visibility to match ticklabels."""
+        # TODO ax could default to None and use attached axes if present
+        # but what to do about the case of facets? Currently using FacetGrid's
+        # set_axis_labels method, which doesn't add labels to the interior even
+        # when the axes are not shared. Maybe that makes sense?
         if not ax.get_xlabel():
-            ax.set_xlabel(self.variables.get("x", default_x))
+            x_visible = any(t.get_visible() for t in ax.get_xticklabels())
+            ax.set_xlabel(self.variables.get("x", default_x), visible=x_visible)
         if not ax.get_ylabel():
-            ax.set_ylabel(self.variables.get("y", default_y))
+            y_visible = any(t.get_visible() for t in ax.get_yticklabels())
+            ax.set_ylabel(self.variables.get("y", default_y), visible=y_visible)
 
 
 def variable_type(vector, boolean_type="numeric"):

--- a/seaborn/relational.py
+++ b/seaborn/relational.py
@@ -190,15 +190,6 @@ class _RelationalPlotter(VectorPlotter):
     # TODO where best to define default parameters?
     sort = True
 
-    def label_axes(self, ax):
-        """Set x and y labels with visibility that matches the ticklabels."""
-        if "x" in self.variables and self.variables["x"] is not None:
-            x_visible = any(t.get_visible() for t in ax.get_xticklabels())
-            ax.set_xlabel(self.variables["x"], visible=x_visible)
-        if "y" in self.variables and self.variables["y"] is not None:
-            y_visible = any(t.get_visible() for t in ax.get_yticklabels())
-            ax.set_ylabel(self.variables["y"], visible=y_visible)
-
     def add_legend_data(self, ax):
         """Add labeled artists to represent the different plot semantics."""
         verbosity = self.legend
@@ -526,7 +517,7 @@ class _LinePlotter(_RelationalPlotter):
                             pass
 
         # Finalize the axes details
-        self.label_axes(ax)
+        self._add_axis_labels(ax)
         if self.legend:
             self.add_legend_data(ax)
             handles, _ = ax.get_legend_handles_labels()
@@ -629,7 +620,7 @@ class _ScatterPlotter(_RelationalPlotter):
             points.set_paths(p)
 
         # Finalize the axes details
-        self.label_axes(ax)
+        self._add_axis_labels(ax)
         if self.legend:
             self.add_legend_data(ax)
             handles, _ = ax.get_legend_handles_labels()

--- a/seaborn/tests/test_core.py
+++ b/seaborn/tests/test_core.py
@@ -846,6 +846,20 @@ class TestVectorPlotter:
         assert ax.get_xlabel() == "existing"
         assert ax.get_ylabel() == "also existing"
 
+        f, (ax1, ax2) = plt.subplots(1, 2, sharey=True)
+        p = VectorPlotter(data=long_df, variables=dict(x="x", y="y"))
+
+        p._add_axis_labels(ax1)
+        p._add_axis_labels(ax2)
+
+        assert ax1.get_xlabel() == "x"
+        assert ax1.get_ylabel() == "y"
+        assert ax1.yaxis.label.get_visible()
+
+        assert ax2.get_xlabel() == "x"
+        assert ax2.get_ylabel() == "y"
+        assert not ax2.yaxis.label.get_visible()
+
     @pytest.mark.parametrize(
         "variables",
         [


### PR DESCRIPTION
This will prevent relational plots from overwriting existing axis labels:

```python
f, ax = plt.subplots()
ax.set(xlabel="Price ($)", ylabel="Carat")
sns.scatterplot(data=diamonds.sample(frac=.1), x="price", y="carat")
```