### PR TITLE
Add set_theme() to replace set()

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -116,13 +116,13 @@ Joint grids
 
 .. _style_api:
 
-Style control 
--------------
+Themes
+------
 
 .. autosummary::
     :toctree: generated/
 
-    set
+    set_theme
     axes_style
     set_style
     plotting_context
@@ -130,6 +130,7 @@ Style control
     set_color_codes
     reset_defaults
     reset_orig
+    set
 
 .. _palette_api:
 

--- a/doc/docstrings/FacetGrid.ipynb
+++ b/doc/docstrings/FacetGrid.ipynb
@@ -11,7 +11,7 @@
    "outputs": [],
    "source": [
     "import seaborn as sns\n",
-    "sns.set(style=\"ticks\")"
+    "sns.set_theme(style=\"ticks\")"
    ]
   },
   {

--- a/doc/docstrings/JointGrid.ipynb
+++ b/doc/docstrings/JointGrid.ipynb
@@ -11,7 +11,7 @@
    "outputs": [],
    "source": [
     "import seaborn as sns\n",
-    "sns.set()"
+    "sns.set_theme()"
    ]
   },
   {

--- a/doc/docstrings/PairGrid.ipynb
+++ b/doc/docstrings/PairGrid.ipynb
@@ -10,7 +10,7 @@
    },
    "outputs": [],
    "source": [
-    "import seaborn as sns; sns.set()\n",
+    "import seaborn as sns; sns.set_theme()\n",
     "import matplotlib.pyplot as plt"
    ]
   },

--- a/doc/docstrings/color_palette.ipynb
+++ b/doc/docstrings/color_palette.ipynb
@@ -10,7 +10,7 @@
    },
    "outputs": [],
    "source": [
-    "import seaborn as sns; sns.set()"
+    "import seaborn as sns; sns.set_theme()"
    ]
   },
   {

--- a/doc/docstrings/displot.ipynb
+++ b/doc/docstrings/displot.ipynb
@@ -10,7 +10,7 @@
    },
    "outputs": [],
    "source": [
-    "import seaborn as sns; sns.set(style=\"ticks\")"
+    "import seaborn as sns; sns.set_theme(style=\"ticks\")"
    ]
   },
   {

--- a/doc/docstrings/ecdfplot.ipynb
+++ b/doc/docstrings/ecdfplot.ipynb
@@ -17,7 +17,7 @@
    },
    "outputs": [],
    "source": [
-    "import seaborn as sns; sns.set()"
+    "import seaborn as sns; sns.set_theme()"
    ]
   },
   {

--- a/doc/docstrings/histplot.ipynb
+++ b/doc/docstrings/histplot.ipynb
@@ -11,7 +11,7 @@
    "outputs": [],
    "source": [
     "import seaborn as sns\n",
-    "sns.set(style=\"white\")"
+    "sns.set_theme(style=\"white\")"
    ]
   },
   {

--- a/doc/docstrings/jointplot.ipynb
+++ b/doc/docstrings/jointplot.ipynb
@@ -11,7 +11,7 @@
    "outputs": [],
    "source": [
     "import seaborn as sns\n",
-    "sns.set(style=\"white\")"
+    "sns.set_theme(style=\"white\")"
    ]
   },
   {

--- a/doc/docstrings/kdeplot.ipynb
+++ b/doc/docstrings/kdeplot.ipynb
@@ -10,7 +10,7 @@
    },
    "outputs": [],
    "source": [
-    "import seaborn as sns; sns.set()"
+    "import seaborn as sns; sns.set_theme()"
    ]
   },
   {

--- a/doc/docstrings/lineplot.ipynb
+++ b/doc/docstrings/lineplot.ipynb
@@ -15,7 +15,7 @@
     "import seaborn as sns\n",
     "import matplotlib as mpl\n",
     "import matplotlib.pyplot as plt\n",
-    "sns.set()"
+    "sns.set_theme()"
    ]
   },
   {

--- a/doc/docstrings/pairplot.ipynb
+++ b/doc/docstrings/pairplot.ipynb
@@ -11,7 +11,7 @@
    "outputs": [],
    "source": [
     "import seaborn as sns\n",
-    "sns.set(style=\"ticks\")"
+    "sns.set_theme(style=\"ticks\")"
    ]
   },
   {

--- a/doc/docstrings/relplot.ipynb
+++ b/doc/docstrings/relplot.ipynb
@@ -19,7 +19,7 @@
    "source": [
     "import seaborn as sns\n",
     "import matplotlib.pyplot as plt\n",
-    "sns.set(style=\"ticks\")"
+    "sns.set_theme(style=\"ticks\")"
    ]
   },
   {

--- a/doc/docstrings/rugplot.ipynb
+++ b/doc/docstrings/rugplot.ipynb
@@ -13,7 +13,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import seaborn as sns; sns.set()\n",
+    "import seaborn as sns; sns.set_theme()\n",
     "tips = sns.load_dataset(\"tips\")\n",
     "sns.kdeplot(data=tips, x=\"total_bill\")\n",
     "sns.rugplot(data=tips, x=\"total_bill\")"

--- a/doc/docstrings/scatterplot.ipynb
+++ b/doc/docstrings/scatterplot.ipynb
@@ -14,7 +14,7 @@
     "import pandas as pd\n",
     "import seaborn as sns\n",
     "import matplotlib.pyplot as plt\n",
-    "sns.set()"
+    "sns.set_theme()"
    ]
   },
   {

--- a/doc/introduction.ipynb
+++ b/doc/introduction.ipynb
@@ -35,7 +35,7 @@
     "import seaborn as sns\n",
     "\n",
     "# Apply the default theme\n",
-    "sns.set()\n",
+    "sns.set_theme()\n",
     "\n",
     "# Load an example dataset\n",
     "tips = sns.load_dataset(\"tips\")\n",
@@ -89,7 +89,7 @@
    "outputs": [],
    "source": [
     "# Apply the default theme\n",
-    "sns.set()"
+    "sns.set_theme()"
    ]
   },
   {
@@ -409,7 +409,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.set(style=\"ticks\", font_scale=1.25)\n",
+    "sns.set_theme(style=\"ticks\", font_scale=1.25)\n",
     "g = sns.relplot(\n",
     "    data=penguins,\n",
     "    x=\"bill_length_mm\", y=\"bill_depth_mm\", hue=\"body_mass_g\",\n",

--- a/doc/releases/v0.11.0.txt
+++ b/doc/releases/v0.11.0.txt
@@ -110,6 +110,11 @@ Documentation improvements
 
 - |Docs| Improved cross-linking within the seaborn docs and between the seaborn and matplotlib docs.
 
+Theming
+~~~~~~~
+
+- |API| The :func:`set` function has been renamed to :func:`set_theme` for more clarity about what it does. For the foreseeable future, :func:`set` will remain as an alias, but it is recommended to update your code.
+
 Relational plots
 ^^^^^^^^^^^^^^^^
 

--- a/doc/tutorial/aesthetics.ipynb
+++ b/doc/tutorial/aesthetics.ipynb
@@ -103,7 +103,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.set()\n",
+    "sns.set_theme()\n",
     "sinplot()"
    ]
   },
