### PR TITLE
Add/restore functionality to long-form data processing

### DIFF
--- a/doc/releases/v0.11.1.txt
+++ b/doc/releases/v0.11.1.txt
@@ -2,13 +2,15 @@
 v0.11.1 (Unreleased)
 --------------------
 
+- |Fix| Restored support for using tuples or numeric keys to reference fields in a long-form `data` object (:pr:`2386`).
+
 - |Fix| Fixed a bug in :func:`lineplot` where NAs were propagating into the confidence interval, sometimes erasing it from the plot (:pr:`2273`).
 
 - |Fix| Fixed a bug in :class:`PairGrid`/:func:`pairplot` where diagonal axes would be empty when the grid was not square and the diagonal axes did not contain the marginal plots (:pr:`2270`).
 
 - |Fix| Fixed a bug in :class:`PairGrid`/:func:`pairplot` where off-diagonal plots would not appear when column names in `data` had non-string type (:pr:`2368`).
 
-- |Fix| Fixed a bug where categorical dtype information was ignored when data consisted of boolean values (:pr:`2379`).
+- |Fix| Fixed a bug where categorical dtype information was ignored when data consisted of boolean or boolean-like values (:pr:`2379`).
 
 - |Fix| Fixed a bug in :class:`FacetGrid` where interior tick labels would be hidden when only the orthogonal axis was shared (:pr:`2347`).
 
@@ -18,12 +20,12 @@ v0.11.1 (Unreleased)
 
 - |Fix| Fixed a bug in :func:`displot` where the ``row_order`` and ``col_order`` parameters were not used (:pr:`2262`).
 
-- |Fix| Fixed a bug in :class:`PairGrid`/:func:`pairplot` that caused an exception when using `corent=True` and `diag_kind=None` (:pr:`2382`).
-
-- |Fix| Raised a more informative error in :class:`PairGrid`/:func:`pairplot` when no variables cold be found to define the rows/columns of the grid (:func:`2382`).
+- |Fix| Fixed a bug in :class:`PairGrid`/:func:`pairplot` that caused an exception when using `corner=True` and `diag_kind=None` (:pr:`2382`).
 
 - |Fix| Fixed a bug in :func:`clustermap` where `annot=False` was ignored (:pr:`2323`).
 
 - |Fix| Fixed a bug in :func:`boxenplot` where the `linewidth` parameter was ignored (:func:`2287`).
 
-- |Fix| Raised a more informative error from :func:`clustermap` if row/col color objects have semantic index but data object does not (:pr:`2313`).
+- |Fix| Raise a more informative error in :class:`PairGrid`/:func:`pairplot` when no variables can be found to define the rows/columns of the grid (:func:`2382`).
+
+- |Fix| Raise a more informative error from :func:`clustermap` if row/col color objects have semantic index but data object does not (:pr:`2313`).

--- a/seaborn/_core.py
+++ b/seaborn/_core.py
@@ -873,9 +873,14 @@ class VectorPlotter:
 
             # First try to treat the argument as a key for the data collection.
             # But be flexible about what can be used as a key.
-            # Usually it will be a string, but allow numbers or tuples too.
+            # Usually it will be a string, but allow numbers or tuples too when
+            # taking from the main data object. Only allow strings to reference
+            # fields in the index, because otherwise there is too much ambiguity.
             try:
-                val_as_data_key = val in data or val in index
+                val_as_data_key = (
+                    val in data
+                    or (isinstance(val, (str, bytes)) and val in index)
+                )
             except (KeyError, TypeError):
                 val_as_data_key = False
 

--- a/seaborn/_core.py
+++ b/seaborn/_core.py
@@ -898,9 +898,9 @@ class VectorPlotter:
 
             else:
 
-                # Otherwise, assume the value is itself a vector of data
+                # Otherwise, assume the value is itself data
 
-                # Raise when data is present and a vector can't be combined with it
+                # Raise when data object is present and a vector can't matched
                 if isinstance(data, pd.DataFrame) and not isinstance(val, pd.Series):
                     if np.ndim(val) and len(data) != len(val):
                         val_cls = val.__class__.__name__

--- a/seaborn/tests/test_core.py
+++ b/seaborn/tests/test_core.py
@@ -605,6 +605,36 @@ class TestVectorPlotter:
     # TODO note that most of the other tests that exercise the core
     # variable assignment code still live in test_relational
 
+    @pytest.mark.parametrize("name", [3, 4.5])
+    def test_long_numeric_name(self, long_df, name):
+
+        long_df[name] = long_df["x"]
+        p = VectorPlotter()
+        p.assign_variables(data=long_df, variables={"x": name})
+        assert_array_equal(p.plot_data["x"], long_df[name])
+        assert p.variables["x"] == name
+
+    def test_long_hierarchical_index(self, rng):
+
+        cols = pd.MultiIndex.from_product([["a"], ["x", "y"]])
+        data = rng.uniform(size=(50, 2))
+        df = pd.DataFrame(data, columns=cols)
+
+        name = ("a", "y")
+        var = "y"
+
+        p = VectorPlotter()
+        p.assign_variables(data=df, variables={var: name})
+        assert_array_equal(p.plot_data[var], df[name])
+        assert p.variables[var] == name
+
+    def test_long_scalar_and_data(self, long_df):
+
+        val = 22
+        p = VectorPlotter(data=long_df, variables={"x": "x", "y": val})
+        assert (p.plot_data["y"] == val).all()
+        assert p.variables["y"] is None
+
     def test_wide_semantic_error(self, wide_df):
 
         err = "The following variable cannot be assigned with wide-form data: `hue`"


### PR DESCRIPTION
The variable processing refactor made long-form argument processing more strict, allowing only string(y) types as keys to the `data` object. While this is basically what was documented, many functions previously worked properly with numeric arguments or even tuples (i.e. as keys for multi-index columns).

This PR makes the processing of named variables with long-form data more flexible.

It introduces a couple minor ambiguities, e.g. when `data` is present and a variable is specified with a number or a tuple, the variable could be interpreted as a key for `data` or as a data value itself (preferring the former). But I think in most cases, the expected behavior it to interpret it as a key.

~Needs tests, but I wanted to get CI going.~

Fixes #2279
Fixes #2263

Wide-form data objects with hierarchical column index still don't work properly, and making that work is nontrivial, so those remain unsupported (for now at least).