### PR TITLE
Add percent-based normalization in histplot

### DIFF
--- a/doc/releases/v0.12.0.txt
+++ b/doc/releases/v0.12.0.txt
@@ -16,6 +16,8 @@ v0.12.0 (Unreleased)
 
   - In :func:`swarmplot`, the proportion of points that must overlap before issuing a warning can now be controlled with the `warn_thresh` parameter (:pr:`2447`).
 
+- |Enhancement| In :func:`histplot`, added `stat="percent"` as an option for normalization such that bar heights sum to 100 (:pr:`2461`).
+
 - |Fix| In :func:`lineplot, allowed the `dashes` keyword to set the style of a line without mapping a `style` variable (:pr:`2449`).
 
 - |Fix| In :func:`rugplot`, fixed a bug that prevented the use of datetime data (:pr:`2458`).

--- a/seaborn/_statistics.py
+++ b/seaborn/_statistics.py
@@ -209,7 +209,7 @@ class Histogram:
 
         Parameters
         ----------
-        stat : {"count", "frequency", "density", "probability"}
+        stat : {"count", "frequency", "density", "probability", "percent"}
             Aggregate statistic to compute in each bin.
 
             - ``count`` shows the number of observations
@@ -234,7 +234,8 @@ class Histogram:
             If True, return the cumulative statistic.
 
         """
-        _check_argument("stat", ["count", "density", "probability", "frequency"], stat)
+        stat_choices = ["count", "frequency", "density", "probability", "percent"]
+        _check_argument("stat", stat_choices, stat)
 
         self.stat = stat
         self.bins = bins
@@ -335,6 +336,8 @@ class Histogram:
 
         if self.stat == "probability":
             hist = hist.astype(float) / hist.sum()
+        elif self.stat == "percent":
+            hist = hist.astype(float) / hist.sum() * 100
         elif self.stat == "frequency":
             hist = hist.astype(float) / area
 
@@ -359,6 +362,8 @@ class Histogram:
 
         if self.stat == "probability":
             hist = hist.astype(float) / hist.sum()
+        elif self.stat == "percent":
+            hist = hist.astype(float) / hist.sum() * 100
         elif self.stat == "frequency":
             hist = hist.astype(float) / np.diff(bin_edges)
 

--- a/seaborn/tests/test_distributions.py
+++ b/seaborn/tests/test_distributions.py
@@ -1295,6 +1295,12 @@ class TestHistPlotUnivariate(SharedAxesLevelTests):
             bar_heights = [b.get_height() for b in bars]
             assert sum(bar_heights) == pytest.approx(1)
 
+    def test_percent_stat(self, flat_series):
+
+        ax = histplot(flat_series, stat="percent")
+        bar_heights = [b.get_height() for b in ax.patches]
+        assert sum(bar_heights) == 100
+
     def test_common_bins(self, long_df):
 
         n = 10

--- a/seaborn/tests/test_distributions.py
+++ b/seaborn/tests/test_distributions.py
@@ -1816,6 +1816,17 @@ class TestHistPlotBivariate:
             density, (x_edges, y_edges) = sub_hist(sub_df["x"], sub_df["y"])
             assert_array_equal(mesh_data.data, density.T.flat)
 
+    @pytest.mark.parametrize("stat", ["probability", "percent"])
+    def test_mesh_normalization(self, long_df, stat):
+
+        ax = histplot(
+            long_df, x="x", y="y", stat=stat,
+        )
+
+        mesh_data = ax.collections[0].get_array()
+        expected_sum = {"probability": 1, "percent": 100}[stat]
+        assert mesh_data.data.sum() == expected_sum
+
     def test_mesh_colors(self, long_df):
 
         color = "r"


### PR DESCRIPTION
e.g.

```python
sns.histplot(
    data=tips,
    x="day", hue="time",
    stat="percent", multiple="dodge", shrink=.8
)
```
![image](https://user-images.githubusercontent.com/315810/106403319-02834d80-63fc-11eb-986b-c110e7a6bc83.png)
