### PR TITLE
Fix histplot auto line width with log scale or categorical y axis

### DIFF
--- a/doc/releases/v0.12.0.txt
+++ b/doc/releases/v0.12.0.txt
@@ -30,6 +30,8 @@ v0.12.0 (Unreleased)
 
 - |Fix| In :func:`histplot`, fixed a bug where using `shrink` with non-discrete bins shifted bar positions inaccurately (:pr:`2477`).
 
+- |Fix| In :func:`histplot`, fixed a bug where automatically computed linewidths were too thick for a log-scaled histogram (:pr:2522`).
+
 - |Fix| In :func:`displot`, fixed a bug where `common_norm` was ignored when `kind="hist"` and faceting was used without assigning `hue` (:pr:`2468`).
 
 - |Defaults| In :func:`displot`, the default alpha value now adjusts to a provided `multiple` parameter even when `hue` is not assigned (:pr:`2462`).

--- a/doc/releases/v0.12.0.txt
+++ b/doc/releases/v0.12.0.txt
@@ -30,7 +30,7 @@ v0.12.0 (Unreleased)
 
 - |Fix| In :func:`histplot`, fixed a bug where using `shrink` with non-discrete bins shifted bar positions inaccurately (:pr:`2477`).
 
-- |Fix| In :func:`histplot`, fixed a bug where automatically computed linewidths were too thick for a log-scaled histogram (:pr:2522`).
+- |Fix| In :func:`histplot`, fixed two bugs where automatically computed edge widths were too thick for log-scaled histograms and categorical histograms on the y axis (:pr:2522`).
 
 - |Fix| In :func:`displot`, fixed a bug where `common_norm` was ignored when `kind="hist"` and faceting was used without assigning `hue` (:pr:`2468`).
 

--- a/seaborn/distributions.py
+++ b/seaborn/distributions.py
@@ -644,15 +644,18 @@ class _DistributionPlotter(VectorPlotter):
                 ax.autoscale_view()
 
                 # We will base everything on the minimum bin width
-                hist_metadata = [h.index.to_frame() for _, h in histograms.items()]
-                binwidth = min([
-                    h["widths"].min() for h in hist_metadata
-                ])
+                hist_metadata = pd.concat([
+                    # Use .items for generality over dict or df
+                    h.index.to_frame() for _, h in histograms.items()
+                ]).reset_index(drop=True)
+                thin_bar_idx = hist_metadata["widths"].idxmin()
+                binwidth = hist_metadata.loc[thin_bar_idx, "widths"]
+                left_edge = hist_metadata.loc[thin_bar_idx, "edges"]
 
                 # Convert binwidth from data coordinates to pixels
                 pts_x, pts_y = 72 / ax.figure.dpi * (
-                    ax.transData.transform([binwidth, binwidth])
-                    - ax.transData.transform([0, 0])
+                    ax.transData.transform([left_edge + binwidth] * 2)
+                    - ax.transData.transform([left_edge] * 2)
                 )
                 if self.data_variable == "x":
                     binwidth_points = pts_x

--- a/seaborn/distributions.py
+++ b/seaborn/distributions.py
@@ -653,7 +653,7 @@ class _DistributionPlotter(VectorPlotter):
                 left_edge = hist_metadata.loc[thin_bar_idx, "edges"]
 
                 # Convert binwidth from data coordinates to pixels
-                pts_x, pts_y = 72 / ax.figure.dpi * (
+                pts_x, pts_y = 72 / ax.figure.dpi * abs(
                     ax.transData.transform([left_edge + binwidth] * 2)
                     - ax.transData.transform([left_edge] * 2)
                 )

--- a/seaborn/tests/test_distributions.py
+++ b/seaborn/tests/test_distributions.py
@@ -940,7 +940,7 @@ class TestKDEPlotBivariate:
         for c1, c2 in zip(ax1.collections, ax2.collections):
             assert_array_equal(c1.get_segments(), c2.get_segments())
 
-    def test_bandwiddth(self, rng):
+    def test_bandwidth(self, rng):
 
         n = 100
         x, y = rng.multivariate_normal([0, 0], [(.2, .5), (.5, 2)], n).T
@@ -1674,6 +1674,12 @@ class TestHistPlotUnivariate(SharedAxesLevelTests):
         histplot(flat_series, **kws, bins=30, ax=ax1)
         histplot(flat_series, **kws, bins=30, ax=ax2)
         assert get_lw(ax1) > get_lw(ax2)
+
+        f, ax1 = plt.subplots(figsize=(4, 5))
+        f, ax2 = plt.subplots(figsize=(4, 5))
+        histplot(flat_series, **kws, bins=30, ax=ax1)
+        histplot(10 ** flat_series, **kws, bins=30, log_scale=True, ax=ax2)
+        assert get_lw(ax1) == pytest.approx(get_lw(ax2))
 
     def test_bar_kwargs(self, flat_series):
 

--- a/seaborn/tests/test_distributions.py
+++ b/seaborn/tests/test_distributions.py
@@ -1681,6 +1681,12 @@ class TestHistPlotUnivariate(SharedAxesLevelTests):
         histplot(10 ** flat_series, **kws, bins=30, log_scale=True, ax=ax2)
         assert get_lw(ax1) == pytest.approx(get_lw(ax2))
 
+        f, ax1 = plt.subplots(figsize=(4, 5))
+        f, ax2 = plt.subplots(figsize=(4, 5))
+        histplot(y=[0, 1, 1], **kws, discrete=True, ax=ax1)
+        histplot(y=["a", "b", "b"], **kws, ax=ax2)
+        assert get_lw(ax1) == pytest.approx(get_lw(ax2))
+
     def test_bar_kwargs(self, flat_series):
 
         lw = 2


### PR DESCRIPTION
Fixes #2513
Fixes #2523

With test case from #2513:

```python
fig, axs = plt.subplots(ncols=3, nrows=2, figsize=(12,6))

vals = np.random.randn(1000)
sns.histplot(x=vals, log_scale=False, ax=axs[0, 0])
sns.histplot(x=10**vals, log_scale=True,ax=axs[1, 0])

vals = np.random.randn(10000)
sns.histplot(x=vals, log_scale=False, ax=axs[0, 1])
sns.histplot(x=10**vals, log_scale=True, ax=axs[1, 1])

vals = np.random.randn(1000000)
sns.histplot(x=vals, log_scale=False, ax=axs[0, 2])
sns.histplot(x=10**vals, log_scale=True, ax=axs[1, 2])

plt.tight_layout()
```

![image](https://user-images.githubusercontent.com/315810/112391867-f070ad80-8cce-11eb-9d87-ae32ebba0ca1.png)

And #2523:

```python
f, axs = plt.subplots(2)
sns.histplot(y=[0, 1, 1], discrete=True, edgecolor="r", ax=axs[0])
sns.histplot(y=["a", "b", "b"], discrete=True, edgecolor="r", ax=axs[1])
```

![image](https://user-images.githubusercontent.com/315810/112512022-5b6ec280-8d69-11eb-97a5-b860dac860b2.png)

Thanks @mgab for the very clear bug report!