### PR TITLE
Working "hello world" for non-notebook user

### DIFF
--- a/doc/introduction.ipynb
+++ b/doc/introduction.ipynb
@@ -52,6 +52,23 @@
    "cell_type": "raw",
    "metadata": {},
    "source": [
+    "To see your plot outside of a notebook environment, run:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
     "A few things have happened here. Let's go through them one by one:"
    ]
   },


### PR DESCRIPTION
I was pretty confused by the intro docs. I wanted a "hello world" ASAP, but `sns.pairplot` was doing nothing. It just returns an object.

It turns out that behind the scenes, seaborn updates the pyplot context, and to see the plot, I needed to use `.show()`.

The current docs seem to assume the user is in a notebook environment. I do not believe this applies to everyone.