### PR TITLE
Add a rich HTML representation of color palette objects

### DIFF
--- a/doc/releases/v0.11.0.txt
+++ b/doc/releases/v0.11.0.txt
@@ -101,6 +101,8 @@ TODO organize by module.
 
 - Fixed a bug where :func:`lineplot` did not pass the ``linestyle`` parameter down to matplotlib (:pr:`2095`).
 
+- Added a rich HTML representation to the object returned by :func:`color_palette` (:pr:2225).
+
 - Changed the default value for ``dropna`` to ``False`` in :class`FacetGrid`, :class:`PairGrid`, :class`JointGrid`, and corresponding functions. As all or nearly all seaborn and matplotlib plotting functions handle missing data well, this option is no longer useful, but it causes problems in some edge cases. It may be deprecated in the future. (:pr:2204).
 
 - Improved the error messages produced when categorical plots process the orientation parameter.
@@ -109,11 +111,9 @@ TODO organize by module.
 
 - Fixed a bug in :class:`PairGrid` that appeared when setting ``corner=True`` and ``despine=False`` (:pr:`2203`).
 
-- Removed an optional (and undocumented) dependency on BeautifulSoup (:pr:`2190`).
-
 - Fixed a bug in :func:`set_context` that prevented ``legend.title_fontsize`` rcParam from scaling when scaling fonts (:pr:`2214`).
 
-- Removed an optional (an undocumented) dependency on BeautifulSoup (:pr:`2190`).
+- Removed an optional (and undocumented) dependency on BeautifulSoup (:pr:`2190`).
 
 - Deprecated the ``axlabel`` function; use ``ax.set(xlabel=, ylabel=)`` instead.
 

