### PR TITLE
fix for an OverflowError

### DIFF
--- a/seaborn/distributions.py
+++ b/seaborn/distributions.py
@@ -2396,7 +2396,10 @@ def _freedman_diaconis_bins(a):
     if h == 0:
         return int(np.sqrt(a.size))
     else:
-        return int(np.ceil((a.max() - a.min()) / h))
+        try:
+            return int(np.ceil((a.max() - a.min()) / h))
+        except OverflowError:
+            return 30
 
 
 def distplot(a=None, bins=None, hist=True, kde=True, rug=False, fit=None,


### PR DESCRIPTION
Libraries like PyFolio still use this function and in some cases it might lead to an OverflowError: cannot convert float infinity to integer. Here is a quick fix for these cases returning just a default value of bins.