### PR TITLE
Delegate hue in PairGrid to plotting functions

### DIFF
--- a/doc/docstrings/PairGrid.ipynb
+++ b/doc/docstrings/PairGrid.ipynb
@@ -1,0 +1,271 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "hide"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "import seaborn as sns; sns.set()\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Calling the constructor sets up a blank grid of subplots with each row and one column corresponding to a numeric variable in the dataset:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "penguins = sns.load_dataset(\"penguins\")\n",
+    "g = sns.PairGrid(penguins)"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Passing a bivariate function to :meth:`PairGrid.map` will draw a bivariate plot on every axes:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "g = sns.PairGrid(penguins)\n",
+    "g.map(sns.scatterplot)"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Passing separate functions to :meth:`PairGrid.map_diag` and :meth:`PairGrid.map_offdiag` will show each variable's marginal distribution on the diagonal:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "g = sns.PairGrid(penguins)\n",
+    "g.map_diag(sns.histplot)\n",
+    "g.map_offdiag(sns.scatterplot)"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "It's also possible to use different functions on the upper and lower triangles of the plot (which are otherwise redundant):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "g = sns.PairGrid(penguins, diag_sharey=False)\n",
+    "g.map_upper(sns.scatterplot)\n",
+    "g.map_lower(sns.kdeplot)\n",
+    "g.map_diag(sns.kdeplot)"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Or to avoid the redundancy altogether:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "g = sns.PairGrid(penguins, diag_sharey=False, corner=True)\n",
+    "g.map_lower(sns.scatterplot)\n",
+    "g.map_diag(sns.kdeplot)"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "The :class:`PairGrid` constructor accepts a ``hue`` variable. This variable is passed directly to functions that understand it:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "g = sns.PairGrid(penguins, hue=\"species\")\n",
+    "g.map_diag(sns.histplot)\n",
+    "g.map_offdiag(sns.scatterplot)\n",
+    "g.add_legend()"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "But you can also pass matplotlib functions, in which case a groupby is performed internally and a separate plot is drawn for each level:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "g = sns.PairGrid(penguins, hue=\"species\")\n",
+    "g.map_diag(plt.hist)\n",
+    "g.map_offdiag(plt.scatter)\n",
+    "g.add_legend()"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Additional semantic variables can be assigned by passing data vectors directly while mapping the function:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "g = sns.PairGrid(penguins, hue=\"species\")\n",
+    "g.map_diag(sns.histplot)\n",
+    "g.map_offdiag(sns.scatterplot, size=penguins[\"sex\"])\n",
+    "g.add_legend(title=\"\", adjust_subtitles=True)"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "When using seaborn functions that can implement a numeric hue mapping, you will want to disable mapping of the variable on the diagonal axes. Note that the ``hue`` variable is excluded from the list of variables shown by default:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "g = sns.PairGrid(penguins, hue=\"body_mass_g\")\n",
+    "g.map_diag(sns.histplot, hue=None, color=\".3\")\n",
+    "g.map_offdiag(sns.scatterplot)\n",
+    "g.add_legend()"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "The ``vars`` parameter can be used to control exactly which variables are used:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "variables = [\"body_mass_g\", \"bill_length_mm\", \"flipper_length_mm\"]\n",
+    "g = sns.PairGrid(penguins, hue=\"body_mass_g\", vars=variables)\n",
+    "g.map_diag(sns.histplot, hue=None, color=\".3\")\n",
+    "g.map_offdiag(sns.scatterplot)\n",
+    "g.add_legend()"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "The plot need not be square: separate variables can be used to define the rows and columns:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x_vars = [\"body_mass_g\", \"bill_length_mm\", \"bill_depth_mm\", \"flipper_length_mm\"]\n",
+    "y_vars = [\"body_mass_g\"]\n",
+    "g = sns.PairGrid(penguins, hue=\"species\", x_vars=x_vars, y_vars=y_vars)\n",
+    "g.map_diag(sns.histplot, color=\".3\")\n",
+    "g.map_offdiag(sns.scatterplot)\n",
+    "g.add_legend()"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "It can be useful to explore different approaches to resolving multiple distributions on the diagonal axes:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "g = sns.PairGrid(penguins, hue=\"species\")\n",
+    "g.map_diag(sns.histplot, multiple=\"stack\", element=\"step\")\n",
+    "g.map_offdiag(sns.scatterplot)\n",
+    "g.add_legend()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "seaborn-py38-latest",
+   "language": "python",
+   "name": "seaborn-py38-latest"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/doc/docstrings/pairplot.ipynb
+++ b/doc/docstrings/pairplot.ipynb
@@ -1,0 +1,225 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "hide"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "import seaborn as sns\n",
+    "sns.set(style=\"ticks\")"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "The simplest invocation uses :func:`scatterplot` for each pairing of the variables and :func:`histplot` for the marginal plots along the diagonal:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "penguins = sns.load_dataset(\"penguins\")\n",
+    "sns.pairplot(penguins)"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Assigning a ``hue`` variable adds a semantic mapping and changes the default marginal plot to a layered kernel density estimate (KDE):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sns.pairplot(penguins, hue=\"species\")"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "It's possible to force marginal histograms:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sns.pairplot(penguins, hue=\"species\", diag_kind=\"hist\")"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "The ``kind`` parameter determines both the diagonal and off-diagonal plotting style. Several options are available, including using :func:`kdeplot` to draw KDEs:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sns.pairplot(penguins, kind=\"kde\")"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Or :func:`histplot` to draw both bivariate and univariate histograms:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sns.pairplot(penguins, kind=\"hist\")"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "The ``markers`` parameter applies a style mapping on the off-diagonal axes. Currently, it will be redundant with the ``hue`` variable:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sns.pairplot(penguins, hue=\"species\", markers=[\"o\", \"s\", \"D\"])"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "As with other figure-level functions, the size of the figure is controlled by setting the ``height`` of each individual subplot:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sns.pairplot(penguins, height=1.5)"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Use ``vars`` or ``x_vars`` and ``y_vars`` to select the variables to plot:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sns.pairplot(\n",
+    "    penguins,\n",
+    "    x_vars=[\"bill_length_mm\", \"bill_depth_mm\", \"flipper_length_mm\"],\n",
+    "    y_vars=[\"bill_length_mm\", \"bill_depth_mm\"],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Set ``corner=True`` to plot only the lower triangle:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sns.pairplot(penguins, corner=True)"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "The ``plot_kws`` and ``diag_kws`` parameters accept dicts of keyword arguments to customize the off-diagonal and diagonal plots, respectively:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sns.pairplot(\n",
+    "    penguins,\n",
+    "    plot_kws=dict(marker=\"+\", linewidth=1),\n",
+    "    diag_kws=dict(fill=False),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "The return object is the underlying :class:`PairGrid`, which can be used to further customize the plot:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "g = sns.pairplot(penguins, diag_kind=\"kde\")\n",
+    "g.map_lower(sns.kdeplot, levels=4, color=\".2\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "seaborn-py38-latest",
+   "language": "python",
+   "name": "seaborn-py38-latest"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/doc/tools/extract_examples.py
+++ b/doc/tools/extract_examples.py
@@ -32,7 +32,7 @@ if __name__ == "__main__":
 
     # Parse the docstring and get the examples section
     obj = getattr(seaborn, name)
-    if obj.__class__ != "function":
+    if obj.__class__.__name__ != "function":
         obj = obj.__init__
     lines = NumpyDocString(pydoc.getdoc(obj))["Examples"]
 

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -1961,10 +1961,10 @@ def pairplot(
     """Plot pairwise relationships in a dataset.
 
     By default, this function will create a grid of Axes such that each numeric
-    variable in ``data`` will by shared in the y-axis across a single row and
-    in the x-axis across a single column. The diagonal Axes are treated
-    differently, drawing a plot to show the univariate distribution of the data
-    for the variable in that column.
+    variable in ``data`` will by shared across the y-axes across a single row and
+    the x-axes across a single column. The diagonal plots are treated
+    differently: a univariate distribution plot is drawn to show the marginal
+    distribution of the data in each column.
 
     It is also possible to show a subset of variables or plot different
     variables on the rows and columns.
@@ -1975,10 +1975,10 @@ def pairplot(
 
     Parameters
     ----------
-    data : DataFrame
+    data : `pandas.DataFrame`
         Tidy (long-form) dataframe where each column is a variable and
         each row is an observation.
-    hue : string (variable name)
+    hue : name of variable in ``data``
         Variable in ``data`` to map plot aspects to different colors.
     hue_order : list of strings
         Order for the levels of the hue variable in the palette
@@ -1991,14 +1991,14 @@ def pairplot(
     {x, y}_vars : lists of variable names
         Variables within ``data`` to use separately for the rows and
         columns of the figure; i.e. to make a non-square plot.
-    kind : {'scatter', 'reg'}
-        Kind of plot for the non-identity relationships.
+    kind : {'scatter', 'kde', 'hist', 'reg'}
+        Kind of plot to make.
     diag_kind : {'auto', 'hist', 'kde', None}
-        Kind of plot for the diagonal subplots. The default depends on whether
-        ``"hue"`` is used or not.
+        Kind of plot for the diagonal subplots. If 'auto', choose based on
+        whether or not ``hue`` is used.
     markers : single matplotlib marker code or list
-        Either the marker to use for all datapoints or a list of markers with
-        a length the same as the number of levels in the hue variable so that
+        Either the marker to use for all scatterplot points or a list of markers
+        with a length the same as the number of levels in the hue variable so that
         differently colored points will also have different scatterplot
         markers.
     height : scalar
@@ -2023,13 +2023,13 @@ def pairplot(
 
     See Also
     --------
-    PairGrid : Subplot grid for more flexible plotting of pairwise
-               relationships.
+    PairGrid : Subplot grid for more flexible plotting of pairwise relationships.
+    JointGrid : Grid for plotting joint and marginal distributions of two variables.
 
     Examples
     --------
 
-    .. include:: ../docstrings/pointplot.rst
+    .. include:: ../docstrings/pairplot.rst
 
     """
     # Avoid circular import

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -2189,7 +2189,7 @@ def pairplot(
 
     """
     # Avoid circular import
-    from .distributions import kdeplot  # TODO histplot
+    from .distributions import histplot, kdeplot
 
     # Handle deprecations
     if size is not None:
@@ -2234,7 +2234,7 @@ def pairplot(
     diag_kws = diag_kws.copy()
     if grid.square_grid:
         if diag_kind == "hist":
-            grid.map_diag(plt.hist, **diag_kws)
+            grid.map_diag(histplot, **diag_kws)
         elif diag_kind == "kde":
             diag_kws.setdefault("fill", True)
             diag_kws["legend"] = False

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -1620,10 +1620,10 @@ class PairGrid(Grid):
         else:
             axes_vars = [x_var, y_var]
 
-        kwargs = kwargs.copy()
-
         hue_grouped = self.data.groupby(self.hue_vals)
         for k, label_k in enumerate(self.hue_names):
+
+            kws = kwargs.copy()
 
             # Attempt to get data for this level, allowing for empty
             try:
@@ -1639,15 +1639,15 @@ class PairGrid(Grid):
             y = data_k[y_var]
 
             for kw, val_list in self.hue_kws.items():
-                kwargs[kw] = val_list[k]
-            kwargs.setdefault("color", self.palette[k])
+                kws[kw] = val_list[k]
+            kws.setdefault("color", self.palette[k])
             if self._hue_var is not None:
-                kwargs["label"] = label_k
+                kws["label"] = label_k
 
             if str(func.__module__).startswith("seaborn"):
-                func(x=x, y=y, **kwargs)
+                func(x=x, y=y, **kws)
             else:
-                func(x, y, **kwargs)
+                func(x, y, **kws)
 
         self._update_legend_data(ax)
         self._clean_axis(ax)

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -1562,8 +1562,7 @@ class PairGrid(Grid):
             self.diag_axes = np.array(diag_axes, np.object)
 
         if "hue" not in signature(func).parameters:
-            self._map_diag_iter_hue(func, **kwargs)
-            return
+            return self._map_diag_iter_hue(func, **kwargs)
 
         # Loop over diagonal variables and axes, making one plot in each
         for var, ax in zip(self.diag_vars, self.diag_axes):
@@ -1591,6 +1590,7 @@ class PairGrid(Grid):
             self._clean_axis(ax)
 
         self._add_axis_labels()
+        return self
 
     def _map_diag_iter_hue(self, func, **kwargs):
         """Put marginal plot on each diagonal axes, iterating over hue."""

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -1261,96 +1261,7 @@ class PairGrid(Grid):
         Examples
         --------
 
-        Draw a scatterplot for each pairwise relationship:
-
-        .. plot::
-            :context: close-figs
-
-            >>> import matplotlib.pyplot as plt
-            >>> import seaborn as sns; sns.set()
-            >>> iris = sns.load_dataset("iris")
-            >>> g = sns.PairGrid(iris)
-            >>> g = g.map(sns.scatterplot)
-
-        Show a univariate distribution on the diagonal:
-
-        .. plot::
-            :context: close-figs
-
-            >>> g = sns.PairGrid(iris)
-            >>> g = g.map_diag(plt.hist)
-            >>> g = g.map_offdiag(sns.scatterplot)
-
-        (It's not actually necessary to catch the return value every time,
-        as it is the same object, but it makes it easier to deal with the
-        doctests).
-
-        Color the points using a categorical variable:
-
-        .. plot::
-            :context: close-figs
-
-            >>> g = sns.PairGrid(iris, hue="species")
-            >>> g = g.map_diag(plt.hist)
-            >>> g = g.map_offdiag(sns.scatterplot)
-            >>> g = g.add_legend()
-
-        Use a different style to show multiple histograms:
-
-        .. plot::
-            :context: close-figs
-
-            >>> g = sns.PairGrid(iris, hue="species")
-            >>> g = g.map_diag(plt.hist, histtype="step", linewidth=3)
-            >>> g = g.map_offdiag(sns.scatterplot)
-            >>> g = g.add_legend()
-
-        Plot a subset of variables
-
-        .. plot::
-            :context: close-figs
-
-            >>> g = sns.PairGrid(iris, vars=["sepal_length", "sepal_width"])
-            >>> g = g.map(sns.scatterplot)
-
-        Pass additional keyword arguments to the functions
-
-        .. plot::
-            :context: close-figs
-
-            >>> g = sns.PairGrid(iris)
-            >>> g = g.map_diag(plt.hist, edgecolor="w")
-            >>> g = g.map_offdiag(sns.scatterplot)
-
-        Use different variables for the rows and columns:
-
-        .. plot::
-            :context: close-figs
-
-            >>> g = sns.PairGrid(iris,
-            ...                  x_vars=["sepal_length", "sepal_width"],
-            ...                  y_vars=["petal_length", "petal_width"])
-            >>> g = g.map(sns.scatterplot)
-
-        Use different functions on the upper and lower triangles:
-
-        .. plot::
-            :context: close-figs
-
-            >>> g = sns.PairGrid(iris)
-            >>> g = g.map_upper(sns.scatterplot)
-            >>> g = g.map_lower(sns.kdeplot, color="C0")
-            >>> g = g.map_diag(sns.kdeplot, lw=2)
-
-        Use different colors and markers for each categorical level:
-
-        .. plot::
-            :context: close-figs
-
-            >>> g = sns.PairGrid(iris, hue="species", palette="Set2",
-            ...                  hue_kws={"marker": ["o", "s", "D"]})
-            >>> g = g.map(sns.scatterplot)
-            >>> g = g.add_legend()
+        .. include:: ../docstrings/PairGrid.rst
 
         """
 
@@ -1438,7 +1349,7 @@ class PairGrid(Grid):
         self.hue_kws = hue_kws if hue_kws is not None else {}
 
         self._orig_palette = palette
-        self._hue_order = hue_order 
+        self._hue_order = hue_order
         self.palette = self._get_palette(data, hue, hue_order, palette)
         self._legend_data = {}
 
@@ -1660,7 +1571,7 @@ class PairGrid(Grid):
         else:
             axes_vars = [x_var, y_var]
 
-        if self._hue_var is not None:
+        if self._hue_var is not None and self._hue_var not in axes_vars:
             axes_vars.append(self._hue_var)
 
         data = self.data[axes_vars]

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -1532,10 +1532,9 @@ class PairGrid(Grid):
 
                 # Attempt to get data for this level, allowing for empty
                 try:
-                    # TODO newer matplotlib(?) doesn't need array for hist
-                    data_k = np.asarray(hue_grouped.get_group(label_k))
+                    data_k = hue_grouped.get_group(label_k)
                 except KeyError:
-                    data_k = np.array([])
+                    data_k = pd.Series([], dtype=float)
 
                 if fixed_color is None:
                     color = self.palette[k]

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -1619,6 +1619,8 @@ class PairGrid(Grid):
         else:
             axes_vars = [x_var, y_var]
 
+        kwargs = kwargs.copy()
+
         hue_grouped = self.data.groupby(self.hue_vals)
         for k, label_k in enumerate(self.hue_names):
 
@@ -1638,11 +1640,14 @@ class PairGrid(Grid):
             for kw, val_list in self.hue_kws.items():
                 kwargs[kw] = val_list[k]
             color = self.palette[k] if kw_color is None else kw_color
+            kwargs.setdefault("color", color)
+            if self._hue_var is not None:
+                kwargs["label"] = label_k
 
             if str(func.__module__).startswith("seaborn"):
-                func(x=x, y=y, label=label_k, color=color, **kwargs)
+                func(x=x, y=y, **kwargs)
             else:
-                func(x, y, label=label_k, color=color, **kwargs)
+                func(x, y, **kwargs)
 
         self._update_legend_data(ax)
         self._clean_axis(ax)
@@ -2091,15 +2096,14 @@ def pairplot(
 
     diag_kws = diag_kws.copy()
     diag_kws.setdefault("legend", False)
-    if grid.square_grid:
-        if diag_kind == "hist":
-            grid.map_diag(histplot, **diag_kws)
-        elif diag_kind == "kde":
-            diag_kws.setdefault("fill", True)
-            grid.map_diag(kdeplot, **diag_kws)
+    if diag_kind == "hist":
+        grid.map_diag(histplot, **diag_kws)
+    elif diag_kind == "kde":
+        diag_kws.setdefault("fill", True)
+        grid.map_diag(kdeplot, **diag_kws)
 
     # Maybe plot on the off-diagonals
-    if grid.square_grid and diag_kind is not None:
+    if diag_kind is not None:
         plotter = grid.map_offdiag
     else:
         plotter = grid.map

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -172,6 +172,14 @@ class Grid(object):
 
         return self
 
+    @property
+    def legend(self):
+        """Access to the legend object."""
+        try:
+            return self._legend
+        except AttributeError:
+            return None
+
     def _clean_axis(self, ax):
         """Turn off axis labels and legend."""
         ax.set_xlabel("")

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -1438,6 +1438,7 @@ class PairGrid(Grid):
         self.hue_kws = hue_kws if hue_kws is not None else {}
 
         self._orig_palette = palette
+        self._hue_order = hue_order 
         self.palette = self._get_palette(data, hue, hue_order, palette)
         self._legend_data = {}
 
@@ -1585,6 +1586,7 @@ class PairGrid(Grid):
                     hue = hue[not_na]
 
             plot_kwargs.setdefault("hue", hue)
+            plot_kwargs.setdefault("hue_order", self._hue_order)
             plot_kwargs.setdefault("palette", self._orig_palette)
             func(x=vector, **plot_kwargs)
             self._clean_axis(ax)
@@ -1673,6 +1675,7 @@ class PairGrid(Grid):
             hue = data.get(self._hue_var)
 
         kwargs.setdefault("hue", hue)
+        kwargs.setdefault("hue_order", self._hue_order)
         kwargs.setdefault("palette", self._orig_palette)
         func(x=x, y=y, **kwargs)
 

--- a/seaborn/distributions.py
+++ b/seaborn/distributions.py
@@ -498,9 +498,7 @@ class _DistributionPlotter(VectorPlotter):
                         # Avoid drawing empty fill_between on date axis
                         # https://github.com/matplotlib/matplotlib/issues/17586
                         scout = None
-                        default_color = plot_kws.pop(
-                            "color", plot_kws.pop("facecolor", None)
-                        )
+                        default_color = plot_kws.pop("facecolor", color)
                         if default_color is None:
                             default_color = "C0"
                     else:
@@ -508,7 +506,6 @@ class _DistributionPlotter(VectorPlotter):
                         plot_kws = _normalize_kwargs(plot_kws, artist)
                         scout = self.ax.fill_between([], [], color=color, **plot_kws)
                         default_color = tuple(scout.get_facecolor().squeeze())
-                        plot_kws.pop("color", None)
                 else:
                     artist = mpl.lines.Line2D
                     plot_kws = _normalize_kwargs(plot_kws, artist)

--- a/seaborn/tests/test_axisgrid.py
+++ b/seaborn/tests/test_axisgrid.py
@@ -934,8 +934,9 @@ class TestPairGrid(object):
 
     def test_map_diag_palette(self):
 
-        pal = color_palette(n_colors=len(self.df.a.unique()))
-        g = ag.PairGrid(self.df, hue="a")
+        palette = "muted"
+        pal = color_palette(palette, n_colors=len(self.df.a.unique()))
+        g = ag.PairGrid(self.df, hue="a", palette=palette)
         g.map_diag(kdeplot)
 
         for ax in g.diag_axes:
@@ -1104,13 +1105,13 @@ class TestPairGrid(object):
 
         plt.close("all")
 
-    def test_nondefault_index(self):
+    def test_nondefault_index(self, func):
 
         df = self.df.copy().set_index("b")
 
         plot_vars = ["x", "y", "z"]
         g1 = ag.PairGrid(df)
-        g1.map(plt.scatter)
+        g1.map(func)
 
         for i, axes_i in enumerate(g1.axes):
             for j, ax in enumerate(axes_i):
@@ -1121,7 +1122,7 @@ class TestPairGrid(object):
                 npt.assert_array_equal(y_in, y_out)
 
         g2 = ag.PairGrid(df, hue="a")
-        g2.map(plt.scatter)
+        g2.map(func)
 
         for i, axes_i in enumerate(g2.axes):
             for j, ax in enumerate(axes_i):
@@ -1134,7 +1135,8 @@ class TestPairGrid(object):
                 npt.assert_array_equal(x_in_k, x_out)
                 npt.assert_array_equal(y_in_k, y_out)
 
-    def test_dropna(self):
+    @pytest.mark.parametrize("func", [scatterplot, plt.scatter])
+    def test_dropna(self, func):
 
         df = self.df.copy()
         n_null = 20
@@ -1143,7 +1145,7 @@ class TestPairGrid(object):
         plot_vars = ["x", "y", "z"]
 
         g1 = ag.PairGrid(df, vars=plot_vars, dropna=True)
-        g1.map(plt.scatter)
+        g1.map(func)
 
         for i, axes_i in enumerate(g1.axes):
             for j, ax in enumerate(axes_i):
@@ -1155,6 +1157,12 @@ class TestPairGrid(object):
 
                 assert n_valid == len(x_out)
                 assert n_valid == len(y_out)
+
+        g1.map_diag(histplot)
+        for i, ax in enumerate(g1.diag_axes):
+            var = plot_vars[i]
+            count = sum([p.get_height() for p in ax.patches])
+            assert count == df[var].notna().sum()
 
     def test_pairplot(self):
 

--- a/seaborn/tests/test_axisgrid.py
+++ b/seaborn/tests/test_axisgrid.py
@@ -1105,13 +1105,13 @@ class TestPairGrid(object):
 
         plt.close("all")
 
-    def test_nondefault_index(self, func):
+    def test_nondefault_index(self):
 
         df = self.df.copy().set_index("b")
 
         plot_vars = ["x", "y", "z"]
         g1 = ag.PairGrid(df)
-        g1.map(func)
+        g1.map(plt.scatter)
 
         for i, axes_i in enumerate(g1.axes):
             for j, ax in enumerate(axes_i):
@@ -1122,7 +1122,7 @@ class TestPairGrid(object):
                 npt.assert_array_equal(y_in, y_out)
 
         g2 = ag.PairGrid(df, hue="a")
-        g2.map(func)
+        g2.map(plt.scatter)
 
         for i, axes_i in enumerate(g2.axes):
             for j, ax in enumerate(axes_i):
@@ -1132,8 +1132,8 @@ class TestPairGrid(object):
                     x_in_k = x_in[self.df.a == k_level]
                     y_in_k = y_in[self.df.a == k_level]
                     x_out, y_out = ax.collections[k].get_offsets().T
-                npt.assert_array_equal(x_in_k, x_out)
-                npt.assert_array_equal(y_in_k, y_out)
+                    npt.assert_array_equal(x_in_k, x_out)
+                    npt.assert_array_equal(y_in_k, y_out)
 
     @pytest.mark.parametrize("func", [scatterplot, plt.scatter])
     def test_dropna(self, func):

--- a/seaborn/tests/test_axisgrid.py
+++ b/seaborn/tests/test_axisgrid.py
@@ -1241,7 +1241,21 @@ class TestPairGrid(object):
             ax = g.axes[i, j]
             nt.assert_equal(len(ax.collections), 0)
 
-    def test_pairplot_kde(self):
+    def test_pairplot_reg_hue(self):
+
+        markers = ["o", "s", "d"]
+        g = ag.pairplot(self.df, kind="reg", hue="a", markers=markers)
+
+        ax = g.axes[-1, 0]
+        c1 = ax.collections[0]
+        c2 = ax.collections[2]
+
+        assert not np.array_equal(c1.get_facecolor(), c2.get_facecolor())
+        assert not np.array_equal(
+            c1.get_paths()[0].vertices, c2.get_paths()[0].vertices,
+        )
+
+    def test_pairplot_diag_kde(self):
 
         vars = ["x", "y", "z"]
         g = ag.pairplot(self.df, diag_kind="kde")
@@ -1269,6 +1283,26 @@ class TestPairGrid(object):
             ax = g.axes[i, j]
             nt.assert_equal(len(ax.collections), 0)
 
+    def test_pairplot_kde(self):
+
+        f, ax1 = plt.subplots()
+        kdeplot(data=self.df, x="x", y="y", ax=ax1)
+
+        g = ag.pairplot(self.df, kind="kde")
+        ax2 = g.axes[1, 0]
+
+        assert_plots_equal(ax1, ax2, labels=False)
+
+    def test_pairplot_hist(self):
+
+        f, ax1 = plt.subplots()
+        histplot(data=self.df, x="x", y="y", ax=ax1)
+
+        g = ag.pairplot(self.df, kind="hist")
+        ax2 = g.axes[1, 0]
+
+        assert_plots_equal(ax1, ax2, labels=False)
+
     def test_pairplot_markers(self):
 
         vars = ["x", "y", "z"]
@@ -1277,7 +1311,6 @@ class TestPairGrid(object):
         m1 = g._legend.legendHandles[0].get_paths()[0]
         m2 = g._legend.legendHandles[1].get_paths()[0]
         assert m1 != m2
-        plt.close("all")
 
         with pytest.raises(ValueError):
             g = ag.pairplot(self.df, hue="a", vars=vars, markers=markers[:-2])
@@ -1296,8 +1329,11 @@ class TestPairGrid(object):
 
     def test_legend(self):
 
-        g = ag.pairplot(self.df, hue="a")
-        assert isinstance(g.legend, mpl.legend.Legend)
+        g1 = ag.pairplot(self.df, hue="a")
+        assert isinstance(g1.legend, mpl.legend.Legend)
+
+        g2 = ag.pairplot(self.df)
+        assert g2.legend is None
 
 
 class TestJointGrid(object):

--- a/seaborn/tests/test_axisgrid.py
+++ b/seaborn/tests/test_axisgrid.py
@@ -1164,6 +1164,15 @@ class TestPairGrid(object):
             count = sum([p.get_height() for p in ax.patches])
             assert count == df[var].notna().sum()
 
+    def test_histplot_legend(self):
+
+        # Tests _extract_legend_handles
+        g = ag.PairGrid(self.df, vars=["x", "y"], hue="a")
+        g.map_offdiag(histplot)
+        g.add_legend()
+
+        assert len(g._legend.legendHandles) == len(self.df["a"].unique())
+
     def test_pairplot(self):
 
         vars = ["x", "y", "z"]

--- a/seaborn/tests/test_axisgrid.py
+++ b/seaborn/tests/test_axisgrid.py
@@ -1272,9 +1272,11 @@ class TestPairGrid(object):
     def test_pairplot_markers(self):
 
         vars = ["x", "y", "z"]
-        markers = ["o", "x", "s"]
+        markers = ["o", "X", "s"]
         g = ag.pairplot(self.df, hue="a", vars=vars, markers=markers)
-        assert g.hue_kws["marker"] == markers
+        m1 = g._legend.legendHandles[0].get_paths()[0]
+        m2 = g._legend.legendHandles[1].get_paths()[0]
+        assert m1 != m2
         plt.close("all")
 
         with pytest.raises(ValueError):

--- a/seaborn/tests/test_axisgrid.py
+++ b/seaborn/tests/test_axisgrid.py
@@ -1294,6 +1294,11 @@ class TestPairGrid(object):
         g.set(xlim=(0, 10))
         assert g.axes[-1, 0].get_xlim() == (0, 10)
 
+    def test_legend(self):
+
+        g = ag.pairplot(self.df, hue="a")
+        assert isinstance(g.legend, mpl.legend.Legend)
+
 
 class TestJointGrid(object):
 

--- a/seaborn/tests/test_axisgrid.py
+++ b/seaborn/tests/test_axisgrid.py
@@ -939,7 +939,7 @@ class TestPairGrid(object):
         g.map_diag(kdeplot)
 
         for ax in g.diag_axes:
-            for line, color in zip(ax.lines, pal):
+            for line, color in zip(ax.lines[::-1], pal):
                 assert line.get_color() == color
 
     def test_map_diag_and_offdiag(self):
@@ -1196,7 +1196,7 @@ class TestPairGrid(object):
         g = ag.pairplot(self.df, diag_kind="hist", kind="reg")
 
         for ax in g.diag_axes:
-            nt.assert_equal(len(ax.patches), 10)
+            assert len(ax.patches)
 
         for i, j in zip(*np.triu_indices_from(g.axes, 1)):
             ax = g.axes[i, j]


### PR DESCRIPTION
The main enhancement here is that `PairGrid` will pass `hue` down to the axes-level functions if they accept it, giving better visuals and more flexibility.

A few other things were cleaned up:

- Added `kind="kde"` and `kind="hist"` in `pairplot`
- Added public access to the `PairGrid` (and `FacetGrid`) legend object
- Made it possible to pass only one of `x_vars` and `y_vars`
- No longer pass `color` or `label` in `PairGrid` when not using `hue` (fixes #1301)
- No longer cast pandas data to a numpy array before plotting on the diagonal (fixes #1663)
- Converted `PairGrid` and `pairplot` API examples to notebooks and updated them


These changes need to be noted in the release notes, using the `docs_cleanup` branch to avoid a merge conflict.

Closes #2198 