### PR TITLE
fix clustermap test: colors parameter

### DIFF
--- a/seaborn/tests/test_matrix.py
+++ b/seaborn/tests/test_matrix.py
@@ -1314,7 +1314,7 @@ class TestClustermap:
     def test_tree_kws(self):
 
         rgb = (1, .5, .2)
-        g = mat.clustermap(self.df_norm, tree_kws=dict(color=rgb))
+        g = mat.clustermap(self.df_norm, tree_kws=dict(colors=rgb))
         for ax in [g.ax_col_dendrogram, g.ax_row_dendrogram]:
             tree, = ax.collections
             assert tuple(tree.get_color().squeeze())[:3] == rgb


### PR DESCRIPTION
the `tree_kws` parameter for [clustermap](https://seaborn.pydata.org/generated/seaborn.clustermap.html?highlight=clustermap#seaborn.clustermap) is forwarded to [matplotlib.collections.LineCollection](https://matplotlib.org/stable/api/collections_api.html#matplotlib.collections.LineCollection). But that constructor does not have a `color` kwarg. The unit test fails on openSUSE Tumbleweed with MPL 3.4.1:

```
[  333s] _________________________ TestClustermap.test_tree_kws _________________________
[  333s] 
[  333s] self = <seaborn.tests.test_matrix.TestClustermap object at 0x7f3043a83100>
[  333s] 
[  333s]     def test_tree_kws(self):
[  333s]     
[  333s]         rgb = (1, .5, .2)
[  333s]         g = mat.clustermap(self.df_norm, tree_kws=dict(color=rgb))
[  333s]         for ax in [g.ax_col_dendrogram, g.ax_row_dendrogram]:
[  333s]             tree, = ax.collections
[  333s] >           assert tuple(tree.get_color().squeeze())[:3] == rgb
[  333s] E           assert (0.2, 0.2, 0.2) == (1, 0.5, 0.2)
[  333s] E             At index 0 diff: 0.2 != 1
[  333s] E             Full diff:
[  333s] E             - (1, 0.5, 0.2)
[  333s] E             + (0.2, 0.2, 0.2)
[  333s] 
[  333s] seaborn/tests/test_matrix.py:1320: AssertionError
```