@@ -334,7 +334,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.set()"
+    "sns.set_theme()"
    ]
   },
   {

--- a/doc/tutorial/aesthetics.ipynb
+++ b/doc/tutorial/aesthetics.ipynb
@@ -94,7 +94,7 @@
    "cell_type": "raw",
    "metadata": {},
    "source": [
-    "To switch to seaborn defaults, simply call the :func:`set` function."
+    "To switch to seaborn defaults, simply call the :func:`set_theme` function."
    ]
   },
   {
@@ -111,7 +111,7 @@
    "cell_type": "raw",
    "metadata": {},
    "source": [
-    "(Note that in versions of seaborn prior to 0.8, :func:`set` was called on import. On later versions, it must be explicitly invoked).\n",
+    "(Note that in versions of seaborn prior to 0.8, :func:`set_theme` was called on import. On later versions, it must be explicitly invoked).\n",
     "\n",
     "Seaborn splits matplotlib parameters into two independent groups. The first group sets the aesthetic style of the plot, and the second scales various elements of the figure so that it can be easily incorporated into different contexts.\n",
     "\n",
@@ -283,7 +283,7 @@
     "Overriding elements of the seaborn styles\n",
     "-----------------------------------------\n",
     "\n",
-    "If you want to customize the seaborn styles, you can pass a dictionary of parameters to the ``rc`` argument of :func:`axes_style` and :func:`set_style`. Note that you can only override the parameters that are part of the style definition through this method. (However, the higher-level :func:`set` function takes a dictionary of any matplotlib parameters).\n",
+    "If you want to customize the seaborn styles, you can pass a dictionary of parameters to the ``rc`` argument of :func:`axes_style` and :func:`set_style`. Note that you can only override the parameters that are part of the style definition through this method. (However, the higher-level :func:`set_theme` function takes a dictionary of any matplotlib parameters).\n",
     "\n",
     "If you want to see what parameters are included, you can just call the function with no arguments, which will return the current settings:"
    ]
@@ -325,7 +325,7 @@
     "\n",
     "A separate set of parameters control the scale of plot elements, which should let you use the same code to make plots that are suited for use in settings where larger or smaller plots are appropriate.\n",
     "\n",
-    "First let's reset the default parameters by calling :func:`set`:"
+    "First let's reset the default parameters by calling :func:`set_theme`:"
    ]
   },
   {

--- a/doc/tutorial/axis_grids.ipynb
+++ b/doc/tutorial/axis_grids.ipynb
@@ -54,7 +54,7 @@
    },
    "outputs": [],
    "source": [
-    "sns.set(style=\"ticks\")"
+    "sns.set_theme(style=\"ticks\")"
    ]
   },
   {

--- a/doc/tutorial/categorical.ipynb
+++ b/doc/tutorial/categorical.ipynb
@@ -56,7 +56,7 @@
    "source": [
     "import seaborn as sns\n",
     "import matplotlib.pyplot as plt\n",
-    "sns.set(style=\"ticks\", color_codes=True)"
+    "sns.set_theme(style=\"ticks\", color_codes=True)"
    ]
   },
   {

--- a/doc/tutorial/color_palettes.ipynb
+++ b/doc/tutorial/color_palettes.ipynb
@@ -38,7 +38,7 @@
     "import numpy as np\n",
     "import seaborn as sns\n",
     "import matplotlib.pyplot as plt\n",
-    "sns.set(style=\"white\", rc={\"xtick.major.pad\": 1, \"ytick.major.pad\": 1})"
+    "sns.set_theme(style=\"white\", rc={\"xtick.major.pad\": 1, \"ytick.major.pad\": 1})"
    ]
   },
   {

--- a/doc/tutorial/data_structure.ipynb
+++ b/doc/tutorial/data_structure.ipynb
@@ -39,7 +39,7 @@
     "import numpy as np\n",
     "import pandas as pd\n",
     "import seaborn as sns\n",
-    "sns.set()"
+    "sns.set_theme()"
    ]
   },
   {

--- a/doc/tutorial/distributions.ipynb
+++ b/doc/tutorial/distributions.ipynb
@@ -38,7 +38,7 @@
    "outputs": [],
    "source": [
     "%matplotlib inline\n",
-    "import seaborn as sns; sns.set()"
+    "import seaborn as sns; sns.set_theme()"
    ]
   },
   {

--- a/doc/tutorial/function_overview.ipynb
+++ b/doc/tutorial/function_overview.ipynb
@@ -38,7 +38,7 @@
     "import seaborn as sns\n",
     "import matplotlib.pyplot as plt\n",
     "from IPython.display import HTML\n",
-    "sns.set()"
+    "sns.set_theme()"
    ]
   },
   {

--- a/doc/tutorial/regression.ipynb
+++ b/doc/tutorial/regression.ipynb
@@ -47,7 +47,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.set(color_codes=True)"
+    "sns.set_theme(color_codes=True)"
    ]
   },
   {

--- a/doc/tutorial/relational.ipynb
+++ b/doc/tutorial/relational.ipynb
@@ -40,7 +40,7 @@
     "import pandas as pd\n",
     "import matplotlib.pyplot as plt\n",
     "import seaborn as sns\n",
-    "sns.set(style=\"darkgrid\")"
+    "sns.set_theme(style=\"darkgrid\")"
    ]
   },
   {

--- a/examples/anscombes_quartet.py
+++ b/examples/anscombes_quartet.py
@@ -5,7 +5,7 @@ Anscombe's quartet
 _thumb: .4, .4
 """
 import seaborn as sns
-sns.set(style="ticks")
+sns.set_theme(style="ticks")
 
 # Load the example dataset for Anscombe's quartet
 df = sns.load_dataset("anscombe")

--- a/examples/different_scatter_variables.py
+++ b/examples/different_scatter_variables.py
@@ -7,7 +7,7 @@ _thumb: .45, .5
 """
 import seaborn as sns
 import matplotlib.pyplot as plt
-sns.set(style="whitegrid")
+sns.set_theme(style="whitegrid")
 
 # Load the example diamonds dataset
 diamonds = sns.load_dataset("diamonds")

--- a/examples/errorband_lineplots.py
+++ b/examples/errorband_lineplots.py
@@ -6,7 +6,7 @@ _thumb: .48, .45
 
 """
 import seaborn as sns
-sns.set(style="darkgrid")
+sns.set_theme(style="darkgrid")
 
 # Load an example dataset with long-form data
 fmri = sns.load_dataset("fmri")

--- a/examples/faceted_histogram.py
+++ b/examples/faceted_histogram.py
@@ -6,7 +6,7 @@ _thumb: .33, .57
 """
 import seaborn as sns
 
-sns.set(style="darkgrid")
+sns.set_theme(style="darkgrid")
 df = sns.load_dataset("penguins")
 sns.displot(
     df, x="flipper_length_mm", col="species", row="sex",

--- a/examples/faceted_lineplot.py
+++ b/examples/faceted_lineplot.py
@@ -6,7 +6,7 @@ _thumb: .48, .42
 
 """
 import seaborn as sns
-sns.set(style="ticks")
+sns.set_theme(style="ticks")
 
 dots = sns.load_dataset("dots")
 

--- a/examples/grouped_barplot.py
+++ b/examples/grouped_barplot.py
@@ -5,7 +5,7 @@ Grouped barplots
 _thumb: .36, .5
 """
 import seaborn as sns
-sns.set(style="whitegrid")
+sns.set_theme(style="whitegrid")
 
 penguins = sns.load_dataset("penguins")
 

--- a/examples/grouped_boxplot.py
+++ b/examples/grouped_boxplot.py
@@ -6,7 +6,7 @@ _thumb: .66, .45
 
 """
 import seaborn as sns
-sns.set(style="ticks", palette="pastel")
+sns.set_theme(style="ticks", palette="pastel")
 
 # Load the example tips dataset
 tips = sns.load_dataset("tips")

--- a/examples/grouped_violinplots.py
+++ b/examples/grouped_violinplots.py
@@ -5,7 +5,7 @@ Grouped violinplots with split violins
 _thumb: .44, .47
 """
 import seaborn as sns
-sns.set(style="whitegrid")
+sns.set_theme(style="whitegrid")
 
 # Load the example tips dataset
 tips = sns.load_dataset("tips")

--- a/examples/heat_scatter.py
+++ b/examples/heat_scatter.py
@@ -6,7 +6,7 @@ _thumb: .5, .5
 
 """
 import seaborn as sns
-sns.set(style="whitegrid")
+sns.set_theme(style="whitegrid")
 
 # Load the brain networks dataset, select subset, and collapse the multi-index
 df = sns.load_dataset("brain_networks", header=[0, 1, 2], index_col=0)

--- a/examples/hexbin_marginals.py
+++ b/examples/hexbin_marginals.py
@@ -6,7 +6,7 @@ _thumb: .45, .4
 """
 import numpy as np
 import seaborn as sns
-sns.set(style="ticks")
+sns.set_theme(style="ticks")
 
 rs = np.random.RandomState(11)
 x = rs.gamma(2, size=1000)

--- a/examples/histogram_stacked.py
+++ b/examples/histogram_stacked.py
@@ -9,7 +9,7 @@ import seaborn as sns
 import matplotlib as mpl
 import matplotlib.pyplot as plt
 
-sns.set(style="ticks")
+sns.set_theme(style="ticks")
 
 diamonds = sns.load_dataset("diamonds")
 

--- a/examples/horizontal_boxplot.py
+++ b/examples/horizontal_boxplot.py
@@ -7,7 +7,7 @@ _thumb: .7, .37
 import seaborn as sns
 import matplotlib.pyplot as plt
 
-sns.set(style="ticks")
+sns.set_theme(style="ticks")
 
 # Initialize the figure with a logarithmic x axis
 f, ax = plt.subplots(figsize=(7, 6))

--- a/examples/jitter_stripplot.py
+++ b/examples/jitter_stripplot.py
@@ -7,7 +7,7 @@ import pandas as pd
 import seaborn as sns
 import matplotlib.pyplot as plt
 
-sns.set(style="whitegrid")
+sns.set_theme(style="whitegrid")
 iris = sns.load_dataset("iris")
 
 # "Melt" the dataset to "long-form" or "tidy" representation

--- a/examples/joint_histogram.py
+++ b/examples/joint_histogram.py
@@ -6,7 +6,7 @@ _thumb: .52, .505
 
 """
 import seaborn as sns
-sns.set(style="ticks")
+sns.set_theme(style="ticks")
 
 # Load the planets dataset and initialize the figure
 planets = sns.load_dataset("planets")

--- a/examples/joint_kde.py
+++ b/examples/joint_kde.py
@@ -5,7 +5,7 @@ Joint kernel density estimate
 _thumb: .6, .4
 """
 import seaborn as sns
-sns.set(style="ticks")
+sns.set_theme(style="ticks")
 
 # Load the penguins dataset
 penguins = sns.load_dataset("penguins")

--- a/examples/kde_ridgeplot.py
+++ b/examples/kde_ridgeplot.py
@@ -8,7 +8,7 @@ import numpy as np
 import pandas as pd
 import seaborn as sns
 import matplotlib.pyplot as plt
-sns.set(style="white", rc={"axes.facecolor": (0, 0, 0, 0)})
+sns.set_theme(style="white", rc={"axes.facecolor": (0, 0, 0, 0)})
 
 # Create the data
 rs = np.random.RandomState(1979)

--- a/examples/large_distributions.py
+++ b/examples/large_distributions.py
@@ -4,7 +4,7 @@ Plotting large distributions
 
 """
 import seaborn as sns
-sns.set(style="whitegrid")
+sns.set_theme(style="whitegrid")
 
 diamonds = sns.load_dataset("diamonds")
 clarity_ranking = ["I1", "SI2", "SI1", "VS2", "VS1", "VVS2", "VVS1", "IF"]

--- a/examples/layered_bivariate_plot.py
+++ b/examples/layered_bivariate_plot.py
@@ -7,7 +7,7 @@ Bivariate plot with multiple elements
 import numpy as np
 import seaborn as sns
 import matplotlib.pyplot as plt
-sns.set(style="dark")
+sns.set_theme(style="dark")
 
 # Simulate data from a bivariate Gaussian
 n = 10000

--- a/examples/logistic_regression.py
+++ b/examples/logistic_regression.py
@@ -5,7 +5,7 @@ Faceted logistic regression
 _thumb: .58, .5
 """
 import seaborn as sns
-sns.set(style="darkgrid")
+sns.set_theme(style="darkgrid")
 
 # Load the example Titanic dataset
 df = sns.load_dataset("titanic")

--- a/examples/many_facets.py
+++ b/examples/many_facets.py
@@ -10,7 +10,7 @@ import pandas as pd
 import seaborn as sns
 import matplotlib.pyplot as plt
 
-sns.set(style="ticks")
+sns.set_theme(style="ticks")
 
 # Create a dataset with many short random walks
 rs = np.random.RandomState(4)

--- a/examples/many_pairwise_correlations.py
+++ b/examples/many_pairwise_correlations.py
@@ -10,7 +10,7 @@ import pandas as pd
 import seaborn as sns
 import matplotlib.pyplot as plt
 
-sns.set(style="white")
+sns.set_theme(style="white")
 
 # Generate a large random dataset
 rs = np.random.RandomState(33)

--- a/examples/marginal_ticks.py
+++ b/examples/marginal_ticks.py
@@ -5,7 +5,7 @@ Scatterplot with marginal ticks
 _thumb: .66, .34
 """
 import seaborn as sns
-sns.set(style="white", color_codes=True)
+sns.set_theme(style="white", color_codes=True)
 mpg = sns.load_dataset("mpg")
 
 # Use JointGrid directly to draw a custom plot

--- a/examples/multiple_bivariate_kde.py
+++ b/examples/multiple_bivariate_kde.py
@@ -7,7 +7,7 @@ _thumb: .6, .45
 import seaborn as sns
 import matplotlib.pyplot as plt
 
-sns.set(style="darkgrid")
+sns.set_theme(style="darkgrid")
 iris = sns.load_dataset("iris")
 
 # Set up the figure

--- a/examples/multiple_conditional_kde.py
+++ b/examples/multiple_conditional_kde.py
@@ -5,7 +5,7 @@ Conditional kernel density estimate
 _thumb: .4, .5
 """
 import seaborn as sns
-sns.set(style="whitegrid")
+sns.set_theme(style="whitegrid")
 
 # Load the diamonds dataset
 diamonds = sns.load_dataset("diamonds")

--- a/examples/multiple_ecdf.py
+++ b/examples/multiple_ecdf.py
@@ -5,7 +5,7 @@ Facetted ECDF plots
 _thumb: .30, .49
 """
 import seaborn as sns
-sns.set(style="ticks")
+sns.set_theme(style="ticks")
 mpg = sns.load_dataset("mpg")
 
 colors = (250, 70, 50), (350, 70, 50)

--- a/examples/multiple_regression.py
+++ b/examples/multiple_regression.py
@@ -5,7 +5,7 @@ Multiple linear regression
 _thumb: .45, .45
 """
 import seaborn as sns
-sns.set()
+sns.set_theme()
 
 # Load the penguins dataset
 penguins = sns.load_dataset("penguins")

--- a/examples/pair_grid_with_kde.py
+++ b/examples/pair_grid_with_kde.py
@@ -5,7 +5,7 @@ Paired density and scatterplot matrix
 _thumb: .5, .5
 """
 import seaborn as sns
-sns.set(style="white")
+sns.set_theme(style="white")
 
 df = sns.load_dataset("penguins")
 

--- a/examples/paired_pointplots.py
+++ b/examples/paired_pointplots.py
@@ -4,7 +4,7 @@ Paired categorical plots
 
 """
 import seaborn as sns
-sns.set(style="whitegrid")
+sns.set_theme(style="whitegrid")
 
 # Load the example Titanic dataset
 titanic = sns.load_dataset("titanic")

--- a/examples/pairgrid_dotplot.py
+++ b/examples/pairgrid_dotplot.py
@@ -5,7 +5,7 @@ Dot plot with several variables
 _thumb: .3, .3
 """
 import seaborn as sns
-sns.set(style="whitegrid")
+sns.set_theme(style="whitegrid")
 
 # Load the dataset
 crashes = sns.load_dataset("car_crashes")

--- a/examples/palette_choices.py
+++ b/examples/palette_choices.py
@@ -6,7 +6,7 @@ Color palette choices
 import numpy as np
 import seaborn as sns
 import matplotlib.pyplot as plt
-sns.set(style="white", context="talk")
+sns.set_theme(style="white", context="talk")
 rs = np.random.RandomState(8)
 
 # Set up the matplotlib figure

--- a/examples/palette_generation.py
+++ b/examples/palette_generation.py
@@ -8,7 +8,7 @@ import numpy as np
 import seaborn as sns
 import matplotlib.pyplot as plt
 
-sns.set(style="white")
+sns.set_theme(style="white")
 rs = np.random.RandomState(50)
 
 # Set up the matplotlib figure

--- a/examples/part_whole_bars.py
+++ b/examples/part_whole_bars.py
@@ -5,7 +5,7 @@ Horizontal bar plots
 """
 import seaborn as sns
 import matplotlib.pyplot as plt
-sns.set(style="whitegrid")
+sns.set_theme(style="whitegrid")
 
 # Initialize the matplotlib figure
 f, ax = plt.subplots(figsize=(6, 15))

--- a/examples/pointplot_anova.py
+++ b/examples/pointplot_anova.py
@@ -5,7 +5,7 @@ Plotting a three-way ANOVA
 _thumb: .42, .5
 """
 import seaborn as sns
-sns.set(style="whitegrid")
+sns.set_theme(style="whitegrid")
 
 # Load the example exercise dataset
 df = sns.load_dataset("exercise")

--- a/examples/radial_facets.py
+++ b/examples/radial_facets.py
@@ -9,7 +9,7 @@ import numpy as np
 import pandas as pd
 import seaborn as sns
 
-sns.set()
+sns.set_theme()
 
 # Generate an example radial datast
 r = np.linspace(0, 10, num=100)

--- a/examples/regression_marginals.py
+++ b/examples/regression_marginals.py
@@ -5,7 +5,7 @@ Linear regression with marginal distributions
 _thumb: .65, .65
 """
 import seaborn as sns
-sns.set(style="darkgrid")
+sns.set_theme(style="darkgrid")
 
 tips = sns.load_dataset("tips")
 g = sns.jointplot(x="total_bill", y="tip", data=tips,

--- a/examples/residplot.py
+++ b/examples/residplot.py
@@ -5,7 +5,7 @@ Plotting model residuals
 """
 import numpy as np
 import seaborn as sns
-sns.set(style="whitegrid")
+sns.set_theme(style="whitegrid")
 
 # Make an example dataset with y ~ x
 rs = np.random.RandomState(7)

--- a/examples/scatter_bubbles.py
+++ b/examples/scatter_bubbles.py
@@ -6,7 +6,7 @@ _thumb: .45, .5
 
 """
 import seaborn as sns
-sns.set(style="white")
+sns.set_theme(style="white")
 
 # Load the example mpg dataset
 mpg = sns.load_dataset("mpg")

--- a/examples/scatterplot_categorical.py
+++ b/examples/scatterplot_categorical.py
@@ -6,7 +6,7 @@ _thumb: .45, .45
 
 """
 import seaborn as sns
-sns.set(style="whitegrid", palette="muted")
+sns.set_theme(style="whitegrid", palette="muted")
 
 # Load the penguins dataset
 df = sns.load_dataset("penguins")

--- a/examples/scatterplot_matrix.py
+++ b/examples/scatterplot_matrix.py
@@ -5,7 +5,7 @@ Scatterplot Matrix
 _thumb: .3, .2
 """
 import seaborn as sns
-sns.set(style="ticks")
+sns.set_theme(style="ticks")
 
 df = sns.load_dataset("penguins")
 sns.pairplot(df, hue="species")

--- a/examples/scatterplot_sizes.py
+++ b/examples/scatterplot_sizes.py
@@ -6,7 +6,7 @@ _thumb: .51, .44
 
 """
 import seaborn as sns
-sns.set(style="whitegrid")
+sns.set_theme(style="whitegrid")
 
 # Load the example planets dataset
 planets = sns.load_dataset("planets")

--- a/examples/simple_violinplots.py
+++ b/examples/simple_violinplots.py
@@ -6,7 +6,7 @@ Violinplots with observations
 import numpy as np
 import seaborn as sns
 
-sns.set()
+sns.set_theme()
 
 # Create a random dataset across several variables
 rs = np.random.default_rng(0)

--- a/examples/smooth_bivariate_kde.py
+++ b/examples/smooth_bivariate_kde.py
@@ -5,7 +5,7 @@ Smooth kernel density with marginal histograms
 _thumb: .48, .41
 """
 import seaborn as sns
-sns.set(style="white")
+sns.set_theme(style="white")
 
 df = sns.load_dataset("penguins")
 

--- a/examples/spreadsheet_heatmap.py
+++ b/examples/spreadsheet_heatmap.py
@@ -5,7 +5,7 @@ Annotated heatmaps
 """
 import matplotlib.pyplot as plt
 import seaborn as sns
-sns.set()
+sns.set_theme()
 
 # Load the example flights dataset and convert to long-form
 flights_long = sns.load_dataset("flights")

--- a/examples/structured_heatmap.py
+++ b/examples/structured_heatmap.py
@@ -6,7 +6,7 @@ _thumb: .3, .25
 """
 import pandas as pd
 import seaborn as sns
-sns.set()
+sns.set_theme()
 
 # Load the brain networks example dataset
 df = sns.load_dataset("brain_networks", header=[0, 1, 2], index_col=0)

--- a/examples/three_variable_histogram.py
+++ b/examples/three_variable_histogram.py
@@ -6,7 +6,7 @@ _thumb: .32, .55
 
 """
 import seaborn as sns
-sns.set(style="dark")
+sns.set_theme(style="dark")
 
 diamonds = sns.load_dataset("diamonds")
 sns.displot(

--- a/examples/timeseries_facets.py
+++ b/examples/timeseries_facets.py
@@ -7,7 +7,7 @@ _thumb: .42, .58
 """
 import seaborn as sns
 
-sns.set(style="dark")
+sns.set_theme(style="dark")
 flights = sns.load_dataset("flights")
 
 # Plot each year's time series in its own facet

--- a/examples/wide_data_lineplot.py
+++ b/examples/wide_data_lineplot.py
@@ -8,7 +8,7 @@ _thumb: .52, .5
 import numpy as np
 import pandas as pd
 import seaborn as sns
-sns.set(style="whitegrid")
+sns.set_theme(style="whitegrid")
 
 rs = np.random.RandomState(365)
 values = rs.randn(365, 4).cumsum(axis=0)

--- a/examples/wide_form_violinplot.py
+++ b/examples/wide_form_violinplot.py
@@ -6,7 +6,7 @@ _thumb: .6, .45
 """
 import seaborn as sns
 import matplotlib.pyplot as plt
-sns.set(style="whitegrid")
+sns.set_theme(style="whitegrid")
 
 # Load the example dataset of brain network correlations
 df = sns.load_dataset("brain_networks", header=[0, 1, 2], index_col=0)

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -2296,7 +2296,7 @@ boxplot.__doc__ = dedent("""\
         :context: close-figs
 
         >>> import seaborn as sns
-        >>> sns.set(style="whitegrid")
+        >>> sns.set_theme(style="whitegrid")
         >>> tips = sns.load_dataset("tips")
         >>> ax = sns.boxplot(x=tips["total_bill"])
 
@@ -2481,7 +2481,7 @@ violinplot.__doc__ = dedent("""\
         :context: close-figs
 
         >>> import seaborn as sns
-        >>> sns.set(style="whitegrid")
+        >>> sns.set_theme(style="whitegrid")
         >>> tips = sns.load_dataset("tips")
         >>> ax = sns.violinplot(x=tips["total_bill"])
 
@@ -2706,7 +2706,7 @@ boxenplot.__doc__ = dedent("""\
         :context: close-figs
 
         >>> import seaborn as sns
-        >>> sns.set(style="whitegrid")
+        >>> sns.set_theme(style="whitegrid")
         >>> tips = sns.load_dataset("tips")
         >>> ax = sns.boxenplot(x=tips["total_bill"])
 
@@ -2872,7 +2872,7 @@ stripplot.__doc__ = dedent("""\
         :context: close-figs
 
         >>> import seaborn as sns
-        >>> sns.set(style="whitegrid")
+        >>> sns.set_theme(style="whitegrid")
         >>> tips = sns.load_dataset("tips")
         >>> ax = sns.stripplot(x=tips["total_bill"])
 
@@ -3072,7 +3072,7 @@ swarmplot.__doc__ = dedent("""\
         :context: close-figs
 
         >>> import seaborn as sns
-        >>> sns.set(style="whitegrid")
+        >>> sns.set_theme(style="whitegrid")
         >>> tips = sns.load_dataset("tips")
         >>> ax = sns.swarmplot(x=tips["total_bill"])
 
@@ -3241,7 +3241,7 @@ barplot.__doc__ = dedent("""\
         :context: close-figs
 
         >>> import seaborn as sns
-        >>> sns.set(style="whitegrid")
+        >>> sns.set_theme(style="whitegrid")
         >>> tips = sns.load_dataset("tips")
         >>> ax = sns.barplot(x="day", y="total_bill", data=tips)
 
@@ -3440,7 +3440,7 @@ pointplot.__doc__ = dedent("""\
         :context: close-figs
 
         >>> import seaborn as sns
-        >>> sns.set(style="darkgrid")
+        >>> sns.set_theme(style="darkgrid")
         >>> tips = sns.load_dataset("tips")
         >>> ax = sns.pointplot(x="time", y="total_bill", data=tips)
 
@@ -3642,7 +3642,7 @@ countplot.__doc__ = dedent("""\
         :context: close-figs
 
         >>> import seaborn as sns
-        >>> sns.set(style="darkgrid")
+        >>> sns.set_theme(style="darkgrid")
         >>> titanic = sns.load_dataset("titanic")
         >>> ax = sns.countplot(x="class", data=titanic)
 
@@ -3943,7 +3943,7 @@ catplot.__doc__ = dedent("""\
         :context: close-figs
 
         >>> import seaborn as sns
-        >>> sns.set(style="ticks")
+        >>> sns.set_theme(style="ticks")
         >>> exercise = sns.load_dataset("exercise")
         >>> g = sns.catplot(x="time", y="pulse", hue="kind", data=exercise)
 

--- a/seaborn/distributions.py
+++ b/seaborn/distributions.py
@@ -2479,7 +2479,7 @@ def distplot(a=None, bins=None, hist=True, kde=True, rug=False, fit=None,
         :context: close-figs
 
         >>> import seaborn as sns, numpy as np
-        >>> sns.set(); np.random.seed(0)
+        >>> sns.set_theme(); np.random.seed(0)
         >>> x = np.random.randn(100)
         >>> ax = sns.distplot(x)
 

--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -447,7 +447,7 @@ def heatmap(
         :context: close-figs
 
         >>> import numpy as np; np.random.seed(0)
-        >>> import seaborn as sns; sns.set()
+        >>> import seaborn as sns; sns.set_theme()
         >>> uniform_data = np.random.rand(10, 12)
         >>> ax = sns.heatmap(uniform_data)
 
@@ -1333,7 +1333,7 @@ def clustermap(
     .. plot::
         :context: close-figs
 
-        >>> import seaborn as sns; sns.set(color_codes=True)
+        >>> import seaborn as sns; sns.set_theme(color_codes=True)
         >>> iris = sns.load_dataset("iris")
         >>> species = iris.pop("species")
         >>> g = sns.clustermap(iris)

--- a/seaborn/palettes.py
+++ b/seaborn/palettes.py
@@ -259,7 +259,7 @@ def hls_palette(n_colors=6, h=.01, l=.6, s=.65, as_cmap=False):  # noqa
     .. plot::
         :context: close-figs
 
-        >>> import seaborn as sns; sns.set()
+        >>> import seaborn as sns; sns.set_theme()
         >>> sns.palplot(sns.hls_palette(10))
 
     Create a palette of 10 colors that begins at a different hue value:
@@ -331,7 +331,7 @@ def husl_palette(n_colors=6, h=.01, s=.9, l=.65, as_cmap=False):  # noqa
     .. plot::
         :context: close-figs
 
-        >>> import seaborn as sns; sns.set()
+        >>> import seaborn as sns; sns.set_theme()
         >>> sns.palplot(sns.husl_palette(10))
 
     Create a palette of 10 colors that begins at a different hue value:
@@ -403,7 +403,7 @@ def mpl_palette(name, n_colors=6, as_cmap=False):
     .. plot::
         :context: close-figs
 
-        >>> import seaborn as sns; sns.set()
+        >>> import seaborn as sns; sns.set_theme()
         >>> sns.palplot(sns.mpl_palette("Set2", 8))
 
     Create a sequential colorbrewer palette:
@@ -512,7 +512,7 @@ def dark_palette(color, n_colors=6, reverse=False, as_cmap=False, input="rgb"):
     .. plot::
         :context: close-figs
 
-        >>> import seaborn as sns; sns.set()
+        >>> import seaborn as sns; sns.set_theme()
         >>> sns.palplot(sns.dark_palette("purple"))
 
     Generate a palette that decreases in lightness:
@@ -593,7 +593,7 @@ def light_palette(color, n_colors=6, reverse=False, as_cmap=False, input="rgb"):
     .. plot::
         :context: close-figs
 
-        >>> import seaborn as sns; sns.set()
+        >>> import seaborn as sns; sns.set_theme()
         >>> sns.palplot(sns.light_palette("purple"))
 
     Generate a palette that increases in lightness:
@@ -670,7 +670,7 @@ def diverging_palette(h_neg, h_pos, s=75, l=50, sep=1, n=6,  # noqa
     .. plot::
         :context: close-figs
 
-        >>> import seaborn as sns; sns.set()
+        >>> import seaborn as sns; sns.set_theme()
         >>> sns.palplot(sns.diverging_palette(240, 10, n=9))
 
     Generate a brighter green-white-purple palette:
@@ -852,7 +852,7 @@ def cubehelix_palette(n_colors=6, start=0, rot=.4, gamma=1.0, hue=0.8,
     .. plot::
         :context: close-figs
 
-        >>> import seaborn as sns; sns.set()
+        >>> import seaborn as sns; sns.set_theme()
         >>> sns.palplot(sns.cubehelix_palette())
 
     Rotate backwards from the same starting location:
@@ -1004,7 +1004,7 @@ def set_color_codes(palette="deep"):
         :context: close-figs
 
         >>> import matplotlib.pyplot as plt
-        >>> import seaborn as sns; sns.set()
+        >>> import seaborn as sns; sns.set_theme()
         >>> sns.set_color_codes()
         >>> _ = plt.plot([0, 1], color="r")
 

--- a/seaborn/rcmod.py
+++ b/seaborn/rcmod.py
@@ -7,7 +7,7 @@ from cycler import cycler
 from . import palettes
 
 
-__all__ = ["set", "reset_defaults", "reset_orig",
+__all__ = ["set_theme", "set", "reset_defaults", "reset_orig",
            "axes_style", "set_style", "plotting_context", "set_context",
            "set_palette"]
 

--- a/seaborn/rcmod.py
+++ b/seaborn/rcmod.py
@@ -83,8 +83,8 @@ if LooseVersion(mpl.__version__) >= "3.0":
     _context_keys.append("legend.title_fontsize")
 
 
-def set(context="notebook", style="darkgrid", palette="deep",
-        font="sans-serif", font_scale=1, color_codes=True, rc=None):
+def set_theme(context="notebook", style="darkgrid", palette="deep",
+              font="sans-serif", font_scale=1, color_codes=True, rc=None):
     """Set multiple theme parameters in one step.
 
     Each set of parameters can be set directly or temporarily, see the
@@ -115,6 +115,11 @@ def set(context="notebook", style="darkgrid", palette="deep",
     set_palette(palette, color_codes=color_codes)
     if rc is not None:
         mpl.rcParams.update(rc)
+
+
+def set(*args, **kwargs):
+    """Alias for :func:`set_theme`, which is the preferred interface."""
+    set_theme(*args, **kwargs)
 
 
 def reset_defaults():

--- a/seaborn/regression.py
+++ b/seaborn/regression.py
@@ -721,7 +721,7 @@ lmplot.__doc__ = dedent("""\
     .. plot::
         :context: close-figs
 
-        >>> import seaborn as sns; sns.set(color_codes=True)
+        >>> import seaborn as sns; sns.set_theme(color_codes=True)
         >>> tips = sns.load_dataset("tips")
         >>> g = sns.lmplot(x="total_bill", y="tip", data=tips)
 
@@ -911,7 +911,7 @@ regplot.__doc__ = dedent("""\
     .. plot::
         :context: close-figs
 
-        >>> import seaborn as sns; sns.set(color_codes=True)
+        >>> import seaborn as sns; sns.set_theme(color_codes=True)
         >>> tips = sns.load_dataset("tips")
         >>> ax = sns.regplot(x="total_bill", y="tip", data=tips)
 

--- a/seaborn/tests/test_rcmod.py
+++ b/seaborn/tests/test_rcmod.py
@@ -102,48 +102,48 @@ class TestAxesStyle(RCParamTester):
 
     def test_set_rc(self):
 
-        rcmod.set(rc={"lines.linewidth": 4})
+        rcmod.set_theme(rc={"lines.linewidth": 4})
         nt.assert_equal(mpl.rcParams["lines.linewidth"], 4)
-        rcmod.set()
+        rcmod.set_theme()
 
     def test_set_with_palette(self):
 
         rcmod.reset_orig()
 
-        rcmod.set(palette="deep")
+        rcmod.set_theme(palette="deep")
         assert utils.get_color_cycle() == palettes.color_palette("deep", 10)
         rcmod.reset_orig()
 
-        rcmod.set(palette="deep", color_codes=False)
+        rcmod.set_theme(palette="deep", color_codes=False)
         assert utils.get_color_cycle() == palettes.color_palette("deep", 10)
         rcmod.reset_orig()
 
         pal = palettes.color_palette("deep")
-        rcmod.set(palette=pal)
+        rcmod.set_theme(palette=pal)
         assert utils.get_color_cycle() == palettes.color_palette("deep", 10)
         rcmod.reset_orig()
 
-        rcmod.set(palette=pal, color_codes=False)
+        rcmod.set_theme(palette=pal, color_codes=False)
         assert utils.get_color_cycle() == palettes.color_palette("deep", 10)
         rcmod.reset_orig()
 
-        rcmod.set()
+        rcmod.set_theme()
 
     def test_reset_defaults(self):
 
         rcmod.reset_defaults()
         self.assert_rc_params(mpl.rcParamsDefault)
-        rcmod.set()
+        rcmod.set_theme()
 
     def test_reset_orig(self):
 
         rcmod.reset_orig()
         self.assert_rc_params(mpl.rcParamsOrig)
-        rcmod.set()
+        rcmod.set_theme()
 
     def test_set_is_alias(self):
 
-        rcmod.set(context="paper", style="white")
+        rcmod.set_theme(context="paper", style="white")
         params1 = mpl.rcParams.copy()
         rcmod.reset_orig()
 
@@ -152,7 +152,7 @@ class TestAxesStyle(RCParamTester):
 
         self.assert_rc_params_equal(params1, params2)
 
-        rcmod.set()
+        rcmod.set_theme()
 
 
 class TestPlottingContext(RCParamTester):
@@ -244,7 +244,7 @@ class TestFonts(object):
 
     def test_set_font(self):
 
-        rcmod.set(font="Verdana")
+        rcmod.set_theme(font="Verdana")
 
         _, ax = plt.subplots()
         ax.set_xlabel("foo")
@@ -258,11 +258,11 @@ class TestFonts(object):
             else:
                 raise nose.SkipTest("Verdana font is not present")
         finally:
-            rcmod.set()
+            rcmod.set_theme()
 
     def test_set_serif_font(self):
 
-        rcmod.set(font="serif")
+        rcmod.set_theme(font="serif")
 
         _, ax = plt.subplots()
         ax.set_xlabel("foo")
@@ -270,11 +270,11 @@ class TestFonts(object):
         nt.assert_in(ax.xaxis.label.get_fontname(),
                      mpl.rcParams["font.serif"])
 
-        rcmod.set()
+        rcmod.set_theme()
 
     def test_different_sans_serif(self):
 
-        rcmod.set()
+        rcmod.set_theme()
         rcmod.set_style(rc={"font.sans-serif": ["Verdana"]})
 
         _, ax = plt.subplots()
@@ -289,7 +289,7 @@ class TestFonts(object):
             else:
                 raise nose.SkipTest("Verdana font is not present")
         finally:
-            rcmod.set()
+            rcmod.set_theme()
 
 
 def has_verdana():

--- a/seaborn/tests/test_rcmod.py
+++ b/seaborn/tests/test_rcmod.py
@@ -30,6 +30,20 @@ class RCParamTester(object):
             else:
                 nt.assert_equal((k, mpl.rcParams[k]), (k, v))
 
+    def assert_rc_params_equal(self, params1, params2):
+
+        for key, v1 in params1.items():
+            # Various subtle issues in matplotlib lead to unexpected
+            # values for the backend rcParam, which isn't relevant here
+            if key == "backend":
+                continue
+
+            v2 = params2[key]
+            if isinstance(v1, np.ndarray):
+                npt.assert_array_equal(v1, v2)
+            else:
+                nt.assert_equal(v1, v2)
+
 
 class TestAxesStyle(RCParamTester):
 
@@ -125,6 +139,19 @@ class TestAxesStyle(RCParamTester):
 
         rcmod.reset_orig()
         self.assert_rc_params(mpl.rcParamsOrig)
+        rcmod.set()
+
+    def test_set_is_alias(self):
+
+        rcmod.set(context="paper", style="white")
+        params1 = mpl.rcParams.copy()
+        rcmod.reset_orig()
+
+        rcmod.set_theme(context="paper", style="white")
+        params2 = mpl.rcParams.copy()
+
+        self.assert_rc_params_equal(params1, params2)
+
         rcmod.set()
 
 


### PR DESCRIPTION
Back when importing seaborn called set() implicitly, it would only be used with specific arguments like `set(style="white")` which made it clear what it was doing. Now that it need to be explicitly invoked, however, most script start with a confusing `sns.set()`, and it's not clear what that might accomplish.

Because it's a small, innocuous function, `set()` will remain as an alias for now, although it may be deprecated in the future.

Closes #2241 