### PR TITLE
Build documentation on Read the Docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,9 @@
+version: 2
+python:
+  version: 3.8
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - all
+    - requirements: doc/requirements.txt

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -303,3 +303,13 @@ intersphinx_mapping = {
     'pandas': ('https://pandas.pydata.org/pandas-docs/stable/', None),
     'statsmodels': ('https://www.statsmodels.org/stable/', None)
 }
+
+# Build notebooks if on Read the Docs
+import subprocess
+if os.getenv("READTHEDOCS") == "True":
+    print("Processing notebooks, please wait...")
+    nb_output = subprocess.check_output(
+        ["make", "notebooks"],
+        env={"NB_KERNEL": "python3", "PATH": os.environ["PATH"]},
+    )
+    print(nb_output.decode(errors="ignore"))


### PR DESCRIPTION
Hi! This is a proposal to build the seaborn documentation on Read the Docs. Doing so has a bunch of interesting niceties, the best one for me being having the complete history of past seaborn versions (I've had to use Wayback Machine in the past to easily look for old documentation).

_Full disclaimer: I work as Developer Advocate at Read the Docs, with a mission to help scientific projects improve their documentation, and I am more than happy to hear feedback or complaints!_

This was proposed [a while back](https://github.com/mwaskom/seaborn/issues/958#issuecomment-253268750), but the build process requires some tweaks to make it work properly on Read the Docs. To that end, this pull request contains three things:

- A proper `.readthedocs.yaml` configuration
- A hack to build the notebooks if an environment variable is detected
- A little hack to create the thumbnails directory before the actual build starts (see #2532)

The end result can be seen here: https://astrojuanlu-seaborn.readthedocs.io/en/rtd/

Although nowadays parts of the seaborn documentation workflow, and in particular `tools/nb_to_doc.py`, could be rewritten using something like [nbsphinx](https://nbsphinx.readthedocs.io/) (which I personally use in other projects to create example galleries based on Jupyter notebooks), I wanted to keep things as simple as possible.

@mwaskom What do you think?

cc @ericholscher

_Edit: Simplified "hacks" after clarification, see discussion below_