### PR TITLE
boxplot whis keyword docstring clarification

### DIFF
--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -2276,9 +2276,9 @@ boxplot.__doc__ = dedent("""\
         Size of the markers used to indicate outlier observations.
     {linewidth}
     whis : float, optional
-        Proportion of the IQR past the low and high quartiles to extend the
-        plot whiskers. Points outside this range will be identified as
-        outliers.
+        Maximum length of the plot whiskers as proportion of the
+        interquartile range. Whiskers extend to the furthest datum within
+        that length. Points further out will be identified as outliers.
     {ax_in}
     kwargs : key, value mappings
         Other keyword arguments are passed through to

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -2277,8 +2277,8 @@ boxplot.__doc__ = dedent("""\
     {linewidth}
     whis : float, optional
         Maximum length of the plot whiskers as proportion of the
-        interquartile range. Whiskers extend to the furthest datum within
-        that length. Points further out will be identified as outliers.
+        interquartile range. Whiskers extend to the furthest datapoint
+        within that range. More extreme points are marked as outliers.
     {ax_in}
     kwargs : key, value mappings
         Other keyword arguments are passed through to


### PR DESCRIPTION
The docstring for the `whis` keyword in `boxplots` has an inaccurate description. That is, whiskers don't extend to 1.5*IQR, rather they extend to the furthest datum within 1.5*IQR. I propose a clearer wording.

Evidence for confusion caused by this inaccuracy can be found [here on Stackoverflow](https://stackoverflow.com/questions/49139299/whisker-is-defined-as-1-5-iqr-how-could-two-whikers-in-plot-from-python-seabor).