### PR TITLE
interquartile range errorbars

### DIFF
--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -1440,6 +1440,10 @@ class _CategoricalStatPlotter(_CategoricalPlotter):
                         sd = np.std(stat_data)
                         confint.append((estimate - sd, estimate + sd))
 
+                    if ci == "iqr":
+                        q25, q75 = np.percentile(stat_data, [25 ,75])
+                        confint.append((q25, q75))
+
                     else:
 
                         boots = bootstrap(stat_data, func=estimator,
@@ -1490,6 +1494,10 @@ class _CategoricalStatPlotter(_CategoricalPlotter):
                             estimate = estimator(stat_data)
                             sd = np.std(stat_data)
                             confint[i].append((estimate - sd, estimate + sd))
+
+                        if ci == "iqr":
+                            q25, q75 = np.percentile(stat_data, [25 ,75])
+                            confint[i].append((q25, q75))
 
                         else:
 


### PR DESCRIPTION
When making categorical plots with median estimator, it would sometimes be useful to show the interquartile range as errorbars similar to the boxes in boxplots. 

What do you think of an option for the confidence interval parameter comparable to the "sd" option such as ci="iqr"?

```
import seaborn as sns
import numpy as np

tips = sns.load_dataset("tips")
ax = sns.pointplot(x="time", 
                   y="total_bill",
                   data=tips,
                   hue="smoker",
                   estimator=np.median, 
                   ci="iqr")
```

I'm not sure if this really is a valuable feature and it adds another option to the ci parameter which I think is not optimal. Feel free to close if you think it is unnecessary or can be achieved in another simple way without changes to the codebase (which I did not find out at least).