### PR TITLE
Increase errorbar flexibility

### DIFF
--- a/doc/docstrings/lineplot.ipynb
+++ b/doc/docstrings/lineplot.ipynb
@@ -222,7 +222,7 @@
    "cell_type": "raw",
    "metadata": {},
    "source": [
-    "Show error bars instead of error bands and plot the 68% confidence interval (standard error):"
+    "Show error bars instead of error bands and extend them to two standard error widths:"
    ]
   },
   {
@@ -232,7 +232,7 @@
    "outputs": [],
    "source": [
     "sns.lineplot(\n",
-    "    data=fmri, x=\"timepoint\", y=\"signal\", hue=\"event\", err_style=\"bars\", ci=68\n",
+    "    data=fmri, x=\"timepoint\", y=\"signal\", hue=\"event\", err_style=\"bars\", errorbar=(\"se\", 2),\n",
     ")"
    ]
   },

--- a/doc/releases/v0.12.0.txt
+++ b/doc/releases/v0.12.0.txt
@@ -2,6 +2,8 @@
 v0.12.0 (Unreleased)
 --------------------
 
+- |API| |Feature| |Enhancement| TODO (Flesh this out further). Increased flexibility of what can be shown by the internally-calculated errorbars (:pr:2407).
+
 - Made `scipy` an optional dependency and added `pip install seaborn[all]` as a method for ensuring the availability of compatible `scipy` and `statsmodels` libraries. This has a few minor implications for existing code, which are explained in the Github pull request (:pr:`2398`).
 
 - Following `NEP29 <https://numpy.org/neps/nep-0029-deprecation_policy.html>`_, dropped support for Python 3.6 and bumped the minimally-supported versions of the library dependencies.

--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -52,6 +52,25 @@ User guide and tutorial
             </div>
           </div>
         </div>
+        <div class="row">
+          <div class="col-md-6">
+            <div class="col-md-4">
+              <a href=./tutorial/error_bars.html>
+                <img src="_images/error_bars_4_0.png" class="img-responsive center-block">
+              </a>
+            </div>
+            <div class="col-md-8">
+
+.. toctree::
+   :maxdepth: 2
+
+   tutorial/error_bars
+
+.. raw:: html
+
+            </div>
+          </div>
+        </div>
       </div>
     </div>
     <div class="row">

