### PR TITLE
Fix jointplot reference syntax in distributions tutorial.

### DIFF
--- a/doc/tutorial/distributions.ipynb
+++ b/doc/tutorial/distributions.ipynb
@@ -22,7 +22,7 @@
     "\n",
     "An early step in any effort to analyze or model data should be to understand how the variables are distributed. Techniques for distribution visualization can provide quick answers to many important questions. What range do the observations cover? What is their central tendency? Are they heavily skewed in one direction? Is there evidence for bimodality? Are there significant outliers? Do the answers to these questions vary across subsets defined by other variables?\n",
     "\n",
-    "The :ref:`distributions module <distribution_api>` contains several functions designed to answer questions such as these. The axes-level functions are :func:`histplot`, :func:`kdeplot`, :func:`ecdfplot`, and :func:`rugplot`. They are grouped together within the figure-level :func:`displot`, :func`jointplot`, and :func:`pairplot` functions.\n",
+    "The :ref:`distributions module <distribution_api>` contains several functions designed to answer questions such as these. The axes-level functions are :func:`histplot`, :func:`kdeplot`, :func:`ecdfplot`, and :func:`rugplot`. They are grouped together within the figure-level :func:`displot`, :func:`jointplot`, and :func:`pairplot` functions.\n",
     "\n",
     "There are several different approaches to visualizing a distribution, and each has its relative advantages and drawbacks. It is important to understand theses factors so that you can choose the best approach for your particular aim."
    ]

--- a/doc/tutorial/distributions.ipynb
+++ b/doc/tutorial/distributions.ipynb
@@ -172,7 +172,7 @@
     "Conditioning on other variables\n",
     "^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
     "\n",
-    "Once you understand the distribution of a variable, the next step is often to ask whether features of that distribution differ across other variables in the dataset. For example, what accounts for the bimodal distribution of flipper lengths that we saw above? :func:`displot` and :func:`histplot` provide support for conditional subsetting via the ``hue``semantic. Assigning a variable to ``hue`` will draw a separate histogram for each of its unique values and distinguish them by color:"
+    "Once you understand the distribution of a variable, the next step is often to ask whether features of that distribution differ across other variables in the dataset. For example, what accounts for the bimodal distribution of flipper lengths that we saw above? :func:`displot` and :func:`histplot` provide support for conditional subsetting via the ``hue`` semantic. Assigning a variable to ``hue`` will draw a separate histogram for each of its unique values and distinguish them by color:"
    ]
   },
   {


### PR DESCRIPTION
Hi! I caught a typo in the Sphinx syntax of this page: https://seaborn.pydata.org/tutorial/distributions.html
This PR fixes the missing colon, which will make the reference render.

I also fixed one other rST syntax error, there was a missing space that prevented the Sphinx double-backtick code block from rendering correctly.

Thanks for the wonderful package. 😄