### PR TITLE
Don't pass a set to ListedColormap in clustermap

### DIFF
--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -1,5 +1,4 @@
 """Functions to visualize matrices of data."""
-import itertools
 import warnings
 
 import matplotlib as mpl
@@ -1037,35 +1036,36 @@ class ClusterGrid(Grid):
         Returns
         -------
         matrix : numpy.array
-            A numpy array of integer values, where each corresponds to a color
-            from the originally provided list of colors
+            A numpy array of integer values, where each indexes into the cmap
         cmap : matplotlib.colors.ListedColormap
 
         """
-        # check for nested lists/color palettes.
-        # Will fail if matplotlib color is list not tuple
-        if any(issubclass(type(x), list) for x in colors):
-            all_colors = set(itertools.chain(*colors))
-            n = len(colors)
-            m = len(colors[0])
+        try:
+            mpl.colors.to_rgb(colors[0])
+        except ValueError:
+            # We have a 2D color structure
+            m, n = len(colors), len(colors[0])
+            if not all(len(c) == n for c in colors[1:]):
+                raise ValueError("Multiple side color vectors must have same size")
         else:
-            all_colors = set(colors)
-            n = 1
-            m = len(colors)
+            # We have one vector of colors
+            m, n = 1, len(colors)
             colors = [colors]
-        color_to_value = dict((col, i) for i, col in enumerate(all_colors))
 
-        matrix = np.array([color_to_value[c]
-                           for color in colors for c in color])
+        # Map from unique colors to colormap index value
+        unique_colors = {}
+        matrix = np.zeros((m, n), int)
+        for i, inner in enumerate(colors):
+            for j, color in enumerate(inner):
+                idx = unique_colors.setdefault(color, len(unique_colors))
+                matrix[i, j] = idx
 
-        shape = (n, m)
-        matrix = matrix.reshape(shape)
+        # Reorder for clustering and transpose for axis
         matrix = matrix[:, ind]
         if axis == 0:
-            # row-side:
             matrix = matrix.T
 
-        cmap = mpl.colors.ListedColormap(all_colors)
+        cmap = mpl.colors.ListedColormap(list(unique_colors))
         return matrix, cmap
 
     def savefig(self, *args, **kwargs):

--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -690,7 +690,7 @@ class _DendrogramPlotter(object):
         """
         tree_kws = {} if tree_kws is None else tree_kws.copy()
         tree_kws.setdefault("linewidths", .5)
-        tree_kws.setdefault("colors", ".2")
+        tree_kws.setdefault("colors", tree_kws.pop("color", (.2, .2, .2)))
 
         if self.rotate and self.axis == 0:
             coords = zip(self.dependent_coord, self.independent_coord)

--- a/seaborn/tests/test_matrix.py
+++ b/seaborn/tests/test_matrix.py
@@ -912,6 +912,12 @@ class TestClustermap:
             color = self.col_colors[leaf]
             assert_colors_equal(cmap(matrix[0, j]), color)
 
+    def test_color_list_to_matrix_and_cmap_different_sizes(self):
+        colors = [self.col_colors, self.col_colors * 2]
+        with pytest.raises(ValueError):
+            matrix, cmap = mat.ClusterGrid.color_list_to_matrix_and_cmap(
+                colors, self.x_norm_leaves, axis=1)
+
     def test_savefig(self):
         # Not sure if this is the right way to test....
         cg = mat.ClusterGrid(self.df_norm, **self.default_kws)

--- a/seaborn/tests/test_matrix.py
+++ b/seaborn/tests/test_matrix.py
@@ -1,4 +1,3 @@
-import itertools
 import tempfile
 import copy
 
@@ -30,6 +29,7 @@ import pytest
 
 from .. import matrix as mat
 from .. import color_palette
+from .._testing import assert_colors_equal
 
 
 class TestHeatmap:
@@ -885,50 +885,32 @@ class TestClustermap:
             mat.ClusterGrid(self.df_norm, **kws)
 
     def test_color_list_to_matrix_and_cmap(self):
+        # Note this uses the attribute named col_colors but tests row colors
         matrix, cmap = mat.ClusterGrid.color_list_to_matrix_and_cmap(
-            self.col_colors, self.x_norm_leaves)
+            self.col_colors, self.x_norm_leaves, axis=0)
 
-        colors_set = set(self.col_colors)
-        col_to_value = dict((col, i) for i, col in enumerate(colors_set))
-        matrix_test = np.array([col_to_value[col] for col in
-                                self.col_colors])[self.x_norm_leaves]
-        shape = len(self.col_colors), 1
-        matrix_test = matrix_test.reshape(shape)
-        cmap_test = mpl.colors.ListedColormap(colors_set)
-        npt.assert_array_equal(matrix, matrix_test)
-        npt.assert_array_equal(cmap.colors, cmap_test.colors)
+        for i, leaf in enumerate(self.x_norm_leaves):
+            color = self.col_colors[leaf]
+            assert_colors_equal(cmap(matrix[i, 0]), color)
 
     def test_nested_color_list_to_matrix_and_cmap(self):
-        colors = [self.col_colors, self.col_colors]
+        # Note this uses the attribute named col_colors but tests row colors
+        colors = [self.col_colors, self.col_colors[::-1]]
         matrix, cmap = mat.ClusterGrid.color_list_to_matrix_and_cmap(
-            colors, self.x_norm_leaves)
+            colors, self.x_norm_leaves, axis=0)
 
-        all_colors = set(itertools.chain(*colors))
-        color_to_value = dict((col, i) for i, col in enumerate(all_colors))
-        matrix_test = np.array(
-            [color_to_value[c] for color in colors for c in color])
-        shape = len(colors), len(colors[0])
-        matrix_test = matrix_test.reshape(shape)
-        matrix_test = matrix_test[:, self.x_norm_leaves]
-        matrix_test = matrix_test.T
-
-        cmap_test = mpl.colors.ListedColormap(all_colors)
-        npt.assert_array_equal(matrix, matrix_test)
-        npt.assert_array_equal(cmap.colors, cmap_test.colors)
+        for i, leaf in enumerate(self.x_norm_leaves):
+            for j, color_row in enumerate(colors):
+                color = color_row[leaf]
+                assert_colors_equal(cmap(matrix[i, j]), color)
 
     def test_color_list_to_matrix_and_cmap_axis1(self):
         matrix, cmap = mat.ClusterGrid.color_list_to_matrix_and_cmap(
             self.col_colors, self.x_norm_leaves, axis=1)
 
-        colors_set = set(self.col_colors)
-        col_to_value = dict((col, i) for i, col in enumerate(colors_set))
-        matrix_test = np.array([col_to_value[col] for col in
-                                self.col_colors])[self.x_norm_leaves]
-        shape = 1, len(self.col_colors)
-        matrix_test = matrix_test.reshape(shape)
-        cmap_test = mpl.colors.ListedColormap(colors_set)
-        npt.assert_array_equal(matrix, matrix_test)
-        npt.assert_array_equal(cmap.colors, cmap_test.colors)
+        for j, leaf in enumerate(self.x_norm_leaves):
+            color = self.col_colors[leaf]
+            assert_colors_equal(cmap(matrix[0, j]), color)
 
     def test_savefig(self):
         # Not sure if this is the right way to test....


### PR DESCRIPTION
Avoids the issue in https://github.com/matplotlib/matplotlib/issues/19544

Matplotlib is going to revert the problematic release candidate behavior, but this PR should make seaborn robust to future such changes.

Also handles an issue where it looks like passing `tree_kwargs={"color": color}` will not work in matplotlib 3.4, due to some change in the resolution of `color`/`colors`.