### PR TITLE
Fix: do not annotate clustermap w/ annot=False

### DIFF
--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -1166,7 +1166,7 @@ class ClusterGrid(Grid):
 
         # Reorganize the annotations to match the heatmap
         annot = kws.pop("annot", None)
-        if annot is None:
+        if annot is None or annot is False:
             pass
         else:
             if isinstance(annot, bool):


### PR DESCRIPTION
Fixes #2319 the `clustermap` function was not catching False as it should have been.