### PR TITLE
MAINT: Drop nose and test on python==3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,9 @@ env:
   - PYTHON=3.6 DEPS=latest MPLBACKEND=agg DOCTESTS=true
   - PYTHON=3.7 DEPS=latest MPLBACKEND=agg DOCTESTS=true
   - PYTHON=3.8 DEPS=latest MPLBACKEND=agg DOCTESTS=true
-  - PYTHON=3.8 DEPS=latest MPLBACKEND=qt5agg DOCTESTS=true
-  - PYTHON=3.8 DEPS=minimal MPLBACKEND=agg DOCTESTS=false
+  - PYTHON=3.9 DEPS=latest MPLBACKEND=agg DOCTESTS=true
+  - PYTHON=3.9 DEPS=latest MPLBACKEND=qt5agg DOCTESTS=true
+  - PYTHON=3.9 DEPS=minimal MPLBACKEND=agg DOCTESTS=false
 
 
 before_install:

--- a/ci/utils.txt
+++ b/ci/utils.txt
@@ -2,4 +2,3 @@ pytest!=5.3.4
 pytest-cov
 pytest-xdist
 flake8
-nose

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,6 +2,4 @@
 filterwarnings =
 ;   Warnings raised from within patsy imports
     ignore:Using or importing the ABCs:DeprecationWarning
-;   Warnings raised from nose utils (can be removed after nose is dropped)
-    ignore:the imp module is deprecated in favour of importlib
 junit_family=xunit1

--- a/seaborn/conftest.py
+++ b/seaborn/conftest.py
@@ -7,6 +7,29 @@ import matplotlib.pyplot as plt
 import pytest
 
 
+def has_verdana():
+    """Helper to verify if Verdana font is present"""
+    # This import is relatively lengthy, so to prevent its import for
+    # testing other tests in this module not requiring this knowledge,
+    # import font_manager here
+    import matplotlib.font_manager as mplfm
+    try:
+        verdana_font = mplfm.findfont('Verdana', fallback_to_default=False)
+    except:  # noqa
+        # if https://github.com/matplotlib/matplotlib/pull/3435
+        # gets accepted
+        return False
+    # otherwise check if not matching the logic for a 'default' one
+    try:
+        unlikely_font = mplfm.findfont("very_unlikely_to_exist1234",
+                                       fallback_to_default=False)
+    except:  # noqa
+        # if matched verdana but not unlikely, Verdana must exist
+        return True
+    # otherwise -- if they match, must be the same default
+    return verdana_font != unlikely_font
+
+
 @pytest.fixture(scope="session", autouse=True)
 def remove_pandas_unit_conversion():
     # Prior to pandas 1.0, it registered its own datetime converters,

--- a/seaborn/tests/test_axisgrid.py
+++ b/seaborn/tests/test_axisgrid.py
@@ -1,12 +1,9 @@
-import warnings
-
 import numpy as np
 import pandas as pd
 import matplotlib as mpl
 import matplotlib.pyplot as plt
 
 import pytest
-import nose.tools as nt
 import numpy.testing as npt
 from numpy.testing import assert_array_equal
 try:
