### PR TITLE
Support Float64Dtype in boxenplot, related to #2434

### DIFF
--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -1840,7 +1840,10 @@ class _LVPlotter(_CategoricalPlotter):
         """Get the number of data points and calculate `depth` of
         letter-value plot."""
         vals = np.asarray(vals)
-        vals = vals[np.isfinite(vals)]
+        # Remove infinite values while handling a 'object' dtype
+        # that can come from pd.Float64Dtype() input
+        with pd.option_context('mode.use_inf_as_null', True):
+            vals = vals[~pd.isnull(vals)]
         n = len(vals)
         p = self.outlier_prop
 

--- a/seaborn/tests/test_categorical.py
+++ b/seaborn/tests/test_categorical.py
@@ -7,6 +7,7 @@ from matplotlib.colors import rgb2hex
 import pytest
 from pytest import approx
 import numpy.testing as npt
+from distutils.version import LooseVersion
 
 from .. import categorical as cat
 from .. import palettes
@@ -3001,5 +3002,17 @@ class TestBoxenPlotter(CategoricalFixture):
             ax = cat.boxenplot(x="g", y="y", hue="h", data=self.df)
             obs = ax.get_legend().get_title().get_fontproperties().get_size()
             assert obs == exp
+
+        plt.close("all")
+
+    @pytest.mark.skipif(
+        LooseVersion(pd.__version__) < "1.2",
+        reason="Test requires pandas>=1.2")
+    def test_Float64_input(self):
+        data = pd.DataFrame(
+            {"x": np.random.choice(["a", "b"], 20), "y": np.random.random(20)}
+        )
+        data['y'] = data['y'].astype(pd.Float64Dtype())
+        _ = cat.boxenplot(x="x", y="y", data=data)
 
         plt.close("all")


### PR DESCRIPTION
This PR solves the above issue.
Test added for when pandas >= 1.2.
