### PR TITLE
Several fixes/improvements related to lmplot axis scaling

### DIFF
--- a/doc/releases/v0.12.0.txt
+++ b/doc/releases/v0.12.0.txt
@@ -28,7 +28,7 @@ A paper describing seaborn was published in the `Journal of Open Source Software
 
 - |Enhancement| |Fix| Improved integration with the matplotlib color cycle in most axes-level functions (:pr:`2449`).
 
-- |API| In :func:`lmplot`, the `sharex`, `sharey`, and `legend_out` parameters have been deprecated from the function signature, but they can be passed using `facet_kws` (:pr:`2576`).
+- |API| In :func:`lmplot`, the `sharex`, `sharey`, and `legend_out` parameters have been deprecated from the function signature, but they can be passed using the new `facet_kws` parameter (:pr:`2576`).
 
 - |Fix| In :func:`lineplot, allowed the `dashes` keyword to set the style of a line without mapping a `style` variable (:pr:`2449`).
 

--- a/doc/releases/v0.12.0.txt
+++ b/doc/releases/v0.12.0.txt
@@ -26,11 +26,17 @@ A paper describing seaborn was published in the `Journal of Open Source Software
 
 - |Enhancement| In :class:`FacetGrid`, :class:`PairGrid`, and functions that use them, the matplotlib `figure.autolayout` parameter is disabled to avoid having the legend overlap the plot (:pr:`2571`).
 
+- |Enhancement| In :func:`lmplot`, added `facet_kws` for additional customization of the underlying grid at setup time.
+
 - |Enhancement| |Fix| Improved integration with the matplotlib color cycle in most axes-level functions (:pr:`2449`).
 
 - |Fix| In :func:`lineplot, allowed the `dashes` keyword to set the style of a line without mapping a `style` variable (:pr:`2449`).
 
 - |Fix| In :func:`rugplot`, fixed a bug that prevented the use of datetime data (:pr:`2458`).
+
+- |Fix| In :func:`lmplot`, fixed a bug where the x axis was clamped to the data limits with `truncate=True` (:pr:`2576`).
+
+- |Fix| In :func:`lmplot`, fixed a bug where `sharey=False` did not always work as expected (:pr:`2576`).
 
 - |Fix| In :func:`histplot` and :func:`kdeplot`, fixed a bug where the `alpha` parameter was ignored when `fill=False` (:pr:`2460`).
 

--- a/doc/releases/v0.12.0.txt
+++ b/doc/releases/v0.12.0.txt
@@ -26,9 +26,9 @@ A paper describing seaborn was published in the `Journal of Open Source Software
 
 - |Enhancement| In :class:`FacetGrid`, :class:`PairGrid`, and functions that use them, the matplotlib `figure.autolayout` parameter is disabled to avoid having the legend overlap the plot (:pr:`2571`).
 
-- |Enhancement| In :func:`lmplot`, added `facet_kws` for additional customization of the underlying grid at setup time.
-
 - |Enhancement| |Fix| Improved integration with the matplotlib color cycle in most axes-level functions (:pr:`2449`).
+
+- |API| In :func:`lmplot`, the `sharex`, `sharey`, and `legend_out` parameters have been deprecated from the function signature, but they can be passed using `facet_kws` (:pr:`2576`).
 
 - |Fix| In :func:`lineplot, allowed the `dashes` keyword to set the style of a line without mapping a `style` variable (:pr:`2449`).
 
@@ -44,7 +44,7 @@ A paper describing seaborn was published in the `Journal of Open Source Software
 
 - |Fix| In :func:`histplot`, fixed a bug where using `shrink` with non-discrete bins shifted bar positions inaccurately (:pr:`2477`).
 
-- |Fix| In :func:`histplot`, fixed two bugs where automatically computed edge widths were too thick for log-scaled histograms and categorical histograms on the y axis (:pr:2522`).
+- |Fix| In :func:`histplot`, fixed two bugs where automatically computed edge widths were too thick for log-scaled histograms and categorical histograms on the y axis (:pr:`2522`).
 
 - |Fix| In :func:`displot`, fixed a bug where `common_norm` was ignored when `kind="hist"` and faceting was used without assigning `hue` (:pr:`2468`).
 

