### PR TITLE
Replace version numbering interface

### DIFF
--- a/seaborn/_core.py
+++ b/seaborn/_core.py
@@ -6,7 +6,7 @@ from collections import UserString
 from collections.abc import Iterable, Sequence, Mapping
 from numbers import Number
 from datetime import datetime
-from distutils.version import LooseVersion
+from packaging import version
 
 import numpy as np
 import pandas as pd
@@ -1251,7 +1251,7 @@ class VectorPlotter:
                     if scale is True:
                         set_scale("log")
                     else:
-                        if LooseVersion(mpl.__version__) >= "3.3":
+                        if version.parse(mpl.__version__) >= version.parse("3.3"):
                             set_scale("log", base=scale)
                         else:
                             set_scale("log", **{f"base{axis}": scale})

--- a/seaborn/tests/test_algorithms.py
+++ b/seaborn/tests/test_algorithms.py
@@ -3,7 +3,7 @@ import numpy.random as npr
 
 import pytest
 from numpy.testing import assert_array_equal
-from distutils.version import LooseVersion
+from packaging import version
 
 from .. import algorithms as algo
 
@@ -151,7 +151,7 @@ def test_bootstrap_reproducibility(random):
         assert_array_equal(boots1, boots2)
 
 
-@pytest.mark.skipif(LooseVersion(np.__version__) < "1.17",
+@pytest.mark.skipif(version.parse(np.__version__) < version.parse("1.17"),
                     reason="Tests new numpy random functionality")
 def test_seed_new():
 
@@ -177,7 +177,7 @@ def test_seed_new():
         assert (rng1.uniform() == rng2.uniform()) == match
 
 
-@pytest.mark.skipif(LooseVersion(np.__version__) >= "1.17",
+@pytest.mark.skipif(version.parse(np.__version__) >= version.parse("1.17"),
                     reason="Tests old numpy random functionality")
 @pytest.mark.parametrize("seed1, seed2, match", [
     (None, None, False),
@@ -194,7 +194,7 @@ def test_seed_old(seed1, seed2, match):
     assert (rng1.uniform() == rng2.uniform()) == match
 
 
-@pytest.mark.skipif(LooseVersion(np.__version__) >= "1.17",
+@pytest.mark.skipif(version.parse(np.__version__) >= version.parse("1.17"),
                     reason="Tests old numpy random functionality")
 def test_bad_seed_old():
 

--- a/seaborn/tests/test_categorical.py
+++ b/seaborn/tests/test_categorical.py
@@ -10,7 +10,7 @@ from matplotlib.colors import rgb2hex, to_rgb, to_rgba
 import pytest
 from pytest import approx
 import numpy.testing as npt
-from distutils.version import LooseVersion
+from packaging import version
 from numpy.testing import (
     assert_array_equal,
     assert_array_less,
@@ -1631,7 +1631,7 @@ class SharedScatterTests(SharedAxesLevelTests):
         self.func(data=long_df, x="a", y="y", facecolor="C4", ax=ax)
         assert self.get_last_color(ax) == to_rgba("C4")
 
-        if LooseVersion(mpl.__version__) >= "3.1.0":
+        if version.parse(mpl.__version__) >= version.parse("3.1.0"):
             # https://github.com/matplotlib/matplotlib/pull/12851
 
             ax = plt.figure().subplots()
@@ -1646,7 +1646,7 @@ class SharedScatterTests(SharedAxesLevelTests):
 
         keys = ["c", "facecolor", "facecolors"]
 
-        if LooseVersion(mpl.__version__) >= "3.1.0":
+        if version.parse(mpl.__version__) >= version.parse("3.1.0"):
             # https://github.com/matplotlib/matplotlib/pull/12851
             keys.append("fc")
 
@@ -2047,7 +2047,7 @@ class SharedScatterTests(SharedAxesLevelTests):
         # (Even though visual output is ok -- so it's not an actual bug).
         # I'm not exactly sure why, so this version check is approximate
         # and should be revisited on a version bump.
-        if LooseVersion(mpl.__version__) < "3.1":
+        if version.parse(mpl.__version__) < version.parse("3.1"):
             pytest.xfail()
 
         ax = plt.figure().subplots()
@@ -3279,7 +3279,7 @@ class TestBoxenPlotter(CategoricalFixture):
         plt.close("all")
 
     @pytest.mark.skipif(
-        LooseVersion(pd.__version__) < "1.2",
+        version.parse(pd.__version__) < version.parse("1.2"),
         reason="Test requires pandas>=1.2")
     def test_Float64_input(self):
         data = pd.DataFrame(

--- a/seaborn/tests/test_distributions.py
+++ b/seaborn/tests/test_distributions.py
@@ -1,5 +1,5 @@
 import itertools
-from distutils.version import LooseVersion
+from packaging import version
 
 import numpy as np
 import matplotlib as mpl
@@ -1376,7 +1376,7 @@ class TestHistPlotUnivariate(SharedAxesLevelTests):
             histplot(long_df, x="s", discrete=True, element="poly")
 
     @pytest.mark.skipif(
-        LooseVersion(np.__version__) < "1.17",
+        version.parse(np.__version__) < version.parse("1.17"),
         reason="Histogram over datetime64 requires numpy >= 1.17",
     )
     def test_datetime_scale(self, long_df):

--- a/seaborn/tests/test_relational.py
+++ b/seaborn/tests/test_relational.py
@@ -1,4 +1,4 @@
-from distutils.version import LooseVersion
+from packaging import version
 from itertools import product
 import numpy as np
 import matplotlib as mpl
@@ -1257,7 +1257,7 @@ class TestScatterPlotter(SharedAxesLevelTests, Helpers):
         self.func(data=long_df, x="x", y="y", facecolors="C6", ax=ax)
         assert self.get_last_color(ax) == to_rgba("C6")
 
-        if LooseVersion(mpl.__version__) >= "3.1.0":
+        if version.parse(mpl.__version__) >= version.parse("3.1.0"):
             # https://github.com/matplotlib/matplotlib/pull/12851
 
             ax = plt.figure().subplots()
@@ -1578,7 +1578,7 @@ class TestScatterPlotter(SharedAxesLevelTests, Helpers):
 
         keys = ["c", "facecolor", "facecolors"]
 
-        if LooseVersion(mpl.__version__) >= "3.1.0":
+        if version.parse(mpl.__version__) >= version.parse("3.1.0"):
             # https://github.com/matplotlib/matplotlib/pull/12851
             keys.append("fc")
 

--- a/seaborn/tests/test_utils.py
+++ b/seaborn/tests/test_utils.py
@@ -18,7 +18,7 @@ from pandas.testing import (
     assert_frame_equal,
 )
 
-from distutils.version import LooseVersion
+from packaging import version
 
 from .. import utils, rcmod
 from ..utils import (
@@ -325,14 +325,14 @@ def test_locator_to_legend_entries():
     locator = mpl.ticker.LogLocator(numticks=5)
     limits = (5, 1425)
     levels, str_levels = utils.locator_to_legend_entries(locator, limits, int)
-    if LooseVersion(mpl.__version__) >= "3.1":
+    if version.parse(mpl.__version__) >= version.parse("3.1"):
         assert str_levels == ['10', '100', '1000']
 
     limits = (0.00003, 0.02)
     levels, str_levels = utils.locator_to_legend_entries(
         locator, limits, float
     )
-    if LooseVersion(mpl.__version__) >= "3.1":
+    if version.parse(mpl.__version__) >= version.parse("3.1"):
         assert str_levels == ['1e-04', '1e-03', '1e-02']
 
 

--- a/seaborn/utils.py
+++ b/seaborn/utils.py
@@ -5,7 +5,7 @@ import inspect
 import warnings
 import colorsys
 from urllib.request import urlopen, urlretrieve
-from distutils.version import LooseVersion
+from packaging import version
 
 import numpy as np
 import pandas as pd
@@ -149,7 +149,7 @@ def _default_color(method, hue, color, kws):
             isinstance(ax.xaxis.converter, mpl.dates.DateConverter),
             isinstance(ax.yaxis.converter, mpl.dates.DateConverter),
         ])
-        if LooseVersion(mpl.__version__) < "3.3" and datetime_axis:
+        if version.parse(mpl.__version__) < version.parse("3.3") and datetime_axis:
             return "C0"
 
         kws = _normalize_kwargs(kws, mpl.collections.PolyCollection)


### PR DESCRIPTION
As the `distutils.version` is deprecating, it was replaced
with the `packaging.version`. In order to give support for all
version numbering, according to PEP 440, parse was used.

Fixes #2466 