--- a/doc/tutorial/error_bars.ipynb
+++ b/doc/tutorial/error_bars.ipynb
@@ -1,0 +1,358 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _errorbar_tutorial:\n",
+    "\n",
+    ".. currentmodule:: seaborn"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "hide"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import seaborn as sns\n",
+    "import matplotlib as mpl\n",
+    "import matplotlib.pyplot as plt\n",
+    "sns.set_theme(style=\"darkgrid\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "hide"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "np.random.seed(sum(map(ord, \"relational\")))"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Statistical estimation and error bars\n",
+    "=====================================\n",
+    "\n",
+    ".. raw:: html\n",
+    "\n",
+    "   <div class=col-md-9>\n",
+    "\n",
+    "Data visualization sometimes involves a step of aggregation or estimation, where multiple data points are reduced to a summary statistic such as the mean or median. When showing a summary statistic, it is usually appropriate to add *error bars*, which provide a visual cue about how well the summary represents the underlying data points.\n",
+    "\n",
+    "Several seaborn functions will automatically calculate both summary statistics and the error bars when \n",
+    "given a full dataset. This chapter explains how you can control what the error bars show and why you might choose each of the options that seaborn affords."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# TODO example plot pointing out what the error bar is"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "The error bars around an estimate of central tendency can show one of two things: either the range of uncertainty about the estimate or the spread of the underlying data around it. These measures are related: given the same sample size, estimates will be more uncertain when data has a broader spread. But uncertainty will decrease as sample sizes grow, whereas spread will not.\n",
+    "\n",
+    "In seaborn, there are two approaches for constructing each kind of error bar. One approach is parametric, using a formula that relies on assumptions about the shape of the distribution. The other approach is nonparametric, using only the data that you provide.\n",
+    "\n",
+    "Your choice is made with the `errorbar` parameter, which exists for each function that does estimation as part of plotting. This parameter accepts the name of the method to use and, optionally, a parameter that controls the size of the interval. The choices can be defined in a 2D taxonomy that depends on what is shown and how it is constructed:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "hide-input"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "f, axs = plt.subplots(2, 2, figsize=(6, 4), sharex=True, sharey=True)\n",
+    "\n",
+    "plt.setp(axs, xlim=(-1, 1), ylim=(-1, 1), xticks=[], yticks=[])\n",
+    "for ax, color in zip(axs.flat, [\"C0\", \"C1\", \"C3\", \"C2\"]):\n",
+    "    ax.set_facecolor(mpl.colors.to_rgba(color, .25))\n",
+    "\n",
+    "kws = dict(x=0, y=.2, ha=\"center\", va=\"center\", size=20)\n",
+    "axs[0, 0].text(s=\"Standard deviation\", **kws)\n",
+    "axs[0, 1].text(s=\"Standard error\", **kws)\n",
+    "axs[1, 0].text(s=\"Percentile interval\", **kws)\n",
+    "axs[1, 1].text(s=\"Confidence interval\", **kws)\n",
+    "\n",
+    "kws = dict(x=0, y=-.2, ha=\"center\", va=\"center\", size=20, font=\"Courier New\")\n",
+    "axs[0, 0].text(s='errorbar=(\"sd\", scale)', **kws)\n",
+    "axs[0, 1].text(s='errorbar=(\"se\", scale)', **kws)\n",
+    "axs[1, 0].text(s='errorbar=(\"pi\", width)', **kws)\n",
+    "axs[1, 1].text(s='errorbar=(\"ci\", width)', **kws)\n",
+    "\n",
+    "kws = dict(size=16)\n",
+    "axs[1, 0].set_xlabel(\"Spread\", **kws)\n",
+    "axs[1, 1].set_xlabel(\"Uncertainty\", **kws)\n",
+    "axs[0, 0].set_ylabel(\"Parametric\", **kws)\n",
+    "axs[1, 0].set_ylabel(\"Nonparametric\", **kws)\n",
+    "\n",
+    "f.tight_layout()\n",
+    "f.subplots_adjust(hspace=.05, wspace=.05 * (4 / 6))"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "You will note that the size parameter is defined differently for the parametric and nonparametric approaches. For parametric error bars, it is a scalar factor that is multiplied by the statistic defining the error (standard error or standard deviation). For nonparametric error bars, it is a percentile width. This is explained further for each specific approach below."
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Measures of data spread\n",
+    "-----------------------\n",
+    "\n",
+    "Error bars that represent data spread present a compact display of the distribution, using three numbers where :func:`boxplot` would use 5 or more and :func:`violinplot` would use a complicated algorithm.\n",
+    "\n",
+    "Standard deviation error bars\n",
+    "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n",
+    "\n",
+    "Standard deviation error bars are the simplest to explain, because the standard deviation is a familiar statistic. It is the average distance from each data point to the sample mean. By default, `errorbar=\"sd\"` will draw error bars at +/- 1 sd around the estimate, but the range can be increased by passing a scaling size parameter. Note that, assuming normally-distributed data, ~68% of the data will lie within one standard deviation, ~95% will lie within two, and ~99.7% will lie within three:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# TODO demonstrate with figure"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Percentile interval error bars\n",
+    "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n",
+    "\n",
+    "Percentile intervals also represent the range where some amount of the data fall, but they do so by \n",
+    "computing those percentiles directly from your sample. By default, `errorbar=\"pi\"` will show a 95% interval, ranging from the 2.5 to the 97.5 percentiles. You can chose a different range by passing a size parameter, e.g., to show the inter-quartile range:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# TODO demonstrate with figure"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "The standard deviation error bars will always be symmetrical around the estimate. This can be a problem when the data are skewed, especially if there are natural bounds (e.g., if the data represent a quantity that can only be positive). In some cases, standard deviation error bars may extend to \"impossible\" values. The nonparametric approach does not have this problem, because it can account for asymmetrical spread and will never extend beyond the range of the data:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# TODO demonstrate with figure"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Measures of estimate uncertainty\n",
+    "--------------------------------\n",
+    "\n",
+    "If your data are a random sample from a larger population, then the mean (or other estimate) will be an imperfect measure of the true population average. Error bars that show estimate uncertainty try to represent the range of likely values for the true parameter.\n",
+    "\n",
+    "Standard error bars\n",
+    "~~~~~~~~~~~~~~~~~~~\n",
+    "\n",
+    "The standard error statistic is related to the standard deviation: in fact it is just the standard deviation divided by the square root of the sample size. The default, with `errorbar=\"se\"`, draws an interval +/- 1 standard error from the mean, but you can draw a different interval by scaling:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# TODO demonstrate with figure"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Confidence interval error bars\n",
+    "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n",
+    "\n",
+    "The nonparametric approach to representing uncertainty uses *bootstrapping*: a procedure where the dataset is randomly resampled with replacement a number of times, and the estimate is recalculated from each resample. This procedure creates a distribution of statistics approximating the distribution of values that you could have gotten for your estimate if you had a different sample.\n",
+    "\n",
+    "The confidence interval is constructed by taking a percentile interval of the *bootstrap distribution*. By default `errorbar=\"ci\"` draws a 95% confidence interval, but you can choose a smaller or larger one by setting a different width:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# TODO demonstrate with figure"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "The seaborn terminology is somewhat specific, because a confidence interval in statistics can be parametric or nonparametric. To draw a parametric confidence interval, you scale the standard error, using a formula similar to the one mentioned above. For example, an approximate 95% confidence interval can be constructed by taking the mean +/- two standard errors:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# TODO demonstrate with figure"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "The nonparametric bootstrap has advantages similar to those of the percentile interval: it will naturally adapt to skwewed and bounded data in a way that a standard error interval cannot. It is also more general. While the standard error formula is specific to the mean, error bars can be computed using the boootstrap for any estimator:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# TODO demonstrate with figure"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "On the other hand, the bootstrap procedure is much more computationally-intensive. For large datasets, bootstrap intervals can be expensive to compute. But because uncertainty decreases with sample size, it may be more informative in that case to use an error bar that represents data spread."
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Custom error bars\n",
+    "-----------------\n",
+    "\n",
+    "If these recipes are not sufficient, it is also possible to pass a generic function to the `errorbar` parameter. This function should take a vector and produce a pair of values representing the minimum and maximum points of the interval:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# TODO demonstrate with figure"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Note that seaborn functions cannot currently draw error bars from values that have been calculated externally, although matplotlib functions can be used to add such error bars to seaborn plots."
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Error bars on regression models\n",
+    "-------------------------------\n",
+    "\n",
+    "The preceding discussion has focused on error bars shown around parameter estimates for aggregate data. Error bars also arise in seaborn when estimating regression models to visualize relationships. Here, the error bars will be represented by a \"band\" around the regression line:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# TODO demonstrate with figure"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Most of the same options apply. A regression line represents a conditional mean: the estimated average value of the *y* variable given a specific *x* value. So a standard error or confidence interval represents the uncertainty around the estimate of that conditional mean, whereas a standard deviation interval represents a prediction about the range of *y* would would see if given that *x*. Because the regression model extrapolates beyond the data at hand, it is not possible to draw a percentile interval around it."
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Are error bars enough?\n",
+    "----------------------\n",
+    "\n",
+    "You should always ask yourself whether it's best to use a plot that displays only a summary statistic and error bars. In many cases, it isn't.\n",
+    "\n",
+    "If you are interested in questions about summaries (such as whether the mean value differs between groups or increases over time), aggregation reduces the complexity of the plot and makes those inferences easier. But in doing so, it obscures valuable information about the underlying data points, such as the shape of the distributions and the presence of outliers.\n",
+    "\n",
+    "When analyzing your own data, don't be satisfied with summary statistics. Always look at the underlying distributions too. Sometimes, it can be helpful to combine both perspectives into the same figure. Many seaborn functions can help with this task, especially those discussed in the :ref:`categorical tutorial <categorical_tutorial>`."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "seaborn-py38-latest",
+   "language": "python",
+   "name": "seaborn-py38-latest"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/doc/tutorial/relational.ipynb
+++ b/doc/tutorial/relational.ipynb
@@ -277,7 +277,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.relplot(x=\"timepoint\", y=\"signal\", ci=None, kind=\"line\", data=fmri);"
+    "sns.relplot(x=\"timepoint\", y=\"signal\", errorbar=None, kind=\"line\", data=fmri);"
    ]
   },
   {
@@ -293,7 +293,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.relplot(x=\"timepoint\", y=\"signal\", kind=\"line\", ci=\"sd\", data=fmri);"
+    "sns.relplot(x=\"timepoint\", y=\"signal\", kind=\"line\", errorbar=\"sd\", data=fmri);"
    ]
   },
   {

--- a/seaborn/_core.py
+++ b/seaborn/_core.py
@@ -1162,6 +1162,9 @@ class VectorPlotter:
 
     def _log_scaled(self, axis):
         """Return True if specified axis is log scaled on all attached axes."""
+        if not hasattr(self, "ax"):
+            return False
+
         if self.ax is None:
             axes_list = self.facets.axes.flatten()
         else:

--- a/seaborn/_statistics.py
+++ b/seaborn/_statistics.py
@@ -508,7 +508,7 @@ def _validate_errorbar_arg(arg):
         "sd": 1,
     }
 
-    usage = "errorbar argument must be a callable, string, or (string, number) tuple"
+    usage = "`errorbar` must be a callable, string, or (string, number) tuple"
 
     if arg is None:
         return None, None

--- a/seaborn/_statistics.py
+++ b/seaborn/_statistics.py
@@ -444,8 +444,8 @@ class EstimateAggregator:
         errorbar : string, (string, number) tuple, or callable
             Name of errorbar method (either "ci", "pi", "se", or "sd"), or a tuple
             with a method name and a level parameter, or a function that maps from a
-            vector to a (min, max) interval.
-            TODO add link to errorbar tutorial when written
+            vector to a (min, max) interval. See the :ref:`tutorial <errorbar_tutorial>`
+            for more information.
         boot_kws
             Additional keywords are passed to bootstrap when error_method is "ci".
 

--- a/seaborn/algorithms.py
+++ b/seaborn/algorithms.py
@@ -61,6 +61,8 @@ def bootstrap(*args, **kwargs):
         units = np.asarray(units)
 
     # Allow for a function that is the name of a method on an array
+    # TODO also allow for named numpy function? Is there an inventory of aggregators?
+    # TODO also check for nans in array, use nan-aware version of available and needed?
     if isinstance(func, str):
         def f(x):
             return getattr(x, func)()

--- a/seaborn/algorithms.py
+++ b/seaborn/algorithms.py
@@ -11,17 +11,18 @@ def bootstrap(*args, **kwargs):
     axis and pass to a summary function.
 
     Keyword arguments:
-        n_boot : int, default 10000
+        n_boot : int, default=10000
             Number of iterations
-        axis : int, default None
+        axis : int, default=None
             Will pass axis to ``func`` as a keyword argument.
-        units : array, default None
+        units : array, default=None
             Array of sampling unit IDs. When used the bootstrap resamples units
             and then observations within units instead of individual
             datapoints.
-        func : string or callable, default np.mean
-            Function to call on the args that are passed in. If string, tries
-            to use as named method on numpy array.
+        func : string or callable, default="mean"
+            Function to call on the args that are passed in. If string, uses as
+            name of function in the numpy namespace. If nans are present in the
+            data, will try to use nan-aware version of named function.
         seed : Generator | SeedSequence | RandomState | int | None
             Seed for the random number generator; useful if you want
             reproducible resamples.
@@ -39,7 +40,7 @@ def bootstrap(*args, **kwargs):
 
     # Default keyword arguments
     n_boot = kwargs.get("n_boot", 10000)
-    func = kwargs.get("func", np.mean)
+    func = kwargs.get("func", "mean")
     axis = kwargs.get("axis", None)
     units = kwargs.get("units", None)
     random_seed = kwargs.get("random_seed", None)
@@ -60,12 +61,22 @@ def bootstrap(*args, **kwargs):
     if units is not None:
         units = np.asarray(units)
 
-    # Allow for a function that is the name of a method on an array
-    # TODO also allow for named numpy function? Is there an inventory of aggregators?
-    # TODO also check for nans in array, use nan-aware version of available and needed?
     if isinstance(func, str):
-        def f(x):
-            return getattr(x, func)()
+
+        # Allow named numpy functions
+        f = getattr(np, func)
+
+        # Try to use nan-aware version of function if necessary
+        missing_data = np.isnan(np.sum(np.column_stack(args)))
+
+        if missing_data and not func.startswith("nan"):
+            nanf = getattr(np, f"nan{func}", None)
+            if nanf is None:
+                msg = f"Data contain nans but no nan-aware version of `{func}` found"
+                warnings.warn(msg, UserWarning)
+            else:
+                f = nanf
+
     else:
         f = func
 

--- a/seaborn/relational.py
+++ b/seaborn/relational.py
@@ -180,6 +180,7 @@ _param_docs = DocstringComponents.from_nested_components(
     core=_core_docs["params"],
     facets=DocstringComponents(_facet_docs),
     rel=DocstringComponents(_relational_docs),
+    stat=DocstringComponents.from_function_params(EstimateAggregator.__init__),
 )
 
 
@@ -774,6 +775,7 @@ err_kws : dict of keyword arguments
     kwargs are passed either to :meth:`matplotlib.axes.Axes.fill_between`
     or :meth:`matplotlib.axes.Axes.errorbar`, depending on ``err_style``.
 {params.rel.legend}
+{params.stat.errorbar}
 {params.core.ax}
 kwargs : key, value mappings
     Other keyword arguments are passed down to

--- a/seaborn/relational.py
+++ b/seaborn/relational.py
@@ -10,6 +10,7 @@ from ._core import (
 from .utils import (
     locator_to_legend_entries,
     adjust_legend_subtitles,
+    _deprecate_ci,
 )
 from ._statistics import EstimateAggregator
 from .axisgrid import FacetGrid, _facet_docs
@@ -141,9 +142,11 @@ estimator : name of pandas method or callable or None
     """,
     ci="""
 ci : int or "sd" or None
-    Size of the confidence interval to draw when aggregating with an
-    estimator. "sd" means to draw the standard deviation of the data.
-    Setting to ``None`` will skip bootstrapping.
+    Size of the confidence interval to draw when aggregating.
+
+    .. deprecated:: 0.12.0
+        Use the new `errorbar` parameter for more flexibility.
+
     """,
     n_boot="""
 n_boot : int
@@ -647,15 +650,8 @@ def lineplot(
     ax=None, **kwargs
 ):
 
-    # TODO deprecate ci=
-    if ci is not None:
-        if ci == "sd":
-            errorbar = "sd"
-            msg = "use `errorbar='sd'` for same effect."
-        else:
-            errorbar = ("ci", ci)
-            msg = f"use `errorbar=('ci', {ci})` for same effect."
-        warnings.warn(f"The `ci` parameter is deprecated; {msg}", UserWarning)
+    # Handle deprecation of ci parameter
+    errorbar = _deprecate_ci(errorbar, ci)
 
     variables = _LinePlotter.get_semantics(locals())
     p = _LinePlotter(

--- a/seaborn/relational.py
+++ b/seaborn/relational.py
@@ -9,12 +9,12 @@ from ._core import (
     VectorPlotter,
 )
 from .utils import (
-    ci_to_errsize,
     locator_to_legend_entries,
     adjust_legend_subtitles,
     ci as ci_func
 )
 from .algorithms import bootstrap
+from ._statistics import EstimateAggregator
 from .axisgrid import FacetGrid, _facet_docs
 from ._decorators import _deprecate_positional_args
 from ._docstrings import (
@@ -354,10 +354,11 @@ class _LinePlotter(_RelationalPlotter):
         self, *,
         data=None, variables={},
         estimator=None, ci=None, n_boot=None, seed=None,
-        sort=True, err_style=None, err_kws=None, legend=None
+        sort=True, err_style=None, err_kws=None, legend=None,
+        errorbar=None,
     ):
 
-        # TODO this is messy, we want the mapping to be agnoistic about
+        # TODO this is messy, we want the mapping to be agnostic about
         # the kind of plot to draw, but for the time being we need to set
         # this information so the SizeMapping can use it
         self._default_size_range = (
@@ -367,6 +368,7 @@ class _LinePlotter(_RelationalPlotter):
         super().__init__(data=data, variables=variables)
 
         self.estimator = estimator
+        self.errorbar = errorbar
         self.ci = ci
         self.n_boot = n_boot
         self.seed = seed
@@ -466,6 +468,15 @@ class _LinePlotter(_RelationalPlotter):
             linestyle=orig_linestyle,
         ))
 
+        # Initialize the aggregation object
+        agg = EstimateAggregator(
+            self.estimator, self.errorbar, n_boot=self.n_boot, seed=self.seed,
+        )
+
+        # TODO abstract variable to aggregate over here-ish. Better name?
+        agg_var = "y"
+        grouper = ["x"]
+
         # Loop over the semantic subsets and add to the plot
         grouping_vars = "hue", "size", "style"
         for sub_vars, sub_data in self.iter_data(grouping_vars, from_comp_data=True):
@@ -482,23 +493,15 @@ class _LinePlotter(_RelationalPlotter):
             # This is straightforward absent aggregation, but complicated with it.
             sub_data = sub_data.dropna()
 
-            # Due to the original design, code below was written assuming that
-            # sub_data always has x, y, and units columns, which may be empty.
-            # Adding this here to avoid otherwise disruptive changes, but it
-            # could get removed if the rest of the logic is sorted out
-            null = pd.Series(index=sub_data.index, dtype=float)
-
-            x = sub_data.get("x", null)
-            y = sub_data.get("y", null)
-            u = sub_data.get("units", null)
-
             if self.estimator is not None:
                 if "units" in self.variables:
+                    # TODO eventually relax this constraint
                     err = "estimator must be None when specifying units"
                     raise ValueError(err)
-                x, y, y_ci = self.aggregate(y, x, u)
-            else:
-                y_ci = None
+                grouped = sub_data.groupby(grouper, sort=self.sort)
+                # Could pass as_index=False instead of reset_index,
+                # but that fails on a corner case with older pandas.
+                sub_data = grouped.apply(agg, agg_var).reset_index()
 
             if "hue" in sub_vars:
                 kws["color"] = self._hue_map(sub_vars["hue"])
@@ -519,39 +522,41 @@ class _LinePlotter(_RelationalPlotter):
 
             # --- Draw the main line
 
-            x, y = np.asarray(x), np.asarray(y)
-
             if "units" in self.variables:
-                for u_i in u.unique():
-                    rows = np.asarray(u == u_i)
-                    ax.plot(x[rows], y[rows], **kws)
+                for _, unit_data in sub_data.groupby("units"):
+                    ax.plot(unit_data["x"], unit_data["y"], **kws)
             else:
-                line, = ax.plot(x, y, **kws)
+                line, = ax.plot(sub_data["x"], sub_data["y"], **kws)
 
             # --- Draw the confidence intervals
 
-            if y_ci is not None:
+            if self.estimator is not None and self.errorbar is not None:
 
-                low, high = np.asarray(y_ci["low"]), np.asarray(y_ci["high"])
+                # TODO handling of orientation will need to happen here
 
                 if self.err_style == "band":
 
-                    ax.fill_between(x, low, high, color=line_color, **err_kws)
+                    ax.fill_between(
+                        sub_data["x"], sub_data["ymin"], sub_data["ymax"],
+                        color=line_color, **err_kws
+                    )
 
                 elif self.err_style == "bars":
 
-                    y_err = ci_to_errsize((low, high), y)
-                    ebars = ax.errorbar(x, y, y_err, linestyle="",
-                                        color=line_color, alpha=line_alpha,
-                                        **err_kws)
+                    error_deltas = (
+                        sub_data["y"] - sub_data["ymin"],
+                        sub_data["ymax"] - sub_data["y"],
+                    )
+                    ebars = ax.errorbar(
+                        sub_data["x"], sub_data["y"], error_deltas,
+                        linestyle="", color=line_color, alpha=line_alpha,
+                        **err_kws
+                    )
 
                     # Set the capstyle properly on the error bars
                     for obj in ebars.get_children():
-                        try:
+                        if isinstance(obj, mpl.collections.LineCollection):
                             obj.set_capstyle(line_capstyle)
-                        except AttributeError:
-                            # Does not exist on mpl < 2.2
-                            pass
 
         # Finalize the axes details
         self._add_axis_labels(ax)
@@ -676,16 +681,29 @@ def lineplot(
     palette=None, hue_order=None, hue_norm=None,
     sizes=None, size_order=None, size_norm=None,
     dashes=True, markers=None, style_order=None,
-    units=None, estimator="mean", ci=95, n_boot=1000, seed=None,
+    units=None, estimator="mean", ci=None, n_boot=1000, seed=None,
     sort=True, err_style="band", err_kws=None,
-    legend="auto", ax=None, **kwargs
+    legend="auto",
+    errorbar=("ci", 95),
+    ax=None, **kwargs
 ):
+
+    # TODO deprecate ci=
+    if ci is not None:
+        if ci == "sd":
+            errorbar = "sd"
+            msg = "use `errorbar='sd'` for same effect."
+        else:
+            errorbar = ("ci", ci)
+            msg = f"use `errorbar=('ci', {ci})` for same effect."
+        warnings.warn(f"The `ci` parameter is deprecated; {msg}", UserWarning)
 
     variables = _LinePlotter.get_semantics(locals())
     p = _LinePlotter(
         data=data, variables=variables,
         estimator=estimator, ci=ci, n_boot=n_boot, seed=seed,
         sort=sort, err_style=err_style, err_kws=err_kws, legend=legend,
+        errorbar=errorbar,
     )
 
     p.map_hue(palette=palette, order=hue_order, norm=hue_norm)

--- a/seaborn/relational.py
+++ b/seaborn/relational.py
@@ -456,6 +456,12 @@ class _LinePlotter(_RelationalPlotter):
                 # but that fails on a corner case with older pandas.
                 sub_data = grouped.apply(agg, agg_var).reset_index()
 
+            # TODO this is pretty ad hoc ; see GH2409
+            for var in "xy":
+                if self._log_scaled(var):
+                    for col in sub_data.filter(regex=f"^{var}"):
+                        sub_data[col] = np.power(10, sub_data[col])
+
             if "hue" in sub_vars:
                 kws["color"] = self._hue_map(sub_vars["hue"])
             if "size" in sub_vars:

--- a/seaborn/tests/test_algorithms.py
+++ b/seaborn/tests/test_algorithms.py
@@ -200,3 +200,20 @@ def test_bad_seed_old():
 
     with pytest.raises(ValueError):
         algo._handle_random_seed("not_a_random_seed")
+
+
+def test_nanaware_func_auto(random):
+
+    x = np.random.normal(size=10)
+    x[0] = np.nan
+    boots = algo.bootstrap(x, func="mean")
+    assert not np.isnan(boots).any()
+
+
+def test_nanaware_func_warning(random):
+
+    x = np.random.normal(size=10)
+    x[0] = np.nan
+    with pytest.warns(UserWarning, match="Data contain nans but"):
+        boots = algo.bootstrap(x, func="ptp")
+    assert np.isnan(boots).any()

--- a/seaborn/tests/test_relational.py
+++ b/seaborn/tests/test_relational.py
@@ -1,5 +1,4 @@
 from itertools import product
-import warnings
 import numpy as np
 import pandas as pd
 import matplotlib as mpl
@@ -719,85 +718,6 @@ class TestRelationalPlotter(Helpers):
 
 
 class TestLinePlotter(Helpers):
-
-    def test_aggregate(self, long_df):
-
-        p = _LinePlotter(data=long_df, variables=dict(x="x", y="y"))
-        p.n_boot = 10000
-        p.sort = False
-
-        x = pd.Series(np.tile([1, 2], 100))
-        y = pd.Series(np.random.randn(200))
-        y_mean = y.groupby(x).mean()
-
-        def sem(x):
-            return np.std(x) / np.sqrt(len(x))
-
-        y_sem = y.groupby(x).apply(sem)
-        y_cis = pd.DataFrame(dict(low=y_mean - y_sem,
-                                  high=y_mean + y_sem),
-                             columns=["low", "high"])
-
-        p.ci = 68
-        p.estimator = "mean"
-        index, est, cis = p.aggregate(y, x)
-        assert_array_equal(index.values, x.unique())
-        assert est.index.equals(index)
-        assert est.values == pytest.approx(y_mean.values)
-        assert cis.values == pytest.approx(y_cis.values, 4)
-        assert list(cis.columns) == ["low", "high"]
-
-        p.estimator = np.mean
-        index, est, cis = p.aggregate(y, x)
-        assert_array_equal(index.values, x.unique())
-        assert est.index.equals(index)
-        assert est.values == pytest.approx(y_mean.values)
-        assert cis.values == pytest.approx(y_cis.values, 4)
-        assert list(cis.columns) == ["low", "high"]
-
-        p.seed = 0
-        _, _, ci1 = p.aggregate(y, x)
-        _, _, ci2 = p.aggregate(y, x)
-        assert_array_equal(ci1, ci2)
-
-        y_std = y.groupby(x).std()
-        y_cis = pd.DataFrame(dict(low=y_mean - y_std,
-                                  high=y_mean + y_std),
-                             columns=["low", "high"])
-
-        p.ci = "sd"
-        index, est, cis = p.aggregate(y, x)
-        assert_array_equal(index.values, x.unique())
-        assert est.index.equals(index)
-        assert est.values == pytest.approx(y_mean.values)
-        assert cis.values == pytest.approx(y_cis.values)
-        assert list(cis.columns) == ["low", "high"]
-
-        p.ci = None
-        index, est, cis = p.aggregate(y, x)
-        assert cis is None
-
-        p.ci = 68
-        x, y = pd.Series([1, 2, 3]), pd.Series([4, 3, 2])
-        index, est, cis = p.aggregate(y, x)
-        assert_array_equal(index.values, x)
-        assert_array_equal(est.values, y)
-        assert cis is None
-
-        x, y = pd.Series([1, 1, 2]), pd.Series([2, 3, 4])
-        index, est, cis = p.aggregate(y, x)
-        assert cis.loc[2].isnull().all()
-
-        p = _LinePlotter(data=long_df, variables=dict(x="x", y="y"))
-        p.estimator = "mean"
-        p.n_boot = 100
-        p.ci = 95
-        x = pd.Categorical(["a", "b", "a", "b"], ["a", "b", "c"])
-        y = pd.Series([1, 1, 2, 2])
-        with warnings.catch_warnings():
-            warnings.simplefilter("error", RuntimeWarning)
-            index, est, cis = p.aggregate(y, x)
-            assert cis.loc[["c"]].isnull().all().all()
 
     def test_legend_data(self, long_df):
 

--- a/seaborn/tests/test_relational.py
+++ b/seaborn/tests/test_relational.py
@@ -1079,7 +1079,7 @@ class TestLinePlotter(Helpers):
         p = _LinePlotter(
             data=long_df,
             variables=dict(x="x", y="y"),
-            estimator="mean", err_style="band", ci="sd", sort=True
+            estimator="mean", err_style="band", errorbar="sd", sort=True
         )
 
         ax.clear()
@@ -1097,7 +1097,7 @@ class TestLinePlotter(Helpers):
                 x=[1, 1, 1, 2, 2, 2, 3, 3, 3],
                 y=[1, 2, 3, 3, np.nan, 5, 4, 5, 6],
             ),
-            estimator="mean", err_style="band", ci=95, n_boot=100, sort=True,
+            estimator="mean", err_style="band", errorbar="ci", n_boot=100, sort=True,
         )
         ax.clear()
         p.plot(ax, {})
@@ -1110,7 +1110,7 @@ class TestLinePlotter(Helpers):
         p = _LinePlotter(
             data=long_df,
             variables=dict(x="x", y="y", hue="a"),
-            estimator="mean", err_style="band", ci="sd"
+            estimator="mean", err_style="band", errorbar="sd"
         )
 
         ax.clear()
@@ -1122,7 +1122,7 @@ class TestLinePlotter(Helpers):
         p = _LinePlotter(
             data=long_df,
             variables=dict(x="x", y="y", hue="a"),
-            estimator="mean", err_style="bars", ci="sd"
+            estimator="mean", err_style="bars", errorbar="sd"
         )
 
         ax.clear()

--- a/seaborn/tests/test_relational.py
+++ b/seaborn/tests/test_relational.py
@@ -20,6 +20,8 @@ from ..relational import (
     scatterplot
 )
 
+from .._testing import assert_plots_equal
+
 
 @pytest.fixture(params=[
     dict(x="x", y="y"),
@@ -1346,6 +1348,20 @@ class TestLinePlotter(Helpers):
 
         lineplot(x="x", y="y", hue="f", size="s", data=object_df)
         ax.clear()
+
+    def test_ci_deprecation(self, long_df):
+
+        axs = plt.figure().subplots(2)
+        lineplot(data=long_df, x="x", y="y", errorbar=("ci", 95), seed=0, ax=axs[0])
+        with pytest.warns(UserWarning, match="The `ci` parameter is deprecated"):
+            lineplot(data=long_df, x="x", y="y", ci=95, seed=0, ax=axs[1])
+        assert_plots_equal(*axs)
+
+        axs = plt.figure().subplots(2)
+        lineplot(data=long_df, x="x", y="y", errorbar="sd", ax=axs[0])
+        with pytest.warns(UserWarning, match="The `ci` parameter is deprecated"):
+            lineplot(data=long_df, x="x", y="y", ci="sd", ax=axs[1])
+        assert_plots_equal(*axs)
 
 
 class TestScatterPlotter(Helpers):

--- a/seaborn/tests/test_relational.py
+++ b/seaborn/tests/test_relational.py
@@ -1122,6 +1122,34 @@ class TestLinePlotter(Helpers):
         ax.clear()
         p.plot(ax, {})
 
+    def test_log_scale(self):
+
+        f, ax = plt.subplots()
+        ax.set_xscale("log")
+
+        x = [1, 10, 100]
+        y = [1, 2, 3]
+
+        lineplot(x=x, y=y)
+        line = ax.lines[0]
+        assert_array_equal(line.get_xdata(), x)
+        assert_array_equal(line.get_ydata(), y)
+
+        f, ax = plt.subplots()
+        ax.set_xscale("log")
+        ax.set_yscale("log")
+
+        x = [1, 1, 2, 2]
+        y = [1, 10, 1, 100]
+
+        lineplot(x=x, y=y, err_style="bars", errorbar=("pi", 100))
+        line = ax.lines[0]
+        assert line.get_ydata()[1] == 10
+
+        ebars = ax.collections[0].get_segments()
+        assert_array_equal(ebars[0][:, 1], y[:2])
+        assert_array_equal(ebars[1][:, 1], y[2:])
+
     def test_axis_labels(self, long_df):
 
         f, (ax1, ax2) = plt.subplots(1, 2, sharey=True)

--- a/seaborn/tests/test_statistics.py
+++ b/seaborn/tests/test_statistics.py
@@ -580,17 +580,14 @@ class TestEstimateAggregator:
         assert method is f
         assert level is None
 
-        with pytest.raises(ValueError, match="`errorbar` must be one of"):
-            _validate_errorbar_arg("sem")
+        bad_args = [
+            ("sem", ValueError),
+            (("std", 2), ValueError),
+            (("pi", 5, 95), ValueError),
+            (95, TypeError),
+            (("ci", "large"), TypeError),
+        ]
 
-        with pytest.raises(ValueError, match="`errorbar` must be one of"):
-            _validate_errorbar_arg(("std", 2))
-
-        with pytest.raises(ValueError, match="errorbar argument must be"):
-            _validate_errorbar_arg(("pi", 5, 95))
-
-        with pytest.raises(TypeError, match="errorbar argument must be"):
-            _validate_errorbar_arg(95)
-
-        with pytest.raises(TypeError, match="errorbar argument must be"):
-            _validate_errorbar_arg(("ci", "large"))
+        for arg, exception in bad_args:
+            with pytest.raises(exception, match="`errorbar` must be"):
+                _validate_errorbar_arg(arg)

--- a/seaborn/utils.py
+++ b/seaborn/utils.py
@@ -613,3 +613,24 @@ def adjust_legend_subtitles(legend):
             for text in text_area.get_children():
                 if font_size is not None:
                     text.set_size(font_size)
+
+
+def _deprecate_ci(errorbar, ci):
+    """
+    Warn on usage of ci= and convert to appropriate errorbar= arg.
+
+    ci was deprecated when errorbar was added in 0.12. It should not be removed
+    completely for some time, but it can be moved out of function definitions
+    (and extracted from kwargs) after one cycle.
+
+    """
+    if ci is not None:
+        if ci == "sd":
+            errorbar = "sd"
+            msg = "use `errorbar='sd'` for same effect."
+        else:
+            errorbar = ("ci", ci)
+            msg = f"use `errorbar=('ci', {ci})` for same effect."
+        warnings.warn(f"The `ci` parameter is deprecated; {msg}", UserWarning)
+
+    return errorbar

--- a/seaborn/utils.py
+++ b/seaborn/utils.py
@@ -631,6 +631,7 @@ def _deprecate_ci(errorbar, ci):
         else:
             errorbar = ("ci", ci)
             msg = f"use `errorbar=('ci', {ci})` for same effect."
-        warnings.warn(f"The `ci` parameter is deprecated; {msg}", UserWarning)
+        msg = f"The `ci` parameter is deprecated; {msg}"
+        warnings.warn(msg, UserWarning)
 
     return errorbar


### PR DESCRIPTION
This PR adds a new internal statistics object for doing aggregation with an estimator function and expands the flexibility of the error bars that operation can produce.

This implements and closes #2403. More logic is given there. Briefly, the new errorbars can be:

- "ci", for a bootstrap confidence interval of a given width (default 95)
- "pi", for a percentile interval of the data with a given width (default 95)
- "se", for +/- the standard error, scaled by a given factor (default 1)
- "sd", for +/- the standard deviation, scaled by a given factor (default 1)
- an arbitrary callable that maps a vector to a (min, max) interval

To Dos:
- [x] Use this function within the relational module (other modules will need to come after refactor)
- [x] Address TODOs in bootstrap function, making it a bit easier to work with
- [x] Deprecate old `ci=` parameter
- [x] Decision about raising on `errorbar="se"` when `estimator` is not `mean`
- [x] Handle log-scaled axes properly
- [x] Write out a stub for a user guide page on this (completion will need integration in other modules)
- [x] Write out a stub for the release notes

This (partly) addresses several longstanding issues. It won't fully address them until the logic is integrated into the other modules; doing so will happen after they are refactored to use the new core objects. But I will close the open issues now, and then link back here when the downstream work is implemented. Relevant issues include #331, #1501, #1427, #1492, #1892, #2283, #2332, 