--- a/seaborn/regression.py
+++ b/seaborn/regression.py
@@ -419,7 +419,8 @@ class _RegressionPlotter(_LinearPlotter):
 
         # Draw the regression line and confidence interval
         line, = ax.plot(grid, yhat, **kws)
-        line.sticky_edges.x[:] = edges  # Prevent mpl from adding margin
+        if not self.truncate:
+            line.sticky_edges.x[:] = edges  # Prevent mpl from adding margin
         if err_bands is not None:
             ax.fill_between(grid, *err_bands, facecolor=fill_color, alpha=.15)
 

--- a/seaborn/regression.py
+++ b/seaborn/regression.py
@@ -569,7 +569,7 @@ def lmplot(
     units=None, seed=None, order=1, logistic=False, lowess=False,
     robust=False, logx=False, x_partial=None, y_partial=None,
     truncate=True, x_jitter=None, y_jitter=None, scatter_kws=None,
-    line_kws=None, size=None
+    line_kws=None, size=None, facet_kws=None,
 ):
 
     # Handle deprecations
@@ -587,13 +587,19 @@ def lmplot(
     cols = np.unique([a for a in need_cols if a is not None]).tolist()
     data = data[cols]
 
+    if facet_kws is None:
+        # TODO deprecate some parameters (sharex, sharey?) from the lmplot
+        # signature and require them to be passed as part of facet_kws?
+        facet_kws = {}
+
     # Initialize the grid
     facets = FacetGrid(
         data, row=row, col=col, hue=hue,
         palette=palette,
         row_order=row_order, col_order=col_order, hue_order=hue_order,
         height=height, aspect=aspect, col_wrap=col_wrap,
-        sharex=sharex, sharey=sharey, legend_out=legend_out
+        sharex=sharex, sharey=sharey, legend_out=legend_out,
+        **facet_kws,
     )
 
     # Add the markers here as FacetGrid has figured out how many levels of the
@@ -695,6 +701,8 @@ lmplot.__doc__ = dedent("""\
     {truncate}
     {xy_jitter}
     {scatter_line_kws}
+    facet_kws : dict
+        Dictionary of keyword arguments for :class:`FacetGrid`.
 
     See Also
     --------

--- a/seaborn/regression.py
+++ b/seaborn/regression.py
@@ -609,12 +609,12 @@ def lmplot(
                           "for each level of the hue variable"))
     facets.hue_kws = {"marker": markers}
 
-    # Hack to set the x limits properly, which needs to happen here
-    # because the extent of the regression estimate is determined
-    # by the limits of the plot
-    if sharex:
-        for ax in facets.axes.flat:
-            ax.scatter(data[x], np.ones(len(data)) * data[y].mean()).remove()
+    def update_datalim(data, x, y, ax, **kws):
+        xys = data[[x, y]]
+        ax.update_datalim(xys, updatey=False)
+        ax.autoscale_view(scaley=False)
+
+    facets.map_dataframe(update_datalim, x=x, y=y)
 
     # Draw the regression plot on each facet
     regplot_kws = dict(
@@ -626,8 +626,6 @@ def lmplot(
         scatter_kws=scatter_kws, line_kws=line_kws,
     )
     facets.map_dataframe(regplot, x=x, y=y, **regplot_kws)
-
-    # TODO this will need to change when we relax string requirement
     facets.set_axis_labels(x, y)
 
     # Add a legend

--- a/seaborn/regression.py
+++ b/seaborn/regression.py
@@ -616,7 +616,7 @@ def lmplot(
     facets.hue_kws = {"marker": markers}
 
     def update_datalim(data, x, y, ax, **kws):
-        xys = data[[x, y]]
+        xys = data[[x, y]].to_numpy().astype(float)
         ax.update_datalim(xys, updatey=False)
         ax.autoscale_view(scaley=False)
 

--- a/seaborn/regression.py
+++ b/seaborn/regression.py
@@ -563,13 +563,13 @@ def lmplot(
     data=None,
     hue=None, col=None, row=None,  # TODO move before data once * is enforced
     palette=None, col_wrap=None, height=5, aspect=1, markers="o",
-    sharex=True, sharey=True, hue_order=None, col_order=None, row_order=None,
-    legend=True, legend_out=True, x_estimator=None, x_bins=None,
+    sharex=None, sharey=None, hue_order=None, col_order=None, row_order=None,
+    legend=True, legend_out=None, x_estimator=None, x_bins=None,
     x_ci="ci", scatter=True, fit_reg=True, ci=95, n_boot=1000,
     units=None, seed=None, order=1, logistic=False, lowess=False,
     robust=False, logx=False, x_partial=None, y_partial=None,
     truncate=True, x_jitter=None, y_jitter=None, scatter_kws=None,
-    line_kws=None, size=None, facet_kws=None,
+    line_kws=None, facet_kws=None, size=None,
 ):
 
     # Handle deprecations
@@ -579,6 +579,22 @@ def lmplot(
                "please update your code.")
         warnings.warn(msg, UserWarning)
 
+    if facet_kws is None:
+        facet_kws = {}
+
+    def facet_kw_deprecation(key, val):
+        msg = (
+            f"{key} is deprecated from the `lmplot` function signature. "
+            "Please update your code to pass it using `facet_kws`."
+        )
+        if val is not None:
+            warnings.warn(msg, UserWarning)
+            facet_kws[key] = val
+
+    facet_kw_deprecation("sharex", sharex)
+    facet_kw_deprecation("sharey", sharey)
+    facet_kw_deprecation("legend_out", legend_out)
+
     if data is None:
         raise TypeError("Missing required keyword argument `data`.")
 
@@ -587,18 +603,12 @@ def lmplot(
     cols = np.unique([a for a in need_cols if a is not None]).tolist()
     data = data[cols]
 
-    if facet_kws is None:
-        # TODO deprecate some parameters (sharex, sharey?) from the lmplot
-        # signature and require them to be passed as part of facet_kws?
-        facet_kws = {}
-
     # Initialize the grid
     facets = FacetGrid(
         data, row=row, col=col, hue=hue,
         palette=palette,
         row_order=row_order, col_order=col_order, hue_order=hue_order,
         height=height, aspect=aspect, col_wrap=col_wrap,
-        sharex=sharex, sharey=sharey, legend_out=legend_out,
         **facet_kws,
     )
 
@@ -676,6 +686,10 @@ lmplot.__doc__ = dedent("""\
         Markers for the scatterplot. If a list, each marker in the list will be
         used for each level of the ``hue`` variable.
     {share_xy}
+
+        .. deprecated:: 0.12.0
+            Pass using the `facet_kws` dictionary.
+
     {{hue,col,row}}_order : lists, optional
         Order for the levels of the faceting variables. By default, this will
         be the order that the levels appear in ``data`` or, if the variables
@@ -683,6 +697,10 @@ lmplot.__doc__ = dedent("""\
     legend : bool, optional
         If ``True`` and there is a ``hue`` variable, add a legend.
     {legend_out}
+
+        .. deprecated:: 0.12.0
+            Pass using the `facet_kws` dictionary.
+
     {x_estimator}
     {x_bins}
     {x_ci}

--- a/seaborn/tests/test_regression.py
+++ b/seaborn/tests/test_regression.py
@@ -1,3 +1,4 @@
+from distutils.version import LooseVersion
 import numpy as np
 import matplotlib as mpl
 import matplotlib.pyplot as plt
@@ -596,11 +597,13 @@ class TestRegressionPlots:
         npt.assert_array_equal(red, red_scatter.get_facecolors()[0, :3])
         npt.assert_array_equal(blue, blue_scatter.get_facecolors()[0, :3])
 
+    @pytest.mark.skipif(LooseVersion(mpl.__version__) < "3.4",
+                        reason="MPL bug #15967")
     @pytest.mark.parametrize("sharex", [True, False])
     def test_lmplot_facet_truncate(self, sharex):
 
         g = lm.lmplot(
-            data=self.df, x="y", y="y", hue="g", col="h",
+            data=self.df, x="x", y="y", hue="g", col="h",
             sharex=sharex, truncate=False
         )
 
@@ -626,7 +629,7 @@ class TestRegressionPlots:
 
         xlim = -4, 20
         g = lm.lmplot(
-            data=self.df, x="y", y="y", col="h", facet_kws={"xlim": xlim}
+            data=self.df, x="x", y="y", col="h", facet_kws={"xlim": xlim}
         )
         for ax in g.axes.flat:
             assert ax.get_xlim() == xlim

--- a/seaborn/tests/test_regression.py
+++ b/seaborn/tests/test_regression.py
@@ -604,7 +604,7 @@ class TestRegressionPlots:
 
         g = lm.lmplot(
             data=self.df, x="x", y="y", hue="g", col="h",
-            sharex=sharex, truncate=False
+            truncate=False, facet_kws=dict(sharex=sharex),
         )
 
         for ax in g.axes.flat:
@@ -620,7 +620,8 @@ class TestRegressionPlots:
             z=["a", "a", "a", "b", "b", "b"],
         ))
 
-        g = lm.lmplot(data=df, x="x", y="y", col="z", sharey=False)
+        with pytest.warns(UserWarning):
+            g = lm.lmplot(data=df, x="x", y="y", col="z", sharey=False)
         ax1, ax2 = g.axes.flat
         assert ax1.get_ylim()[0] > ax2.get_ylim()[0]
         assert ax1.get_ylim()[1] < ax2.get_ylim()[1]

--- a/seaborn/tests/test_regression.py
+++ b/seaborn/tests/test_regression.py
@@ -596,6 +596,32 @@ class TestRegressionPlots:
         npt.assert_array_equal(red, red_scatter.get_facecolors()[0, :3])
         npt.assert_array_equal(blue, blue_scatter.get_facecolors()[0, :3])
 
+    @pytest.mark.parametrize("sharex", [True, False])
+    def test_lmplot_facet_truncate(self, sharex):
+
+        g = lm.lmplot(
+            data=self.df, x="y", y="y", hue="g", col="h",
+            sharex=sharex, truncate=False
+        )
+
+        for ax in g.axes.flat:
+            for line in ax.lines:
+                xdata = line.get_xdata()
+                assert ax.get_xlim() == tuple(xdata[[0, -1]])
+
+    def test_lmplot_sharey(self):
+
+        df = pd.DataFrame(dict(
+            x=[0, 1, 2, 0, 1, 2],
+            y=[1, -1, 0, -100, 200, 0],
+            z=["a", "a", "a", "b", "b", "b"],
+        ))
+
+        g = lm.lmplot(data=df, x="x", y="y", col="z", sharey=False)
+        ax1, ax2 = g.axes.flat
+        assert ax1.get_ylim()[0] > ax2.get_ylim()[0]
+        assert ax1.get_ylim()[1] < ax2.get_ylim()[1]
+
     def test_residplot(self):
 
         x, y = self.df.x, self.df.y

--- a/seaborn/tests/test_regression.py
+++ b/seaborn/tests/test_regression.py
@@ -622,6 +622,15 @@ class TestRegressionPlots:
         assert ax1.get_ylim()[0] > ax2.get_ylim()[0]
         assert ax1.get_ylim()[1] < ax2.get_ylim()[1]
 
+    def test_lmplot_facet_kws(self):
+
+        xlim = -4, 20
+        g = lm.lmplot(
+            data=self.df, x="y", y="y", col="h", facet_kws={"xlim": xlim}
+        )
+        for ax in g.axes.flat:
+            assert ax.get_xlim() == xlim
+
     def test_residplot(self):
 
         x, y = self.df.x, self.df.y


### PR DESCRIPTION
This PR rolls together a couple small fixes to semi-related issues in `lmplot`.

## Fixes sticky edges on regression line with `truncate=True`

I don't actually think there's an issue about this, but it's ugly and not intentional:

Old:

![image](https://user-images.githubusercontent.com/315810/117348075-c555ae00-ae77-11eb-9e06-436ea2ab4165.png)

New:

![image](https://user-images.githubusercontent.com/315810/117348223-f635e300-ae77-11eb-95f0-5835da1559a6.png)

## Fixes `sharey` with very different scales

This improves the code that scales the x axis to the data limits before plotting so that it does not interfere with `sharey=False` (fixes #2509)

Using the example case from that issue:

![image](https://user-images.githubusercontent.com/315810/117348333-149bde80-ae78-11eb-9e05-85c9878cf5ba.png)

## Adds `facet_kws` to `lmplot` and deprecate a couple params from the signature

Fixes #2518.

Additionally, `sharex`/`sharey`/`legend_out` have been deprecated from the `lmplot` signature, but they can now be passed using this parameter dictionary.