### PR TITLE
Set heatmap yticklabel alignment while rotating

### DIFF
--- a/doc/releases/v0.12.0.txt
+++ b/doc/releases/v0.12.0.txt
@@ -42,6 +42,8 @@ A paper describing seaborn was published in the `Journal of Open Source Software
 
 - |Fix| In :func:`displot`, fixed a bug where `common_norm` was ignored when `kind="hist"` and faceting was used without assigning `hue` (:pr:`2468`).
 
+- |Fix| In :func:`heatmap`, fixed a bug where vertically-rotated y-axis tick labels would be misaligned with their rows (:pr:`2574`).
+
 - |Defaults| In :func:`displot`, the default alpha value now adjusts to a provided `multiple` parameter even when `hue` is not assigned (:pr:`2462`).
 
 - |Docs| Improved the API documentation for theme-related functions (:pr:`2573`).

--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -334,6 +334,7 @@ class _HeatMapper:
         ax.set(xticks=xticks, yticks=yticks)
         xtl = ax.set_xticklabels(xticklabels)
         ytl = ax.set_yticklabels(yticklabels, rotation="vertical")
+        plt.setp(ytl, va="center")  # GH2484
 
         # Possibly rotate them if they overlap
         _draw_figure(ax.figure)


### PR DESCRIPTION
Closes #2484

With the case from that issue:

```python
m = ['January', 'February', 'March']
sns.heatmap(data=np.random.rand(3, 3), yticklabels=m, xticklabels=m)
```
![image](https://user-images.githubusercontent.com/315810/117216370-a6024680-adcd-11eb-95e2-f6de3b919078.png)
