### PR TITLE
MAINT: avoid deprecation warnings with future numpy releases

### DIFF
--- a/examples/many_pairwise_correlations.py
+++ b/examples/many_pairwise_correlations.py
@@ -21,7 +21,7 @@ d = pd.DataFrame(data=rs.normal(size=(100, 26)),
 corr = d.corr()
 
 # Generate a mask for the upper triangle
-mask = np.triu(np.ones_like(corr, dtype=np.bool))
+mask = np.triu(np.ones_like(corr, dtype=bool))
 
 # Set up the matplotlib figure
 f, ax = plt.subplots(figsize=(11, 9))

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -308,7 +308,7 @@ class FacetGrid(Grid):
 
         # Make a boolean mask that is True anywhere there is an NA
         # value in one of the faceting variables, but only if dropna is True
-        none_na = np.zeros(len(data), np.bool)
+        none_na = np.zeros(len(data), bool)
         if dropna:
             row_na = none_na if row is None else data[row].isnull()
             col_na = none_na if col is None else data[col].isnull()
@@ -1546,8 +1546,8 @@ class PairGrid(Grid):
                 for ax in diag_axes[1:]:
                     group.join(ax, diag_axes[0])
 
-            self.diag_vars = np.array(diag_vars, np.object)
-            self.diag_axes = np.array(diag_axes, np.object)
+            self.diag_vars = np.array(diag_vars, np.object_)
+            self.diag_axes = np.array(diag_axes, np.object_)
 
         # Plot on each of the diagonal axes
         fixed_color = kwargs.pop("color", None)
@@ -1611,7 +1611,7 @@ class PairGrid(Grid):
                 data_k = hue_grouped.get_group(label_k)
             except KeyError:
                 data_k = pd.DataFrame(columns=axes_vars,
-                                      dtype=np.float)
+                                      dtype=float)
 
             if self._dropna:
                 data_k = data_k[axes_vars].dropna()

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -79,7 +79,7 @@ class _CategoricalPlotter(object):
 
                 # Convert to a list of arrays, the common representation
                 iter_data = plot_data.iteritems()
-                plot_data = [np.asarray(s, np.float) for k, s in iter_data]
+                plot_data = [np.asarray(s, float) for k, s in iter_data]
 
             # Option 1b:
             # The input data is an array or list
@@ -125,7 +125,7 @@ class _CategoricalPlotter(object):
                     plot_data = data
 
                 # Convert to a list of arrays, the common representation
-                plot_data = [np.asarray(d, np.float) for d in plot_data]
+                plot_data = [np.asarray(d, float) for d in plot_data]
 
                 # The group names will just be numeric indices
                 group_names = list(range((len(plot_data))))
@@ -1058,7 +1058,7 @@ class _CategoricalScatterPlotter(_CategoricalPlotter):
         for i, group_data in enumerate(self.plot_data):
 
             # Initialize the array for this group level
-            group_colors = np.empty(group_data.size, np.int)
+            group_colors = np.empty(group_data.size, int)
             if isinstance(group_data, pd.Series):
                 group_colors = pd.Series(group_colors, group_data.index)
 
@@ -1118,10 +1118,10 @@ class _StripPlotter(_CategoricalScatterPlotter):
             if self.plot_hues is None or not self.dodge:
 
                 if self.hue_names is None:
-                    hue_mask = np.ones(group_data.size, np.bool)
+                    hue_mask = np.ones(group_data.size, bool)
                 else:
                     hue_mask = np.array([h in self.hue_names
-                                         for h in self.plot_hues[i]], np.bool)
+                                         for h in self.plot_hues[i]], bool)
                     # Broken on older numpys
                     # hue_mask = np.in1d(self.plot_hues[i], self.hue_names)
 
@@ -1354,10 +1354,10 @@ class _SwarmPlotter(_CategoricalScatterPlotter):
                 width = self.width
 
                 if self.hue_names is None:
-                    hue_mask = np.ones(group_data.size, np.bool)
+                    hue_mask = np.ones(group_data.size, bool)
                 else:
                     hue_mask = np.array([h in self.hue_names
-                                         for h in self.plot_hues[i]], np.bool)
+                                         for h in self.plot_hues[i]], bool)
                     # Broken on older numpys
                     # hue_mask = np.in1d(self.plot_hues[i], self.hue_names)
 

