### PR TITLE
DOC: misc fixes.

### DIFF
--- a/seaborn/_core.py
+++ b/seaborn/_core.py
@@ -1529,8 +1529,8 @@ def infer_orient(x=None, y=None, orient=None, require_numeric=True):
     variable. Practically, this is used when determining the axis for
     numerical aggregation.
 
-    Paramters
-    ---------
+    Parameters
+    ----------
     x, y : Vector data or None
         Positional data vectors for the plot.
     orient : string or None

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -1677,7 +1677,7 @@ class JointGrid(object):
 
         Parameters
         ----------
-        joint_func, marginal_func: callables
+        joint_func, marginal_func : callables
             Functions to draw the bivariate and univariate plots. See methods
             referenced above for information about the required characteristics
             of these functions.

--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -972,9 +972,6 @@ class ClusterGrid(Grid):
         axis : int
             Which axis to normalize across. If 0, normalize across rows, if 1,
             normalize across columns.
-        vmin : int
-            If 0, then subtract the minimum of the data before dividing by
-            the range.
 
         Returns
         -------

--- a/seaborn/palettes.py
+++ b/seaborn/palettes.py
@@ -111,7 +111,7 @@ def color_palette(palette=None, n_colors=None, desat=None, as_cmap=False):
 
     Parameters
     ----------
-    palette: None, string, or sequence, optional
+    palette : None, string, or sequence, optional
         Name of palette or None to return current palette. If a sequence, input
         colors are used but possibly cycled and desaturated.
     n_colors : int, optional

--- a/seaborn/utils.py
+++ b/seaborn/utils.py
@@ -24,7 +24,7 @@ def ci_to_errsize(cis, heights):
 
     Parameters
     ----------
-    cis: 2 x n sequence
+    cis : 2 x n sequence
         sequence of confidence interval limits
     heights : n sequence
         sequence of plot heights


### PR DESCRIPTION
Typos, non-existing parameters, and the fact that space before colon in
parameters is necessary for numpydoc to correctly parse the name and
type