### PR TITLE
make Freedman-Diaconis-rule NaN-agnostic

### DIFF
--- a/seaborn/distributions.py
+++ b/seaborn/distributions.py
@@ -2392,7 +2392,7 @@ about the breadth of options available for each plot kind.
 def _freedman_diaconis_bins(a):
     """Calculate number of hist bins using Freedman-Diaconis rule."""
     # From https://stats.stackexchange.com/questions/798/
-    a = np.asarray(a)
+    a = remove_na(np.asarray(a))
     if len(a) < 2:
         return 1
     iqr = np.subtract.reduce(np.nanpercentile(a, [75, 25]))


### PR DESCRIPTION
This makes the function `_freedman_diaconis_bins` more robust.

As discussed in #2414 the arrays that are passed to the function in the seaborn code undergo are submitted to the `remove_na` function beforehand and the na removal is thereby mute.

@mwaskom Feel free to close the PR, if you disagree that this change adds value to the codebase. 