### PR TITLE
Reduce usage of global matplotlib state in axisgrid objects

### DIFF
--- a/doc/releases/v0.11.1.txt
+++ b/doc/releases/v0.11.1.txt
@@ -2,6 +2,8 @@
 v0.11.1 (Unreleased)
 --------------------
 
+- [Enhancement| Reduced the use of matplotlib global state in the :ref:`multi-grid classes <multi-plot-grids>` (pr:`2388`).
+
 - |Fix| Restored support for using tuples or numeric keys to reference fields in a long-form `data` object (:pr:`2386`).
 
 - |Fix| Fixed a bug in :func:`lineplot` where NAs were propagating into the confidence interval, sometimes erasing it from the plot (:pr:`2273`).
@@ -23,6 +25,8 @@ v0.11.1 (Unreleased)
 - |Fix| Fixed a bug in :class:`PairGrid`/:func:`pairplot` that caused an exception when using `corner=True` and `diag_kind=None` (:pr:`2382`).
 
 - |Fix| Fixed a bug in :func:`clustermap` where `annot=False` was ignored (:pr:`2323`).
+
+- |Fix| Fixed a bug in :func:`clustermap` where row/col color annotations could not have a categorical dtype (:pr:`2389`).
 
 - |Fix| Fixed a bug in :func:`boxenplot` where the `linewidth` parameter was ignored (:func:`2287`).
 

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -727,7 +727,7 @@ class FacetGrid(Grid):
                 continue
 
             # Get the current axis
-            modify_state = not func.__module__.startswith("seaborn")
+            modify_state = not str(func.__module__).startswith("seaborn")
             ax = self.facet_axis(row_i, col_j, modify_state)
 
             # Decide what color to plot with

--- a/seaborn/tests/test_axisgrid.py
+++ b/seaborn/tests/test_axisgrid.py
@@ -15,7 +15,7 @@ from .._core import categorical_order
 from .. import rcmod
 from ..palettes import color_palette
 from ..relational import scatterplot
-from ..distributions import histplot, kdeplot
+from ..distributions import histplot, kdeplot, distplot
 from ..categorical import pointplot
 from .. import axisgrid as ag
 from .._testing import (
@@ -1005,6 +1005,20 @@ class TestPairGrid:
         for ax in g.diag_axes[1:]:
             assert ax.get_ylim() == g.diag_axes[0].get_ylim()
 
+    def test_map_diag_matplotlib(self):
+
+        bins = 10
+        g = ag.PairGrid(self.df)
+        g.map_diag(plt.hist, bins=bins)
+        for ax in g.diag_axes:
+            assert len(ax.patches) == bins
+
+        levels = len(self.df["a"].unique())
+        g = ag.PairGrid(self.df, hue="a")
+        g.map_diag(plt.hist, bins=bins)
+        for ax in g.diag_axes:
+            assert len(ax.patches) == (bins * levels)
+
     def test_palette(self):
 
         rcmod.set()
@@ -1459,6 +1473,25 @@ class TestJointGrid:
         _, y1 = g.ax_marg_x.lines[0].get_xydata().T
         y2, _ = g.ax_marg_y.lines[0].get_xydata().T
         npt.assert_array_equal(y1, y2)
+
+    def test_univariate_plot_distplot(self):
+
+        bins = 10
+        g = ag.JointGrid(x="x", y="x", data=self.data)
+        with pytest.warns(FutureWarning):
+            g.plot_marginals(distplot, bins=bins)
+        assert len(g.ax_marg_x.patches) == bins
+        assert len(g.ax_marg_y.patches) == bins
+        for x, y in zip(g.ax_marg_x.patches, g.ax_marg_y.patches):
+            assert x.get_height() == y.get_width()
+
+    def test_univariate_plot_matplotlib(self):
+
+        bins = 10
+        g = ag.JointGrid(x="x", y="x", data=self.data)
+        g.plot_marginals(plt.hist, bins=bins)
+        assert len(g.ax_marg_x.patches) == bins
+        assert len(g.ax_marg_y.patches) == bins
 
     def test_plot(self):
 

--- a/seaborn/tests/test_axisgrid.py
+++ b/seaborn/tests/test_axisgrid.py
@@ -415,6 +415,8 @@ class TestFacetGrid:
 
         def plot(x, y, data=None, **kws):
             plt.plot(data[x], data[y], **kws)
+        # Modify __module__ so this doesn't look like a seaborn function
+        plot.__module__ = "test"
 
         g.map_dataframe(plot, "x", "y", linestyle="--")
 


### PR DESCRIPTION
Most of the axisgrid objects (`FacetGrid`, `PairGrid`, `JointGrid`) were written before there were many axes-level seaborn functions and were originally designed to interface with `pyplot` functions. They make use of matplotlib global state to allow a generic interface for spreading a plot across multiple Axes instances. Because they control the state internally, this ends up not being a huge problem, but one potential source of issues would arise in the context of parallel execution (cf. #2380).

All seaborn-axes level functions accept `ax=` for explicit placement, so this PR special-cases seaborn functions to pass the relevant `Axes` around explicitly rather than setting and using the global state.

It would probably be fine to more generically pass `ax` explicitly when the function signature for the to-be-mapped function includes `ax`. But while there are some esoteric corner cases there that might case issues, just handling seaborn functions should (?) be completely transparent. So that is what we will do for this point release.