--- a/seaborn/distributions.py
+++ b/seaborn/distributions.py
@@ -2556,7 +2556,7 @@ def distplot(a=None, bins=None, hist=True, kde=True, rug=False, fit=None,
         a = x
 
     # Make a a 1-d float array
-    a = np.asarray(a, np.float)
+    a = np.asarray(a, float)
     if a.ndim > 1:
         a = a.squeeze()
 

--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -66,7 +66,7 @@ def _matrix_mask(data, mask):
 
     """
     if mask is None:
-        mask = np.zeros(data.shape, np.bool)
+        mask = np.zeros(data.shape, bool)
 
     if isinstance(mask, np.ndarray):
         # For array masks, ensure that shape matches data then convert
@@ -76,7 +76,7 @@ def _matrix_mask(data, mask):
         mask = pd.DataFrame(mask,
                             index=data.index,
                             columns=data.columns,
-                            dtype=np.bool)
+                            dtype=bool)
 
     elif isinstance(mask, pd.DataFrame):
         # For DataFrame masks, ensure that semantic labels match data
@@ -196,7 +196,7 @@ class _HeatMapper(object):
         """Use some heuristics to set good defaults for colorbar and range."""
 
         # plot_data is a np.ma.array instance
-        calc_data = plot_data.astype(np.float).filled(np.nan)
+        calc_data = plot_data.astype(float).filled(np.nan)
         if vmin is None:
             if robust:
                 vmin = np.nanpercentile(calc_data, 2)

--- a/seaborn/relational.py
+++ b/seaborn/relational.py
@@ -354,7 +354,7 @@ class _LinePlotter(_RelationalPlotter):
         seed = self.seed
 
         # Define a "null" CI for when we only have one value
-        null_ci = pd.Series(index=["low", "high"], dtype=np.float)
+        null_ci = pd.Series(index=["low", "high"], dtype=float)
 
         # Function to bootstrap in the context of a pandas group by
         def bootstrapped_cis(vals):

--- a/seaborn/tests/test_axisgrid.py
+++ b/seaborn/tests/test_axisgrid.py
@@ -622,7 +622,7 @@ class TestFacetGrid(object):
     def test_dropna(self):
 
         df = self.df.copy()
-        hasna = pd.Series(np.tile(np.arange(6), 10), dtype=np.float)
+        hasna = pd.Series(np.tile(np.arange(6), 10), dtype=float)
         hasna[hasna == 5] = np.nan
         df["hasna"] = hasna
         g = ag.FacetGrid(df, dropna=False, row="hasna")

--- a/seaborn/tests/test_matrix.py
+++ b/seaborn/tests/test_matrix.py
@@ -87,7 +87,7 @@ class TestHeatmap(object):
         npt.assert_array_equal(p.xticklabels, combined_tick_labels)
         nt.assert_equal(p.xlabel, "letter-number")
 
-    @pytest.mark.parametrize("dtype", [np.float, np.int64, np.object])
+    @pytest.mark.parametrize("dtype", [float, np.int64, object])
     def test_mask_input(self, dtype):
         kws = self.default_kws.copy()
 
@@ -443,7 +443,7 @@ class TestHeatmap(object):
 
     def test_missing_data_mask(self):
 
-        data = pd.DataFrame(np.arange(4, dtype=np.float).reshape(2, 2))
+        data = pd.DataFrame(np.arange(4, dtype=float).reshape(2, 2))
         data.loc[0, 0] = np.nan
         mask = mat._matrix_mask(data, None)
         npt.assert_array_equal(mask, [[True, False], [False, False]])


### PR DESCRIPTION
The next minor numpy version (1.20) [deprecated](https://github.com/numpy/numpy/pull/14882) the usage of numpy types that are just aliases to python builtin types. This includes `np.bool`, `np.int`, `np.float` and others. This PR replaces these occurrences with the native types to avoid deprecation warnings on future numpy versions. I changed `np.object` to `np.object_` and not the builtin type since it resulted with slight differences in the relevant test suit (`test_matrix.py`).