@@ -28,7 +25,7 @@ from .._testing import (
 rs = np.random.RandomState(0)
 
 
-class TestFacetGrid(object):
+class TestFacetGrid:
 
     df = pd.DataFrame(dict(x=rs.normal(size=60),
                            y=rs.gamma(4, size=60),
@@ -40,55 +37,54 @@ class TestFacetGrid(object):
     def test_self_data(self):
 
         g = ag.FacetGrid(self.df)
-        nt.assert_is(g.data, self.df)
+        assert g.data is self.df
 
     def test_self_fig(self):
 
         g = ag.FacetGrid(self.df)
-        nt.assert_is_instance(g.fig, plt.Figure)
+        assert isinstance(g.fig, plt.Figure)
 
     def test_self_axes(self):
 
         g = ag.FacetGrid(self.df, row="a", col="b", hue="c")
         for ax in g.axes.flat:
-            nt.assert_is_instance(ax, plt.Axes)
+            assert isinstance(ax, plt.Axes)
 
     def test_axes_array_size(self):
 
-        g1 = ag.FacetGrid(self.df)
-        nt.assert_equal(g1.axes.shape, (1, 1))
+        g = ag.FacetGrid(self.df)
+        assert g.axes.shape == (1, 1)
 
-        g2 = ag.FacetGrid(self.df, row="a")
-        nt.assert_equal(g2.axes.shape, (3, 1))
+        g = ag.FacetGrid(self.df, row="a")
+        assert g.axes.shape == (3, 1)
 
-        g3 = ag.FacetGrid(self.df, col="b")
-        nt.assert_equal(g3.axes.shape, (1, 2))
+        g = ag.FacetGrid(self.df, col="b")
+        assert g.axes.shape == (1, 2)
 
-        g4 = ag.FacetGrid(self.df, hue="c")
-        nt.assert_equal(g4.axes.shape, (1, 1))
+        g = ag.FacetGrid(self.df, hue="c")
+        assert g.axes.shape == (1, 1)
 
-        g5 = ag.FacetGrid(self.df, row="a", col="b", hue="c")
-        nt.assert_equal(g5.axes.shape, (3, 2))
-
-        for ax in g5.axes.flat:
-            nt.assert_is_instance(ax, plt.Axes)
+        g = ag.FacetGrid(self.df, row="a", col="b", hue="c")
+        assert g.axes.shape == (3, 2)
+        for ax in g.axes.flat:
+            assert isinstance(ax, plt.Axes)
 
     def test_single_axes(self):
 
-        g1 = ag.FacetGrid(self.df)
-        nt.assert_is_instance(g1.ax, plt.Axes)
+        g = ag.FacetGrid(self.df)
+        assert isinstance(g.ax, plt.Axes)
 
-        g2 = ag.FacetGrid(self.df, row="a")
-        with nt.assert_raises(AttributeError):
-            g2.ax
+        g = ag.FacetGrid(self.df, row="a")
+        with pytest.raises(AttributeError):
+            g.ax
 
-        g3 = ag.FacetGrid(self.df, col="a")
-        with nt.assert_raises(AttributeError):
-            g3.ax
+        g = ag.FacetGrid(self.df, col="a")
+        with pytest.raises(AttributeError):
+            g.ax
 
-        g4 = ag.FacetGrid(self.df, col="a", row="b")
-        with nt.assert_raises(AttributeError):
-            g4.ax
+        g = ag.FacetGrid(self.df, col="a", row="b")
+        with pytest.raises(AttributeError):
+            g.ax
 
     def test_col_wrap(self):
 
@@ -202,88 +198,88 @@ class TestFacetGrid(object):
 
     def test_figure_size_with_legend(self):
 
-        g1 = ag.FacetGrid(self.df, col="a", hue="c", height=4, aspect=.5)
-        npt.assert_array_equal(g1.fig.get_size_inches(), (6, 4))
-        g1.add_legend()
-        nt.assert_greater(g1.fig.get_size_inches()[0], 6)
+        g = ag.FacetGrid(self.df, col="a", hue="c", height=4, aspect=.5)
+        npt.assert_array_equal(g.fig.get_size_inches(), (6, 4))
+        g.add_legend()
+        assert g.fig.get_size_inches()[0] > 6
 
-        g2 = ag.FacetGrid(self.df, col="a", hue="c", height=4, aspect=.5,
-                          legend_out=False)
-        npt.assert_array_equal(g2.fig.get_size_inches(), (6, 4))
-        g2.add_legend()
-        npt.assert_array_equal(g2.fig.get_size_inches(), (6, 4))
+        g = ag.FacetGrid(self.df, col="a", hue="c", height=4, aspect=.5,
+                         legend_out=False)
+        npt.assert_array_equal(g.fig.get_size_inches(), (6, 4))
+        g.add_legend()
+        npt.assert_array_equal(g.fig.get_size_inches(), (6, 4))
 
     def test_legend_data(self):
 
-        g1 = ag.FacetGrid(self.df, hue="a")
-        g1.map(plt.plot, "x", "y")
-        g1.add_legend()
+        g = ag.FacetGrid(self.df, hue="a")
+        g.map(plt.plot, "x", "y")
+        g.add_legend()
         palette = color_palette(n_colors=3)
 
-        nt.assert_equal(g1._legend.get_title().get_text(), "a")
+        assert g._legend.get_title().get_text() == "a"
 
         a_levels = sorted(self.df.a.unique())
 
-        lines = g1._legend.get_lines()
-        nt.assert_equal(len(lines), len(a_levels))
+        lines = g._legend.get_lines()
+        assert len(lines) == len(a_levels)
 
         for line, hue in zip(lines, palette):
-            nt.assert_equal(line.get_color(), hue)
+            assert line.get_color() == hue
 
-        labels = g1._legend.get_texts()
-        nt.assert_equal(len(labels), len(a_levels))
+        labels = g._legend.get_texts()
+        assert len(labels) == len(a_levels)
 
         for label, level in zip(labels, a_levels):
-            nt.assert_equal(label.get_text(), level)
+            assert label.get_text() == level
 
     def test_legend_data_missing_level(self):
 
-        g1 = ag.FacetGrid(self.df, hue="a", hue_order=list("azbc"))
-        g1.map(plt.plot, "x", "y")
-        g1.add_legend()
+        g = ag.FacetGrid(self.df, hue="a", hue_order=list("azbc"))
+        g.map(plt.plot, "x", "y")
+        g.add_legend()
 
-        b, g, r, p = color_palette(n_colors=4)
-        palette = [b, r, p]
+        c1, c2, c3, c4 = color_palette(n_colors=4)
+        palette = [c1, c3, c4]
 
-        nt.assert_equal(g1._legend.get_title().get_text(), "a")
+        assert g._legend.get_title().get_text() == "a"
 
         a_levels = sorted(self.df.a.unique())
 
-        lines = g1._legend.get_lines()
-        nt.assert_equal(len(lines), len(a_levels))
+        lines = g._legend.get_lines()
+        assert len(lines) == len(a_levels)
 
         for line, hue in zip(lines, palette):
-            nt.assert_equal(line.get_color(), hue)
+            assert line.get_color() == hue
 
-        labels = g1._legend.get_texts()
-        nt.assert_equal(len(labels), 4)
+        labels = g._legend.get_texts()
+        assert len(labels) == 4
 
         for label, level in zip(labels, list("azbc")):
-            nt.assert_equal(label.get_text(), level)
+            assert label.get_text() == level
 
     def test_get_boolean_legend_data(self):
 
         self.df["b_bool"] = self.df.b == "m"
-        g1 = ag.FacetGrid(self.df, hue="b_bool")
-        g1.map(plt.plot, "x", "y")
-        g1.add_legend()
+        g = ag.FacetGrid(self.df, hue="b_bool")
+        g.map(plt.plot, "x", "y")
+        g.add_legend()
         palette = color_palette(n_colors=2)
 
-        nt.assert_equal(g1._legend.get_title().get_text(), "b_bool")
+        assert g._legend.get_title().get_text() == "b_bool"
 
         b_levels = list(map(str, categorical_order(self.df.b_bool)))
 
-        lines = g1._legend.get_lines()
-        nt.assert_equal(len(lines), len(b_levels))
+        lines = g._legend.get_lines()
+        assert len(lines) == len(b_levels)
 
         for line, hue in zip(lines, palette):
-            nt.assert_equal(line.get_color(), hue)
+            assert line.get_color() == hue
 
-        labels = g1._legend.get_texts()
-        nt.assert_equal(len(labels), len(b_levels))
+        labels = g._legend.get_texts()
+        assert len(labels) == len(b_levels)
 
         for label, level in zip(labels, b_levels):
-            nt.assert_equal(label.get_text(), level)
+            assert label.get_text() == level
 
     def test_legend_tuples(self):
 
@@ -299,9 +295,9 @@ class TestFacetGrid(object):
 
     def test_legend_options(self):
 
-        g1 = ag.FacetGrid(self.df, hue="b")
-        g1.map(plt.plot, "x", "y")
-        g1.add_legend()
+        g = ag.FacetGrid(self.df, hue="b")
+        g.map(plt.plot, "x", "y")
+        g.add_legend()
 
     def test_legendout_with_colwrap(self):
 
@@ -327,7 +323,7 @@ class TestFacetGrid(object):
         g = ag.FacetGrid(self.df, despine=False,
                          subplot_kws=dict(projection="polar"))
         for ax in g.axes.flat:
-            nt.assert_true("PolarAxesSubplot" in str(type(ax)))
+            assert "PolarAxesSubplot" in str(type(ax))
 
     def test_gridspec_kws(self):
         ratios = [3, 1, 2]
@@ -349,51 +345,48 @@ class TestFacetGrid(object):
         ratios = [3, 1, 2, 1, 1]
 
         gskws = dict(width_ratios=ratios)
-        with warnings.catch_warnings():
-            warnings.resetwarnings()
-            warnings.simplefilter("always")
-            npt.assert_warns(UserWarning, ag.FacetGrid, self.df, col='d',
-                             col_wrap=5, gridspec_kws=gskws)
+        with pytest.warns(UserWarning):
+            ag.FacetGrid(self.df, col='d', col_wrap=5, gridspec_kws=gskws)
 
     def test_data_generator(self):
 
         g = ag.FacetGrid(self.df, row="a")
         d = list(g.facet_data())
-        nt.assert_equal(len(d), 3)
+        assert len(d) == 3
 
         tup, data = d[0]
-        nt.assert_equal(tup, (0, 0, 0))
-        nt.assert_true((data["a"] == "a").all())
+        assert tup == (0, 0, 0)
+        assert (data["a"] == "a").all()
 
         tup, data = d[1]
-        nt.assert_equal(tup, (1, 0, 0))
-        nt.assert_true((data["a"] == "b").all())
+        assert tup == (1, 0, 0)
+        assert (data["a"] == "b").all()
 
         g = ag.FacetGrid(self.df, row="a", col="b")
         d = list(g.facet_data())
-        nt.assert_equal(len(d), 6)
+        assert len(d) == 6
 
         tup, data = d[0]
-        nt.assert_equal(tup, (0, 0, 0))
-        nt.assert_true((data["a"] == "a").all())
-        nt.assert_true((data["b"] == "m").all())
+        assert tup == (0, 0, 0)
+        assert (data["a"] == "a").all()
+        assert (data["b"] == "m").all()
 
         tup, data = d[1]
-        nt.assert_equal(tup, (0, 1, 0))
-        nt.assert_true((data["a"] == "a").all())
-        nt.assert_true((data["b"] == "n").all())
+        assert tup == (0, 1, 0)
+        assert (data["a"] == "a").all()
+        assert (data["b"] == "n").all()
 
         tup, data = d[2]
-        nt.assert_equal(tup, (1, 0, 0))
-        nt.assert_true((data["a"] == "b").all())
-        nt.assert_true((data["b"] == "m").all())
+        assert tup == (1, 0, 0)
+        assert (data["a"] == "b").all()
+        assert (data["b"] == "m").all()
 
         g = ag.FacetGrid(self.df, hue="c")
         d = list(g.facet_data())
-        nt.assert_equal(len(d), 3)
+        assert len(d) == 3
         tup, data = d[1]
-        nt.assert_equal(tup, (0, 0, 1))
-        nt.assert_true((data["c"] == "u").all())
+        assert tup == (0, 0, 1)
+        assert (data["c"] == "u").all()
 
     def test_map(self):
 
@@ -401,10 +394,10 @@ class TestFacetGrid(object):
         g.map(plt.plot, "x", "y", linewidth=3)
 
         lines = g.axes[0, 0].lines
-        nt.assert_equal(len(lines), 3)
+        assert len(lines) == 3
 
         line1, _, _ = lines
-        nt.assert_equal(line1.get_linewidth(), 3)
+        assert line1.get_linewidth() == 3
         x, y = line1.get_data()
         mask = (self.df.a == "a") & (self.df.b == "m") & (self.df.c == "t")
         npt.assert_array_equal(x, self.df.x[mask])
@@ -420,10 +413,10 @@ class TestFacetGrid(object):
         g.map_dataframe(plot, "x", "y", linestyle="--")
 
         lines = g.axes[0, 0].lines
-        nt.assert_equal(len(lines), 3)
+        assert len(g.axes[0, 0].lines) == 3
 
         line1, _, _ = lines
-        nt.assert_equal(line1.get_linestyle(), "--")
+        assert line1.get_linestyle() == "--"
         x, y = line1.get_data()
         mask = (self.df.a == "a") & (self.df.b == "m") & (self.df.c == "t")
         npt.assert_array_equal(x, self.df.x[mask])
@@ -449,23 +442,23 @@ class TestFacetGrid(object):
         g.map(plt.plot, "x", "y")
 
         # Test the default titles
-        nt.assert_equal(g.axes[0, 0].get_title(), "a = a | b = m")
-        nt.assert_equal(g.axes[0, 1].get_title(), "a = a | b = n")
-        nt.assert_equal(g.axes[1, 0].get_title(), "a = b | b = m")
+        assert g.axes[0, 0].get_title() == "a = a | b = m"
+        assert g.axes[0, 1].get_title() == "a = a | b = n"
+        assert g.axes[1, 0].get_title() == "a = b | b = m"
 
         # Test a provided title
         g.set_titles("{row_var} == {row_name} \\/ {col_var} == {col_name}")
-        nt.assert_equal(g.axes[0, 0].get_title(), "a == a \\/ b == m")
-        nt.assert_equal(g.axes[0, 1].get_title(), "a == a \\/ b == n")
-        nt.assert_equal(g.axes[1, 0].get_title(), "a == b \\/ b == m")
+        assert g.axes[0, 0].get_title() == "a == a \\/ b == m"
+        assert g.axes[0, 1].get_title() == "a == a \\/ b == n"
+        assert g.axes[1, 0].get_title() == "a == b \\/ b == m"
 
         # Test a single row
         g = ag.FacetGrid(self.df, col="b")
         g.map(plt.plot, "x", "y")
 
         # Test the default titles
-        nt.assert_equal(g.axes[0, 0].get_title(), "b = m")
-        nt.assert_equal(g.axes[0, 1].get_title(), "b = n")
+        assert g.axes[0, 0].get_title() == "b = m"
+        assert g.axes[0, 1].get_title() == "b = n"
 
         # test with dropna=False
         g = ag.FacetGrid(self.df, col="b", hue="b", dropna=False)
@@ -524,10 +517,10 @@ class TestFacetGrid(object):
         g.set_yticklabels(rotation=75)
         for ax in g._bottom_axes:
             for l in ax.get_xticklabels():
-                nt.assert_equal(l.get_rotation(), 45)
+                assert l.get_rotation() == 45
         for ax in g._left_axes:
             for l in ax.get_yticklabels():
-                nt.assert_equal(l.get_rotation(), 75)
+                assert l.get_rotation() == 75
 
     def test_set_axis_labels(self):
 
@@ -555,37 +548,37 @@ class TestFacetGrid(object):
     def test_axis_lims(self):
 
         g = ag.FacetGrid(self.df, row="a", col="b", xlim=(0, 4), ylim=(-2, 3))
-        nt.assert_equal(g.axes[0, 0].get_xlim(), (0, 4))
-        nt.assert_equal(g.axes[0, 0].get_ylim(), (-2, 3))
+        assert g.axes[0, 0].get_xlim() == (0, 4)
+        assert g.axes[0, 0].get_ylim() == (-2, 3)
 
     def test_data_orders(self):
 
         g = ag.FacetGrid(self.df, row="a", col="b", hue="c")
 
-        nt.assert_equal(g.row_names, list("abc"))
-        nt.assert_equal(g.col_names, list("mn"))
-        nt.assert_equal(g.hue_names, list("tuv"))
-        nt.assert_equal(g.axes.shape, (3, 2))
+        assert g.row_names == list("abc")
+        assert g.col_names == list("mn")
+        assert g.hue_names == list("tuv")
+        assert g.axes.shape == (3, 2)
 
         g = ag.FacetGrid(self.df, row="a", col="b", hue="c",
                          row_order=list("bca"),
                          col_order=list("nm"),
                          hue_order=list("vtu"))
 
-        nt.assert_equal(g.row_names, list("bca"))
-        nt.assert_equal(g.col_names, list("nm"))
-        nt.assert_equal(g.hue_names, list("vtu"))
-        nt.assert_equal(g.axes.shape, (3, 2))
+        assert g.row_names == list("bca")
+        assert g.col_names == list("nm")
+        assert g.hue_names == list("vtu")
+        assert g.axes.shape == (3, 2)
 
         g = ag.FacetGrid(self.df, row="a", col="b", hue="c",
                          row_order=list("bcda"),
                          col_order=list("nom"),
                          hue_order=list("qvtu"))
 
-        nt.assert_equal(g.row_names, list("bcda"))
-        nt.assert_equal(g.col_names, list("nom"))
-        nt.assert_equal(g.hue_names, list("qvtu"))
-        nt.assert_equal(g.axes.shape, (4, 3))
+        assert g.row_names == list("bcda")
+        assert g.col_names == list("nom")
+        assert g.hue_names == list("qvtu")
+        assert g.axes.shape == (4, 3)
 
     def test_palette(self):
 
@@ -617,7 +610,7 @@ class TestFacetGrid(object):
         g.map(plt.plot, "x", "y")
 
         for line, marker in zip(g.axes[0, 0].lines, kws["marker"]):
-            nt.assert_equal(line.get_marker(), marker)
+            assert line.get_marker() == marker
 
     def test_dropna(self):
 
@@ -626,10 +619,10 @@ class TestFacetGrid(object):
         hasna[hasna == 5] = np.nan
         df["hasna"] = hasna
         g = ag.FacetGrid(df, dropna=False, row="hasna")
-        nt.assert_equal(g._not_na.sum(), 60)
+        assert g._not_na.sum() == 60
 
         g = ag.FacetGrid(df, dropna=True, row="hasna")
-        nt.assert_equal(g._not_na.sum(), 50)
+        assert g._not_na.sum() == 50
 
     def test_categorical_column_missing_categories(self):
 
@@ -638,18 +631,16 @@ class TestFacetGrid(object):
 
         g = ag.FacetGrid(df[df['a'] == 'a'], col="a", col_wrap=1)
 
-        nt.assert_equal(g.axes.shape, (len(df['a'].cat.categories),))
+        assert g.axes.shape == (len(df['a'].cat.categories),)
 
     def test_categorical_warning(self):
 
         g = ag.FacetGrid(self.df, col="b")
-        with warnings.catch_warnings():
-            warnings.resetwarnings()
-            warnings.simplefilter("always")
-            npt.assert_warns(UserWarning, g.map, pointplot, "b", "x")
+        with pytest.warns(UserWarning):
+            g.map(pointplot, "b", "x")
 
 
-class TestPairGrid(object):
+class TestPairGrid:
 
     rs = np.random.RandomState(sum(map(ord, "PairGrid")))
     df = pd.DataFrame(dict(x=rs.normal(size=60),
@@ -661,7 +652,7 @@ class TestPairGrid(object):
     def test_self_data(self):
 
         g = ag.PairGrid(self.df)
-        nt.assert_is(g.data, self.df)
+        assert g.data is self.df
 
     def test_ignore_datelike_data(self):
 
@@ -674,30 +665,30 @@ class TestPairGrid(object):
     def test_self_fig(self):
 
         g = ag.PairGrid(self.df)
-        nt.assert_is_instance(g.fig, plt.Figure)
+        assert isinstance(g.fig, plt.Figure)
 
     def test_self_axes(self):
 
         g = ag.PairGrid(self.df)
         for ax in g.axes.flat:
-            nt.assert_is_instance(ax, plt.Axes)
+            assert isinstance(ax, plt.Axes)
 
     def test_default_axes(self):
 
         g = ag.PairGrid(self.df)
-        nt.assert_equal(g.axes.shape, (3, 3))
-        nt.assert_equal(g.x_vars, ["x", "y", "z"])
-        nt.assert_equal(g.y_vars, ["x", "y", "z"])
-        nt.assert_true(g.square_grid)
+        assert g.axes.shape == (3, 3)
+        assert g.x_vars == ["x", "y", "z"]
+        assert g.y_vars == ["x", "y", "z"]
+        assert g.square_grid
 
     def test_specific_square_axes(self):
 
         vars = ["z", "x"]
         g = ag.PairGrid(self.df, vars=vars)
-        nt.assert_equal(g.axes.shape, (len(vars), len(vars)))
-        nt.assert_equal(g.x_vars, vars)
-        nt.assert_equal(g.y_vars, vars)
-        nt.assert_true(g.square_grid)
+        assert g.axes.shape == (len(vars), len(vars))
+        assert g.x_vars == vars
+        assert g.y_vars == vars
+        assert g.square_grid
 
     def test_remove_hue_from_default(self):
 
@@ -716,37 +707,37 @@ class TestPairGrid(object):
         x_vars = ["x", "y"]
         y_vars = ["z", "y", "x"]
         g = ag.PairGrid(self.df, x_vars=x_vars, y_vars=y_vars)
-        nt.assert_equal(g.axes.shape, (len(y_vars), len(x_vars)))
-        nt.assert_equal(g.x_vars, x_vars)
-        nt.assert_equal(g.y_vars, y_vars)
-        nt.assert_true(not g.square_grid)
+        assert g.axes.shape == (len(y_vars), len(x_vars))
+        assert g.x_vars == x_vars
+        assert g.y_vars == y_vars
+        assert not g.square_grid
 
         x_vars = ["x", "y"]
         y_vars = "z"
         g = ag.PairGrid(self.df, x_vars=x_vars, y_vars=y_vars)
-        nt.assert_equal(g.axes.shape, (len(y_vars), len(x_vars)))
-        nt.assert_equal(g.x_vars, list(x_vars))
-        nt.assert_equal(g.y_vars, list(y_vars))
-        nt.assert_true(not g.square_grid)
+        assert g.axes.shape, (len(y_vars), len(x_vars))
+        assert g.x_vars, list(x_vars)
+        assert g.y_vars, list(y_vars)
+        assert not g.square_grid
 
     def test_specific_square_axes_with_array(self):
 
         vars = np.array(["z", "x"])
         g = ag.PairGrid(self.df, vars=vars)
-        nt.assert_equal(g.axes.shape, (len(vars), len(vars)))
-        nt.assert_equal(g.x_vars, list(vars))
-        nt.assert_equal(g.y_vars, list(vars))
-        nt.assert_true(g.square_grid)
+        assert g.axes.shape == (len(vars), len(vars))
+        assert g.x_vars, list(vars)
+        assert g.y_vars, list(vars)
+        assert g.square_grid
 
     def test_specific_nonsquare_axes_with_array(self):
 
         x_vars = np.array(["x", "y"])
         y_vars = np.array(["z", "y", "x"])
         g = ag.PairGrid(self.df, x_vars=x_vars, y_vars=y_vars)
-        nt.assert_equal(g.axes.shape, (len(y_vars), len(x_vars)))
-        nt.assert_equal(g.x_vars, list(x_vars))
-        nt.assert_equal(g.y_vars, list(y_vars))
-        nt.assert_true(not g.square_grid)
+        assert g.axes.shape == (len(y_vars), len(x_vars))
+        assert g.x_vars == list(x_vars)
+        assert g.y_vars == list(y_vars)
+        assert not g.square_grid
 
     def test_corner(self):
 
@@ -833,7 +824,7 @@ class TestPairGrid(object):
 
         for i, j in zip(*np.triu_indices_from(g.axes)):
             ax = g.axes[i, j]
-            nt.assert_equal(len(ax.collections), 0)
+            assert len(ax.collections) == 0
 
     def test_map_upper(self):
 
@@ -851,29 +842,29 @@ class TestPairGrid(object):
 
         for i, j in zip(*np.tril_indices_from(g.axes)):
             ax = g.axes[i, j]
-            nt.assert_equal(len(ax.collections), 0)
+            assert len(ax.collections) == 0
 
     def test_map_diag(self):
 
-        g1 = ag.PairGrid(self.df)
-        g1.map_diag(plt.hist)
+        g = ag.PairGrid(self.df)
+        g.map_diag(plt.hist)
 
-        for var, ax in zip(g1.diag_vars, g1.diag_axes):
-            nt.assert_equal(len(ax.patches), 10)
+        for var, ax in zip(g.diag_vars, g.diag_axes):
+            assert len(ax.patches) == 10
             assert pytest.approx(ax.patches[0].get_x()) == self.df[var].min()
 
-        g2 = ag.PairGrid(self.df, hue="a")
-        g2.map_diag(plt.hist)
+        g = ag.PairGrid(self.df, hue="a")
+        g.map_diag(plt.hist)
 
-        for ax in g2.diag_axes:
-            nt.assert_equal(len(ax.patches), 30)
+        for ax in g.diag_axes:
+            assert len(ax.patches) == 30
 
-        g3 = ag.PairGrid(self.df, hue="a")
-        g3.map_diag(plt.hist, histtype='step')
+        g = ag.PairGrid(self.df, hue="a")
+        g.map_diag(plt.hist, histtype='step')
 
-        for ax in g3.diag_axes:
+        for ax in g.diag_axes:
             for ptch in ax.patches:
-                nt.assert_equal(ptch.fill, False)
+                assert not ptch.fill
 
     def test_map_diag_rectangular(self):
 
@@ -885,7 +876,7 @@ class TestPairGrid(object):
         assert set(g1.diag_vars) == (set(x_vars) & set(y_vars))
 
         for var, ax in zip(g1.diag_vars, g1.diag_axes):
-            nt.assert_equal(len(ax.patches), 10)
+            assert len(ax.patches) == 10
             assert pytest.approx(ax.patches[0].get_x()) == self.df[var].min()
 
         for i, ax in enumerate(np.diag(g1.axes)):
@@ -897,7 +888,7 @@ class TestPairGrid(object):
         assert set(g2.diag_vars) == (set(x_vars) & set(y_vars))
 
         for ax in g2.diag_axes:
-            nt.assert_equal(len(ax.patches), 30)
+            assert len(ax.patches) == 30
 
         x_vars = ["x", "y", "z"]
         y_vars = ["x", "y"]
@@ -907,7 +898,7 @@ class TestPairGrid(object):
         assert set(g3.diag_vars) == (set(x_vars) & set(y_vars))
 
         for var, ax in zip(g3.diag_vars, g3.diag_axes):
-            nt.assert_equal(len(ax.patches), 10)
+            assert len(ax.patches) == 10
             assert pytest.approx(ax.patches[0].get_x()) == self.df[var].min()
 
         for i, ax in enumerate(np.diag(g3.axes)):
@@ -951,7 +942,7 @@ class TestPairGrid(object):
         g.map_diag(plt.hist)
 
         for ax in g.diag_axes:
-            nt.assert_equal(len(ax.patches), 10)
+            assert len(ax.patches) == 10
 
         for i, j in zip(*np.triu_indices_from(g.axes, 1)):
             ax = g.axes[i, j]
@@ -971,7 +962,7 @@ class TestPairGrid(object):
 
         for i, j in zip(*np.diag_indices_from(g.axes)):
             ax = g.axes[i, j]
-            nt.assert_equal(len(ax.collections), 0)
+            assert len(ax.collections) == 0
 
     def test_diag_sharey(self):
 
@@ -1010,14 +1001,14 @@ class TestPairGrid(object):
         g.map(plt.plot)
 
         for line, marker in zip(g.axes[0, 0].lines, kws["marker"]):
-            nt.assert_equal(line.get_marker(), marker)
+            assert line.get_marker() == marker
 
         g = ag.PairGrid(self.df, hue="a", hue_kws=kws,
                         hue_order=list("dcab"))
         g.map(plt.plot)
 
         for line, marker in zip(g.axes[0, 0].lines, kws["marker"]):
-            nt.assert_equal(line.get_marker(), marker)
+            assert line.get_marker() == marker
 
     def test_hue_order(self):
 
@@ -1199,7 +1190,7 @@ class TestPairGrid(object):
 
         for i, j in zip(*np.diag_indices_from(g.axes)):
             ax = g.axes[i, j]
-            nt.assert_equal(len(ax.collections), 0)
+            assert len(ax.collections) == 0
 
         g = ag.pairplot(self.df, hue="a")
         n = len(self.df.a.unique())
@@ -1223,8 +1214,8 @@ class TestPairGrid(object):
             npt.assert_array_equal(x_in, x_out)
             npt.assert_array_equal(y_in, y_out)
 
-            nt.assert_equal(len(ax.lines), 1)
-            nt.assert_equal(len(ax.collections), 2)
+            assert len(ax.lines) == 1
+            assert len(ax.collections) == 2
 
         for i, j in zip(*np.tril_indices_from(g.axes, -1)):
             ax = g.axes[i, j]
@@ -1234,12 +1225,12 @@ class TestPairGrid(object):
             npt.assert_array_equal(x_in, x_out)
             npt.assert_array_equal(y_in, y_out)
 
-            nt.assert_equal(len(ax.lines), 1)
-            nt.assert_equal(len(ax.collections), 2)
+            assert len(ax.lines) == 1
+            assert len(ax.collections) == 2
 
         for i, j in zip(*np.diag_indices_from(g.axes)):
             ax = g.axes[i, j]
-            nt.assert_equal(len(ax.collections), 0)
+            assert len(ax.collections) == 0
 
     def test_pairplot_reg_hue(self):
 
@@ -1261,7 +1252,7 @@ class TestPairGrid(object):
         g = ag.pairplot(self.df, diag_kind="kde")
 
         for ax in g.diag_axes:
-            nt.assert_equal(len(ax.collections), 1)
+            assert len(ax.collections) == 1
 
         for i, j in zip(*np.triu_indices_from(g.axes, 1)):
             ax = g.axes[i, j]
@@ -1281,7 +1272,7 @@ class TestPairGrid(object):
 
         for i, j in zip(*np.diag_indices_from(g.axes)):
             ax = g.axes[i, j]
-            nt.assert_equal(len(ax.collections), 0)
+            assert len(ax.collections) == 0
 
     def test_pairplot_kde(self):
 
@@ -1336,7 +1327,7 @@ class TestPairGrid(object):
         assert g2.legend is None
 
 
-class TestJointGrid(object):
+class TestJointGrid:
 
     rs = np.random.RandomState(sum(map(ord, "JointGrid")))
     x = rs.randn(100)
@@ -1372,7 +1363,7 @@ class TestJointGrid(object):
 
     def test_margin_grid_from_dataframe_bad_variable(self):
 
-        with nt.assert_raises(ValueError):
+        with pytest.raises(ValueError):
             ag.JointGrid(x="x", y="bad_column", data=self.data)
 
     def test_margin_grid_axis_labels(self):
@@ -1380,32 +1371,32 @@ class TestJointGrid(object):
         g = ag.JointGrid(x="x", y="y", data=self.data)
 
         xlabel, ylabel = g.ax_joint.get_xlabel(), g.ax_joint.get_ylabel()
-        nt.assert_equal(xlabel, "x")
-        nt.assert_equal(ylabel, "y")
+        assert xlabel == "x"
+        assert ylabel == "y"
 
         g.set_axis_labels("x variable", "y variable")
         xlabel, ylabel = g.ax_joint.get_xlabel(), g.ax_joint.get_ylabel()
-        nt.assert_equal(xlabel, "x variable")
-        nt.assert_equal(ylabel, "y variable")
+        assert xlabel == "x variable"
+        assert ylabel == "y variable"
 
     def test_dropna(self):
 
         g = ag.JointGrid(x="x_na", y="y", data=self.data, dropna=False)
-        nt.assert_equal(len(g.x), len(self.x_na))
+        assert len(g.x) == len(self.x_na)
 
         g = ag.JointGrid(x="x_na", y="y", data=self.data, dropna=True)
-        nt.assert_equal(len(g.x), pd.notnull(self.x_na).sum())
+        assert len(g.x) == pd.notnull(self.x_na).sum()
 
     def test_axlims(self):
 
         lim = (-3, 3)
         g = ag.JointGrid(x="x", y="y", data=self.data, xlim=lim, ylim=lim)
 
-        nt.assert_equal(g.ax_joint.get_xlim(), lim)
-        nt.assert_equal(g.ax_joint.get_ylim(), lim)
+        assert g.ax_joint.get_xlim() == lim
+        assert g.ax_joint.get_ylim() == lim
 
-        nt.assert_equal(g.ax_marg_x.get_xlim(), lim)
-        nt.assert_equal(g.ax_marg_y.get_ylim(), lim)
+        assert g.ax_marg_x.get_xlim() == lim
+        assert g.ax_marg_y.get_ylim() == lim
 
     def test_marginal_ticks(self):
 
@@ -1456,8 +1447,8 @@ class TestJointGrid(object):
         marg_x_bounds = g.ax_marg_x.bbox.bounds
         marg_y_bounds = g.ax_marg_y.bbox.bounds
 
-        nt.assert_equal(joint_bounds[2], marg_x_bounds[2])
-        nt.assert_equal(joint_bounds[3], marg_y_bounds[3])
+        assert joint_bounds[2] == marg_x_bounds[2]
+        assert joint_bounds[3] == marg_y_bounds[3]
 
     @pytest.mark.parametrize(
         "as_vector", [True, False],
@@ -1485,7 +1476,7 @@ class TestJointGrid(object):
         assert_plots_equal(g.ax_marg_y, g2.ax_marg_y, labels=False)
 
 
-class TestJointPlot(object):
+class TestJointPlot:
 
     rs = np.random.RandomState(sum(map(ord, "jointplot")))
     x = rs.randn(100)

--- a/seaborn/tests/test_axisgrid.py
+++ b/seaborn/tests/test_axisgrid.py
@@ -681,13 +681,13 @@ class TestPairGrid:
         assert g.y_vars == ["x", "y", "z"]
         assert g.square_grid
 
-    def test_specific_square_axes(self):
+    @pytest.mark.parametrize("vars", [["z", "x"], np.array(["z", "x"])])
+    def test_specific_square_axes(self, vars):
 
-        vars = ["z", "x"]
         g = ag.PairGrid(self.df, vars=vars)
         assert g.axes.shape == (len(vars), len(vars))
-        assert g.x_vars == vars
-        assert g.y_vars == vars
+        assert g.x_vars == list(vars)
+        assert g.y_vars == list(vars)
         assert g.square_grid
 
     def test_remove_hue_from_default(self):
@@ -702,37 +702,16 @@ class TestPairGrid:
         assert hue in g.x_vars
         assert hue in g.y_vars
 
-    def test_specific_nonsquare_axes(self):
+    @pytest.mark.parametrize(
+        "x_vars, y_vars",
+        [
+            (["x", "y"], ["z", "y", "x"]),
+            (["x", "y"], "z"),
+            (np.array(["x", "y"]), np.array(["z", "y", "x"])),
+        ],
+    )
+    def test_specific_nonsquare_axes(self, x_vars, y_vars):
 
-        x_vars = ["x", "y"]
-        y_vars = ["z", "y", "x"]
-        g = ag.PairGrid(self.df, x_vars=x_vars, y_vars=y_vars)
-        assert g.axes.shape == (len(y_vars), len(x_vars))
-        assert g.x_vars == x_vars
-        assert g.y_vars == y_vars
-        assert not g.square_grid
-
-        x_vars = ["x", "y"]
-        y_vars = "z"
-        g = ag.PairGrid(self.df, x_vars=x_vars, y_vars=y_vars)
-        assert g.axes.shape, (len(y_vars), len(x_vars))
-        assert g.x_vars, list(x_vars)
-        assert g.y_vars, list(y_vars)
-        assert not g.square_grid
-
-    def test_specific_square_axes_with_array(self):
-
-        vars = np.array(["z", "x"])
-        g = ag.PairGrid(self.df, vars=vars)
-        assert g.axes.shape == (len(vars), len(vars))
-        assert g.x_vars, list(vars)
-        assert g.y_vars, list(vars)
-        assert g.square_grid
-
-    def test_specific_nonsquare_axes_with_array(self):
-
-        x_vars = np.array(["x", "y"])
-        y_vars = np.array(["z", "y", "x"])
         g = ag.PairGrid(self.df, x_vars=x_vars, y_vars=y_vars)
         assert g.axes.shape == (len(y_vars), len(x_vars))
         assert g.x_vars == list(x_vars)

--- a/seaborn/tests/test_categorical.py
+++ b/seaborn/tests/test_categorical.py
@@ -7,7 +7,7 @@ from matplotlib.colors import rgb2hex
 from distutils.version import LooseVersion
 
 import pytest
-import nose.tools as nt
+from pytest import approx
 import numpy.testing as npt
 
 from .. import categorical as cat
@@ -43,17 +43,17 @@ class TestCategoricalPlotter(CategoricalFixture):
             npt.assert_array_equal(x, y)
 
         # Check semantic attributes
-        nt.assert_equal(p.orient, "v")
-        nt.assert_is(p.plot_hues, None)
-        nt.assert_is(p.group_label, "big")
-        nt.assert_is(p.value_label, None)
+        assert p.orient == "v"
+        assert p.plot_hues is None
+        assert p.group_label == "big"
+        assert p.value_label is None
 
         # Test wide dataframe with forced horizontal orientation
         p.establish_variables(data=self.x_df, orient="horiz")
-        nt.assert_equal(p.orient, "h")
+        assert p.orient == "h"
 
-        # Text exception by trying to hue-group with a wide dataframe
-        with nt.assert_raises(ValueError):
+        # Test exception by trying to hue-group with a wide dataframe
+        with pytest.raises(ValueError):
             p.establish_variables(hue="d", data=self.x_df)
 
     def test_1d_input_data(self):
@@ -63,29 +63,29 @@ class TestCategoricalPlotter(CategoricalFixture):
         # Test basic vector data
         x_1d_array = self.x.ravel()
         p.establish_variables(data=x_1d_array)
-        nt.assert_equal(len(p.plot_data), 1)
-        nt.assert_equal(len(p.plot_data[0]), self.n_total)
-        nt.assert_is(p.group_label, None)
-        nt.assert_is(p.value_label, None)
+        assert len(p.plot_data) == 1
+        assert len(p.plot_data[0]) == self.n_total
+        assert p.group_label is None
+        assert p.value_label is None
 
         # Test basic vector data in list form
         x_1d_list = x_1d_array.tolist()
         p.establish_variables(data=x_1d_list)
-        nt.assert_equal(len(p.plot_data), 1)
-        nt.assert_equal(len(p.plot_data[0]), self.n_total)
-        nt.assert_is(p.group_label, None)
-        nt.assert_is(p.value_label, None)
+        assert len(p.plot_data) == 1
+        assert len(p.plot_data[0]) == self.n_total
+        assert p.group_label is None
+        assert p.value_label is None
 
         # Test an object array that looks 1D but isn't
         x_notreally_1d = np.array([self.x.ravel(),
                                    self.x.ravel()[:int(self.n_total / 2)]],
                                   dtype=object)
         p.establish_variables(data=x_notreally_1d)
-        nt.assert_equal(len(p.plot_data), 2)
-        nt.assert_equal(len(p.plot_data[0]), self.n_total)
-        nt.assert_equal(len(p.plot_data[1]), self.n_total / 2)
-        nt.assert_is(p.group_label, None)
-        nt.assert_is(p.value_label, None)
+        assert len(p.plot_data) == 2
+        assert len(p.plot_data[0]) == self.n_total
+        assert len(p.plot_data[1]) == self.n_total / 2
+        assert p.group_label is None
+        assert p.value_label is None
 
     def test_2d_input_data(self):
 
@@ -95,17 +95,17 @@ class TestCategoricalPlotter(CategoricalFixture):
 
         # Test vector data that looks 2D but doesn't really have columns
         p.establish_variables(data=x[:, np.newaxis])
-        nt.assert_equal(len(p.plot_data), 1)
-        nt.assert_equal(len(p.plot_data[0]), self.x.shape[0])
-        nt.assert_is(p.group_label, None)
-        nt.assert_is(p.value_label, None)
+        assert len(p.plot_data) == 1
+        assert len(p.plot_data[0]) == self.x.shape[0]
+        assert p.group_label is None
+        assert p.value_label is None
 
         # Test vector data that looks 2D but doesn't really have rows
         p.establish_variables(data=x[np.newaxis, :])
-        nt.assert_equal(len(p.plot_data), 1)
-        nt.assert_equal(len(p.plot_data[0]), self.x.shape[0])
-        nt.assert_is(p.group_label, None)
-        nt.assert_is(p.value_label, None)
+        assert len(p.plot_data) == 1
+        assert len(p.plot_data[0]) == self.x.shape[0]
+        assert p.group_label is None
+        assert p.value_label is None
 
     def test_3d_input_data(self):
 
@@ -113,7 +113,7 @@ class TestCategoricalPlotter(CategoricalFixture):
 
         # Test that passing actually 3D data raises
         x = np.zeros((5, 5, 5))
-        with nt.assert_raises(ValueError):
+        with pytest.raises(ValueError):
             p.establish_variables(data=x)
 
     def test_list_of_array_input_data(self):
@@ -123,13 +123,13 @@ class TestCategoricalPlotter(CategoricalFixture):
         # Test 2D input in list form
         x_list = self.x.T.tolist()
         p.establish_variables(data=x_list)
-        nt.assert_equal(len(p.plot_data), 3)
+        assert len(p.plot_data) == 3
 
         lengths = [len(v_i) for v_i in p.plot_data]
-        nt.assert_equal(lengths, [self.n_total / 3] * 3)
+        assert lengths == [self.n_total / 3] * 3
 
-        nt.assert_is(p.group_label, None)
-        nt.assert_is(p.value_label, None)
+        assert p.group_label is None
+        assert p.value_label is None
 
     def test_wide_array_input_data(self):
 
@@ -137,11 +137,11 @@ class TestCategoricalPlotter(CategoricalFixture):
 
         # Test 2D input in array form
         p.establish_variables(data=self.x)
-        nt.assert_equal(np.shape(p.plot_data), (3, self.n_total / 3))
+        assert np.shape(p.plot_data) == (3, self.n_total / 3)
         npt.assert_array_equal(p.plot_data, self.x.T)
 
-        nt.assert_is(p.group_label, None)
-        nt.assert_is(p.value_label, None)
+        assert p.group_label is None
+        assert p.value_label is None
 
     def test_single_long_direct_inputs(self):
 
@@ -150,23 +150,23 @@ class TestCategoricalPlotter(CategoricalFixture):
         # Test passing a series to the x variable
         p.establish_variables(x=self.y)
         npt.assert_equal(p.plot_data, [self.y])
-        nt.assert_equal(p.orient, "h")
-        nt.assert_equal(p.value_label, "y_data")
-        nt.assert_is(p.group_label, None)
+        assert p.orient == "h"
+        assert p.value_label == "y_data"
+        assert p.group_label is None
 
         # Test passing a series to the y variable
         p.establish_variables(y=self.y)
         npt.assert_equal(p.plot_data, [self.y])
-        nt.assert_equal(p.orient, "v")
-        nt.assert_equal(p.value_label, "y_data")
-        nt.assert_is(p.group_label, None)
+        assert p.orient == "v"
+        assert p.value_label == "y_data"
+        assert p.group_label is None
 
         # Test passing an array to the y variable
         p.establish_variables(y=self.y.values)
         npt.assert_equal(p.plot_data, [self.y])
-        nt.assert_equal(p.orient, "v")
-        nt.assert_is(p.value_label, None)
-        nt.assert_is(p.group_label, None)
+        assert p.orient == "v"
+        assert p.group_label is None
+        assert p.value_label is None
 
         # Test array and series with non-default index
         x = pd.Series([1, 1, 1, 1], index=[0, 2, 4, 6])
@@ -181,16 +181,16 @@ class TestCategoricalPlotter(CategoricalFixture):
         # Test referencing a DataFrame series in the x variable
         p.establish_variables(x="y", data=self.df)
         npt.assert_equal(p.plot_data, [self.y])
-        nt.assert_equal(p.orient, "h")
-        nt.assert_equal(p.value_label, "y")
-        nt.assert_is(p.group_label, None)
+        assert p.orient == "h"
+        assert p.value_label == "y"
+        assert p.group_label is None
 
         # Test referencing a DataFrame series in the y variable
         p.establish_variables(y="y", data=self.df)
         npt.assert_equal(p.plot_data, [self.y])
-        nt.assert_equal(p.orient, "v")
-        nt.assert_equal(p.value_label, "y")
-        nt.assert_is(p.group_label, None)
+        assert p.orient == "v"
+        assert p.value_label == "y"
+        assert p.group_label is None
 
     def test_longform_groupby(self):
 
@@ -198,12 +198,12 @@ class TestCategoricalPlotter(CategoricalFixture):
 
         # Test a vertically oriented grouped and nested plot
         p.establish_variables("g", "y", hue="h", data=self.df)
-        nt.assert_equal(len(p.plot_data), 3)
-        nt.assert_equal(len(p.plot_hues), 3)
-        nt.assert_equal(p.orient, "v")
-        nt.assert_equal(p.value_label, "y")
-        nt.assert_equal(p.group_label, "g")
-        nt.assert_equal(p.hue_title, "h")
+        assert len(p.plot_data) == 3
+        assert len(p.plot_hues) == 3
+        assert p.orient == "v"
+        assert p.value_label == "y"
+        assert p.group_label == "g"
+        assert p.hue_title == "h"
 
         for group, vals in zip(["a", "b", "c"], p.plot_data):
             npt.assert_array_equal(vals, self.y[self.g == group])
@@ -213,8 +213,8 @@ class TestCategoricalPlotter(CategoricalFixture):
 
         # Test a grouped and nested plot with direct array value data
         p.establish_variables("g", self.y.values, "h", self.df)
-        nt.assert_is(p.value_label, None)
-        nt.assert_equal(p.group_label, "g")
+        assert p.value_label is None
+        assert p.group_label == "g"
 
         for group, vals in zip(["a", "b", "c"], p.plot_data):
             npt.assert_array_equal(vals, self.y[self.g == group])
@@ -231,12 +231,12 @@ class TestCategoricalPlotter(CategoricalFixture):
 
         # Test that horizontal orientation is automatically detected
         p.establish_variables("y", "g", hue="h", data=df)
-        nt.assert_equal(len(p.plot_data), 3)
-        nt.assert_equal(len(p.plot_hues), 3)
-        nt.assert_equal(p.orient, "h")
-        nt.assert_equal(p.value_label, "y")
-        nt.assert_equal(p.group_label, "g")
-        nt.assert_equal(p.hue_title, "h")
+        assert len(p.plot_data) == 3
+        assert len(p.plot_hues) == 3
+        assert p.orient == "h"
+        assert p.value_label == "y"
+        assert p.group_label == "g"
+        assert p.hue_title == "h"
 
         for group, vals in zip(["a", "b", "c"], p.plot_data):
             npt.assert_array_equal(vals, self.y[self.g == group])
@@ -260,7 +260,7 @@ class TestCategoricalPlotter(CategoricalFixture):
         for var in ["x", "y", "hue", "units"]:
             input_kws = kws.copy()
             input_kws[var] = "bad_input"
-            with nt.assert_raises(ValueError):
+            with pytest.raises(ValueError):
                 p.establish_variables(**input_kws)
 
     def test_order(self):
@@ -269,25 +269,25 @@ class TestCategoricalPlotter(CategoricalFixture):
 
         # Test inferred order from a wide dataframe input
         p.establish_variables(data=self.x_df)
-        nt.assert_equal(p.group_names, ["X", "Y", "Z"])
+        assert p.group_names == ["X", "Y", "Z"]
 
         # Test specified order with a wide dataframe input
         p.establish_variables(data=self.x_df, order=["Y", "Z", "X"])
-        nt.assert_equal(p.group_names, ["Y", "Z", "X"])
+        assert p.group_names == ["Y", "Z", "X"]
 
         for group, vals in zip(["Y", "Z", "X"], p.plot_data):
             npt.assert_array_equal(vals, self.x_df[group])
 
-        with nt.assert_raises(ValueError):
+        with pytest.raises(ValueError):
             p.establish_variables(data=self.x, order=[1, 2, 0])
 
         # Test inferred order from a grouped longform input
         p.establish_variables("g", "y", data=self.df)
-        nt.assert_equal(p.group_names, ["a", "b", "c"])
+        assert p.group_names == ["a", "b", "c"]
 
         # Test specified order from a grouped longform input
         p.establish_variables("g", "y", data=self.df, order=["b", "a", "c"])
-        nt.assert_equal(p.group_names, ["b", "a", "c"])
+        assert p.group_names == ["b", "a", "c"]
 
         for group, vals in zip(["b", "a", "c"], p.plot_data):
             npt.assert_array_equal(vals, self.y[self.g == group])
@@ -297,7 +297,7 @@ class TestCategoricalPlotter(CategoricalFixture):
         df.g = df.g.astype("category")
         df.g = df.g.cat.reorder_categories(["c", "b", "a"])
         p.establish_variables("g", "y", data=df)
-        nt.assert_equal(p.group_names, ["c", "b", "a"])
+        assert p.group_names == ["c", "b", "a"]
 
         for group, vals in zip(["c", "b", "a"], p.plot_data):
             npt.assert_array_equal(vals, self.y[self.g == group])
@@ -305,7 +305,7 @@ class TestCategoricalPlotter(CategoricalFixture):
         df.g = (df.g.cat.add_categories("d")
                     .cat.reorder_categories(["c", "b", "d", "a"]))
         p.establish_variables("g", "y", data=df)
-        nt.assert_equal(p.group_names, ["c", "b", "d", "a"])
+        assert p.group_names == ["c", "b", "d", "a"]
 
     def test_hue_order(self):
 
@@ -313,30 +313,30 @@ class TestCategoricalPlotter(CategoricalFixture):
 
         # Test inferred hue order
         p.establish_variables("g", "y", hue="h", data=self.df)
-        nt.assert_equal(p.hue_names, ["m", "n"])
+        assert p.hue_names == ["m", "n"]
 
         # Test specified hue order
         p.establish_variables("g", "y", hue="h", data=self.df,
                               hue_order=["n", "m"])
-        nt.assert_equal(p.hue_names, ["n", "m"])
+        assert p.hue_names == ["n", "m"]
 
         # Test inferred hue order from a categorical hue input
         df = self.df.copy()
         df.h = df.h.astype("category")
         df.h = df.h.cat.reorder_categories(["n", "m"])
         p.establish_variables("g", "y", hue="h", data=df)
-        nt.assert_equal(p.hue_names, ["n", "m"])
+        assert p.hue_names == ["n", "m"]
 
         df.h = (df.h.cat.add_categories("o")
                     .cat.reorder_categories(["o", "m", "n"]))
         p.establish_variables("g", "y", hue="h", data=df)
-        nt.assert_equal(p.hue_names, ["o", "m", "n"])
+        assert p.hue_names == ["o", "m", "n"]
 
     def test_plot_units(self):
 
         p = cat._CategoricalPlotter()
         p.establish_variables("g", "y", hue="h", data=self.df)
-        nt.assert_is(p.plot_units, None)
+        assert p.plot_units is None
 
         p.establish_variables("g", "y", hue="h", data=self.df, units="u")
         for group, units in zip(["a", "b", "c"], p.plot_units):
@@ -349,12 +349,12 @@ class TestCategoricalPlotter(CategoricalFixture):
         # Test palette mapping the x position
         p.establish_variables("g", "y", data=self.df)
         p.establish_colors(None, None, 1)
-        nt.assert_equal(p.colors, palettes.color_palette(n_colors=3))
+        assert p.colors == palettes.color_palette(n_colors=3)
 
         # Test palette mapping the hue position
         p.establish_variables("g", "y", hue="h", data=self.df)
         p.establish_colors(None, None, 1)
-        nt.assert_equal(p.colors, palettes.color_palette(n_colors=2))
+        assert p.colors == palettes.color_palette(n_colors=2)
 
     def test_default_palette_with_many_levels(self):
 
@@ -373,7 +373,7 @@ class TestCategoricalPlotter(CategoricalFixture):
         p.establish_variables("g", "y", data=self.df)
         p.establish_colors("blue", None, 1)
         blue_rgb = mpl.colors.colorConverter.to_rgb("blue")
-        nt.assert_equal(p.colors, [blue_rgb] * 3)
+        assert p.colors == [blue_rgb] * 3
 
         # Test a color-based blend for the hue mapping
         p.establish_variables("g", "y", hue="h", data=self.df)
@@ -389,18 +389,18 @@ class TestCategoricalPlotter(CategoricalFixture):
         # Test palette mapping the x position
         p.establish_variables("g", "y", data=self.df)
         p.establish_colors(None, "dark", 1)
-        nt.assert_equal(p.colors, palettes.color_palette("dark", 3))
+        assert p.colors == palettes.color_palette("dark", 3)
 
         # Test that non-None `color` and `hue` raises an error
         p.establish_variables("g", "y", hue="h", data=self.df)
         p.establish_colors(None, "muted", 1)
-        nt.assert_equal(p.colors, palettes.color_palette("muted", 2))
+        assert p.colors == palettes.color_palette("muted", 2)
 
         # Test that specified palette overrides specified color
         p = cat._CategoricalPlotter()
         p.establish_variables("g", "y", data=self.df)
         p.establish_colors("blue", "deep", 1)
-        nt.assert_equal(p.colors, palettes.color_palette("deep", 3))
+        assert p.colors == palettes.color_palette("deep", 3)
 
     def test_dict_as_palette(self):
 
@@ -408,19 +408,17 @@ class TestCategoricalPlotter(CategoricalFixture):
         p.establish_variables("g", "y", hue="h", data=self.df)
         pal = {"m": (0, 0, 1), "n": (1, 0, 0)}
         p.establish_colors(None, pal, 1)
-        nt.assert_equal(p.colors, [(0, 0, 1), (1, 0, 0)])
+        assert p.colors == [(0, 0, 1), (1, 0, 0)]
 
     def test_palette_desaturation(self):
 
         p = cat._CategoricalPlotter()
         p.establish_variables("g", "y", data=self.df)
         p.establish_colors((0, 0, 1), None, .5)
-        nt.assert_equal(p.colors, [(.25, .25, .75)] * 3)
+        assert p.colors == [(.25, .25, .75)] * 3
 
         p.establish_colors(None, [(0, 0, 1), (1, 0, 0), "w"], .5)
-        nt.assert_equal(p.colors, [(.25, .25, .75),
-                                   (.75, .25, .25),
-                                   (1, 1, 1)])
+        assert p.colors == [(.25, .25, .75), (.75, .25, .25), (1, 1, 1)]
 
 
 class TestCategoricalStatPlotter(CategoricalFixture):
@@ -446,8 +444,8 @@ class TestCategoricalStatPlotter(CategoricalFixture):
         p.establish_variables(g, y)
         p.estimate_statistic(np.mean, 95, 10000, None)
 
-        nt.assert_equal(p.statistic.shape, (3,))
-        nt.assert_equal(p.confint.shape, (3, 2))
+        assert p.statistic.shape == (3,)
+        assert p.confint.shape == (3, 2)
 
         npt.assert_array_almost_equal(p.statistic,
                                       y.groupby(g).mean())
@@ -493,8 +491,8 @@ class TestCategoricalStatPlotter(CategoricalFixture):
         p.establish_variables(g, y, order=list("abdc"))
         p.estimate_statistic(np.mean, 95, 10000, None)
 
-        nt.assert_equal(p.statistic.shape, (4,))
-        nt.assert_equal(p.confint.shape, (4, 2))
+        assert p.statistic.shape == (4,)
+        assert p.confint.shape == (4, 2)
 
         mean = y[g == "b"].mean()
         sem = stats.sem(y[g == "b"])
@@ -517,8 +515,8 @@ class TestCategoricalStatPlotter(CategoricalFixture):
         p.establish_variables(g, y, h)
         p.estimate_statistic(np.mean, 95, 50000, None)
 
-        nt.assert_equal(p.statistic.shape, (3, 2))
-        nt.assert_equal(p.confint.shape, (3, 2, 2))
+        assert p.statistic.shape == (3, 2)
+        assert p.confint.shape == (3, 2, 2)
 
         npt.assert_array_almost_equal(p.statistic,
                                       y.groupby([g, h]).mean().unstack())
@@ -584,8 +582,8 @@ class TestCategoricalStatPlotter(CategoricalFixture):
                               hue_order=list("zyx"))
         p.estimate_statistic(np.mean, 95, 50000, None)
 
-        nt.assert_equal(p.statistic.shape, (4, 3))
-        nt.assert_equal(p.confint.shape, (4, 3, 2))
+        assert p.statistic.shape == (4, 3)
+        assert p.confint.shape == (4, 3, 2)
 
         mean = y[(g == "b") & (h == "x")].mean()
         sem = stats.sem(y[(g == "b") & (h == "x")])
@@ -611,8 +609,8 @@ class TestCategoricalStatPlotter(CategoricalFixture):
         p.establish_variables(g, y)
         p.estimate_statistic(np.mean, "sd", None, None)
 
-        nt.assert_equal(p.statistic.shape, (3,))
-        nt.assert_equal(p.confint.shape, (3, 2))
+        assert p.statistic.shape == (3,)
+        assert p.confint.shape == (3, 2)
 
         npt.assert_array_almost_equal(p.statistic,
                                       y.groupby(g).mean())
@@ -634,8 +632,8 @@ class TestCategoricalStatPlotter(CategoricalFixture):
         p.establish_variables(g, y, h)
         p.estimate_statistic(np.mean, "sd", None, None)
 
-        nt.assert_equal(p.statistic.shape, (3, 2))
-        nt.assert_equal(p.confint.shape, (3, 2, 2))
+        assert p.statistic.shape == (3, 2)
+        assert p.confint.shape == (3, 2, 2)
 
         npt.assert_array_almost_equal(p.statistic,
                                       y.groupby([g, h]).mean().unstack())
@@ -665,7 +663,7 @@ class TestCategoricalStatPlotter(CategoricalFixture):
             x, y = line.get_xydata().T
             npt.assert_array_equal(x, [at, at])
             npt.assert_array_equal(y, ci)
-            nt.assert_equal(line.get_color(), c)
+            assert line.get_color() == c
 
         plt.close("all")
 
@@ -680,7 +678,7 @@ class TestCategoricalStatPlotter(CategoricalFixture):
             x, y = line.get_xydata().T
             npt.assert_array_equal(x, ci)
             npt.assert_array_equal(y, [at, at])
-            nt.assert_equal(line.get_color(), c)
+            assert line.get_color() == c
 
         plt.close("all")
 
@@ -693,8 +691,8 @@ class TestCategoricalStatPlotter(CategoricalFixture):
         caplinestart = capline.get_xdata()[0]
         caplineend = capline.get_xdata()[1]
         caplinelength = abs(caplineend - caplinestart)
-        nt.assert_almost_equal(caplinelength, 0.3)
-        nt.assert_equal(len(ax.lines), 6)
+        assert caplinelength == approx(0.3)
+        assert len(ax.lines) == 6
 
         plt.close("all")
 
@@ -707,14 +705,14 @@ class TestCategoricalStatPlotter(CategoricalFixture):
         caplinestart = capline.get_ydata()[0]
         caplineend = capline.get_ydata()[1]
         caplinelength = abs(caplineend - caplinestart)
-        nt.assert_almost_equal(caplinelength, 0.3)
-        nt.assert_equal(len(ax.lines), 6)
+        assert caplinelength == approx(0.3)
+        assert len(ax.lines) == 6
 
         # Test extra keyword arguments
         f, ax = plt.subplots()
         p.draw_confints(ax, at_group, confints, colors, lw=4)
         line = ax.lines[0]
-        nt.assert_equal(line.get_linewidth(), 4)
+        assert line.get_linewidth() == 4
 
         plt.close("all")
 
@@ -722,8 +720,8 @@ class TestCategoricalStatPlotter(CategoricalFixture):
         f, ax = plt.subplots()
         p.draw_confints(ax, at_group, confints, colors, errwidth=2)
         capline = ax.lines[len(ax.lines) - 1]
-        nt.assert_equal(capline._linewidth, 2)
-        nt.assert_equal(len(ax.lines), 2)
+        assert capline._linewidth == 2
+        assert len(ax.lines) == 2
 
         plt.close("all")
 
@@ -741,19 +739,19 @@ class TestBoxPlotter(CategoricalFixture):
         kws = self.default_kws.copy()
         p = cat._BoxPlotter(**kws)
         p.establish_variables("g", "y", hue="h", data=self.df)
-        nt.assert_equal(p.nested_width, .4 * .98)
+        assert p.nested_width == .4 * .98
 
         kws = self.default_kws.copy()
         kws["width"] = .6
         p = cat._BoxPlotter(**kws)
         p.establish_variables("g", "y", hue="h", data=self.df)
-        nt.assert_equal(p.nested_width, .3 * .98)
+        assert p.nested_width == .3 * .98
 
         kws = self.default_kws.copy()
         kws["dodge"] = False
         p = cat._BoxPlotter(**kws)
         p.establish_variables("g", "y", hue="h", data=self.df)
-        nt.assert_equal(p.nested_width, .8)
+        assert p.nested_width == .8
 
     def test_hue_offsets(self):
 
@@ -774,12 +772,12 @@ class TestBoxPlotter(CategoricalFixture):
     def test_axes_data(self):
 
         ax = cat.boxplot(x="g", y="y", data=self.df)
-        nt.assert_equal(len(ax.artists), 3)
+        assert len(ax.artists) == 3
 
         plt.close("all")
 
         ax = cat.boxplot(x="g", y="y", hue="h", data=self.df)
-        nt.assert_equal(len(ax.artists), 6)
+        assert len(ax.artists) == 6
 
         plt.close("all")
 
@@ -788,14 +786,14 @@ class TestBoxPlotter(CategoricalFixture):
         ax = cat.boxplot(x="g", y="y", data=self.df, saturation=1)
         pal = palettes.color_palette(n_colors=3)
         for patch, color in zip(ax.artists, pal):
-            nt.assert_equal(patch.get_facecolor()[:3], color)
+            assert patch.get_facecolor()[:3] == color
 
         plt.close("all")
 
         ax = cat.boxplot(x="g", y="y", hue="h", data=self.df, saturation=1)
         pal = palettes.color_palette(n_colors=2)
         for patch, color in zip(ax.artists, pal * 2):
-            nt.assert_equal(patch.get_facecolor()[:3], color)
+            assert patch.get_facecolor()[:3] == color
 
         plt.close("all")
 
@@ -803,7 +801,7 @@ class TestBoxPlotter(CategoricalFixture):
 
         ax = cat.boxplot(x="g", y="y", data=self.df,
                          order=["a", "b", "c", "d"])
-        nt.assert_equal(len(ax.artists), 3)
+        assert len(ax.artists) == 3
 
     def test_missing_data(self):
 
@@ -813,13 +811,13 @@ class TestBoxPlotter(CategoricalFixture):
         y[-2:] = np.nan
 
         ax = cat.boxplot(x=x, y=y)
-        nt.assert_equal(len(ax.artists), 3)
+        assert len(ax.artists) == 3
 
         plt.close("all")
 
         y[-1] = 0
         ax = cat.boxplot(x=x, y=y, hue=h)
-        nt.assert_equal(len(ax.artists), 7)
+        assert len(ax.artists) == 7
 
         plt.close("all")
 
@@ -871,9 +869,9 @@ class TestBoxPlotter(CategoricalFixture):
     def test_axes_annotation(self):
 
         ax = cat.boxplot(x="g", y="y", data=self.df)
-        nt.assert_equal(ax.get_xlabel(), "g")
-        nt.assert_equal(ax.get_ylabel(), "y")
-        nt.assert_equal(ax.get_xlim(), (-.5, 2.5))
+        assert ax.get_xlabel() == "g"
+        assert ax.get_ylabel() == "y"
+        assert ax.get_xlim() == (-.5, 2.5)
         npt.assert_array_equal(ax.get_xticks(), [0, 1, 2])
         npt.assert_array_equal([l.get_text() for l in ax.get_xticklabels()],
                                ["a", "b", "c"])
@@ -881,8 +879,8 @@ class TestBoxPlotter(CategoricalFixture):
         plt.close("all")
 
         ax = cat.boxplot(x="g", y="y", hue="h", data=self.df)
-        nt.assert_equal(ax.get_xlabel(), "g")
-        nt.assert_equal(ax.get_ylabel(), "y")
+        assert ax.get_xlabel() == "g"
+        assert ax.get_ylabel() == "y"
         npt.assert_array_equal(ax.get_xticks(), [0, 1, 2])
         npt.assert_array_equal([l.get_text() for l in ax.get_xticklabels()],
                                ["a", "b", "c"])
@@ -892,9 +890,9 @@ class TestBoxPlotter(CategoricalFixture):
         plt.close("all")
 
         ax = cat.boxplot(x="y", y="g", data=self.df, orient="h")
-        nt.assert_equal(ax.get_xlabel(), "y")
-        nt.assert_equal(ax.get_ylabel(), "g")
-        nt.assert_equal(ax.get_ylim(), (2.5, -.5))
+        assert ax.get_xlabel() == "y"
+        assert ax.get_ylabel() == "g"
+        assert ax.get_ylim() == (2.5, -.5)
         npt.assert_array_equal(ax.get_yticks(), [0, 1, 2])
         npt.assert_array_equal([l.get_text() for l in ax.get_yticklabels()],
                                ["a", "b", "c"])
@@ -916,7 +914,7 @@ class TestViolinPlotter(CategoricalFixture):
         kws = self.default_kws.copy()
         kws.update(dict(x="h", y="y", hue="g", data=self.df, split=True))
 
-        with nt.assert_raises(ValueError):
+        with pytest.raises(ValueError):
             cat._ViolinPlotter(**kws)
 
     def test_no_observations(self):
@@ -929,16 +927,16 @@ class TestViolinPlotter(CategoricalFixture):
         p.establish_variables(x, y)
         p.estimate_densities("scott", 2, "area", True, 20)
 
-        nt.assert_equal(len(p.support[0]), 20)
-        nt.assert_equal(len(p.support[1]), 0)
+        assert len(p.support[0]) == 20
+        assert len(p.support[1]) == 0
 
-        nt.assert_equal(len(p.density[0]), 20)
-        nt.assert_equal(len(p.density[1]), 1)
+        assert len(p.density[0]) == 20
+        assert len(p.density[1]) == 1
 
-        nt.assert_equal(p.density[1].item(), 1)
+        assert p.density[1].item() == 1
 
         p.estimate_densities("scott", 2, "count", True, 20)
-        nt.assert_equal(p.density[1].item(), 0)
+        assert p.density[1].item() == 0
 
         x = ["a"] * 4 + ["b"] * 2
         y = self.rs.randn(6)
@@ -947,16 +945,16 @@ class TestViolinPlotter(CategoricalFixture):
         p.establish_variables(x, y, hue=h)
         p.estimate_densities("scott", 2, "area", True, 20)
 
-        nt.assert_equal(len(p.support[1][0]), 20)
-        nt.assert_equal(len(p.support[1][1]), 0)
+        assert len(p.support[1][0]) == 20
+        assert len(p.support[1][1]) == 0
 
-        nt.assert_equal(len(p.density[1][0]), 20)
-        nt.assert_equal(len(p.density[1][1]), 1)
+        assert len(p.density[1][0]) == 20
+        assert len(p.density[1][1]) == 1
 
-        nt.assert_equal(p.density[1][1].item(), 1)
+        assert p.density[1][1].item() == 1
 
         p.estimate_densities("scott", 2, "count", False, 20)
-        nt.assert_equal(p.density[1][1].item(), 0)
+        assert p.density[1][1].item() == 0
 
     def test_single_observation(self):
 
@@ -967,16 +965,16 @@ class TestViolinPlotter(CategoricalFixture):
         p.establish_variables(x, y)
         p.estimate_densities("scott", 2, "area", True, 20)
 
-        nt.assert_equal(len(p.support[0]), 20)
-        nt.assert_equal(len(p.support[1]), 1)
+        assert len(p.support[0]) == 20
+        assert len(p.support[1]) == 1
 
-        nt.assert_equal(len(p.density[0]), 20)
-        nt.assert_equal(len(p.density[1]), 1)
+        assert len(p.density[0]) == 20
+        assert len(p.density[1]) == 1
 
-        nt.assert_equal(p.density[1].item(), 1)
+        assert p.density[1].item() == 1
 
         p.estimate_densities("scott", 2, "count", True, 20)
-        nt.assert_equal(p.density[1].item(), .5)
+        assert p.density[1].item() == .5
 
         x = ["b"] * 4 + ["a"] * 3
         y = self.rs.randn(7)
@@ -985,16 +983,16 @@ class TestViolinPlotter(CategoricalFixture):
         p.establish_variables(x, y, hue=h)
         p.estimate_densities("scott", 2, "area", True, 20)
 
-        nt.assert_equal(len(p.support[1][0]), 20)
-        nt.assert_equal(len(p.support[1][1]), 1)
+        assert len(p.support[1][0]) == 20
+        assert len(p.support[1][1]) == 1
 
-        nt.assert_equal(len(p.density[1][0]), 20)
-        nt.assert_equal(len(p.density[1][1]), 1)
+        assert len(p.density[1][0]) == 20
+        assert len(p.density[1][1]) == 1
 
-        nt.assert_equal(p.density[1][1].item(), 1)
+        assert p.density[1][1].item() == 1
 
         p.estimate_densities("scott", 2, "count", False, 20)
-        nt.assert_equal(p.density[1][1].item(), .5)
+        assert p.density[1][1].item() == .5
 
     def test_dwidth(self):
 
@@ -1002,19 +1000,19 @@ class TestViolinPlotter(CategoricalFixture):
         kws.update(dict(x="g", y="y", data=self.df))
 
         p = cat._ViolinPlotter(**kws)
-        nt.assert_equal(p.dwidth, .4)
+        assert p.dwidth == .4
 
         kws.update(dict(width=.4))
         p = cat._ViolinPlotter(**kws)
-        nt.assert_equal(p.dwidth, .2)
+        assert p.dwidth == .2
 
         kws.update(dict(hue="h", width=.8))
         p = cat._ViolinPlotter(**kws)
-        nt.assert_equal(p.dwidth, .2)
+        assert p.dwidth == .2
 
         kws.update(dict(split=True))
         p = cat._ViolinPlotter(**kws)
-        nt.assert_equal(p.dwidth, .4)
+        assert p.dwidth == .4
 
     def test_scale_area(self):
 
@@ -1028,11 +1026,11 @@ class TestViolinPlotter(CategoricalFixture):
         max_before = np.array([d.max() for d in density])
         p.scale_area(density, max_before, False)
         max_after = np.array([d.max() for d in density])
-        nt.assert_equal(max_after[0], 1)
+        assert max_after[0] == 1
 
         before_ratio = max_before[1] / max_before[0]
         after_ratio = max_after[1] / max_after[0]
-        nt.assert_equal(before_ratio, after_ratio)
+        assert before_ratio == after_ratio
 
         # Test nested grouping scaling across all densities
         p.hue_names = ["foo", "bar"]
@@ -1042,11 +1040,11 @@ class TestViolinPlotter(CategoricalFixture):
         max_before = np.array([[r.max() for r in row] for row in density])
         p.scale_area(density, max_before, False)
         max_after = np.array([[r.max() for r in row] for row in density])
-        nt.assert_equal(max_after[0, 0], 1)
+        assert max_after[0, 0] == 1
 
         before_ratio = max_before[1, 1] / max_before[0, 0]
         after_ratio = max_after[1, 1] / max_after[0, 0]
-        nt.assert_equal(before_ratio, after_ratio)
+        assert before_ratio == after_ratio
 
         # Test nested grouping scaling within hue
         p.hue_names = ["foo", "bar"]
@@ -1056,12 +1054,12 @@ class TestViolinPlotter(CategoricalFixture):
         max_before = np.array([[r.max() for r in row] for row in density])
         p.scale_area(density, max_before, True)
         max_after = np.array([[r.max() for r in row] for row in density])
-        nt.assert_equal(max_after[0, 0], 1)
-        nt.assert_equal(max_after[1, 0], 1)
+        assert max_after[0, 0] == 1
+        assert max_after[1, 0] == 1
 
         before_ratio = max_before[1, 1] / max_before[1, 0]
         after_ratio = max_after[1, 1] / max_after[1, 0]
-        nt.assert_equal(before_ratio, after_ratio)
+        assert before_ratio == after_ratio
 
     def test_scale_width(self):
 
@@ -1123,7 +1121,7 @@ class TestViolinPlotter(CategoricalFixture):
 
         kws = self.default_kws.copy()
         kws["scale"] = "not_a_scale_type"
-        with nt.assert_raises(ValueError):
+        with pytest.raises(ValueError):
             cat._ViolinPlotter(**kws)
 
     def test_kde_fit(self):
@@ -1134,15 +1132,15 @@ class TestViolinPlotter(CategoricalFixture):
 
         # Test reference rule bandwidth
         kde, bw = p.fit_kde(data, "scott")
-        nt.assert_is_instance(kde, stats.gaussian_kde)
-        nt.assert_equal(kde.factor, kde.scotts_factor())
-        nt.assert_equal(bw, kde.scotts_factor() * data_std)
+        assert isinstance(kde, stats.gaussian_kde)
+        assert kde.factor == kde.scotts_factor()
+        assert bw == kde.scotts_factor() * data_std
 
         # Test numeric scale factor
         kde, bw = p.fit_kde(self.y, .2)
-        nt.assert_is_instance(kde, stats.gaussian_kde)
-        nt.assert_equal(kde.factor, .2)
-        nt.assert_equal(bw, .2 * data_std)
+        assert isinstance(kde, stats.gaussian_kde)
+        assert kde.factor == .2
+        assert bw == .2 * data_std
 
     def test_draw_to_density(self):
 
@@ -1238,14 +1236,14 @@ class TestViolinPlotter(CategoricalFixture):
 
         _, ax = plt.subplots()
         p.draw_box_lines(ax, self.y, p.support[0], p.density[0], 0)
-        nt.assert_equal(len(ax.lines), 2)
+        assert len(ax.lines) == 2
 
         q25, q50, q75 = np.percentile(self.y, [25, 50, 75])
         _, y = ax.lines[1].get_xydata().T
         npt.assert_array_equal(y, [q25, q75])
 
         _, y = ax.collections[0].get_offsets().T
-        nt.assert_equal(y, q50)
+        assert y == q50
 
         plt.close("all")
 
@@ -1256,14 +1254,14 @@ class TestViolinPlotter(CategoricalFixture):
 
         _, ax = plt.subplots()
         p.draw_box_lines(ax, self.y, p.support[0], p.density[0], 0)
-        nt.assert_equal(len(ax.lines), 2)
+        assert len(ax.lines) == 2
 
         q25, q50, q75 = np.percentile(self.y, [25, 50, 75])
         x, _ = ax.lines[1].get_xydata().T
         npt.assert_array_equal(x, [q25, q75])
 
         x, _ = ax.collections[0].get_offsets().T
-        nt.assert_equal(x, q50)
+        assert x == q50
 
         plt.close("all")
 
@@ -1327,7 +1325,7 @@ class TestViolinPlotter(CategoricalFixture):
 
         kws = self.default_kws.copy()
         kws.update(dict(inner="bad_inner"))
-        with nt.assert_raises(ValueError):
+        with pytest.raises(ValueError):
             cat._ViolinPlotter(**kws)
 
     def test_draw_violinplots(self):
@@ -1341,7 +1339,7 @@ class TestViolinPlotter(CategoricalFixture):
 
         _, ax = plt.subplots()
         p.draw_violins(ax)
-        nt.assert_equal(len(ax.collections), 1)
+        assert len(ax.collections) == 1
         npt.assert_array_equal(ax.collections[0].get_facecolors(),
                                [(1, 0, 0, 1)])
         plt.close("all")
@@ -1352,7 +1350,7 @@ class TestViolinPlotter(CategoricalFixture):
 
         _, ax = plt.subplots()
         p.draw_violins(ax)
-        nt.assert_equal(len(ax.collections), 1)
+        assert len(ax.collections) == 1
         npt.assert_array_equal(ax.collections[0].get_facecolors(),
                                [(0, 1, 0, 1)])
         plt.close("all")
@@ -1363,7 +1361,7 @@ class TestViolinPlotter(CategoricalFixture):
 
         _, ax = plt.subplots()
         p.draw_violins(ax)
-        nt.assert_equal(len(ax.collections), 3)
+        assert len(ax.collections) == 3
         for violin, color in zip(ax.collections, palettes.color_palette()):
             npt.assert_array_equal(violin.get_facecolors()[0, :-1], color)
         plt.close("all")
@@ -1374,7 +1372,7 @@ class TestViolinPlotter(CategoricalFixture):
 
         _, ax = plt.subplots()
         p.draw_violins(ax)
-        nt.assert_equal(len(ax.collections), 6)
+        assert len(ax.collections) == 6
         for violin, color in zip(ax.collections,
                                  palettes.color_palette(n_colors=2) * 3):
             npt.assert_array_equal(violin.get_facecolors()[0, :-1], color)
@@ -1386,7 +1384,7 @@ class TestViolinPlotter(CategoricalFixture):
 
         _, ax = plt.subplots()
         p.draw_violins(ax)
-        nt.assert_equal(len(ax.collections), 6)
+        assert len(ax.collections) == 6
         for violin, color in zip(ax.collections,
                                  palettes.color_palette("muted",
                                                         n_colors=2) * 3):
@@ -1407,8 +1405,8 @@ class TestViolinPlotter(CategoricalFixture):
 
         _, ax = plt.subplots()
         p.draw_violins(ax)
-        nt.assert_equal(len(ax.collections), 1)
-        nt.assert_equal(len(ax.lines), 0)
+        assert len(ax.collections) == 1
+        assert len(ax.lines) == 0
         plt.close("all")
 
         # Test nested hue grouping
@@ -1420,8 +1418,8 @@ class TestViolinPlotter(CategoricalFixture):
 
         _, ax = plt.subplots()
         p.draw_violins(ax)
-        nt.assert_equal(len(ax.collections), 3)
-        nt.assert_equal(len(ax.lines), 0)
+        assert len(ax.collections) == 3
+        assert len(ax.lines) == 0
         plt.close("all")
 
     def test_draw_violinplots_single_observations(self):
@@ -1437,8 +1435,8 @@ class TestViolinPlotter(CategoricalFixture):
 
         _, ax = plt.subplots()
         p.draw_violins(ax)
-        nt.assert_equal(len(ax.collections), 1)
-        nt.assert_equal(len(ax.lines), 1)
+        assert len(ax.collections) == 1
+        assert len(ax.lines) == 1
         plt.close("all")
 
         # Test nested hue grouping
@@ -1450,8 +1448,8 @@ class TestViolinPlotter(CategoricalFixture):
 
         _, ax = plt.subplots()
         p.draw_violins(ax)
-        nt.assert_equal(len(ax.collections), 3)
-        nt.assert_equal(len(ax.lines), 1)
+        assert len(ax.collections) == 3
+        assert len(ax.lines) == 1
         plt.close("all")
 
         # Test nested hue grouping with split
@@ -1460,8 +1458,8 @@ class TestViolinPlotter(CategoricalFixture):
 
         _, ax = plt.subplots()
         p.draw_violins(ax)
-        nt.assert_equal(len(ax.collections), 3)
-        nt.assert_equal(len(ax.lines), 1)
+        assert len(ax.collections) == 3
+        assert len(ax.lines) == 1
         plt.close("all")
 
     def test_violinplots(self):
@@ -1558,11 +1556,11 @@ class TestCategoricalScatterPlotter(CategoricalFixture):
         leg = ax.legend()
 
         for i, t in enumerate(leg.get_texts()):
-            nt.assert_equal(t.get_text(), hue_order[i])
+            assert t.get_text() == hue_order[i]
 
         for i, h in enumerate(leg.legendHandles):
             rgb = h.get_facecolor()[0, :3]
-            nt.assert_equal(tuple(rgb), tuple(deep_colors[i]))
+            assert tuple(rgb) == tuple(deep_colors[i])
 
 
 class TestStripPlotter(CategoricalFixture):
@@ -1672,7 +1670,7 @@ class TestStripPlotter(CategoricalFixture):
         x = np.arange(3)
         ax = cat.stripplot(x=x)
         facecolors = ax.collections[0].get_facecolor()
-        nt.assert_equal(facecolors.shape, (3, 4))
+        assert facecolors.shape == (3, 4)
         npt.assert_array_equal(facecolors[0], facecolors[1])
 
     def test_unaligned_index(self):
@@ -1920,16 +1918,16 @@ class TestBarPlotter(CategoricalFixture):
 
         p = cat._BarPlotter(**kws)
         p.establish_variables("g", "y", hue="h", data=self.df)
-        nt.assert_equal(p.nested_width, .8 / 2)
+        assert p.nested_width == .8 / 2
 
         p = cat._BarPlotter(**kws)
         p.establish_variables("h", "y", "g", data=self.df)
-        nt.assert_equal(p.nested_width, .8 / 3)
+        assert p.nested_width == .8 / 3
 
         kws["dodge"] = False
         p = cat._BarPlotter(**kws)
         p.establish_variables("h", "y", "g", data=self.df)
-        nt.assert_equal(p.nested_width, .8)
+        assert p.nested_width == .8
 
     def test_draw_vertical_bars(self):
 
@@ -1940,18 +1938,18 @@ class TestBarPlotter(CategoricalFixture):
         f, ax = plt.subplots()
         p.draw_bars(ax, {})
 
-        nt.assert_equal(len(ax.patches), len(p.plot_data))
-        nt.assert_equal(len(ax.lines), len(p.plot_data))
+        assert len(ax.patches) == len(p.plot_data)
+        assert len(ax.lines) == len(p.plot_data)
 
         for bar, color in zip(ax.patches, p.colors):
-            nt.assert_equal(bar.get_facecolor()[:-1], color)
+            assert bar.get_facecolor()[:-1] == color
 
         positions = np.arange(len(p.plot_data)) - p.width / 2
         for bar, pos, stat in zip(ax.patches, positions, p.statistic):
-            nt.assert_equal(bar.get_x(), pos)
-            nt.assert_equal(bar.get_width(), p.width)
-            nt.assert_equal(bar.get_y(), 0)
-            nt.assert_equal(bar.get_height(), stat)
+            assert bar.get_x() == pos
+            assert bar.get_width() == p.width
+            assert bar.get_y() == 0
+            assert bar.get_height() == stat
 
     def test_draw_horizontal_bars(self):
 
@@ -1962,18 +1960,18 @@ class TestBarPlotter(CategoricalFixture):
         f, ax = plt.subplots()
         p.draw_bars(ax, {})
 
-        nt.assert_equal(len(ax.patches), len(p.plot_data))
-        nt.assert_equal(len(ax.lines), len(p.plot_data))
+        assert len(ax.patches) == len(p.plot_data)
+        assert len(ax.lines) == len(p.plot_data)
 
         for bar, color in zip(ax.patches, p.colors):
-            nt.assert_equal(bar.get_facecolor()[:-1], color)
+            assert bar.get_facecolor()[:-1] == color
 
         positions = np.arange(len(p.plot_data)) - p.width / 2
         for bar, pos, stat in zip(ax.patches, positions, p.statistic):
-            nt.assert_equal(bar.get_y(), pos)
-            nt.assert_equal(bar.get_height(), p.width)
-            nt.assert_equal(bar.get_x(), 0)
-            nt.assert_equal(bar.get_width(), stat)
+            assert bar.get_y() == pos
+            assert bar.get_height() == p.width
+            assert bar.get_x() == 0
+            assert bar.get_width() == stat
 
     def test_draw_nested_vertical_bars(self):
 
@@ -1985,22 +1983,22 @@ class TestBarPlotter(CategoricalFixture):
         p.draw_bars(ax, {})
 
         n_groups, n_hues = len(p.plot_data), len(p.hue_names)
-        nt.assert_equal(len(ax.patches), n_groups * n_hues)
-        nt.assert_equal(len(ax.lines), n_groups * n_hues)
+        assert len(ax.patches) == n_groups * n_hues
+        assert len(ax.lines) == n_groups * n_hues
 
         for bar in ax.patches[:n_groups]:
-            nt.assert_equal(bar.get_facecolor()[:-1], p.colors[0])
+            assert bar.get_facecolor()[:-1] == p.colors[0]
         for bar in ax.patches[n_groups:]:
-            nt.assert_equal(bar.get_facecolor()[:-1], p.colors[1])
+            assert bar.get_facecolor()[:-1] == p.colors[1]
 
         positions = np.arange(len(p.plot_data))
         for bar, pos in zip(ax.patches[:n_groups], positions):
-            nt.assert_almost_equal(bar.get_x(), pos - p.width / 2)
-            nt.assert_almost_equal(bar.get_width(), p.nested_width)
+            assert bar.get_x() == approx(pos - p.width / 2)
+            assert bar.get_width() == approx(p.nested_width)
 
         for bar, stat in zip(ax.patches, p.statistic.T.flat):
-            nt.assert_almost_equal(bar.get_y(), 0)
-            nt.assert_almost_equal(bar.get_height(), stat)
+            assert bar.get_y() == approx(0)
+            assert bar.get_height() == approx(stat)
 
     def test_draw_nested_horizontal_bars(self):
 
@@ -2012,22 +2010,22 @@ class TestBarPlotter(CategoricalFixture):
         p.draw_bars(ax, {})
 
         n_groups, n_hues = len(p.plot_data), len(p.hue_names)
-        nt.assert_equal(len(ax.patches), n_groups * n_hues)
-        nt.assert_equal(len(ax.lines), n_groups * n_hues)
+        assert len(ax.patches) == n_groups * n_hues
+        assert len(ax.lines) == n_groups * n_hues
 
         for bar in ax.patches[:n_groups]:
-            nt.assert_equal(bar.get_facecolor()[:-1], p.colors[0])
+            assert bar.get_facecolor()[:-1] == p.colors[0]
         for bar in ax.patches[n_groups:]:
-            nt.assert_equal(bar.get_facecolor()[:-1], p.colors[1])
+            assert bar.get_facecolor()[:-1] == p.colors[1]
 
         positions = np.arange(len(p.plot_data))
         for bar, pos in zip(ax.patches[:n_groups], positions):
-            nt.assert_almost_equal(bar.get_y(), pos - p.width / 2)
-            nt.assert_almost_equal(bar.get_height(), p.nested_width)
+            assert bar.get_y() == approx(pos - p.width / 2)
+            assert bar.get_height() == approx(p.nested_width)
 
         for bar, stat in zip(ax.patches, p.statistic.T.flat):
-            nt.assert_almost_equal(bar.get_x(), 0)
-            nt.assert_almost_equal(bar.get_width(), stat)
+            assert bar.get_x() == approx(0)
+            assert bar.get_width() == approx(stat)
 
     def test_draw_missing_bars(self):
 
@@ -2040,8 +2038,8 @@ class TestBarPlotter(CategoricalFixture):
         f, ax = plt.subplots()
         p.draw_bars(ax, {})
 
-        nt.assert_equal(len(ax.patches), len(order))
-        nt.assert_equal(len(ax.lines), len(order))
+        assert len(ax.patches) == len(order)
+        assert len(ax.lines) == len(order)
 
         plt.close("all")
 
@@ -2052,8 +2050,8 @@ class TestBarPlotter(CategoricalFixture):
         f, ax = plt.subplots()
         p.draw_bars(ax, {})
 
-        nt.assert_equal(len(ax.patches), len(p.plot_data) * len(hue_order))
-        nt.assert_equal(len(ax.lines), len(p.plot_data) * len(hue_order))
+        assert len(ax.patches) == len(p.plot_data) * len(hue_order)
+        assert len(ax.lines) == len(p.plot_data) * len(hue_order)
 
         plt.close("all")
 
@@ -2063,11 +2061,11 @@ class TestBarPlotter(CategoricalFixture):
         cat.barplot(x=self.g, y=self.y, ci="sd", ax=ax1)
         cat.barplot(x=self.g, y=self.y_perm, ci="sd", ax=ax2)
         for l1, l2 in zip(ax1.lines, ax2.lines):
-            assert pytest.approx(l1.get_xydata()) == l2.get_xydata()
+            assert approx(l1.get_xydata()) == l2.get_xydata()
         for p1, p2 in zip(ax1.patches, ax2.patches):
-            assert pytest.approx(p1.get_xy()) == p2.get_xy()
-            assert pytest.approx(p1.get_height()) == p2.get_height()
-            assert pytest.approx(p1.get_width()) == p2.get_width()
+            assert approx(p1.get_xy()) == p2.get_xy()
+            assert approx(p1.get_height()) == p2.get_height()
+            assert approx(p1.get_width()) == p2.get_width()
 
         f, (ax1, ax2) = plt.subplots(2)
         hue_order = self.h.unique()
@@ -2076,11 +2074,11 @@ class TestBarPlotter(CategoricalFixture):
         cat.barplot(x=self.g, y=self.y_perm, hue=self.h,
                     hue_order=hue_order, ci="sd", ax=ax2)
         for l1, l2 in zip(ax1.lines, ax2.lines):
-            assert pytest.approx(l1.get_xydata()) == l2.get_xydata()
+            assert approx(l1.get_xydata()) == l2.get_xydata()
         for p1, p2 in zip(ax1.patches, ax2.patches):
-            assert pytest.approx(p1.get_xy()) == p2.get_xy()
-            assert pytest.approx(p1.get_height()) == p2.get_height()
-            assert pytest.approx(p1.get_width()) == p2.get_width()
+            assert approx(p1.get_xy()) == p2.get_xy()
+            assert approx(p1.get_height()) == p2.get_height()
+            assert approx(p1.get_width()) == p2.get_width()
 
     def test_barplot_colors(self):
 
@@ -2095,7 +2093,7 @@ class TestBarPlotter(CategoricalFixture):
 
         palette = palettes.color_palette("muted", len(self.g.unique()))
         for patch, pal_color in zip(ax.patches, palette):
-            nt.assert_equal(patch.get_facecolor()[:-1], pal_color)
+            assert patch.get_facecolor()[:-1] == pal_color
 
         plt.close("all")
 
@@ -2110,7 +2108,7 @@ class TestBarPlotter(CategoricalFixture):
         p.draw_bars(ax, {})
 
         for patch in ax.patches:
-            nt.assert_equal(patch.get_facecolor(), color)
+            assert patch.get_facecolor() == color
 
         plt.close("all")
 
@@ -2125,38 +2123,36 @@ class TestBarPlotter(CategoricalFixture):
 
         palette = palettes.color_palette("Set2", len(self.h.unique()))
         for patch in ax.patches[:len(self.g.unique())]:
-            nt.assert_equal(patch.get_facecolor()[:-1], palette[0])
+            assert patch.get_facecolor()[:-1] == palette[0]
         for patch in ax.patches[len(self.g.unique()):]:
-            nt.assert_equal(patch.get_facecolor()[:-1], palette[1])
+            assert patch.get_facecolor()[:-1] == palette[1]
 
         plt.close("all")
 
     def test_simple_barplots(self):
 
         ax = cat.barplot(x="g", y="y", data=self.df)
-        nt.assert_equal(len(ax.patches), len(self.g.unique()))
-        nt.assert_equal(ax.get_xlabel(), "g")
-        nt.assert_equal(ax.get_ylabel(), "y")
+        assert len(ax.patches) == len(self.g.unique())
+        assert ax.get_xlabel() == "g"
+        assert ax.get_ylabel() == "y"
         plt.close("all")
 
         ax = cat.barplot(x="y", y="g", orient="h", data=self.df)
-        nt.assert_equal(len(ax.patches), len(self.g.unique()))
-        nt.assert_equal(ax.get_xlabel(), "y")
-        nt.assert_equal(ax.get_ylabel(), "g")
+        assert len(ax.patches) == len(self.g.unique())
+        assert ax.get_xlabel() == "y"
+        assert ax.get_ylabel() == "g"
         plt.close("all")
 
         ax = cat.barplot(x="g", y="y", hue="h", data=self.df)
-        nt.assert_equal(len(ax.patches),
-                        len(self.g.unique()) * len(self.h.unique()))
-        nt.assert_equal(ax.get_xlabel(), "g")
-        nt.assert_equal(ax.get_ylabel(), "y")
+        assert len(ax.patches) == len(self.g.unique()) * len(self.h.unique())
+        assert ax.get_xlabel() == "g"
+        assert ax.get_ylabel() == "y"
         plt.close("all")
 
         ax = cat.barplot(x="y", y="g", hue="h", orient="h", data=self.df)
-        nt.assert_equal(len(ax.patches),
-                        len(self.g.unique()) * len(self.h.unique()))
-        nt.assert_equal(ax.get_xlabel(), "y")
-        nt.assert_equal(ax.get_ylabel(), "g")
+        assert len(ax.patches) == len(self.g.unique()) * len(self.h.unique())
+        assert ax.get_xlabel() == "y"
+        assert ax.get_ylabel() == "g"
         plt.close("all")
 
 
@@ -2211,10 +2207,10 @@ class TestPointPlotter(CategoricalFixture):
         f, ax = plt.subplots()
         p.draw_points(ax)
 
-        nt.assert_equal(len(ax.collections), 1)
-        nt.assert_equal(len(ax.lines), len(p.plot_data) + 1)
+        assert len(ax.collections) == 1
+        assert len(ax.lines) == len(p.plot_data) + 1
         points = ax.collections[0]
-        nt.assert_equal(len(points.get_offsets()), len(p.plot_data))
+        assert len(points.get_offsets()) == len(p.plot_data)
 
         x, y = points.get_offsets().T
         npt.assert_array_equal(x, np.arange(len(p.plot_data)))
@@ -2233,10 +2229,10 @@ class TestPointPlotter(CategoricalFixture):
         f, ax = plt.subplots()
         p.draw_points(ax)
 
-        nt.assert_equal(len(ax.collections), 1)
-        nt.assert_equal(len(ax.lines), len(p.plot_data) + 1)
+        assert len(ax.collections) == 1
+        assert len(ax.lines) == len(p.plot_data) + 1
         points = ax.collections[0]
-        nt.assert_equal(len(points.get_offsets()), len(p.plot_data))
+        assert len(points.get_offsets()) == len(p.plot_data)
 
         x, y = points.get_offsets().T
         npt.assert_array_equal(x, p.statistic)
@@ -2255,15 +2251,14 @@ class TestPointPlotter(CategoricalFixture):
         f, ax = plt.subplots()
         p.draw_points(ax)
 
-        nt.assert_equal(len(ax.collections), 2)
-        nt.assert_equal(len(ax.lines),
-                        len(p.plot_data) * len(p.hue_names) + len(p.hue_names))
+        assert len(ax.collections) == 2
+        assert len(ax.lines) == len(p.plot_data) * len(p.hue_names) + len(p.hue_names)
 
         for points, numbers, color in zip(ax.collections,
                                           p.statistic.T,
                                           p.colors):
 
-            nt.assert_equal(len(points.get_offsets()), len(p.plot_data))
+            assert len(points.get_offsets()) == len(p.plot_data)
 
             x, y = points.get_offsets().T
             npt.assert_array_equal(x, np.arange(len(p.plot_data)))
@@ -2281,15 +2276,14 @@ class TestPointPlotter(CategoricalFixture):
         f, ax = plt.subplots()
         p.draw_points(ax)
 
-        nt.assert_equal(len(ax.collections), 2)
-        nt.assert_equal(len(ax.lines),
-                        len(p.plot_data) * len(p.hue_names) + len(p.hue_names))
+        assert len(ax.collections) == 2
+        assert len(ax.lines) == len(p.plot_data) * len(p.hue_names) + len(p.hue_names)
 
         for points, numbers, color in zip(ax.collections,
                                           p.statistic.T,
                                           p.colors):
 
-            nt.assert_equal(len(points.get_offsets()), len(p.plot_data))
+            assert len(points.get_offsets()) == len(p.plot_data)
 
             x, y = points.get_offsets().T
             npt.assert_array_equal(x, numbers)
@@ -2320,9 +2314,9 @@ class TestPointPlotter(CategoricalFixture):
         cat.pointplot(x=self.g, y=self.y, ci="sd", ax=ax1)
         cat.pointplot(x=self.g, y=self.y_perm, ci="sd", ax=ax2)
         for l1, l2 in zip(ax1.lines, ax2.lines):
-            assert pytest.approx(l1.get_xydata()) == l2.get_xydata()
+            assert approx(l1.get_xydata()) == l2.get_xydata()
         for p1, p2 in zip(ax1.collections, ax2.collections):
-            assert pytest.approx(p1.get_offsets()) == p2.get_offsets()
+            assert approx(p1.get_offsets()) == p2.get_offsets()
 
         f, (ax1, ax2) = plt.subplots(2)
         hue_order = self.h.unique()
@@ -2331,9 +2325,9 @@ class TestPointPlotter(CategoricalFixture):
         cat.pointplot(x=self.g, y=self.y_perm, hue=self.h,
                       hue_order=hue_order, ci="sd", ax=ax2)
         for l1, l2 in zip(ax1.lines, ax2.lines):
-            assert pytest.approx(l1.get_xydata()) == l2.get_xydata()
+            assert approx(l1.get_xydata()) == l2.get_xydata()
         for p1, p2 in zip(ax1.collections, ax2.collections):
-            assert pytest.approx(p1.get_offsets()) == p2.get_offsets()
+            assert approx(p1.get_offsets()) == p2.get_offsets()
 
     def test_pointplot_colors(self):
 
@@ -2347,7 +2341,7 @@ class TestPointPlotter(CategoricalFixture):
         p.draw_points(ax)
 
         for line in ax.lines:
-            nt.assert_equal(line.get_color(), color[:-1])
+            assert line.get_color() == color[:-1]
 
         for got_color in ax.collections[0].get_facecolors():
             npt.assert_array_equal(rgb2hex(got_color), rgb2hex(color))
@@ -2359,7 +2353,7 @@ class TestPointPlotter(CategoricalFixture):
         kws.update(x="g", y="y", data=self.df, palette="Set1")
         p = cat._PointPlotter(**kws)
 
-        nt.assert_true(not p.join)
+        assert not p.join
 
         f, ax = plt.subplots()
         p.draw_points(ax)
@@ -2382,9 +2376,9 @@ class TestPointPlotter(CategoricalFixture):
         p.draw_points(ax)
 
         for line in ax.lines[:(len(p.plot_data) + 1)]:
-            nt.assert_equal(line.get_color(), palette[0])
+            assert line.get_color() == palette[0]
         for line in ax.lines[(len(p.plot_data) + 1):]:
-            nt.assert_equal(line.get_color(), palette[1])
+            assert line.get_color() == palette[1]
 
         for i, pal_color in enumerate(palette):
             for point_color in ax.collections[i].get_facecolors():
@@ -2395,37 +2389,35 @@ class TestPointPlotter(CategoricalFixture):
     def test_simple_pointplots(self):
 
         ax = cat.pointplot(x="g", y="y", data=self.df)
-        nt.assert_equal(len(ax.collections), 1)
-        nt.assert_equal(len(ax.lines), len(self.g.unique()) + 1)
-        nt.assert_equal(ax.get_xlabel(), "g")
-        nt.assert_equal(ax.get_ylabel(), "y")
+        assert len(ax.collections) == 1
+        assert len(ax.lines) == len(self.g.unique()) + 1
+        assert ax.get_xlabel() == "g"
+        assert ax.get_ylabel() == "y"
         plt.close("all")
 
         ax = cat.pointplot(x="y", y="g", orient="h", data=self.df)
-        nt.assert_equal(len(ax.collections), 1)
-        nt.assert_equal(len(ax.lines), len(self.g.unique()) + 1)
-        nt.assert_equal(ax.get_xlabel(), "y")
-        nt.assert_equal(ax.get_ylabel(), "g")
+        assert len(ax.collections) == 1
+        assert len(ax.lines) == len(self.g.unique()) + 1
+        assert ax.get_xlabel() == "y"
+        assert ax.get_ylabel() == "g"
         plt.close("all")
 
         ax = cat.pointplot(x="g", y="y", hue="h", data=self.df)
-        nt.assert_equal(len(ax.collections), len(self.h.unique()))
-        nt.assert_equal(len(ax.lines),
-                        (len(self.g.unique())
-                         * len(self.h.unique())
-                         + len(self.h.unique())))
-        nt.assert_equal(ax.get_xlabel(), "g")
-        nt.assert_equal(ax.get_ylabel(), "y")
+        assert len(ax.collections) == len(self.h.unique())
+        assert len(ax.lines) == (
+            len(self.g.unique()) * len(self.h.unique()) + len(self.h.unique())
+        )
+        assert ax.get_xlabel() == "g"
+        assert ax.get_ylabel() == "y"
         plt.close("all")
 
         ax = cat.pointplot(x="y", y="g", hue="h", orient="h", data=self.df)
-        nt.assert_equal(len(ax.collections), len(self.h.unique()))
-        nt.assert_equal(len(ax.lines),
-                        (len(self.g.unique())
-                        * len(self.h.unique())
-                        + len(self.h.unique())))
-        nt.assert_equal(ax.get_xlabel(), "y")
-        nt.assert_equal(ax.get_ylabel(), "g")
+        assert len(ax.collections) == len(self.h.unique())
+        assert len(ax.lines) == (
+            len(self.g.unique()) * len(self.h.unique()) + len(self.h.unique())
+        )
+        assert ax.get_xlabel() == "y"
+        assert ax.get_ylabel() == "g"
         plt.close("all")
 
 
@@ -2434,34 +2426,30 @@ class TestCountPlot(CategoricalFixture):
     def test_plot_elements(self):
 
         ax = cat.countplot(x="g", data=self.df)
-        nt.assert_equal(len(ax.patches), self.g.unique().size)
+        assert len(ax.patches) == self.g.unique().size
         for p in ax.patches:
-            nt.assert_equal(p.get_y(), 0)
-            nt.assert_equal(p.get_height(),
-                            self.g.size / self.g.unique().size)
+            assert p.get_y() == 0
+            assert p.get_height() == self.g.size / self.g.unique().size
         plt.close("all")
 
         ax = cat.countplot(y="g", data=self.df)
-        nt.assert_equal(len(ax.patches), self.g.unique().size)
+        assert len(ax.patches) == self.g.unique().size
         for p in ax.patches:
-            nt.assert_equal(p.get_x(), 0)
-            nt.assert_equal(p.get_width(),
-                            self.g.size / self.g.unique().size)
+            assert p.get_x() == 0
+            assert p.get_width() == self.g.size / self.g.unique().size
         plt.close("all")
 
         ax = cat.countplot(x="g", hue="h", data=self.df)
-        nt.assert_equal(len(ax.patches),
-                        self.g.unique().size * self.h.unique().size)
+        assert len(ax.patches) == self.g.unique().size * self.h.unique().size
         plt.close("all")
 
         ax = cat.countplot(y="g", hue="h", data=self.df)
-        nt.assert_equal(len(ax.patches),
-                        self.g.unique().size * self.h.unique().size)
+        assert len(ax.patches) == self.g.unique().size * self.h.unique().size
         plt.close("all")
 
     def test_input_error(self):
 
-        with nt.assert_raises(ValueError):
+        with pytest.raises(ValueError):
             cat.countplot(x="g", y="h", data=self.df)
 
 
@@ -2470,84 +2458,84 @@ class TestCatPlot(CategoricalFixture):
     def test_facet_organization(self):
 
         g = cat.catplot(x="g", y="y", data=self.df)
-        nt.assert_equal(g.axes.shape, (1, 1))
+        assert g.axes.shape == (1, 1)
 
         g = cat.catplot(x="g", y="y", col="h", data=self.df)
-        nt.assert_equal(g.axes.shape, (1, 2))
+        assert g.axes.shape == (1, 2)
 
         g = cat.catplot(x="g", y="y", row="h", data=self.df)
-        nt.assert_equal(g.axes.shape, (2, 1))
+        assert g.axes.shape == (2, 1)
 
         g = cat.catplot(x="g", y="y", col="u", row="h", data=self.df)
-        nt.assert_equal(g.axes.shape, (2, 3))
+        assert g.axes.shape == (2, 3)
 
     def test_plot_elements(self):
 
         g = cat.catplot(x="g", y="y", data=self.df, kind="point")
-        nt.assert_equal(len(g.ax.collections), 1)
+        assert len(g.ax.collections) == 1
         want_lines = self.g.unique().size + 1
-        nt.assert_equal(len(g.ax.lines), want_lines)
+        assert len(g.ax.lines) == want_lines
 
         g = cat.catplot(x="g", y="y", hue="h", data=self.df, kind="point")
         want_collections = self.h.unique().size
-        nt.assert_equal(len(g.ax.collections), want_collections)
+        assert len(g.ax.collections) == want_collections
         want_lines = (self.g.unique().size + 1) * self.h.unique().size
-        nt.assert_equal(len(g.ax.lines), want_lines)
+        assert len(g.ax.lines) == want_lines
 
         g = cat.catplot(x="g", y="y", data=self.df, kind="bar")
         want_elements = self.g.unique().size
-        nt.assert_equal(len(g.ax.patches), want_elements)
-        nt.assert_equal(len(g.ax.lines), want_elements)
+        assert len(g.ax.patches) == want_elements
+        assert len(g.ax.lines) == want_elements
 
         g = cat.catplot(x="g", y="y", hue="h", data=self.df, kind="bar")
         want_elements = self.g.unique().size * self.h.unique().size
-        nt.assert_equal(len(g.ax.patches), want_elements)
-        nt.assert_equal(len(g.ax.lines), want_elements)
+        assert len(g.ax.patches) == want_elements
+        assert len(g.ax.lines) == want_elements
 
         g = cat.catplot(x="g", data=self.df, kind="count")
         want_elements = self.g.unique().size
-        nt.assert_equal(len(g.ax.patches), want_elements)
-        nt.assert_equal(len(g.ax.lines), 0)
+        assert len(g.ax.patches) == want_elements
+        assert len(g.ax.lines) == 0
 
         g = cat.catplot(x="g", hue="h", data=self.df, kind="count")
         want_elements = self.g.unique().size * self.h.unique().size
-        nt.assert_equal(len(g.ax.patches), want_elements)
-        nt.assert_equal(len(g.ax.lines), 0)
+        assert len(g.ax.patches) == want_elements
+        assert len(g.ax.lines) == 0
 
         g = cat.catplot(x="g", y="y", data=self.df, kind="box")
         want_artists = self.g.unique().size
-        nt.assert_equal(len(g.ax.artists), want_artists)
+        assert len(g.ax.artists) == want_artists
 
         g = cat.catplot(x="g", y="y", hue="h", data=self.df, kind="box")
         want_artists = self.g.unique().size * self.h.unique().size
-        nt.assert_equal(len(g.ax.artists), want_artists)
+        assert len(g.ax.artists) == want_artists
 
         g = cat.catplot(x="g", y="y", data=self.df,
                         kind="violin", inner=None)
         want_elements = self.g.unique().size
-        nt.assert_equal(len(g.ax.collections), want_elements)
+        assert len(g.ax.collections) == want_elements
 
         g = cat.catplot(x="g", y="y", hue="h", data=self.df,
                         kind="violin", inner=None)
         want_elements = self.g.unique().size * self.h.unique().size
-        nt.assert_equal(len(g.ax.collections), want_elements)
+        assert len(g.ax.collections) == want_elements
 
         g = cat.catplot(x="g", y="y", data=self.df, kind="strip")
         want_elements = self.g.unique().size
-        nt.assert_equal(len(g.ax.collections), want_elements)
+        assert len(g.ax.collections) == want_elements
 
         g = cat.catplot(x="g", y="y", hue="h", data=self.df, kind="strip")
         want_elements = self.g.unique().size + self.h.unique().size
-        nt.assert_equal(len(g.ax.collections), want_elements)
+        assert len(g.ax.collections) == want_elements
 
     def test_bad_plot_kind_error(self):
 
-        with nt.assert_raises(ValueError):
+        with pytest.raises(ValueError):
             cat.catplot(x="g", y="y", data=self.df, kind="not_a_kind")
 
     def test_count_x_and_y(self):
 
-        with nt.assert_raises(ValueError):
+        with pytest.raises(ValueError):
             cat.catplot(x="g", y="y", data=self.df, kind="count")
 
     def test_plot_colors(self):
@@ -2555,39 +2543,39 @@ class TestCatPlot(CategoricalFixture):
         ax = cat.barplot(x="g", y="y", data=self.df)
         g = cat.catplot(x="g", y="y", data=self.df, kind="bar")
         for p1, p2 in zip(ax.patches, g.ax.patches):
-            nt.assert_equal(p1.get_facecolor(), p2.get_facecolor())
+            assert p1.get_facecolor() == p2.get_facecolor()
         plt.close("all")
 
         ax = cat.barplot(x="g", y="y", data=self.df, color="purple")
         g = cat.catplot(x="g", y="y", data=self.df,
                         kind="bar", color="purple")
         for p1, p2 in zip(ax.patches, g.ax.patches):
-            nt.assert_equal(p1.get_facecolor(), p2.get_facecolor())
+            assert p1.get_facecolor() == p2.get_facecolor()
         plt.close("all")
 
         ax = cat.barplot(x="g", y="y", data=self.df, palette="Set2")
         g = cat.catplot(x="g", y="y", data=self.df,
                         kind="bar", palette="Set2")
         for p1, p2 in zip(ax.patches, g.ax.patches):
-            nt.assert_equal(p1.get_facecolor(), p2.get_facecolor())
+            assert p1.get_facecolor() == p2.get_facecolor()
         plt.close("all")
 
         ax = cat.pointplot(x="g", y="y", data=self.df)
         g = cat.catplot(x="g", y="y", data=self.df)
         for l1, l2 in zip(ax.lines, g.ax.lines):
-            nt.assert_equal(l1.get_color(), l2.get_color())
+            assert l1.get_color() == l2.get_color()
         plt.close("all")
 
         ax = cat.pointplot(x="g", y="y", data=self.df, color="purple")
         g = cat.catplot(x="g", y="y", data=self.df, color="purple")
         for l1, l2 in zip(ax.lines, g.ax.lines):
-            nt.assert_equal(l1.get_color(), l2.get_color())
+            assert l1.get_color() == l2.get_color()
         plt.close("all")
 
         ax = cat.pointplot(x="g", y="y", data=self.df, palette="Set2")
         g = cat.catplot(x="g", y="y", data=self.df, palette="Set2")
         for l1, l2 in zip(ax.lines, g.ax.lines):
-            nt.assert_equal(l1.get_color(), l2.get_color())
+            assert l1.get_color() == l2.get_color()
         plt.close("all")
 
     def test_ax_kwarg_removal(self):
@@ -2603,9 +2591,9 @@ class TestCatPlot(CategoricalFixture):
         with pytest.warns(UserWarning):
             g = cat.factorplot(x="g", y="y", data=self.df)
 
-        nt.assert_equal(len(g.ax.collections), 1)
+        assert len(g.ax.collections) == 1
         want_lines = self.g.unique().size + 1
-        nt.assert_equal(len(g.ax.lines), want_lines)
+        assert len(g.ax.lines) == want_lines
 
     def test_share_xy(self):
 
@@ -2856,13 +2844,13 @@ class TestBoxenPlotter(CategoricalFixture):
 
         ax = cat.boxenplot(x="g", y="y", data=self.df)
         patches = filter(self.ispatch, ax.collections)
-        nt.assert_equal(len(list(patches)), 3)
+        assert len(list(patches)) == 3
 
         plt.close("all")
 
         ax = cat.boxenplot(x="g", y="y", hue="h", data=self.df)
         patches = filter(self.ispatch, ax.collections)
-        nt.assert_equal(len(list(patches)), 6)
+        assert len(list(patches)) == 6
 
         plt.close("all")
 
@@ -2871,14 +2859,14 @@ class TestBoxenPlotter(CategoricalFixture):
         ax = cat.boxenplot(x="g", y="y", data=self.df, saturation=1)
         pal = palettes.color_palette(n_colors=3)
         for patch, color in zip(ax.artists, pal):
-            nt.assert_equal(patch.get_facecolor()[:3], color)
+            assert patch.get_facecolor()[:3] == color
 
         plt.close("all")
 
         ax = cat.boxenplot(x="g", y="y", hue="h", data=self.df, saturation=1)
         pal = palettes.color_palette(n_colors=2)
         for patch, color in zip(ax.artists, pal * 2):
-            nt.assert_equal(patch.get_facecolor()[:3], color)
+            assert patch.get_facecolor()[:3] == color
 
         plt.close("all")
 
@@ -2888,7 +2876,7 @@ class TestBoxenPlotter(CategoricalFixture):
                            order=["a", "b", "c", "d"])
 
         patches = filter(self.ispatch, ax.collections)
-        nt.assert_equal(len(list(patches)), 3)
+        assert len(list(patches)) == 3
         plt.close("all")
 
     def test_unaligned_index(self):
@@ -2916,13 +2904,13 @@ class TestBoxenPlotter(CategoricalFixture):
         y[-2:] = np.nan
 
         ax = cat.boxenplot(x=x, y=y)
-        nt.assert_equal(len(ax.lines), 3)
+        assert len(ax.lines) == 3
 
         plt.close("all")
 
         y[-1] = 0
         ax = cat.boxenplot(x=x, y=y, hue=h)
-        nt.assert_equal(len(ax.lines), 7)
+        assert len(ax.lines) == 7
 
         plt.close("all")
 
@@ -2975,9 +2963,9 @@ class TestBoxenPlotter(CategoricalFixture):
     def test_axes_annotation(self):
 
         ax = cat.boxenplot(x="g", y="y", data=self.df)
-        nt.assert_equal(ax.get_xlabel(), "g")
-        nt.assert_equal(ax.get_ylabel(), "y")
-        nt.assert_equal(ax.get_xlim(), (-.5, 2.5))
+        assert ax.get_xlabel() == "g"
+        assert ax.get_ylabel() == "y"
+        assert ax.get_xlim() == (-.5, 2.5)
         npt.assert_array_equal(ax.get_xticks(), [0, 1, 2])
         npt.assert_array_equal([l.get_text() for l in ax.get_xticklabels()],
                                ["a", "b", "c"])
@@ -2985,8 +2973,8 @@ class TestBoxenPlotter(CategoricalFixture):
         plt.close("all")
 
         ax = cat.boxenplot(x="g", y="y", hue="h", data=self.df)
-        nt.assert_equal(ax.get_xlabel(), "g")
-        nt.assert_equal(ax.get_ylabel(), "y")
+        assert ax.get_xlabel() == "g"
+        assert ax.get_ylabel() == "y"
         npt.assert_array_equal(ax.get_xticks(), [0, 1, 2])
         npt.assert_array_equal([l.get_text() for l in ax.get_xticklabels()],
                                ["a", "b", "c"])
@@ -2996,9 +2984,9 @@ class TestBoxenPlotter(CategoricalFixture):
         plt.close("all")
 
         ax = cat.boxenplot(x="y", y="g", data=self.df, orient="h")
-        nt.assert_equal(ax.get_xlabel(), "y")
-        nt.assert_equal(ax.get_ylabel(), "g")
-        nt.assert_equal(ax.get_ylim(), (2.5, -.5))
+        assert ax.get_xlabel() == "y"
+        assert ax.get_ylabel() == "g"
+        assert ax.get_ylim() == (2.5, -.5)
         npt.assert_array_equal(ax.get_yticks(), [0, 1, 2])
         npt.assert_array_equal([l.get_text() for l in ax.get_yticklabels()],
                                ["a", "b", "c"])

--- a/seaborn/tests/test_matrix.py
+++ b/seaborn/tests/test_matrix.py
@@ -9,7 +9,6 @@ import pandas as pd
 from scipy.spatial import distance
 from scipy.cluster import hierarchy
 
-import nose.tools as nt
 import numpy.testing as npt
 try:
     import pandas.testing as pdt
@@ -29,7 +28,7 @@ except ImportError:
     _no_fastcluster = True
 
 
-class TestHeatmap(object):
+class TestHeatmap:
     rs = np.random.RandomState(sum(map(ord, "heatmap")))
 
     x_norm = rs.randn(4, 8)
@@ -52,8 +51,8 @@ class TestHeatmap(object):
         npt.assert_array_equal(p.xticklabels, np.arange(8))
         npt.assert_array_equal(p.yticklabels, np.arange(4))
 
-        nt.assert_equal(p.xlabel, "")
-        nt.assert_equal(p.ylabel, "")
+        assert p.xlabel == ""
+        assert p.ylabel == ""
 
     def test_df_input(self):
 
@@ -64,8 +63,8 @@ class TestHeatmap(object):
         npt.assert_array_equal(p.xticklabels, np.arange(8))
         npt.assert_array_equal(p.yticklabels, self.letters.values)
 
-        nt.assert_equal(p.xlabel, "")
-        nt.assert_equal(p.ylabel, "letters")
+        assert p.xlabel == ""
+        assert p.ylabel == "letters"
 
     def test_df_multindex_input(self):
 
@@ -80,12 +79,12 @@ class TestHeatmap(object):
 
         combined_tick_labels = ["A-1", "B-2", "C-3", "D-4"]
         npt.assert_array_equal(p.yticklabels, combined_tick_labels)
-        nt.assert_equal(p.ylabel, "letter-number")
+        assert p.ylabel == "letter-number"
 
         p = mat._HeatMapper(df.T, **self.default_kws)
 
         npt.assert_array_equal(p.xticklabels, combined_tick_labels)
-        nt.assert_equal(p.xlabel, "letter-number")
+        assert p.xlabel == "letter-number"
 
     @pytest.mark.parametrize("dtype", [float, np.int64, object])
     def test_mask_input(self, dtype):
@@ -121,8 +120,8 @@ class TestHeatmap(object):
     def test_default_vlims(self):
 
         p = mat._HeatMapper(self.df_unif, **self.default_kws)
-        nt.assert_equal(p.vmin, self.x_unif.min())
-        nt.assert_equal(p.vmax, self.x_unif.max())
+        assert p.vmin == self.x_unif.min()
+        assert p.vmax == self.x_unif.max()
 
     def test_robust_vlims(self):
 
@@ -130,8 +129,8 @@ class TestHeatmap(object):
         kws["robust"] = True
         p = mat._HeatMapper(self.df_unif, **kws)
 
-        nt.assert_equal(p.vmin, np.percentile(self.x_unif, 2))
-        nt.assert_equal(p.vmax, np.percentile(self.x_unif, 98))
+        assert p.vmin == np.percentile(self.x_unif, 2)
+        assert p.vmax == np.percentile(self.x_unif, 98)
 
     def test_custom_sequential_vlims(self):
 
@@ -140,8 +139,8 @@ class TestHeatmap(object):
         kws["vmax"] = 1
         p = mat._HeatMapper(self.df_unif, **kws)
 
-        nt.assert_equal(p.vmin, 0)
-        nt.assert_equal(p.vmax, 1)
+        assert p.vmin == 0
+        assert p.vmax == 1
 
     def test_custom_diverging_vlims(self):
 
@@ -151,8 +150,8 @@ class TestHeatmap(object):
         kws["center"] = 0
         p = mat._HeatMapper(self.df_norm, **kws)
 
-        nt.assert_equal(p.vmin, -4)
-        nt.assert_equal(p.vmax, 5)
+        assert p.vmin == -4
+        assert p.vmax == 5
 
     def test_array_with_nans(self):
 
@@ -163,8 +162,8 @@ class TestHeatmap(object):
         m1 = mat._HeatMapper(x1, **self.default_kws)
         m2 = mat._HeatMapper(x2, **self.default_kws)
 
-        nt.assert_equal(m1.vmin, m2.vmin)
-        nt.assert_equal(m1.vmax, m2.vmax)
+        assert m1.vmin == m2.vmin
+        assert m1.vmax == m2.vmax
 
     def test_mask(self):
 
@@ -185,7 +184,7 @@ class TestHeatmap(object):
         kws = self.default_kws.copy()
         kws["cmap"] = "BuGn"
         p = mat._HeatMapper(self.df_unif, **kws)
-        nt.assert_equal(p.cmap, mpl.cm.BuGn)
+        assert p.cmap == mpl.cm.BuGn
 
     def test_centered_vlims(self):
 
@@ -194,8 +193,8 @@ class TestHeatmap(object):
 
         p = mat._HeatMapper(self.df_unif, **kws)
 
-        nt.assert_equal(p.vmin, self.df_unif.values.min())
-        nt.assert_equal(p.vmax, self.df_unif.values.max())
+        assert p.vmin == self.df_unif.values.min()
+        assert p.vmax == self.df_unif.values.max()
 
     def test_default_colors(self):
 
@@ -266,8 +265,8 @@ class TestHeatmap(object):
         kws['xticklabels'] = False
         kws['yticklabels'] = False
         p = mat._HeatMapper(self.df_norm, **kws)
-        nt.assert_equal(p.xticklabels, [])
-        nt.assert_equal(p.yticklabels, [])
+        assert p.xticklabels == []
+        assert p.yticklabels == []
 
     def test_custom_ticklabels(self):
         kws = self.default_kws.copy()
@@ -276,8 +275,8 @@ class TestHeatmap(object):
         kws['xticklabels'] = xticklabels
         kws['yticklabels'] = yticklabels
         p = mat._HeatMapper(self.df_norm, **kws)
-        nt.assert_equal(p.xticklabels, xticklabels)
-        nt.assert_equal(p.yticklabels, yticklabels)
+        assert p.xticklabels == xticklabels
+        assert p.yticklabels == yticklabels
 
     def test_custom_ticklabel_interval(self):
 
@@ -300,8 +299,8 @@ class TestHeatmap(object):
         ax = mat.heatmap(self.df_norm, annot=True, fmt=".1f",
                          annot_kws={"fontsize": 14})
         for val, text in zip(self.x_norm.flat, ax.texts):
-            nt.assert_equal(text.get_text(), "{:.1f}".format(val))
-            nt.assert_equal(text.get_fontsize(), 14)
+            assert text.get_text() == "{:.1f}".format(val)
+            assert text.get_fontsize() == 14
 
     def test_heatmap_annotation_overwrite_kws(self):
 
@@ -309,9 +308,9 @@ class TestHeatmap(object):
         ax = mat.heatmap(self.df_norm, annot=True, fmt=".1f",
                          annot_kws=annot_kws)
         for text in ax.texts:
-            nt.assert_equal(text.get_color(), "0.3")
-            nt.assert_equal(text.get_ha(), "left")
-            nt.assert_equal(text.get_va(), "bottom")
+            assert text.get_color() == "0.3"
+            assert text.get_ha() == "left"
+            assert text.get_va() == "bottom"
 
     def test_heatmap_annotation_with_mask(self):
 
@@ -321,15 +320,15 @@ class TestHeatmap(object):
         mask = np.isnan(df.values)
         df_masked = np.ma.masked_where(mask, df)
         ax = mat.heatmap(df, annot=True, fmt='.1f', mask=mask)
-        nt.assert_equal(len(df_masked.compressed()), len(ax.texts))
+        assert len(df_masked.compressed()) == len(ax.texts)
         for val, text in zip(df_masked.compressed(), ax.texts):
-            nt.assert_equal("{:.1f}".format(val), text.get_text())
+            assert "{:.1f}".format(val) == text.get_text()
 
     def test_heatmap_annotation_mesh_colors(self):
 
         ax = mat.heatmap(self.df_norm, annot=True)
         mesh = ax.collections[0]
-        nt.assert_equal(len(mesh.get_facecolors()), self.df_norm.values.size)
+        assert len(mesh.get_facecolors()) == self.df_norm.values.size
 
         plt.close("all")
 
@@ -340,30 +339,30 @@ class TestHeatmap(object):
                          annot_kws={"fontsize": 14})
 
         for val, text in zip(annot_data.values.flat, ax.texts):
-            nt.assert_equal(text.get_text(), "{:.1f}".format(val))
-            nt.assert_equal(text.get_fontsize(), 14)
+            assert text.get_text() == "{:.1f}".format(val)
+            assert text.get_fontsize() == 14
 
     def test_heatmap_annotation_with_limited_ticklabels(self):
         ax = mat.heatmap(self.df_norm, fmt=".2f", annot=True,
                          xticklabels=False, yticklabels=False)
         for val, text in zip(self.x_norm.flat, ax.texts):
-            nt.assert_equal(text.get_text(), "{:.2f}".format(val))
+            assert text.get_text() == "{:.2f}".format(val)
 
     def test_heatmap_cbar(self):
 
         f = plt.figure()
         mat.heatmap(self.df_norm)
-        nt.assert_equal(len(f.axes), 2)
+        assert len(f.axes) == 2
         plt.close(f)
 
         f = plt.figure()
         mat.heatmap(self.df_norm, cbar=False)
-        nt.assert_equal(len(f.axes), 1)
+        assert len(f.axes) == 1
         plt.close(f)
 
         f, (ax1, ax2) = plt.subplots(2)
         mat.heatmap(self.df_norm, ax=ax1, cbar_ax=ax2)
-        nt.assert_equal(len(f.axes), 2)
+        assert len(f.axes) == 2
         plt.close(f)
 
     @pytest.mark.xfail(mpl.__version__ == "3.1.1",
@@ -373,15 +372,15 @@ class TestHeatmap(object):
         ax = mat.heatmap(self.df_norm)
 
         xtl = [int(l.get_text()) for l in ax.get_xticklabels()]
-        nt.assert_equal(xtl, list(self.df_norm.columns))
+        assert xtl == list(self.df_norm.columns)
         ytl = [l.get_text() for l in ax.get_yticklabels()]
-        nt.assert_equal(ytl, list(self.df_norm.index))
+        assert ytl == list(self.df_norm.index)
 
-        nt.assert_equal(ax.get_xlabel(), "")
-        nt.assert_equal(ax.get_ylabel(), "letters")
+        assert ax.get_xlabel() == ""
+        assert ax.get_ylabel() == "letters"
 
-        nt.assert_equal(ax.get_xlim(), (0, 8))
-        nt.assert_equal(ax.get_ylim(), (4, 0))
+        assert ax.get_xlim() == (0, 8)
+        assert ax.get_ylim() == (4, 0)
 
     def test_heatmap_ticklabel_rotation(self):
 
@@ -389,10 +388,10 @@ class TestHeatmap(object):
         mat.heatmap(self.df_norm, xticklabels=1, yticklabels=1, ax=ax)
 
         for t in ax.get_xticklabels():
-            nt.assert_equal(t.get_rotation(), 0)
+            assert t.get_rotation() == 0
 
         for t in ax.get_yticklabels():
-            nt.assert_equal(t.get_rotation(), 90)
+            assert t.get_rotation() == 90
 
         plt.close(f)
 
@@ -404,10 +403,10 @@ class TestHeatmap(object):
         mat.heatmap(df, xticklabels=1, yticklabels=1, ax=ax)
 
         for t in ax.get_xticklabels():
-            nt.assert_equal(t.get_rotation(), 90)
+            assert t.get_rotation() == 90
 
         for t in ax.get_yticklabels():
-            nt.assert_equal(t.get_rotation(), 0)
+            assert t.get_rotation() == 0
 
         plt.close(f)
 
@@ -416,8 +415,8 @@ class TestHeatmap(object):
         c = (0, 0, 1, 1)
         ax = mat.heatmap(self.df_norm, linewidths=2, linecolor=c)
         mesh = ax.collections[0]
-        nt.assert_equal(mesh.get_linewidths()[0], 2)
-        nt.assert_equal(tuple(mesh.get_edgecolor()[0]), c)
+        assert mesh.get_linewidths()[0] == 2
+        assert tuple(mesh.get_edgecolor()[0]) == c
 
     def test_square_aspect(self):
 
@@ -430,14 +429,14 @@ class TestHeatmap(object):
     def test_mask_validation(self):
 
         mask = mat._matrix_mask(self.df_norm, None)
-        nt.assert_equal(mask.shape, self.df_norm.shape)
-        nt.assert_equal(mask.values.sum(), 0)
+        assert mask.shape == self.df_norm.shape
+        assert mask.values.sum() == 0
 
-        with nt.assert_raises(ValueError):
+        with pytest.raises(ValueError):
             bad_array_mask = self.rs.randn(3, 6) > 0
             mat._matrix_mask(self.df_norm, bad_array_mask)
 
-        with nt.assert_raises(ValueError):
+        with pytest.raises(ValueError):
             bad_df_mask = pd.DataFrame(self.rs.randn(4, 8) > 0)
             mat._matrix_mask(self.df_norm, bad_df_mask)
 
@@ -460,7 +459,7 @@ class TestHeatmap(object):
         assert len(ax2.collections) == 2
 
 
-class TestDendrogram(object):
+class TestDendrogram:
     rs = np.random.RandomState(sum(map(ord, "dendrogram")))
 
     x_norm = rs.randn(4, 8) + np.arange(8)
@@ -492,15 +491,15 @@ class TestDendrogram(object):
         pdt.assert_frame_equal(p.data.T, pd.DataFrame(self.x_norm))
 
         npt.assert_array_equal(p.linkage, self.x_norm_linkage)
-        nt.assert_dict_equal(p.dendrogram, self.x_norm_dendrogram)
+        assert p.dendrogram == self.x_norm_dendrogram
 
         npt.assert_array_equal(p.reordered_ind, self.x_norm_leaves)
 
         npt.assert_array_equal(p.xticklabels, self.x_norm_leaves)
         npt.assert_array_equal(p.yticklabels, [])
 
-        nt.assert_equal(p.xlabel, None)
-        nt.assert_equal(p.ylabel, '')
+        assert p.xlabel is None
+        assert p.ylabel == ''
 
     def test_df_input(self):
         p = mat._DendrogramPlotter(self.df_norm, **self.default_kws)
@@ -508,15 +507,15 @@ class TestDendrogram(object):
         pdt.assert_frame_equal(p.data.T, self.df_norm)
 
         npt.assert_array_equal(p.linkage, self.x_norm_linkage)
-        nt.assert_dict_equal(p.dendrogram, self.x_norm_dendrogram)
+        assert p.dendrogram == self.x_norm_dendrogram
 
         npt.assert_array_equal(p.xticklabels,
                                np.asarray(self.df_norm.columns)[
                                    self.x_norm_leaves])
         npt.assert_array_equal(p.yticklabels, [])
 
-        nt.assert_equal(p.xlabel, 'letters')
-        nt.assert_equal(p.ylabel, '')
+        assert p.xlabel == 'letters'
+        assert p.ylabel == ''
 
     def test_df_multindex_input(self):
 
@@ -535,7 +534,7 @@ class TestDendrogram(object):
         xticklabels = [xticklabels[i] for i in p.reordered_ind]
         npt.assert_array_equal(p.xticklabels, xticklabels)
         npt.assert_array_equal(p.yticklabels, [])
-        nt.assert_equal(p.xlabel, "letter-number")
+        assert p.xlabel == "letter-number"
 
     def test_axis0_input(self):
         kws = self.default_kws.copy()
@@ -546,13 +545,13 @@ class TestDendrogram(object):
         pdt.assert_frame_equal(p.data, self.df_norm.T)
 
         npt.assert_array_equal(p.linkage, self.x_norm_linkage)
-        nt.assert_dict_equal(p.dendrogram, self.x_norm_dendrogram)
+        assert p.dendrogram == self.x_norm_dendrogram
 
         npt.assert_array_equal(p.xticklabels, self.df_norm_leaves)
         npt.assert_array_equal(p.yticklabels, [])
 
-        nt.assert_equal(p.xlabel, 'letters')
-        nt.assert_equal(p.ylabel, '')
+        assert p.xlabel == 'letters'
+        assert p.ylabel == ''
 
     def test_rotate_input(self):
         kws = self.default_kws.copy()
@@ -564,8 +563,8 @@ class TestDendrogram(object):
         npt.assert_array_equal(p.xticklabels, [])
         npt.assert_array_equal(p.yticklabels, self.df_norm_leaves)
 
-        nt.assert_equal(p.xlabel, '')
-        nt.assert_equal(p.ylabel, 'letters')
+        assert p.xlabel == ''
+        assert p.ylabel == 'letters'
 
     def test_rotate_axis0_input(self):
         kws = self.default_kws.copy()
@@ -592,18 +591,18 @@ class TestDendrogram(object):
         p = mat._DendrogramPlotter(self.df_norm, **kws)
 
         npt.assert_array_equal(p.linkage, linkage)
-        nt.assert_dict_equal(p.dendrogram, dendrogram)
+        assert p.dendrogram == dendrogram
 
     def test_label_false(self):
         kws = self.default_kws.copy()
         kws['label'] = False
         p = mat._DendrogramPlotter(self.df_norm, **kws)
-        nt.assert_equal(p.xticks, [])
-        nt.assert_equal(p.yticks, [])
-        nt.assert_equal(p.xticklabels, [])
-        nt.assert_equal(p.yticklabels, [])
-        nt.assert_equal(p.xlabel, "")
-        nt.assert_equal(p.ylabel, "")
+        assert p.xticks == []
+        assert p.yticks == []
+        assert p.xticklabels == []
+        assert p.yticklabels == []
+        assert p.xlabel == ""
+        assert p.ylabel == ""
 
     def test_linkage_scipy(self):
         p = mat._DendrogramPlotter(self.x_norm, **self.default_kws)
@@ -650,11 +649,10 @@ class TestDendrogram(object):
         # 10 comes from _plot_dendrogram in scipy.cluster.hierarchy
         xmax = len(d.reordered_ind) * 10
 
-        nt.assert_equal(xlim[0], 0)
-        nt.assert_equal(xlim[1], xmax)
+        assert xlim[0] == 0
+        assert xlim[1] == xmax
 
-        nt.assert_equal(len(ax.collections[0].get_paths()),
-                        len(d.dependent_coord))
+        assert len(ax.collections[0].get_paths()) == len(d.dependent_coord)
 
     @pytest.mark.xfail(mpl.__version__ == "3.1.1",
                        reason="matplotlib 3.1.1 bug")
@@ -672,15 +670,15 @@ class TestDendrogram(object):
 
         # Since y axis is inverted, ylim is (80, 0)
         # and therefore not (0, 80) as usual:
-        nt.assert_equal(ylim[1], 0)
-        nt.assert_equal(ylim[0], ymax)
+        assert ylim[1] == 0
+        assert ylim[0] == ymax
 
     def test_dendrogram_ticklabel_rotation(self):
         f, ax = plt.subplots(figsize=(2, 2))
         mat.dendrogram(self.df_norm, ax=ax)
 
         for t in ax.get_xticklabels():
-            nt.assert_equal(t.get_rotation(), 0)
+            assert t.get_rotation() == 0
 
         plt.close(f)
 
@@ -692,18 +690,18 @@ class TestDendrogram(object):
         mat.dendrogram(df, ax=ax)
 
         for t in ax.get_xticklabels():
-            nt.assert_equal(t.get_rotation(), 90)
+            assert t.get_rotation() == 90
 
         plt.close(f)
 
         f, ax = plt.subplots(figsize=(2, 2))
         mat.dendrogram(df.T, axis=0, rotate=True)
         for t in ax.get_yticklabels():
-            nt.assert_equal(t.get_rotation(), 0)
+            assert t.get_rotation() == 0
         plt.close(f)
 
 
-class TestClustermap(object):
+class TestClustermap:
     rs = np.random.RandomState(sum(map(ord, "clustermap")))
 
     x_norm = rs.randn(4, 8) + np.arange(8)
@@ -741,15 +739,15 @@ class TestClustermap(object):
     col_colors = color_palette('Dark2', df_norm.shape[1])
 
     def test_ndarray_input(self):
-        cm = mat.ClusterGrid(self.x_norm, **self.default_kws)
-        pdt.assert_frame_equal(cm.data, pd.DataFrame(self.x_norm))
-        nt.assert_equal(len(cm.fig.axes), 4)
-        nt.assert_equal(cm.ax_row_colors, None)
-        nt.assert_equal(cm.ax_col_colors, None)
+        cg = mat.ClusterGrid(self.x_norm, **self.default_kws)
+        pdt.assert_frame_equal(cg.data, pd.DataFrame(self.x_norm))
+        assert len(cg.fig.axes) == 4
+        assert cg.ax_row_colors is None
+        assert cg.ax_col_colors is None
 
     def test_df_input(self):
-        cm = mat.ClusterGrid(self.df_norm, **self.default_kws)
-        pdt.assert_frame_equal(cm.data, self.df_norm)
+        cg = mat.ClusterGrid(self.df_norm, **self.default_kws)
+        pdt.assert_frame_equal(cg.data, self.df_norm)
 
     def test_corr_df_input(self):
         df = self.df_norm.corr()
@@ -766,9 +764,9 @@ class TestClustermap(object):
         kws = self.default_kws.copy()
         kws['pivot_kws'] = dict(index='numbers', columns='letters',
                                 values='value')
-        cm = mat.ClusterGrid(df_long, **kws)
+        cg = mat.ClusterGrid(df_long, **kws)
 
-        pdt.assert_frame_equal(cm.data2d, df_norm)
+        pdt.assert_frame_equal(cg.data2d, df_norm)
 
     def test_colors_input(self):
         kws = self.default_kws.copy()
@@ -776,11 +774,11 @@ class TestClustermap(object):
         kws['row_colors'] = self.row_colors
         kws['col_colors'] = self.col_colors
 
-        cm = mat.ClusterGrid(self.df_norm, **kws)
-        npt.assert_array_equal(cm.row_colors, self.row_colors)
-        npt.assert_array_equal(cm.col_colors, self.col_colors)
+        cg = mat.ClusterGrid(self.df_norm, **kws)
+        npt.assert_array_equal(cg.row_colors, self.row_colors)
+        npt.assert_array_equal(cg.col_colors, self.col_colors)
 
-        nt.assert_equal(len(cm.fig.axes), 6)
+        assert len(cg.fig.axes) == 6
 
     def test_nested_colors_input(self):
         kws = self.default_kws.copy()
@@ -794,7 +792,7 @@ class TestClustermap(object):
         npt.assert_array_equal(cm.row_colors, row_colors)
         npt.assert_array_equal(cm.col_colors, col_colors)
 
-        nt.assert_equal(len(cm.fig.axes), 6)
+        assert len(cm.fig.axes) == 6
 
     def test_colors_input_custom_cmap(self):
         kws = self.default_kws.copy()
@@ -803,11 +801,11 @@ class TestClustermap(object):
         kws['row_colors'] = self.row_colors
         kws['col_colors'] = self.col_colors
 
-        cm = mat.clustermap(self.df_norm, **kws)
-        npt.assert_array_equal(cm.row_colors, self.row_colors)
-        npt.assert_array_equal(cm.col_colors, self.col_colors)
+        cg = mat.clustermap(self.df_norm, **kws)
+        npt.assert_array_equal(cg.row_colors, self.row_colors)
+        npt.assert_array_equal(cg.col_colors, self.col_colors)
 
-        nt.assert_equal(len(cm.fig.axes), 6)
+        assert len(cg.fig.axes) == 6
 
     def test_z_score(self):
         df = self.df_norm.copy()
@@ -815,8 +813,8 @@ class TestClustermap(object):
         kws = self.default_kws.copy()
         kws['z_score'] = 1
 
-        cm = mat.ClusterGrid(self.df_norm, **kws)
-        pdt.assert_frame_equal(cm.data2d, df)
+        cg = mat.ClusterGrid(self.df_norm, **kws)
+        pdt.assert_frame_equal(cg.data2d, df)
 
     def test_z_score_axis0(self):
         df = self.df_norm.copy()
@@ -826,8 +824,8 @@ class TestClustermap(object):
         kws = self.default_kws.copy()
         kws['z_score'] = 0
 
-        cm = mat.ClusterGrid(self.df_norm, **kws)
-        pdt.assert_frame_equal(cm.data2d, df)
+        cg = mat.ClusterGrid(self.df_norm, **kws)
+        pdt.assert_frame_equal(cg.data2d, df)
 
     def test_standard_scale(self):
         df = self.df_norm.copy()
@@ -835,8 +833,8 @@ class TestClustermap(object):
         kws = self.default_kws.copy()
         kws['standard_scale'] = 1
 
-        cm = mat.ClusterGrid(self.df_norm, **kws)
-        pdt.assert_frame_equal(cm.data2d, df)
+        cg = mat.ClusterGrid(self.df_norm, **kws)
+        pdt.assert_frame_equal(cg.data2d, df)
 
     def test_standard_scale_axis0(self):
         df = self.df_norm.copy()
@@ -846,14 +844,14 @@ class TestClustermap(object):
         kws = self.default_kws.copy()
         kws['standard_scale'] = 0
 
-        cm = mat.ClusterGrid(self.df_norm, **kws)
-        pdt.assert_frame_equal(cm.data2d, df)
+        cg = mat.ClusterGrid(self.df_norm, **kws)
+        pdt.assert_frame_equal(cg.data2d, df)
 
     def test_z_score_standard_scale(self):
         kws = self.default_kws.copy()
         kws['z_score'] = True
         kws['standard_scale'] = True
-        with nt.assert_raises(ValueError):
+        with pytest.raises(ValueError):
             mat.ClusterGrid(self.df_norm, **kws)
 
     def test_color_list_to_matrix_and_cmap(self):
@@ -904,17 +902,19 @@ class TestClustermap(object):
 
     def test_savefig(self):
         # Not sure if this is the right way to test....
-        cm = mat.ClusterGrid(self.df_norm, **self.default_kws)
-        cm.plot(**self.default_plot_kws)
-        cm.savefig(tempfile.NamedTemporaryFile(), format='png')
+        cg = mat.ClusterGrid(self.df_norm, **self.default_kws)
+        cg.plot(**self.default_plot_kws)
+        cg.savefig(tempfile.NamedTemporaryFile(), format='png')
 
     def test_plot_dendrograms(self):
         cm = mat.clustermap(self.df_norm, **self.default_kws)
 
-        nt.assert_equal(len(cm.ax_row_dendrogram.collections[0].get_paths()),
-                        len(cm.dendrogram_row.independent_coord))
-        nt.assert_equal(len(cm.ax_col_dendrogram.collections[0].get_paths()),
-                        len(cm.dendrogram_col.independent_coord))
+        assert len(cm.ax_row_dendrogram.collections[0].get_paths()) == len(
+            cm.dendrogram_row.independent_coord
+        )
+        assert len(cm.ax_col_dendrogram.collections[0].get_paths()) == len(
+            cm.dendrogram_col.independent_coord
+        )
         data2d = self.df_norm.iloc[cm.dendrogram_row.reordered_ind,
                                    cm.dendrogram_col.reordered_ind]
         pdt.assert_frame_equal(cm.data2d, data2d)
@@ -925,13 +925,13 @@ class TestClustermap(object):
         kws['col_cluster'] = False
 
         cm = mat.clustermap(self.df_norm, **kws)
-        nt.assert_equal(len(cm.ax_row_dendrogram.lines), 0)
-        nt.assert_equal(len(cm.ax_col_dendrogram.lines), 0)
+        assert len(cm.ax_row_dendrogram.lines) == 0
+        assert len(cm.ax_col_dendrogram.lines) == 0
 
-        nt.assert_equal(len(cm.ax_row_dendrogram.get_xticks()), 0)
-        nt.assert_equal(len(cm.ax_row_dendrogram.get_yticks()), 0)
-        nt.assert_equal(len(cm.ax_col_dendrogram.get_xticks()), 0)
-        nt.assert_equal(len(cm.ax_col_dendrogram.get_yticks()), 0)
+        assert len(cm.ax_row_dendrogram.get_xticks()) == 0
+        assert len(cm.ax_row_dendrogram.get_yticks()) == 0
+        assert len(cm.ax_col_dendrogram.get_xticks()) == 0
+        assert len(cm.ax_col_dendrogram.get_yticks()) == 0
 
         pdt.assert_frame_equal(cm.data2d, self.df_norm)
 
@@ -942,8 +942,8 @@ class TestClustermap(object):
 
         cm = mat.clustermap(self.df_norm, **kws)
 
-        nt.assert_equal(len(cm.ax_row_colors.collections), 1)
-        nt.assert_equal(len(cm.ax_col_colors.collections), 1)
+        assert len(cm.ax_row_colors.collections) == 1
+        assert len(cm.ax_col_colors.collections) == 1
 
     def test_cluster_false_row_col_colors(self):
         kws = self.default_kws.copy()
@@ -953,15 +953,15 @@ class TestClustermap(object):
         kws['col_colors'] = self.col_colors
 
         cm = mat.clustermap(self.df_norm, **kws)
-        nt.assert_equal(len(cm.ax_row_dendrogram.lines), 0)
-        nt.assert_equal(len(cm.ax_col_dendrogram.lines), 0)
+        assert len(cm.ax_row_dendrogram.lines) == 0
+        assert len(cm.ax_col_dendrogram.lines) == 0
 
-        nt.assert_equal(len(cm.ax_row_dendrogram.get_xticks()), 0)
-        nt.assert_equal(len(cm.ax_row_dendrogram.get_yticks()), 0)
-        nt.assert_equal(len(cm.ax_col_dendrogram.get_xticks()), 0)
-        nt.assert_equal(len(cm.ax_col_dendrogram.get_yticks()), 0)
-        nt.assert_equal(len(cm.ax_row_colors.collections), 1)
-        nt.assert_equal(len(cm.ax_col_colors.collections), 1)
+        assert len(cm.ax_row_dendrogram.get_xticks()) == 0
+        assert len(cm.ax_row_dendrogram.get_yticks()) == 0
+        assert len(cm.ax_col_dendrogram.get_xticks()) == 0
+        assert len(cm.ax_col_dendrogram.get_yticks()) == 0
+        assert len(cm.ax_row_colors.collections) == 1
+        assert len(cm.ax_col_colors.collections) == 1
 
         pdt.assert_frame_equal(cm.data2d, self.df_norm)
 
@@ -980,13 +980,13 @@ class TestClustermap(object):
 
         row_labels = [l.get_text() for l in
                       cm.ax_row_colors.get_xticklabels()]
-        nt.assert_equal(cm.row_color_labels, ['row_1', 'row_2'])
-        nt.assert_equal(row_labels, cm.row_color_labels)
+        assert cm.row_color_labels == ['row_1', 'row_2']
+        assert row_labels == cm.row_color_labels
 
         col_labels = [l.get_text() for l in
                       cm.ax_col_colors.get_yticklabels()]
-        nt.assert_equal(cm.col_color_labels, ['col_1', 'col_2'])
-        nt.assert_equal(col_labels, cm.col_color_labels)
+        assert cm.col_color_labels == ['col_1', 'col_2']
+        assert col_labels == cm.col_color_labels
 
     def test_row_col_colors_df_shuffled(self):
         # Tests if colors are properly matched, even if given in wrong order
@@ -1008,8 +1008,8 @@ class TestClustermap(object):
         kws['col_colors'] = col_colors.loc[shuffled_cols]
 
         cm = mat.clustermap(self.df_norm, **kws)
-        nt.assert_equal(list(cm.col_colors)[0], list(self.col_colors))
-        nt.assert_equal(list(cm.row_colors)[0], list(self.row_colors))
+        assert list(cm.col_colors)[0] == list(self.col_colors)
+        assert list(cm.row_colors)[0] == list(self.row_colors)
 
     def test_row_col_colors_df_missing(self):
         kws = self.default_kws.copy()
@@ -1023,10 +1023,8 @@ class TestClustermap(object):
 
         cm = mat.clustermap(self.df_norm, **kws)
 
-        nt.assert_equal(list(cm.col_colors)[0],
-                        [(1.0, 1.0, 1.0)] + list(self.col_colors[1:]))
-        nt.assert_equal(list(cm.row_colors)[0],
-                        [(1.0, 1.0, 1.0)] + list(self.row_colors[1:]))
+        assert list(cm.col_colors)[0] == [(1.0, 1.0, 1.0)] + list(self.col_colors[1:])
+        assert list(cm.row_colors)[0] == [(1.0, 1.0, 1.0)] + list(self.row_colors[1:])
 
     def test_row_col_colors_df_one_axis(self):
         # Test case with only row annotation.
@@ -1040,10 +1038,10 @@ class TestClustermap(object):
 
         row_labels = [l.get_text() for l in
                       cm1.ax_row_colors.get_xticklabels()]
-        nt.assert_equal(cm1.row_color_labels, ['row_1', 'row_2'])
-        nt.assert_equal(row_labels, cm1.row_color_labels)
+        assert cm1.row_color_labels == ['row_1', 'row_2']
+        assert row_labels == cm1.row_color_labels
 
-        # Test case with onl col annotation.
+        # Test case with only col annotation.
         kws2 = self.default_kws.copy()
         kws2['col_colors'] = pd.DataFrame({'col_1': list(self.col_colors),
                                            'col_2': list(self.col_colors)},
@@ -1054,8 +1052,8 @@ class TestClustermap(object):
 
         col_labels = [l.get_text() for l in
                       cm2.ax_col_colors.get_yticklabels()]
-        nt.assert_equal(cm2.col_color_labels, ['col_1', 'col_2'])
-        nt.assert_equal(col_labels, cm2.col_color_labels)
+        assert cm2.col_color_labels == ['col_1', 'col_2']
+        assert col_labels == cm2.col_color_labels
 
     def test_row_col_colors_series(self):
         kws = self.default_kws.copy()
@@ -1066,15 +1064,13 @@ class TestClustermap(object):
 
         cm = mat.clustermap(self.df_norm, **kws)
 
-        row_labels = [l.get_text() for l in
-                      cm.ax_row_colors.get_xticklabels()]
-        nt.assert_equal(cm.row_color_labels, ['row_annot'])
-        nt.assert_equal(row_labels, cm.row_color_labels)
+        row_labels = [l.get_text() for l in cm.ax_row_colors.get_xticklabels()]
+        assert cm.row_color_labels == ['row_annot']
+        assert row_labels == cm.row_color_labels
 
-        col_labels = [l.get_text() for l in
-                      cm.ax_col_colors.get_yticklabels()]
-        nt.assert_equal(cm.col_color_labels, ['col_annot'])
-        nt.assert_equal(col_labels, cm.col_color_labels)
+        col_labels = [l.get_text() for l in cm.ax_col_colors.get_yticklabels()]
+        assert cm.col_color_labels == ['col_annot']
+        assert col_labels == cm.col_color_labels
 
     def test_row_col_colors_series_shuffled(self):
         # Tests if colors are properly matched, even if given in wrong order
@@ -1097,8 +1093,8 @@ class TestClustermap(object):
 
         cm = mat.clustermap(self.df_norm, **kws)
 
-        nt.assert_equal(list(cm.col_colors), list(self.col_colors))
-        nt.assert_equal(list(cm.row_colors), list(self.row_colors))
+        assert list(cm.col_colors) == list(self.col_colors)
+        assert list(cm.row_colors) == list(self.row_colors)
 
     def test_row_col_colors_series_missing(self):
         kws = self.default_kws.copy()
@@ -1111,10 +1107,8 @@ class TestClustermap(object):
         kws['col_colors'] = col_colors.drop(self.df_norm.columns[0])
 
         cm = mat.clustermap(self.df_norm, **kws)
-        nt.assert_equal(list(cm.col_colors),
-                        [(1.0, 1.0, 1.0)] + list(self.col_colors[1:]))
-        nt.assert_equal(list(cm.row_colors),
-                        [(1.0, 1.0, 1.0)] + list(self.row_colors[1:]))
+        assert list(cm.col_colors) == [(1.0, 1.0, 1.0)] + list(self.col_colors[1:])
+        assert list(cm.row_colors) == [(1.0, 1.0, 1.0)] + list(self.row_colors[1:])
 
     def test_row_col_colors_ignore_heatmap_kwargs(self):
 
@@ -1180,8 +1174,8 @@ class TestClustermap(object):
 
         xtl_actual = [t.get_text() for t in g.ax_heatmap.get_xticklabels()]
         ytl_actual = [t.get_text() for t in g.ax_heatmap.get_yticklabels()]
-        nt.assert_equal(xtl_actual, [])
-        nt.assert_equal(ytl_actual, [])
+        assert xtl_actual == []
+        assert ytl_actual == []
 
     def test_size_ratios(self):
 

--- a/seaborn/tests/test_miscplot.py
+++ b/seaborn/tests/test_miscplot.py
@@ -1,4 +1,3 @@
-import nose.tools as nt
 import matplotlib.pyplot as plt
 
 from .. import miscplot as misc
@@ -6,27 +5,27 @@ from ..palettes import color_palette
 from .test_utils import _network
 
 
-class TestPalPlot(object):
+class TestPalPlot:
     """Test the function that visualizes a color palette."""
     def test_palplot_size(self):
 
         pal4 = color_palette("husl", 4)
         misc.palplot(pal4)
         size4 = plt.gcf().get_size_inches()
-        nt.assert_equal(tuple(size4), (4, 1))
+        assert tuple(size4) == (4, 1)
 
         pal5 = color_palette("husl", 5)
         misc.palplot(pal5)
         size5 = plt.gcf().get_size_inches()
-        nt.assert_equal(tuple(size5), (5, 1))
+        assert tuple(size5) == (5, 1)
 
         palbig = color_palette("husl", 3)
         misc.palplot(palbig, 2)
         sizebig = plt.gcf().get_size_inches()
-        nt.assert_equal(tuple(sizebig), (6, 2))
+        assert tuple(sizebig) == (6, 2)
 
 
-class TestDogPlot(object):
+class TestDogPlot:
 
     @_network(url="https://github.com/mwaskom/seaborn-data")
     def test_dogplot(self):

--- a/seaborn/tests/test_palettes.py
+++ b/seaborn/tests/test_palettes.py
@@ -3,7 +3,6 @@ import numpy as np
 import matplotlib as mpl
 
 import pytest
-import nose.tools as nt
 import numpy.testing as npt
 
 from .. import palettes, utils, rcmod
@@ -11,7 +10,7 @@ from ..external import husl
 from ..colors import xkcd_rgb, crayons
 
 
-class TestColorPalettes(object):
+class TestColorPalettes:
 
     def test_current_palette(self):
 
@@ -26,9 +25,9 @@ class TestColorPalettes(object):
         context_pal = palettes.color_palette("muted")
 
         with palettes.color_palette(context_pal):
-            nt.assert_equal(utils.get_color_cycle(), context_pal)
+            assert utils.get_color_cycle() == context_pal
 
-        nt.assert_equal(utils.get_color_cycle(), default_pal)
+        assert utils.get_color_cycle() == default_pal
 
     def test_big_palette_context(self):
 
@@ -37,9 +36,9 @@ class TestColorPalettes(object):
 
         rcmod.set_palette(original_pal)
         with palettes.color_palette(context_pal, 10):
-            nt.assert_equal(utils.get_color_cycle(), context_pal)
+            assert utils.get_color_cycle() == context_pal
 
-        nt.assert_equal(utils.get_color_cycle(), original_pal)
+        assert utils.get_color_cycle() == original_pal
 
         # Reset default
         rcmod.set()
@@ -114,18 +113,18 @@ class TestColorPalettes(object):
 
     def test_bad_palette_name(self):
 
-        with nt.assert_raises(ValueError):
+        with pytest.raises(ValueError):
             palettes.color_palette("IAmNotAPalette")
 
     def test_terrible_palette_name(self):
 
-        with nt.assert_raises(ValueError):
+        with pytest.raises(ValueError):
             palettes.color_palette("jet")
 
     def test_bad_palette_colors(self):
 
         pal = ["red", "blue", "iamnotacolor"]
-        with nt.assert_raises(ValueError):
+        with pytest.raises(ValueError):
             palettes.color_palette(pal)
 
     def test_palette_desat(self):
@@ -140,16 +139,16 @@ class TestColorPalettes(object):
         pal_in = np.array(["red", "blue", "green"])
         pal_out = palettes.color_palette(pal_in, 3)
 
-        nt.assert_is_instance(pal_out, list)
-        nt.assert_is_instance(pal_out[0], tuple)
-        nt.assert_is_instance(pal_out[0][0], float)
-        nt.assert_equal(len(pal_out[0]), 3)
+        assert isinstance(pal_out, list)
+        assert isinstance(pal_out[0], tuple)
+        assert isinstance(pal_out[0][0], float)
+        assert len(pal_out[0]) == 3
 
     def test_palette_cycles(self):
 
         deep = palettes.color_palette("deep6")
         double_deep = palettes.color_palette("deep6", 12)
-        nt.assert_equal(double_deep, deep + deep)
+        assert double_deep == deep + deep
 
     def test_hls_values(self):
 
@@ -189,11 +188,11 @@ class TestColorPalettes(object):
 
         pal_short = palettes.mpl_palette("Set1", 4)
         pal_long = palettes.mpl_palette("Set1", 6)
-        nt.assert_equal(pal_short, pal_long[:4])
+        assert pal_short == pal_long[:4]
 
         pal_full = palettes.mpl_palette("Set2", 8)
         pal_long = palettes.mpl_palette("Set2", 10)
-        nt.assert_equal(pal_full, pal_long[:8])
+        assert pal_full == pal_long[:8]
 
     def test_mpl_reversal(self):
 
@@ -206,7 +205,7 @@ class TestColorPalettes(object):
         color = .5, .8, .4
         rgb_got = palettes._color_to_rgb(color, "hls")
         rgb_want = colorsys.hls_to_rgb(*color)
-        nt.assert_equal(rgb_got, rgb_want)
+        assert rgb_got == rgb_want
 
     def test_rgb_from_husl(self):
 
@@ -226,7 +225,7 @@ class TestColorPalettes(object):
         color = "dull red"
         rgb_got = palettes._color_to_rgb(color, "xkcd")
         rgb_want = mpl.colors.to_rgb(xkcd_rgb[color])
-        nt.assert_equal(rgb_got, rgb_want)
+        assert rgb_got == rgb_want
 
     def test_light_palette(self):
 
@@ -322,24 +321,24 @@ class TestColorPalettes(object):
         sns_pal = palettes.cubehelix_palette(8, start=0.5, rot=-1.5, hue=1,
                                              dark=0, light=1, reverse=True)
 
-        nt.assert_list_equal(sns_pal, mpl_pal)
+        assert sns_pal == mpl_pal
 
     def test_cubehelix_n_colors(self):
 
         for n in [3, 5, 8]:
             pal = palettes.cubehelix_palette(n)
-            nt.assert_equal(len(pal), n)
+            assert len(pal) == n
 
     def test_cubehelix_reverse(self):
 
         pal_forward = palettes.cubehelix_palette()
         pal_reverse = palettes.cubehelix_palette(reverse=True)
-        nt.assert_list_equal(pal_forward, pal_reverse[::-1])
+        assert pal_forward == pal_reverse[::-1]
 
     def test_cubehelix_cmap(self):
 
         cmap = palettes.cubehelix_palette(as_cmap=True)
-        nt.assert_is_instance(cmap, mpl.colors.ListedColormap)
+        assert isinstance(cmap, mpl.colors.ListedColormap)
         pal = palettes.cubehelix_palette()
         x = np.linspace(0, 1, 6)
         npt.assert_array_equal(cmap(x)[:, :3], pal)
@@ -348,7 +347,7 @@ class TestColorPalettes(object):
         x = np.linspace(0, 1, 6)
         pal_forward = cmap(x).tolist()
         pal_reverse = cmap_rev(x[::-1]).tolist()
-        nt.assert_list_equal(pal_forward, pal_reverse)
+        assert pal_forward == pal_reverse
 
     def test_cubehelix_code(self):
 
@@ -381,7 +380,7 @@ class TestColorPalettes(object):
         colors = palettes.xkcd_palette(names)
         for name, color in zip(names, colors):
             as_hex = mpl.colors.rgb2hex(color)
-            nt.assert_equal(as_hex, xkcd_rgb[name])
+            assert as_hex == xkcd_rgb[name]
 
     def test_crayon_palette(self):
 
@@ -389,7 +388,7 @@ class TestColorPalettes(object):
         colors = palettes.crayon_palette(names)
         for name, color in zip(names, colors):
             as_hex = mpl.colors.rgb2hex(color)
-            nt.assert_equal(as_hex, crayons[name].lower())
+            assert as_hex == crayons[name].lower()
 
     def test_color_codes(self):
 
@@ -398,7 +397,7 @@ class TestColorPalettes(object):
         for code, color in zip("bgrmyck", colors):
             rgb_want = mpl.colors.colorConverter.to_rgb(color)
             rgb_got = mpl.colors.colorConverter.to_rgb(code)
-            nt.assert_equal(rgb_want, rgb_got)
+            assert rgb_want == rgb_got
         palettes.set_color_codes("reset")
 
         with pytest.raises(ValueError):
@@ -408,13 +407,13 @@ class TestColorPalettes(object):
 
         pal = palettes.color_palette("deep")
         for rgb, hex in zip(pal, pal.as_hex()):
-            nt.assert_equal(mpl.colors.rgb2hex(rgb), hex)
+            assert mpl.colors.rgb2hex(rgb) == hex
 
     def test_preserved_palette_length(self):
 
         pal_in = palettes.color_palette("Set1", 10)
         pal_out = palettes.color_palette(pal_in)
-        nt.assert_equal(pal_in, pal_out)
+        assert pal_in == pal_out
 
     def test_html_rep(self):
 

--- a/seaborn/tests/test_rcmod.py
+++ b/seaborn/tests/test_rcmod.py
@@ -242,7 +242,9 @@ class TestPalette:
 
 class TestFonts:
 
-    @pytest.mark.skipif(not has_verdana(), reason="Verdana font is not present")
+    _no_verdana = not has_verdana()
+
+    @pytest.mark.skipif(_no_verdana, reason="Verdana font is not present")
     def test_set_font(self):
 
         rcmod.set_theme(font="Verdana")
@@ -265,7 +267,7 @@ class TestFonts:
 
         rcmod.set_theme()
 
-    @pytest.mark.skipif(not has_verdana(), reason="Verdana font is not present")
+    @pytest.mark.skipif(_no_verdana, reason="Verdana font is not present")
     def test_different_sans_serif(self):
 
         rcmod.set_theme()

--- a/seaborn/tests/test_rcmod.py
+++ b/seaborn/tests/test_rcmod.py
@@ -1,16 +1,16 @@
 from distutils.version import LooseVersion
 
+import pytest
 import numpy as np
 import matplotlib as mpl
-import nose
 import matplotlib.pyplot as plt
-import nose.tools as nt
 import numpy.testing as npt
 
 from .. import rcmod, palettes, utils
+from ..conftest import has_verdana
 
 
-class RCParamTester(object):
+class RCParamTester:
 
     def flatten_list(self, orig_list):
 
@@ -28,7 +28,7 @@ class RCParamTester(object):
             if isinstance(v, np.ndarray):
                 npt.assert_array_equal(mpl.rcParams[k], v)
             else:
-                nt.assert_equal((k, mpl.rcParams[k]), (k, v))
+                assert mpl.rcParams[k] == v
 
     def assert_rc_params_equal(self, params1, params2):
 
@@ -42,7 +42,7 @@ class RCParamTester(object):
             if isinstance(v1, np.ndarray):
                 npt.assert_array_equal(v1, v2)
             else:
-                nt.assert_equal(v1, v2)
+                assert v1 == v2
 
 
 class TestAxesStyle(RCParamTester):
@@ -58,19 +58,19 @@ class TestAxesStyle(RCParamTester):
 
         _style_keys = set(rcmod._style_keys)
         for style in self.styles:
-            nt.assert_true(not set(rcmod.axes_style(style)) ^ _style_keys)
+            assert not set(rcmod.axes_style(style)) ^ _style_keys
 
     def test_bad_style(self):
 
-        with nt.assert_raises(ValueError):
+        with pytest.raises(ValueError):
             rcmod.axes_style("i_am_not_a_style")
 
     def test_rc_override(self):
 
         rc = {"axes.facecolor": "blue", "foo.notaparam": "bar"}
         out = rcmod.axes_style("darkgrid", rc)
-        nt.assert_equal(out["axes.facecolor"], "blue")
-        nt.assert_not_in("foo.notaparam", out)
+        assert out["axes.facecolor"] == "blue"
+        assert "foo.notaparam" not in out
 
     def test_set_style(self):
 
@@ -98,12 +98,12 @@ class TestAxesStyle(RCParamTester):
 
     def test_style_context_independence(self):
 
-        nt.assert_true(set(rcmod._style_keys) ^ set(rcmod._context_keys))
+        assert set(rcmod._style_keys) ^ set(rcmod._context_keys)
 
     def test_set_rc(self):
 
         rcmod.set_theme(rc={"lines.linewidth": 4})
-        nt.assert_equal(mpl.rcParams["lines.linewidth"], 4)
+        assert mpl.rcParams["lines.linewidth"] == 4
         rcmod.set_theme()
 
     def test_set_with_palette(self):
@@ -169,11 +169,11 @@ class TestPlottingContext(RCParamTester):
         _context_keys = set(rcmod._context_keys)
         for context in self.contexts:
             missing = set(rcmod.plotting_context(context)) ^ _context_keys
-            nt.assert_true(not missing)
+            assert not missing
 
     def test_bad_context(self):
 
-        with nt.assert_raises(ValueError):
+        with pytest.raises(ValueError):
             rcmod.plotting_context("i_am_not_a_context")
 
     def test_font_scale(self):
@@ -188,15 +188,15 @@ class TestPlottingContext(RCParamTester):
             font_keys.append("legend.title_fontsize")
 
         for k in font_keys:
-            nt.assert_equal(notebook_ref[k] * 2, notebook_big[k])
+            assert notebook_ref[k] * 2 == notebook_big[k]
 
     def test_rc_override(self):
 
         key, val = "grid.linewidth", 5
         rc = {key: val, "foo": "bar"}
         out = rcmod.plotting_context("talk", rc=rc)
-        nt.assert_equal(out[key], val)
-        nt.assert_not_in("foo", out)
+        assert out[key] == val
+        assert "foo" not in out
 
     def test_set_context(self):
 
@@ -223,7 +223,7 @@ class TestPlottingContext(RCParamTester):
         self.assert_rc_params(orig_params)
 
 
-class TestPalette(object):
+class TestPalette:
 
     def test_set_palette(self):
 
@@ -240,8 +240,9 @@ class TestPalette(object):
         assert utils.get_color_cycle() == palettes.color_palette("Set2", 8)
 
 
-class TestFonts(object):
+class TestFonts:
 
+    @pytest.mark.skipif(not has_verdana(), reason="Verdana font is not present")
     def test_set_font(self):
 
         rcmod.set_theme(font="Verdana")
@@ -249,16 +250,9 @@ class TestFonts(object):
         _, ax = plt.subplots()
         ax.set_xlabel("foo")
 
-        try:
-            nt.assert_equal(ax.xaxis.label.get_fontname(),
-                            "Verdana")
-        except AssertionError:
-            if has_verdana():
-                raise
-            else:
-                raise nose.SkipTest("Verdana font is not present")
-        finally:
-            rcmod.set_theme()
+        assert ax.xaxis.label.get_fontname() == "Verdana"
+
+        rcmod.set_theme()
 
     def test_set_serif_font(self):
 
@@ -267,11 +261,11 @@ class TestFonts(object):
         _, ax = plt.subplots()
         ax.set_xlabel("foo")
 
-        nt.assert_in(ax.xaxis.label.get_fontname(),
-                     mpl.rcParams["font.serif"])
+        assert ax.xaxis.label.get_fontname() in mpl.rcParams["font.serif"]
 
         rcmod.set_theme()
 
+    @pytest.mark.skipif(not has_verdana(), reason="Verdana font is not present")
     def test_different_sans_serif(self):
 
         rcmod.set_theme()
@@ -280,36 +274,6 @@ class TestFonts(object):
         _, ax = plt.subplots()
         ax.set_xlabel("foo")
 
-        try:
-            nt.assert_equal(ax.xaxis.label.get_fontname(),
-                            "Verdana")
-        except AssertionError:
-            if has_verdana():
-                raise
-            else:
-                raise nose.SkipTest("Verdana font is not present")
-        finally:
-            rcmod.set_theme()
+        assert ax.xaxis.label.get_fontname() == "Verdana"
 
-
-def has_verdana():
-    """Helper to verify if Verdana font is present"""
-    # This import is relatively lengthy, so to prevent its import for
-    # testing other tests in this module not requiring this knowledge,
-    # import font_manager here
-    import matplotlib.font_manager as mplfm
-    try:
-        verdana_font = mplfm.findfont('Verdana', fallback_to_default=False)
-    except:  # noqa
-        # if https://github.com/matplotlib/matplotlib/pull/3435
-        # gets accepted
-        return False
-    # otherwise check if not matching the logic for a 'default' one
-    try:
-        unlikely_font = mplfm.findfont("very_unlikely_to_exist1234",
-                                       fallback_to_default=False)
-    except:  # noqa
-        # if matched verdana but not unlikely, Verdana must exist
-        return True
-    # otherwise -- if they match, must be the same default
-    return verdana_font != unlikely_font
+        rcmod.set_theme()

--- a/seaborn/tests/test_regression.py
+++ b/seaborn/tests/test_regression.py
@@ -4,7 +4,6 @@ import matplotlib.pyplot as plt
 import pandas as pd
 
 import pytest
-import nose.tools as nt
 import numpy.testing as npt
 try:
     import pandas.testing as pdt
@@ -23,7 +22,7 @@ from ..palettes import color_palette
 rs = np.random.RandomState(0)
 
 
-class TestLinearPlotter(object):
+class TestLinearPlotter:
 
     rs = np.random.RandomState(77)
     df = pd.DataFrame(dict(x=rs.normal(size=60),
@@ -48,7 +47,7 @@ class TestLinearPlotter(object):
         p.establish_variables(None, x=self.df.x, y=self.df.y)
         pdt.assert_series_equal(p.x, self.df.x)
         pdt.assert_series_equal(p.y, self.df.y)
-        nt.assert_is(p.data, None)
+        assert p.data is None
 
     def test_establish_variables_from_array(self):
 
@@ -58,7 +57,7 @@ class TestLinearPlotter(object):
                               y=self.df.y.values)
         npt.assert_array_equal(p.x, self.df.x)
         npt.assert_array_equal(p.y, self.df.y)
-        nt.assert_is(p.data, None)
+        assert p.data is None
 
     def test_establish_variables_from_lists(self):
 
@@ -68,7 +67,7 @@ class TestLinearPlotter(object):
                               y=self.df.y.values.tolist())
         npt.assert_array_equal(p.x, self.df.x)
         npt.assert_array_equal(p.y, self.df.y)
-        nt.assert_is(p.data, None)
+        assert p.data is None
 
     def test_establish_variables_from_mix(self):
 
@@ -81,7 +80,7 @@ class TestLinearPlotter(object):
     def test_establish_variables_from_bad(self):
 
         p = lm._LinearPlotter()
-        with nt.assert_raises(ValueError):
+        with pytest.raises(ValueError):
             p.establish_variables(None, x="x", y=self.df.y)
 
     def test_dropna(self):
@@ -97,7 +96,7 @@ class TestLinearPlotter(object):
         pdt.assert_series_equal(p.y_na, self.df.y_na[mask])
 
 
-class TestRegressionPlotter(object):
+class TestRegressionPlotter:
 
     rs = np.random.RandomState(49)
 
@@ -136,7 +135,7 @@ class TestRegressionPlotter(object):
         npt.assert_array_equal(p.x, self.df.x)
         npt.assert_array_equal(p.y, self.df.y)
         npt.assert_array_equal(p.units, self.df.s)
-        nt.assert_is(p.data, None)
+        assert p.data is None
 
     def test_variables_from_mix(self):
 
@@ -158,10 +157,10 @@ class TestRegressionPlotter(object):
     def test_dropna(self):
 
         p = lm._RegressionPlotter("x", "y_na", data=self.df)
-        nt.assert_equal(len(p.x), pd.notnull(self.df.y_na).sum())
+        assert len(p.x) == pd.notnull(self.df.y_na).sum()
 
         p = lm._RegressionPlotter("x", "y_na", data=self.df, dropna=False)
-        nt.assert_equal(len(p.x), len(self.df.y_na))
+        assert len(p.x) == len(self.df.y_na)
 
     @pytest.mark.parametrize("x,y",
                              [([1.5], [2]),
@@ -174,16 +173,16 @@ class TestRegressionPlotter(object):
     def test_ci(self):
 
         p = lm._RegressionPlotter("x", "y", data=self.df, ci=95)
-        nt.assert_equal(p.ci, 95)
-        nt.assert_equal(p.x_ci, 95)
+        assert p.ci == 95
+        assert p.x_ci == 95
 
         p = lm._RegressionPlotter("x", "y", data=self.df, ci=95, x_ci=68)
-        nt.assert_equal(p.ci, 95)
-        nt.assert_equal(p.x_ci, 68)
+        assert p.ci == 95
+        assert p.x_ci == 68
 
         p = lm._RegressionPlotter("x", "y", data=self.df, ci=95, x_ci="sd")
-        nt.assert_equal(p.ci, 95)
-        nt.assert_equal(p.x_ci, "sd")
+        assert p.ci == 95
+        assert p.x_ci == "sd"
 
     @pytest.mark.skipif(_no_statsmodels, reason="no statsmodels")
     def test_fast_regression(self):
@@ -223,9 +222,9 @@ class TestRegressionPlotter(object):
         yhat_lin, _ = p.fit_fast(grid)
         yhat_log, _ = p.fit_logx(grid)
 
-        nt.assert_greater(yhat_lin[0], yhat_log[0])
-        nt.assert_greater(yhat_log[20], yhat_lin[20])
-        nt.assert_greater(yhat_lin[90], yhat_log[90])
+        assert yhat_lin[0] > yhat_log[0]
+        assert yhat_log[20] > yhat_lin[20]
+        assert yhat_lin[90] > yhat_log[90]
 
     @pytest.mark.skipif(_no_statsmodels, reason="no statsmodels")
     def test_regress_n_boot(self):
@@ -252,15 +251,15 @@ class TestRegressionPlotter(object):
 
         # Fast (linear algebra) version
         _, boots_fast = p.fit_fast(self.grid)
-        nt.assert_is(boots_fast, None)
+        assert boots_fast is None
 
         # Slower (np.polyfit) version
         _, boots_poly = p.fit_poly(self.grid, 1)
-        nt.assert_is(boots_poly, None)
+        assert boots_poly is None
 
         # Slowest (statsmodels) version
         _, boots_smod = p.fit_statsmodels(self.grid, smlm.OLS)
-        nt.assert_is(boots_smod, None)
+        assert boots_smod is None
 
     def test_regress_bootstrap_seed(self):
 
@@ -291,10 +290,8 @@ class TestRegressionPlotter(object):
 
         p = lm._RegressionPlotter(self.df.x, self.df.y)
         x_binned, bins = p.bin_predictor(self.bins_given)
-        nt.assert_greater(self.df.x[x_binned == 0].min(),
-                          self.df.x[x_binned == -1].max())
-        nt.assert_greater(self.df.x[x_binned == 1].min(),
-                          self.df.x[x_binned == 0].max())
+        assert self.df.x[x_binned == 0].min() > self.df.x[x_binned == -1].max()
+        assert self.df.x[x_binned == 1].min() > self.df.x[x_binned == 0].max()
 
     def test_scatter_data(self):
 
@@ -310,7 +307,7 @@ class TestRegressionPlotter(object):
 
         p = lm._RegressionPlotter(self.df.d, self.df.y, x_jitter=.1)
         x, y = p.scatter_data
-        nt.assert_true((x != self.df.d).any())
+        assert (x != self.df.d).any()
         npt.assert_array_less(np.abs(self.df.d - x), np.repeat(.1, len(x)))
         npt.assert_array_equal(y, self.df.y)
 
@@ -375,17 +372,17 @@ class TestRegressionPlotter(object):
 
         p = lm._RegressionPlotter(y, z, y_partial=x)
         _, r_semipartial = np.corrcoef(p.x, p.y)[0]
-        nt.assert_less(r_semipartial, r_orig)
+        assert r_semipartial < r_orig
 
         p = lm._RegressionPlotter(y, z, x_partial=x, y_partial=x)
         _, r_partial = np.corrcoef(p.x, p.y)[0]
-        nt.assert_less(r_partial, r_orig)
+        assert r_partial < r_orig
 
         x = pd.Series(x)
         y = pd.Series(y)
         p = lm._RegressionPlotter(y, z, x_partial=x, y_partial=x)
         _, r_partial = np.corrcoef(p.x, p.y)[0]
-        nt.assert_less(r_partial, r_orig)
+        assert r_partial < r_orig
 
     @pytest.mark.skipif(_no_statsmodels, reason="no statsmodels")
     def test_logistic_regression(self):
@@ -404,7 +401,7 @@ class TestRegressionPlotter(object):
                                   logistic=True, n_boot=10)
         with np.errstate(all="ignore"):
             _, yhat, _ = p.fit_regression(x_range=(-3, 3))
-        nt.assert_true(np.isnan(yhat).all())
+        assert np.isnan(yhat).all()
 
     @pytest.mark.skipif(_no_statsmodels, reason="no statsmodels")
     def test_robust_regression(self):
@@ -417,7 +414,7 @@ class TestRegressionPlotter(object):
                                          robust=True, n_boot=self.n_boot)
         _, robust_yhat, _ = p_robust.fit_regression(x_range=(-3, 3))
 
-        nt.assert_equal(len(ols_yhat), len(robust_yhat))
+        assert len(ols_yhat) == len(robust_yhat)
 
     @pytest.mark.skipif(_no_statsmodels, reason="no statsmodels")
     def test_lowess_regression(self):
@@ -425,16 +422,16 @@ class TestRegressionPlotter(object):
         p = lm._RegressionPlotter("x", "y", data=self.df, lowess=True)
         grid, yhat, err_bands = p.fit_regression(x_range=(-3, 3))
 
-        nt.assert_equal(len(grid), len(yhat))
-        nt.assert_is(err_bands, None)
+        assert len(grid) == len(yhat)
+        assert err_bands is None
 
     def test_regression_options(self):
 
-        with nt.assert_raises(ValueError):
+        with pytest.raises(ValueError):
             lm._RegressionPlotter("x", "y", data=self.df,
                                   lowess=True, order=2)
 
-        with nt.assert_raises(ValueError):
+        with pytest.raises(ValueError):
             lm._RegressionPlotter("x", "y", data=self.df,
                                   lowess=True, logistic=True)
 
@@ -445,16 +442,16 @@ class TestRegressionPlotter(object):
         p = lm._RegressionPlotter("x", "y", data=self.df)
         grid, _, _ = p.fit_regression(ax)
         xlim = ax.get_xlim()
-        nt.assert_equal(grid.min(), xlim[0])
-        nt.assert_equal(grid.max(), xlim[1])
+        assert grid.min() == xlim[0]
+        assert grid.max() == xlim[1]
 
         p = lm._RegressionPlotter("x", "y", data=self.df, truncate=True)
         grid, _, _ = p.fit_regression()
-        nt.assert_equal(grid.min(), self.df.x.min())
-        nt.assert_equal(grid.max(), self.df.x.max())
+        assert grid.min() == self.df.x.min()
+        assert grid.max() == self.df.x.max()
 
 
-class TestRegressionPlots(object):
+class TestRegressionPlots:
 
     rs = np.random.RandomState(56)
     df = pd.DataFrame(dict(x=rs.randn(90),
@@ -470,8 +467,8 @@ class TestRegressionPlots(object):
 
         f, ax = plt.subplots()
         lm.regplot(x="x", y="y", data=self.df)
-        nt.assert_equal(len(ax.lines), 1)
-        nt.assert_equal(len(ax.collections), 2)
+        assert len(ax.lines) == 1
+        assert len(ax.collections) == 2
 
         x, y = ax.collections[0].get_offsets().T
         npt.assert_array_equal(x, self.df.x)
@@ -481,20 +478,20 @@ class TestRegressionPlots(object):
 
         f, ax = plt.subplots()
         ax = lm.regplot(x="x", y="y", data=self.df, scatter=False, ax=ax)
-        nt.assert_equal(len(ax.lines), 1)
-        nt.assert_equal(len(ax.collections), 1)
+        assert len(ax.lines) == 1
+        assert len(ax.collections) == 1
         ax.clear()
 
         f, ax = plt.subplots()
         ax = lm.regplot(x="x", y="y", data=self.df, fit_reg=False)
-        nt.assert_equal(len(ax.lines), 0)
-        nt.assert_equal(len(ax.collections), 1)
+        assert len(ax.lines) == 0
+        assert len(ax.collections) == 1
         ax.clear()
 
         f, ax = plt.subplots()
         ax = lm.regplot(x="x", y="y", data=self.df, ci=None)
-        nt.assert_equal(len(ax.lines), 1)
-        nt.assert_equal(len(ax.collections), 1)
+        assert len(ax.lines) == 1
+        assert len(ax.collections) == 1
         ax.clear()
 
     def test_regplot_scatter_kws_alpha(self):
@@ -503,39 +500,39 @@ class TestRegressionPlots(object):
         color = np.array([[0.3, 0.8, 0.5, 0.5]])
         ax = lm.regplot(x="x", y="y", data=self.df,
                         scatter_kws={'color': color})
-        nt.assert_is(ax.collections[0]._alpha, None)
-        nt.assert_equal(ax.collections[0]._facecolors[0, 3], 0.5)
+        assert ax.collections[0]._alpha is None
+        assert ax.collections[0]._facecolors[0, 3] == 0.5
 
         f, ax = plt.subplots()
         color = np.array([[0.3, 0.8, 0.5]])
         ax = lm.regplot(x="x", y="y", data=self.df,
                         scatter_kws={'color': color})
-        nt.assert_equal(ax.collections[0]._alpha, 0.8)
+        assert ax.collections[0]._alpha == 0.8
 
         f, ax = plt.subplots()
         color = np.array([[0.3, 0.8, 0.5]])
         ax = lm.regplot(x="x", y="y", data=self.df,
                         scatter_kws={'color': color, 'alpha': 0.4})
-        nt.assert_equal(ax.collections[0]._alpha, 0.4)
+        assert ax.collections[0]._alpha == 0.4
 
         f, ax = plt.subplots()
         color = 'r'
         ax = lm.regplot(x="x", y="y", data=self.df,
                         scatter_kws={'color': color})
-        nt.assert_equal(ax.collections[0]._alpha, 0.8)
+        assert ax.collections[0]._alpha == 0.8
 
     def test_regplot_binned(self):
 
         ax = lm.regplot(x="x", y="y", data=self.df, x_bins=5)
-        nt.assert_equal(len(ax.lines), 6)
-        nt.assert_equal(len(ax.collections), 2)
+        assert len(ax.lines) == 6
+        assert len(ax.collections) == 2
 
     def test_lmplot_basic(self):
 
         g = lm.lmplot(x="x", y="y", data=self.df)
         ax = g.axes[0, 0]
-        nt.assert_equal(len(ax.lines), 1)
-        nt.assert_equal(len(ax.collections), 2)
+        assert len(ax.lines) == 1
+        assert len(ax.collections) == 2
 
         x, y = ax.collections[0].get_offsets().T
         npt.assert_array_equal(x, self.df.x)
@@ -546,18 +543,18 @@ class TestRegressionPlots(object):
         g = lm.lmplot(x="x", y="y", data=self.df, hue="h")
         ax = g.axes[0, 0]
 
-        nt.assert_equal(len(ax.lines), 2)
-        nt.assert_equal(len(ax.collections), 4)
+        assert len(ax.lines) == 2
+        assert len(ax.collections) == 4
 
     def test_lmplot_markers(self):
 
         g1 = lm.lmplot(x="x", y="y", data=self.df, hue="h", markers="s")
-        nt.assert_equal(g1.hue_kws, {"marker": ["s", "s"]})
+        assert g1.hue_kws == {"marker": ["s", "s"]}
 
         g2 = lm.lmplot(x="x", y="y", data=self.df, hue="h", markers=["o", "s"])
-        nt.assert_equal(g2.hue_kws, {"marker": ["o", "s"]})
+        assert g2.hue_kws == {"marker": ["o", "s"]}
 
-        with nt.assert_raises(ValueError):
+        with pytest.raises(ValueError):
             lm.lmplot(x="x", y="y", data=self.df, hue="h",
                       markers=["o", "s", "d"])
 
@@ -566,24 +563,23 @@ class TestRegressionPlots(object):
         g = lm.lmplot(x="x", y="y", data=self.df, hue="h",
                       fit_reg=False, markers=["o", "+"])
         c = g.axes[0, 0].collections
-        nt.assert_equal(c[1].get_linewidths()[0],
-                        mpl.rcParams["lines.linewidth"])
+        assert c[1].get_linewidths()[0] == mpl.rcParams["lines.linewidth"]
 
     def test_lmplot_facets(self):
 
         g = lm.lmplot(x="x", y="y", data=self.df, row="g", col="h")
-        nt.assert_equal(g.axes.shape, (3, 2))
+        assert g.axes.shape == (3, 2)
 
         g = lm.lmplot(x="x", y="y", data=self.df, col="u", col_wrap=4)
-        nt.assert_equal(g.axes.shape, (6,))
+        assert g.axes.shape == (6,)
 
         g = lm.lmplot(x="x", y="y", data=self.df, hue="h", col="u")
-        nt.assert_equal(g.axes.shape, (1, 6))
+        assert g.axes.shape == (1, 6)
 
     def test_lmplot_hue_col_nolegend(self):
 
         g = lm.lmplot(x="x", y="y", data=self.df, col="h", hue="h")
-        nt.assert_is(g._legend, None)
+        assert g._legend is None
 
     def test_lmplot_scatter_kws(self):
 
@@ -609,7 +605,7 @@ class TestRegressionPlots(object):
     def test_residplot_lowess(self):
 
         ax = lm.residplot(x="x", y="y", data=self.df, lowess=True)
-        nt.assert_equal(len(ax.lines), 2)
+        assert len(ax.lines) == 2
 
         x, y = ax.lines[1].get_xydata().T
         npt.assert_array_equal(x, np.sort(self.df.x))

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ CLASSIFIERS = [
     'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',
+    'Programming Language :: Python :: 3.9',
     'License :: OSI Approved :: BSD License',
     'Topic :: Scientific/Engineering :: Visualization',
     'Topic :: Multimedia :: Graphics',


### PR DESCRIPTION
This PR drops the obsolete `nose` package, and rewrites all nose-style tests as modern `pytest`-style tests. Most changes are simple translations of nose asserts to their equivalent pytest `assert` expressions. In a few places pytest parameterization was utilized as well. I did my best to keep the changes to the minimum, but I also changed a few variable names occasionally and removed subclassing from object when I encountered such cases (leftovers from py2-style code).

This PR also adds python==3.9 to the CI tests matrix.