### PR TITLE
Add warn_singular parameter in kdeplot

### DIFF
--- a/doc/releases/v0.12.0.txt
+++ b/doc/releases/v0.12.0.txt
@@ -20,6 +20,8 @@ A paper describing seaborn was published in the `Journal of Open Source Software
 
 - |Enhancement| In :func:`histplot`, added `stat="percent"` as an option for normalization such that bar heights sum to 100 (:pr:`2461`).
 
+- |Enhancement| In :func:`kdeplot`, added the `warn_singular` parameter to allow silencing of the warning about data with zero variance (:pr:`2566`).
+
 - |Enhancement| |Fix| Improved integration with the matplotlib color cycle in most axes-level functions (:pr:`2449`).
 
 - |Fix| In :func:`lineplot, allowed the `dashes` keyword to set the style of a line without mapping a `style` variable (:pr:`2449`).

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -2012,6 +2012,7 @@ def pairplot(
         grid.map_diag(histplot, **diag_kws)
     elif diag_kind == "kde":
         diag_kws.setdefault("fill", True)
+        diag_kws.setdefault("warn_singular", False)
         grid.map_diag(kdeplot, **diag_kws)
 
     # Maybe plot on the off-diagonals
@@ -2028,6 +2029,7 @@ def pairplot(
         plotter(regplot, **plot_kws)
     elif kind == "kde":
         from .distributions import kdeplot  # Avoid circular import
+        plot_kws.setdefault("warn_singular", False)
         plotter(kdeplot, **plot_kws)
     elif kind == "hist":
         from .distributions import histplot  # Avoid circular import
@@ -2131,6 +2133,7 @@ def jointplot(
             marg_func = histplot
         else:
             marg_func = kdeplot
+            marginal_kws.setdefault("warn_singular", False)
             marginal_kws.setdefault("fill", True)
 
         marginal_kws.setdefault("color", color)
@@ -2163,6 +2166,7 @@ def jointplot(
     elif kind.startswith("kde"):
 
         joint_kws.setdefault("color", color)
+        joint_kws.setdefault("warn_singular", False)
         grid.plot_joint(kdeplot, **joint_kws)
 
         marginal_kws.setdefault("color", color)

--- a/seaborn/distributions.py
+++ b/seaborn/distributions.py
@@ -324,7 +324,7 @@ class _DistributionPlotter(VectorPlotter):
             if math.isclose(observation_variance, 0) or np.isnan(observation_variance):
                 msg = (
                     "Dataset has 0 variance; skipping density estimate. "
-                    "Pass `warn_singular=False` in `kdeplot` to disable this warning."
+                    "Pass `warn_singular=False` to disable this warning."
                 )
                 if warn_singular:
                     warnings.warn(msg, UserWarning)
@@ -435,6 +435,7 @@ class _DistributionPlotter(VectorPlotter):
                 common_bins,
                 kde_kws,
                 log_scale,
+                warn_singular=False,
             )
 
         # First pass through the data to compute the histograms
@@ -1051,7 +1052,7 @@ class _DistributionPlotter(VectorPlotter):
             if any(math.isclose(x, 0) for x in variance) or variance.isna().any():
                 msg = (
                     "Dataset has 0 variance; skipping density estimate. "
-                    "Pass `warn_singular=False` in `kdeplot` to disable this warning."
+                    "Pass `warn_singular=False` to disable this warning."
                 )
                 if warn_singular:
                     warnings.warn(msg, UserWarning)

--- a/seaborn/distributions.py
+++ b/seaborn/distributions.py
@@ -298,6 +298,7 @@ class _DistributionPlotter(VectorPlotter):
         common_grid,
         estimate_kws,
         log_scale,
+        warn_singular=True,
     ):
 
         # Initialize the estimator object
@@ -321,8 +322,12 @@ class _DistributionPlotter(VectorPlotter):
 
             observation_variance = observations.var()
             if math.isclose(observation_variance, 0) or np.isnan(observation_variance):
-                msg = "Dataset has 0 variance; skipping density estimate."
-                warnings.warn(msg, UserWarning)
+                msg = (
+                    "Dataset has 0 variance; skipping density estimate. "
+                    "Pass `warn_singular=False` in `kdeplot` to disable this warning."
+                )
+                if warn_singular:
+                    warnings.warn(msg, UserWarning)
                 continue
 
             # Extract the weights for this subset of observations
@@ -872,6 +877,7 @@ class _DistributionPlotter(VectorPlotter):
         multiple,
         common_norm,
         common_grid,
+        warn_singular,
         fill,
         color,
         legend,
@@ -908,6 +914,7 @@ class _DistributionPlotter(VectorPlotter):
             common_grid,
             estimate_kws,
             log_scale,
+            warn_singular,
         )
 
         # Adjust densities based on the `multiple` rule
@@ -1009,6 +1016,7 @@ class _DistributionPlotter(VectorPlotter):
         color,
         legend,
         cbar,
+        warn_singular,
         cbar_ax,
         cbar_kws,
         estimate_kws,
@@ -1041,8 +1049,12 @@ class _DistributionPlotter(VectorPlotter):
             # Check that KDE will not error out
             variance = observations[["x", "y"]].var()
             if any(math.isclose(x, 0) for x in variance) or variance.isna().any():
-                msg = "Dataset has 0 variance; skipping density estimate."
-                warnings.warn(msg, UserWarning)
+                msg = (
+                    "Dataset has 0 variance; skipping density estimate. "
+                    "Pass `warn_singular=False` in `kdeplot` to disable this warning."
+                )
+                if warn_singular:
+                    warnings.warn(msg, UserWarning)
                 continue
 
             # Estimate the density of observations at this level
@@ -1584,6 +1596,9 @@ def kdeplot(
     # Renamed params
     data=None, data2=None,
 
+    # New in v0.12
+    warn_singular=True,
+
     **kwargs,
 ):
 
@@ -1705,6 +1720,7 @@ def kdeplot(
             fill=fill,
             color=color,
             legend=legend,
+            warn_singular=warn_singular,
             estimate_kws=estimate_kws,
             **plot_kws,
         )
@@ -1718,6 +1734,7 @@ def kdeplot(
             thresh=thresh,
             legend=legend,
             color=color,
+            warn_singular=warn_singular,
             cbar=cbar,
             cbar_ax=cbar_ax,
             cbar_kws=cbar_kws,
@@ -1813,6 +1830,9 @@ fill : bool or None
     If True, fill in the area under univariate density curves or between
     bivariate contours. If None, the default depends on ``multiple``.
 {params.core.data}
+warn_singular : bool
+    If True, issue a warning when trying to estimate the density of data
+    with zero variance.
 kwargs
     Other keyword arguments are passed to one of the following matplotlib
     functions:

--- a/seaborn/tests/test_distributions.py
+++ b/seaborn/tests/test_distributions.py
@@ -390,6 +390,10 @@ class TestKDEPlotUnivariate(SharedAxesLevelTests):
             ax = kdeplot(x=[5])
         assert not ax.lines
 
+        with pytest.warns(None) as record:
+            ax = kdeplot(x=[5], warn_singular=False)
+        assert not record
+
     def test_variable_assignment(self, long_df):
 
         f, ax = plt.subplots()
@@ -887,6 +891,10 @@ class TestKDEPlotBivariate:
         with pytest.warns(UserWarning):
             ax = dist.kdeplot(x=[5], y=[6])
         assert not ax.lines
+
+        with pytest.warns(None) as record:
+            ax = kdeplot(x=[5], y=[7], warn_singular=False)
+        assert not record
 
     def test_fill_artists(self, long_df):
 

--- a/seaborn/tests/test_distributions.py
+++ b/seaborn/tests/test_distributions.py
@@ -1485,12 +1485,14 @@ class TestHistPlotUnivariate(SharedAxesLevelTests):
 
     def test_kde_singular_data(self):
 
-        with pytest.warns(UserWarning):
+        with pytest.warns(None) as record:
             ax = histplot(x=np.ones(10), kde=True)
+        assert not record
         assert not ax.lines
 
-        with pytest.warns(UserWarning):
+        with pytest.warns(None) as record:
             ax = histplot(x=[5], kde=True)
+        assert not record
         assert not ax.lines
 
     def test_element_default(self, long_df):


### PR DESCRIPTION
Set to False to silence the warning about zero variance datasets.

~One downside is that if you run into this in the `histplot(..., kde=True)` context the suggestion for how to disable it is incorrect (or at least unhelpful). Could potentially have `histplot` set this to False internally. In general I think I probably should have trusted my "non-deprecation-related warnings are almost always more annoying then helpful" intuition here.~

Most cases where `kdeplot` is called internally now have this set to `False`, as I think the warning makes most sense in the "hey, why is my single plot empty" context, not when one kde curve in a large pairplot (or etc.) has disappeared.

Closes #2499