### PR TITLE
Corrects typo in the diverging palette doc sub-section title

### DIFF
--- a/doc/tutorial/color_palettes.ipynb
+++ b/doc/tutorial/color_palettes.ipynb
@@ -856,7 +856,7 @@
     "\n",
     "The third class of color palettes is called \"diverging\". These are used for data where both large low and high values are interesting and span a midpoint value (often 0) that should be demphasized. The rules for choosing good diverging palettes are similar to good sequential palettes, except now there should be two dominant hues in the colormap, one at (or near) each pole. It's also important that the starting values are of similar brightness and saturation.\n",
     "\n",
-    "Perceptually uniform divering palettes\n",
+    "Perceptually uniform diverging palettes\n",
     "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n",
     "\n",
     "Seaborn includes two perceptually uniform diverging palettes: ``\"vlag\"`` and ``\"icefire\"``. They both use blue and red at their poles, which many intuitively processes as \"cold\" and \"hot\":"

--- a/doc/tutorial/color_palettes.ipynb
+++ b/doc/tutorial/color_palettes.ipynb
@@ -857,7 +857,7 @@
     "The third class of color palettes is called \"diverging\". These are used for data where both large low and high values are interesting and span a midpoint value (often 0) that should be demphasized. The rules for choosing good diverging palettes are similar to good sequential palettes, except now there should be two dominant hues in the colormap, one at (or near) each pole. It's also important that the starting values are of similar brightness and saturation.\n",
     "\n",
     "Perceptually uniform diverging palettes\n",
-    "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n",
+    "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n",
     "\n",
     "Seaborn includes two perceptually uniform diverging palettes: ``\"vlag\"`` and ``\"icefire\"``. They both use blue and red at their poles, which many intuitively processes as \"cold\" and \"hot\":"
    ]


### PR DESCRIPTION
This pull request corrects a typo in the [color palette tutorial](https://seaborn.pydata.org/tutorial/color_palettes.html#perceptually-uniform-divering-palettes).

```diff
- Perceptually uniform divering palettes
+ Perceptually uniform diverging palettes
```