### PR TITLE
Disable autolayout rcparam when constructing Facet/PairGrid

### DIFF
--- a/doc/releases/v0.12.0.txt
+++ b/doc/releases/v0.12.0.txt
@@ -24,6 +24,8 @@ A paper describing seaborn was published in the `Journal of Open Source Software
 
 - |Enhancement| In :func:`kdeplot`, added the `warn_singular` parameter to allow silencing of the warning about data with zero variance (:pr:`2566`).
 
+- |Enhancement| In :class:`FacetGrid`, :class:`PairGrid`, and functions that use them, the matplotlib `figure.autolayout` parameter is disabled to avoid having the legend overlap the plot (:pr:`2571`).
+
 - |Enhancement| |Fix| Improved integration with the matplotlib color cycle in most axes-level functions (:pr:`2449`).
 
 - |Fix| In :func:`lineplot, allowed the `dashes` keyword to set the style of a line without mapping a `style` variable (:pr:`2449`).

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -373,14 +373,19 @@ class FacetGrid(Grid):
             subplot_kws["ylim"] = ylim
 
         # --- Initialize the subplot grid
+
+        # Disable autolayout so legend_out works properly
+        with mpl.rc_context({"figure.autolayout": False}):
+            fig = plt.figure(figsize=figsize)
+
         if col_wrap is None:
 
-            kwargs = dict(figsize=figsize, squeeze=False,
+            kwargs = dict(squeeze=False,
                           sharex=sharex, sharey=sharey,
                           subplot_kw=subplot_kws,
                           gridspec_kw=gridspec_kws)
 
-            fig, axes = plt.subplots(nrow, ncol, **kwargs)
+            axes = fig.subplots(nrow, ncol, **kwargs)
 
             if col is None and row is None:
                 axes_dict = {}
@@ -399,7 +404,6 @@ class FacetGrid(Grid):
                 warnings.warn("`gridspec_kws` ignored when using `col_wrap`")
 
             n_axes = len(col_names)
-            fig = plt.figure(figsize=figsize)
             axes = np.empty(n_axes, object)
             axes[0] = fig.add_subplot(nrow, ncol, 1, **subplot_kws)
             if sharex:
@@ -533,7 +537,7 @@ class FacetGrid(Grid):
         gridspec_kws : dict
             Dictionary of keyword arguments passed to
             :class:`matplotlib.gridspec.GridSpec`
-            (via :func:`matplotlib.pyplot.subplots`).
+            (via :meth:`matplotlib.figure.Figure.subplots`).
             Ignored if ``col_wrap`` is not ``None``.
 
         See Also
@@ -1173,16 +1177,19 @@ class PairGrid(Grid):
         # Create the figure and the array of subplots
         figsize = len(x_vars) * height * aspect, len(y_vars) * height
 
-        fig, axes = plt.subplots(len(y_vars), len(x_vars),
-                                 figsize=figsize,
-                                 sharex="col", sharey="row",
-                                 squeeze=False)
+        # Disable autolayout so legend_out works
+        with mpl.rc_context({"figure.autolayout": False}):
+            fig = plt.figure(figsize=figsize)
+
+        axes = fig.subplots(len(y_vars), len(x_vars),
+                            sharex="col", sharey="row",
+                            squeeze=False)
 
         # Possibly remove upper axes to make a corner grid
         # Note: setting up the axes is usually the most time-intensive part
         # of using the PairGrid. We are foregoing the speed improvement that
         # we would get by just not setting up the hidden axes so that we can
-        # avoid implementing plt.subplots ourselves. But worth thinking about.
+        # avoid implementing fig.subplots ourselves. But worth thinking about.
         self._corner = corner
         if corner:
             hide_indices = np.triu_indices_from(axes, 1)


### PR DESCRIPTION
This prevents matplotlib from doing a naive tight_layout operation that ignores the space the legend needs to occupy.

Closes #2496