### PR TITLE
add sem error band option to lineplot 

### DIFF
--- a/seaborn/relational.py
+++ b/seaborn/relational.py
@@ -410,6 +410,11 @@ class _LinePlotter(_RelationalPlotter):
             cis = pd.DataFrame(np.c_[est - sd, est + sd],
                                index=est.index,
                                columns=["low", "high"]).stack()
+        elif ci == "sem":
+            sem = grouped.std()
+            cis = pd.DataFrame(np.c_[est - sem, est + sem],
+                               index=est.index,
+                               columns=["low", "high"]).stack()
         else:
             cis = grouped.apply(bootstrapped_cis)
 


### PR DESCRIPTION
Currently only standard deviation (SD) and confidence interval (CI) are allowed when specifying error band in lineplot. This PR add an option to use standard error of mean (SEM) as error band. 