### PR TITLE
Fix histplot shrink with non-discrete bins

### DIFF
--- a/doc/releases/v0.12.0.txt
+++ b/doc/releases/v0.12.0.txt
@@ -28,6 +28,8 @@ v0.12.0 (Unreleased)
 
 - |Fix| In :func:`histplot` and :func:`kdeplot`, fixed a bug where the `multiple` was ignored when `hue` was provided as a vector without a name (:pr:`2462`).
 
+- |Fix| In :func:`histplot`, fixed a bug where using `shrink` with non-discrete bins shifted bar positions inaccurately (:pr:`2477`).
+
 - |Fix| In :func:`displot`, fixed a bug where `common_norm` was ignored when `kind="hist"` and faceting was used without assigning `hue` (:pr:`2468`).
 
 - |Defaults| In :func:`displot`, the default alpha value now adjusts to a provided `multiple` parameter even when `hue` is not assigned (:pr:`2462`).

--- a/seaborn/distributions.py
+++ b/seaborn/distributions.py
@@ -459,9 +459,12 @@ class _DistributionPlotter(VectorPlotter):
                 edges = np.power(10, edges)
 
             # Pack the histogram data and metadata together
+            orig_widths = np.diff(edges)
+            widths = shrink * orig_widths
+            edges = edges[:-1] + (1 - shrink) / 2 * orig_widths
             index = pd.MultiIndex.from_arrays([
-                pd.Index(edges[:-1], name="edges"),
-                pd.Index(np.diff(edges) * shrink, name="widths"),
+                pd.Index(edges, name="edges"),
+                pd.Index(widths, name="widths"),
             ])
             hist = pd.Series(heights, index=index, name="heights")
 
@@ -536,9 +539,8 @@ class _DistributionPlotter(VectorPlotter):
                 # Use matplotlib bar plotting
 
                 plot_func = ax.bar if self.data_variable == "x" else ax.barh
-                move = .5 * (1 - shrink)
                 artists = plot_func(
-                    hist["edges"] + move,
+                    hist["edges"],
                     hist["heights"] - bottom,
                     hist["widths"],
                     bottom,

--- a/seaborn/tests/test_distributions.py
+++ b/seaborn/tests/test_distributions.py
@@ -1604,10 +1604,21 @@ class TestHistPlotUnivariate(SharedAxesLevelTests):
 
     def test_shrink(self, long_df):
 
+        f, (ax1, ax2) = plt.subplots(2)
+
         bw = 2
-        shrink = .5
-        ax = histplot(long_df, x="x", binwidth=bw, shrink=shrink)
-        assert ax.patches[0].get_width() == bw * shrink
+        shrink = .4
+
+        histplot(long_df, x="x", binwidth=bw, ax=ax1)
+        histplot(long_df, x="x", binwidth=bw, shrink=shrink, ax=ax2)
+
+        for p1, p2 in zip(ax1.patches, ax2.patches):
+
+            w1, w2 = p1.get_width(), p2.get_width()
+            assert w2 == pytest.approx(shrink * w1)
+
+            x1, x2 = p1.get_x(), p2.get_x()
+            assert (x2 + w2 / 2) == pytest.approx(x1 + w1 / 2)
 
     def test_log_scale_explicit(self, rng):
 


### PR DESCRIPTION
Fixes #2476

The code for shifting the shrunken bars assumed that discrete binning
was in effect. This is probably the only situation where shrinking
really makes sense, but there was no prevention or warning of getting
an innacurate result when using it with continuous bins.

It works properly now:

```python
sns.histplot(data=tips, x="total_bill", binwidth=8)
sns.histplot(data=tips, x="total_bill", binwidth=8, shrink=.6)
```
![image](https://user-images.githubusercontent.com/315810/107373188-3e7d7900-6ab4-11eb-9a35-821bd76fbfd0.png)

```python
sns.histplot(data=tips, x="total_bill", binwidth=8, color=".6")
sns.histplot(data=tips, x="total_bill", hue="time", multiple="dodge", binwidth=8, shrink=.6)
```
![image](https://user-images.githubusercontent.com/315810/107373289-610f9200-6ab4-11eb-990d-727132a53526.png)
