### PR TITLE
Create example_thumbs while running conf.py

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -164,6 +164,9 @@ html_favicon = "_static/favicon.ico"
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static', 'example_thumbs']
+for path in html_static_path:
+    if not os.path.exists(path):
+        os.makedirs(path)
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.


### PR DESCRIPTION
This is a little hacky, but including the thumbnail images in the build seems otherwise complicated because they are written into raw html source with an `<img>` tag, not using the sphinx image directive.

Fixes #2532