### PR TITLE
Fix NA propagation in lineplot

### DIFF
--- a/seaborn/relational.py
+++ b/seaborn/relational.py
@@ -475,6 +475,13 @@ class _LinePlotter(_RelationalPlotter):
                 sort_cols = [var for var in sort_vars if var in self.variables]
                 sub_data = sub_data.sort_values(sort_cols)
 
+            # TODO
+            # How to handle NA? We don't want NA to propagate through to the
+            # estimate/CI when some values are present, but we would also like
+            # matplotlib to show "gaps" in the line when all values are missing.
+            # This is straightforward absent aggregation, but complicated with it.
+            sub_data = sub_data.dropna()
+
             # Due to the original design, code below was written assuming that
             # sub_data always has x, y, and units columns, which may be empty.
             # Adding this here to avoid otherwise disruptive changes, but it

--- a/seaborn/tests/test_relational.py
+++ b/seaborn/tests/test_relational.py
@@ -718,7 +718,7 @@ class TestRelationalPlotter(Helpers):
 
 class TestLinePlotter(Helpers):
 
-    def test_aggregate(self, long_df):
+    def test_aggregate(self, long_df, missing_df):
 
         p = _LinePlotter(data=long_df, variables=dict(x="x", y="y"))
         p.n_boot = 10000
@@ -796,6 +796,18 @@ class TestLinePlotter(Helpers):
             warnings.simplefilter("error", RuntimeWarning)
             index, est, cis = p.aggregate(y, x)
             assert cis.loc[["c"]].isnull().all().all()
+
+        p = _LinePlotter(data=missing_df, variables=dict(x="s", y="y"))
+        p.estimator = "mean"
+        p.n_boot = 100
+        p.ci = 95
+
+        x = p.plot_data["x"]
+        y = p.plot_data["y"]
+
+        _, est, cis = p.aggregate(y, x)
+        assert not est.isna().any()
+        assert not cis.isna().any().any()
 
     def test_legend_data(self, long_df):
 

--- a/seaborn/utils.py
+++ b/seaborn/utils.py
@@ -371,7 +371,7 @@ def percentiles(a, pcts, axis=None):
 def ci(a, which=95, axis=None):
     """Return a percentile range from an array of values."""
     p = 50 - which / 2, 50 + which / 2
-    return np.percentile(a, p, axis)
+    return np.nanpercentile(a, p, axis)
 
 
 def sig_stars(p):


### PR DESCRIPTION
Fixes #2272

This now drops NA internally (basically restoring the previous behavior) so that NAs don't propagate and erase the confidence intervals. It also uses `np.nanpercentile` which better matches the previous behavior, which used the (apparently NA aware) `scipy.stats.percentileofscore`.

A related issue I would like to address here is #1552, but on a first stab I ran into some complexities and that may need to be handled separately with more thought.

Ideally the aggregation could use pandas NA-aware mean when `estimator="mean"` and then we would need to do less NA bookkeeping. But the bootstrapping algorithm converts data to numpy arrays because sampling with replacement is about an order of magnitude slower with pandas objects. One possibility would be to use `np.nanmean` if the estimator is `"mean"` and there are NAs in the data, but that is not fully general. It's possible I'm missing something about how to do fast positional row indexing of pandas objects, but I can't figure it out.