### PR TITLE
Allow independent variable to be plotted on y-axes in lineplot

### DIFF
--- a/seaborn/tests/test_relational.py
+++ b/seaborn/tests/test_relational.py
@@ -1117,6 +1117,48 @@ class TestLinePlotter(Helpers):
             assert isinstance(c, mpl.collections.LineCollection)
 
         p = _LinePlotter(
+            data=long_df,
+            variables=dict(x="y", y="x", hue="a"),
+            sort_dim="y",
+            estimator="mean", err_style="band", ci="sd"
+        )
+
+        ax.clear()
+        p.plot(ax, {})
+        assert len(ax.lines) == len(ax.collections) == len(p._hue_map.levels)
+        for c in ax.collections:
+            assert isinstance(c, mpl.collections.PolyCollection)
+        for line in ax.lines:
+            x, y = line.get_data()
+            assert((y == sorted(y)).all())
+
+        p = _LinePlotter(
+            data=long_df,
+            variables=dict(x="y", y="x", hue="a"),
+            sort_dim="y",
+            estimator="mean", err_style="bars", ci="sd"
+        )
+
+        ax.clear()
+        p.plot(ax, {})
+        n_lines = len(ax.lines)
+        assert n_lines / 2 == len(ax.collections) == len(p._hue_map.levels)
+        assert len(ax.collections) == len(p._hue_map.levels)
+        for c in ax.collections:
+            assert isinstance(c, mpl.collections.LineCollection)
+        for line in ax.lines:
+            x, y = line.get_data()
+            assert((y == sorted(y)).all())
+
+        with pytest.raises(ValueError):
+            p = _LinePlotter(
+                data=long_df,
+                variables=dict(x="y", y="x", hue="a"),
+                sort_dim="bad"
+            )
+            p.plot(ax, {})
+
+        p = _LinePlotter(
             data=repeated_df,
             variables=dict(x="x", y="y", units="u"),
             estimator=None


### PR DESCRIPTION
In lineplots, seaborn assumes the independent variable to be drawn on the x-axis and thus sorts the x-dimension first. If we want the independent variable to be drawn on the y-axis and therefore swap the axes by using the x and y arguments of `lineplot`, we do not get a mirror image of the former plot. Instead, the values are still ordered along the x dimension. Drawing error bars or bands, then will not work at all.
To allow producing such a mirror image, the `vals` and `grouper` variables for the `aggregate` function need to be swapped. I introduced the argument `sort_dim` to allow the user to decide which dimension should be sorted first.
To draw the errors correctly in the case of `sort_dim="y"`, `fill_betweenx` is used for band style and `xerr` is used instead of `yerr` for bar style.
I find this feature important when plotting e.g. meteorological variables as a function of height. Apart from [this](https://stackoverflow.com/questions/55362200/switch-seaborn-x-and-y-axes-but-compute-standard-deviation-on-original-orientati) stackoverflow question, I couldn't find any information on this issue.

example code:

```
import seaborn as sns
import numpy as np
import pandas as pd
import matplotlib.pyplot as plt

height= np.arange(0, 6.3, 0.1)
height_ind = np.repeat(height, 200)
rand = np.random.normal(scale=0.1, size=200*len(height))
vals = np.sin(height_ind) + rand

df = pd.DataFrame()
df["height"] = height_ind
df["vals"] = vals

#independent variable on x-axis
plt.figure()
g = sns.lineplot(x="height", y="vals", ci="sd", data=df)
plt.show()

#independent variable on y-axis with data still sorted along x
plt.figure()
g = sns.lineplot(y="height", x="vals", ci="sd", data=df)
plt.show()

#independent variable on y-axis with data sorted along y
plt.figure()
g = sns.lineplot(y="height", x="vals", ci="sd", sort_dim="y", data=df)
plt.show()

```