--- a/doc/tutorial/color_palettes.ipynb
+++ b/doc/tutorial/color_palettes.ipynb
@@ -37,7 +37,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "hide"
+    ]
+   },
    "outputs": [],
    "source": [
     "import numpy as np\n",
@@ -101,14 +105,14 @@
    "outputs": [],
    "source": [
     "current_palette = sns.color_palette()\n",
-    "sns.palplot(current_palette)"
+    "current_palette"
    ]
   },
   {
    "cell_type": "raw",
    "metadata": {},
    "source": [
-    "There are six variations of the default theme, called ``deep``, ``muted``, ``pastel``, ``bright``, ``dark``, and ``colorblind``."
+    "There are six variations of the default theme, called ``deep``, ``muted``, ``pastel``, ``bright``, ``dark``, and ``colorblind``. These span a range of luminance and saturation values:"
    ]
   },
   {
@@ -121,7 +125,6 @@
    },
    "outputs": [],
    "source": [
-    "# TODO hide input here when merged with doc updating branch\n",
     "f = plt.figure(figsize=(6, 6))\n",
     "\n",
     "ax_locs = dict(\n",
@@ -173,7 +176,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.palplot(sns.color_palette(\"hls\", 8))"
+    "sns.color_palette(\"hls\", 8)"
    ]
   },
   {
@@ -189,7 +192,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.palplot(sns.hls_palette(8, l=.3, s=.8))"
+    "sns.hls_palette(8, l=.7, s=.4)"
    ]
   },
   {
@@ -209,7 +212,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.palplot(sns.color_palette(\"husl\", 8))"
+    "sns.color_palette(\"husl\", 8)"
    ]
   },
   {
@@ -232,7 +235,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.palplot(sns.color_palette(\"Paired\"))"
+    "sns.color_palette(\"Paired\")"
    ]
   },
   {
@@ -241,7 +244,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.palplot(sns.color_palette(\"Set2\"))"
+    "sns.color_palette(\"Set2\")"
    ]
   },
   {
@@ -260,7 +263,7 @@
    "outputs": [],
    "source": [
     "flatui = [\"#9b59b6\", \"#3498db\", \"#95a5a6\", \"#e74c3c\", \"#34495e\", \"#2ecc71\"]\n",
-    "sns.palplot(sns.color_palette(flatui))"
+    "sns.color_palette(flatui)"
    ]
   },
   {
@@ -272,25 +275,7 @@
     "Using named colors from the xkcd color survey\n",
     "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n",
     "\n",
-    "A while back, `xkcd <https://xkcd.com/>`_ ran a `crowdsourced effort <https://blog.xkcd.com/2010/05/03/color-survey-results/>`_ to name random RGB colors. This produced a set of `954 named colors <https://xkcd.com/color/rgb/>`_, which you can now reference in seaborn using the ``xkcd_rgb`` dictionary:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "plt.plot([0, 1], [0, 1], sns.xkcd_rgb[\"pale red\"], lw=3)\n",
-    "plt.plot([0, 1], [0, 2], sns.xkcd_rgb[\"medium green\"], lw=3)\n",
-    "plt.plot([0, 1], [0, 3], sns.xkcd_rgb[\"denim blue\"], lw=3);"
-   ]
-  },
-  {
-   "cell_type": "raw",
-   "metadata": {},
-   "source": [
-    "In addition to pulling out single colors from the ``xkcd_rgb`` dictionary, you can also pass a list of names to the :func:`xkcd_palette` function."
+    "A while back, `xkcd <https://xkcd.com/>`_ ran a `crowdsourced effort <https://blog.xkcd.com/2010/05/03/color-survey-results/>`_ to name random RGB colors. This produced a set of `954 named colors <https://xkcd.com/color/rgb/>`_, which you can reference in seaborn using the :func:`xkcd_palette` function:"
    ]
   },
   {
@@ -300,7 +285,7 @@
    "outputs": [],
    "source": [
     "colors = [\"windows blue\", \"amber\", \"greyish\", \"faded green\", \"dusty purple\"]\n",
-    "sns.palplot(sns.xkcd_palette(colors))"
+    "sns.xkcd_palette(colors)"
    ]
   },
   {
@@ -327,7 +312,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.palplot(sns.color_palette(\"Blues\"))"
+    "sns.color_palette(\"Blues\")"
    ]
   },
   {
@@ -343,23 +328,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.palplot(sns.color_palette(\"BuGn_r\"))"
-   ]
-  },
-  {
-   "cell_type": "raw",
-   "metadata": {},
-   "source": [
-    "Seaborn also adds a trick that allows you to create \"dark\" palettes, which do not have as wide a dynamic range. This can be useful if you want to map lines or points sequentially, as brighter-colored lines might otherwise be hard to distinguish."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "sns.palplot(sns.color_palette(\"GnBu_d\"))"
+    "sns.color_palette(\"BuGn_r\")"
    ]
   },
   {
@@ -391,7 +360,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.palplot(sns.color_palette(\"cubehelix\", 8))"
+    "sns.color_palette(\"cubehelix\", 8)"
    ]
   },
   {
@@ -409,7 +378,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.palplot(sns.cubehelix_palette(8))"
+    "sns.cubehelix_palette(8)"
    ]
   },
   {
@@ -425,7 +394,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.palplot(sns.cubehelix_palette(8, start=.5, rot=-.75))"
+    "sns.cubehelix_palette(8, start=.5, rot=-.75)"
    ]
   },
   {
@@ -441,7 +410,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.palplot(sns.cubehelix_palette(8, start=2, rot=0, dark=0, light=.95, reverse=True))"
+    "sns.cubehelix_palette(8, start=2, rot=0, dark=0, light=.95, reverse=True)"
    ]
   },
   {
@@ -458,15 +427,15 @@
    "outputs": [],
    "source": [
     "x, y = np.random.multivariate_normal([0, 0], [[1, -.5], [-.5, 1]], size=300).T\n",
-    "cmap = sns.cubehelix_palette(light=1, as_cmap=True)\n",
-    "sns.kdeplot(x=x, y=y, cmap=cmap, fill=True);"
+    "cmap = sns.cubehelix_palette(light=.85, as_cmap=True)\n",
+    "sns.histplot(x=x, y=y, cmap=cmap, fill=True);"
    ]
   },
   {
    "cell_type": "raw",
    "metadata": {},
    "source": [
-    "To help select good palettes or colormaps using this system, you can use the :func:`choose_cubehelix_palette` function in a notebook to launch an interactive app that will let you play with the different parameters. Pass ``as_cmap=True`` if you want the function to return a colormap (rather than a list) for use in function like ``hexbin``."
+    "To help select good palettes or colormaps using this system, you can use the :func:`choose_cubehelix_palette` function in a notebook to launch an interactive app that will let you play with the different parameters. Pass ``as_cmap=True`` if you want the function to return a colormap (rather than a list) for use in function like :func:`histplot`."
    ]
   },
   {
@@ -485,7 +454,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.palplot(sns.light_palette(\"green\"))"
+    "sns.light_palette(\"green\")"
    ]
   },
   {
@@ -494,7 +463,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.palplot(sns.dark_palette(\"purple\"))"
+    "sns.dark_palette(\"purple\")"
    ]
   },
   {
@@ -510,7 +479,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.palplot(sns.light_palette(\"navy\", reverse=True))"
+    "sns.light_palette(\"navy\", reverse=True)"
    ]
   },
   {
@@ -526,8 +495,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pal = sns.dark_palette(\"palegreen\", as_cmap=True)\n",
-    "sns.kdeplot(x=x, y=y, cmap=pal);"
+    "pal = sns.light_palette(\"navy\", as_cmap=True)\n",
+    "sns.histplot(x=x, y=y, cmap=pal);"
    ]
   },
   {
@@ -543,7 +512,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.palplot(sns.light_palette((210, 90, 60), input=\"husl\"))"
+    "sns.light_palette((210, 90, 60), input=\"husl\")"
    ]
   },
   {
@@ -552,7 +521,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.palplot(sns.dark_palette(\"muted purple\", input=\"xkcd\"))"
+    "sns.dark_palette(\"muted purple\", input=\"xkcd\")"
    ]
   },
   {
@@ -586,7 +555,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.palplot(sns.color_palette(\"BrBG\", 7))"
+    "sns.color_palette(\"BrBG\", 7)"
    ]
   },
   {
@@ -595,7 +564,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.palplot(sns.color_palette(\"RdBu_r\", 7))"
+    "sns.color_palette(\"RdBu_r\", 7)"
    ]
   },
   {
@@ -611,7 +580,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.palplot(sns.color_palette(\"coolwarm\", 7))"
+    "sns.color_palette(\"coolwarm\", 7)"
    ]
   },
   {
@@ -630,7 +599,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.palplot(sns.diverging_palette(220, 20, n=7))"
+    "sns.diverging_palette(220, 20, n=7)"
    ]
   },
   {
@@ -639,7 +608,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.palplot(sns.diverging_palette(145, 280, s=85, l=25, n=7))"
+    "sns.diverging_palette(145, 280, s=85, l=25, n=7)"
    ]
   },
   {
@@ -655,7 +624,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.palplot(sns.diverging_palette(10, 220, sep=80, n=7))"
+    "sns.diverging_palette(10, 220, sep=80, n=7)"
    ]
   },
   {
@@ -671,7 +640,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.palplot(sns.diverging_palette(255, 133, l=60, n=7, center=\"dark\"))"
+    "sns.diverging_palette(255, 133, l=60, n=7, center=\"dark\")"
    ]
   },
   {
@@ -721,7 +690,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "with sns.color_palette(\"PuBuGn_d\"):\n",
+    "with sns.color_palette(\"muted\"):\n",
     "    sinplot()"
    ]
   },
@@ -733,14 +702,21 @@
     "\n",
     "   </div>"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "celltoolbar": "Tags",
   "kernelspec": {
-   "display_name": "seaborn-py37-latest",
+   "display_name": "seaborn-py38-latest",
    "language": "python",
-   "name": "seaborn-py37-latest"
+   "name": "seaborn-py38-latest"
   },
   "language_info": {
    "codemirror_mode": {
@@ -752,7 +728,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.8.3"
   }
  },
  "nbformat": 4,

--- a/seaborn/palettes.py
+++ b/seaborn/palettes.py
@@ -76,6 +76,19 @@ class _ColorPalette(list):
         hex = [mpl.colors.rgb2hex(rgb) for rgb in self]
         return _ColorPalette(hex)
 
+    def _repr_html_(self):
+        """Rich display of the color palette in an HTML frontend."""
+        s = 55
+        n = len(self)
+        html = f'<svg  width="{n * s}" height="{s}">'
+        for i, c in enumerate(self.as_hex()):
+            html += (
+                f'<rect x="{i * s}" y="0" width="{s}" height="{s}" style="fill:{c};'
+                'stroke-width:2;stroke:rgb(255,255,255)"/>'
+            )
+        html += '</svg>'
+        return html
+
 
 def color_palette(palette=None, n_colors=None, desat=None):
     """Return a list of colors defining a color palette.

--- a/seaborn/tests/test_palettes.py
+++ b/seaborn/tests/test_palettes.py
@@ -359,3 +359,10 @@ class TestColorPalettes(object):
         pal_in = palettes.color_palette("Set1", 10)
         pal_out = palettes.color_palette(pal_in)
         nt.assert_equal(pal_in, pal_out)
+
+    def test_html_rep(self):
+
+        pal = palettes.color_palette()
+        html = pal._repr_html_()
+        for color in pal.as_hex():
+            assert color in html


### PR DESCRIPTION
e.g, in a notebook:

![image](https://user-images.githubusercontent.com/315810/91346615-1bce0100-e7af-11ea-9394-8c3bc60c8b0f.png)
