### PR TITLE
FIX: Infer categorical dtypes before boolean resolution

### DIFF
--- a/seaborn/_core.py
+++ b/seaborn/_core.py
@@ -1199,6 +1199,10 @@ def variable_type(vector, boolean_type="numeric"):
     var_type : 'numeric', 'categorical', or 'datetime'
         Name identifying the type of data in the vector.
     """
+    # If a categorical dtype is set, infer categorical
+    if pd.api.types.is_categorical_dtype(vector):
+        return "categorical"
+
     # Special-case all-na data, which is always "numeric"
     if pd.isna(vector).all():
         return "numeric"
@@ -1221,9 +1225,6 @@ def variable_type(vector, boolean_type="numeric"):
     # Defer to positive pandas tests
     if pd.api.types.is_numeric_dtype(vector):
         return "numeric"
-
-    if pd.api.types.is_categorical_dtype(vector):
-        return "categorical"
 
     if pd.api.types.is_datetime64_dtype(vector):
         return "datetime"

--- a/seaborn/_core.py
+++ b/seaborn/_core.py
@@ -1177,27 +1177,27 @@ class VectorPlotter:
 
 
 def variable_type(vector, boolean_type="numeric"):
-    """Determine whether a vector contains numeric, categorical, or dateime data.
+    """
+    Determine whether a vector contains numeric, categorical, or datetime data.
 
     This function differs from the pandas typing API in two ways:
 
     - Python sequences or object-typed PyData objects are considered numeric if
       all of their entries are numeric.
     - String or mixed-type data are considered categorical even if not
-      explicitly represented as a :class:pandas.api.types.CategoricalDtype`.
+      explicitly represented as a :class:`pandas.api.types.CategoricalDtype`.
 
     Parameters
     ----------
     vector : :func:`pandas.Series`, :func:`numpy.ndarray`, or Python sequence
         Input data to test.
-    binary_type : 'numeric' or 'categorical'
+    boolean_type : 'numeric' or 'categorical'
         Type to use for vectors containing only 0s and 1s (and NAs).
 
     Returns
     -------
     var_type : 'numeric', 'categorical', or 'datetime'
         Name identifying the type of data in the vector.
-
     """
     # Special-case all-na data, which is always "numeric"
     if pd.isna(vector).all():

--- a/seaborn/tests/test_core.py
+++ b/seaborn/tests/test_core.py
@@ -1107,6 +1107,9 @@ class TestCoreFunc:
         s = pd.Series([True, False, False])
         assert variable_type(s) == "numeric"
         assert variable_type(s, boolean_type="categorical") == "categorical"
+        s_cat = s.astype("category")
+        assert variable_type(s_cat, boolean_type="categorical") == "categorical"
+        assert variable_type(s_cat, boolean_type="numeric") == "categorical"
 
         s = pd.Series([pd.Timestamp(1), pd.Timestamp(2)])
         assert variable_type(s) == "datetime"


### PR DESCRIPTION
Fixes #2317, with small changes to the docstring of `variable_type`.