### PR TITLE
DOC: Clarify how to derive dodge parameter value for aligning pointplot in stripplot

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -26,4 +26,4 @@ Because matplotlib handles the actual rendering, errors or incorrect outputs may
 New features
 ------------
 
-If you think there is a new feature that should be added to seaborn, you can open an issue to discuss it. But please be aware that current development efforts are mostly focused on standardizing the API and internals, and there may be relatively low enthusiasm for novel features that do not fit well into short- and medium-term develpoment plans.
+If you think there is a new feature that should be added to seaborn, you can open an issue to discuss it. But please be aware that current development efforts are mostly focused on standardizing the API and internals, and there may be relatively low enthusiasm for novel features that do not fit well into short- and medium-term development plans.

--- a/examples/jitter_stripplot.py
+++ b/examples/jitter_stripplot.py
@@ -21,12 +21,15 @@ sns.despine(bottom=True, left=True)
 sns.stripplot(x="value", y="measurement", hue="species",
               data=iris, dodge=True, alpha=.25, zorder=1)
 
-# Show the conditional means
+# Show the conditional means, aligning each pointplot in the
+# center of the strips by adjusting the width allotted to each
+# category (.8 by default) by the number of hue levels
 sns.pointplot(x="value", y="measurement", hue="species",
-              data=iris, dodge=.532, join=False, palette="dark",
+              data=iris, dodge=.8 - .8 / 3,
+              join=False, palette="dark",
               markers="d", scale=.75, ci=None)
 
-# Improve the legend 
+# Improve the legend
 handles, labels = ax.get_legend_handles_labels()
 ax.legend(handles[3:], labels[3:], title="species",
           handletextpad=0, columnspacing=1,


### PR DESCRIPTION
Coming from Twitter: https://twitter.com/michaelwaskom/status/1376595092014833667

This PR clarifies an example. Previously there was the magic number `.532`, which is now replaced by `.8 - .8/3` and an accompanying comment-explanation.

- 0.8 is the default width allotted to each category
- `0.8 - 0.8 /3` equals `.532` but will allow users to adjust the example to their need if they have different numbers of hues