### PR TITLE
throw a meaningful error message in lmplot in case  kwarg is missing

### DIFF
--- a/seaborn/regression.py
+++ b/seaborn/regression.py
@@ -579,6 +579,9 @@ def lmplot(
                "please update your code.")
         warnings.warn(msg, UserWarning)
 
+    if data is None:
+        raise TypeError("Missing required keyword argument `data`.")
+
     # Reduce the dataframe to only needed columns
     need_cols = [x, y, hue, col, row, units, x_partial, y_partial]
     cols = np.unique([a for a in need_cols if a is not None]).tolist()

--- a/seaborn/tests/test_regression.py
+++ b/seaborn/tests/test_regression.py
@@ -530,6 +530,12 @@ class TestRegressionPlots(object):
         nt.assert_equal(len(ax.lines), 6)
         nt.assert_equal(len(ax.collections), 2)
 
+    def test_lmplot_no_data(self):
+
+        with pytest.raises(TypeError):
+            # keyword argument `data` is required
+            lm.lmplot(x="x", y="y")
+
     def test_lmplot_basic(self):
 
         g = lm.lmplot(x="x", y="y", data=self.df)


### PR DESCRIPTION
`lmplot` de facto requires a `data` keyword argument. Currently, not specifying it throws the following error.
```
TypeError: NoneType is not suscriptatble
```

This patch improves the error message as
```
TypeError: Missing required keyword argument `data`.
```