### PR TITLE
x_estimator bars now inherit scatter_kws alpha

### DIFF
--- a/seaborn/regression.py
+++ b/seaborn/regression.py
@@ -397,6 +397,8 @@ class _RegressionPlotter(_LinearPlotter):
         else:
             # TODO abstraction
             ci_kws = {"color": kws["color"]}
+            if "alpha" in kws:
+                ci_kws["alpha"] = kws["alpha"]
             ci_kws["linewidth"] = mpl.rcParams["lines.linewidth"] * 1.75
             kws.setdefault("s", 50)
 


### PR DESCRIPTION
x_estimator error bars were previously always opaque, but now inherit alpha parameter from scatterplot settings (if present), since the error bars replace the scatterplot.

Fixes #2538 