### PR TITLE
Revert change to forced draw command

### DIFF
--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -131,7 +131,10 @@ class Grid:
                 adjust_legend_subtitles(figlegend)
 
             # Draw the plot to set the bounding boxes correctly
-            self.fig.canvas.draw()
+            # self.fig.canvas.draw()
+            if hasattr(self.fig.canvas, "get_renderer"):
+                self.fig.draw(self.fig.canvas.get_renderer())
+
 
             # Calculate and set the new width of the figure so the legend fits
             legend_width = figlegend.get_window_extent().width / self.fig.dpi
@@ -139,7 +142,9 @@ class Grid:
             self.fig.set_size_inches(fig_width + legend_width, fig_height)
 
             # Draw the plot again to get the new transformations
-            self.fig.canvas.draw()
+            # self.fig.canvas.draw()
+            if hasattr(self.fig.canvas, "get_renderer"):
+                self.fig.draw(self.fig.canvas.get_renderer())
 
             # Now calculate how much space we need on the right side
             legend_width = figlegend.get_window_extent().width / self.fig.dpi

--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -332,7 +332,10 @@ class _HeatMapper:
         ytl = ax.set_yticklabels(yticklabels, rotation="vertical")
 
         # Possibly rotate them if they overlap
-        ax.figure.canvas.draw()
+        # ax.figure.canvas.draw()
+        if hasattr(ax.figure.canvas, "get_renderer"):
+            ax.figure.draw(ax.figure.canvas.get_renderer())
+
         if axis_ticklabels_overlap(xtl):
             plt.setp(xtl, rotation="vertical")
         if axis_ticklabels_overlap(ytl):
@@ -722,7 +725,10 @@ class _DendrogramPlotter(object):
         ytl = ax.set_yticklabels(self.yticklabels, rotation='vertical')
 
         # Force a draw of the plot to avoid matplotlib window error
-        ax.figure.canvas.draw()
+        # ax.figure.canvas.draw()
+        if hasattr(ax.figure.canvas, "get_renderer"):
+            ax.figure.draw(ax.figure.canvas.get_renderer())
+
         if len(ytl) > 0 and axis_ticklabels_overlap(ytl):
             plt.setp(ytl, rotation="horizontal")
         if len(xtl) > 0 and axis_ticklabels_overlap(xtl):


### PR DESCRIPTION
The change in #2399 inadvertantly broke seaborn on the macosx mpl backend.

See https://github.com/matplotlib/matplotlib/issues/19197

This PR reverts that change until the issue can be sorted out.