### PR TITLE
Use ticks to infer number of categorical levels on an axis

### DIFF
--- a/seaborn/_core.py
+++ b/seaborn/_core.py
@@ -1086,6 +1086,7 @@ class VectorPlotter:
                 .copy(deep=False)
                 .drop(["x", "y"], axis=1, errors="ignore")
             )
+
             for var in "yx":
                 if var not in self.variables:
                     continue
@@ -1095,6 +1096,11 @@ class VectorPlotter:
                 for converter, orig in grouped:
                     with pd.option_context('mode.use_inf_as_null', True):
                         orig = orig.dropna()
+                        if var in self.var_levels:
+                            # TODO this should happen in some centralized location
+                            # it is similar to GH2419, but more complicated because
+                            # supporting `order` in categorical plots is tricky
+                            orig = orig[orig.isin(self.var_levels[var])]
                     comp = pd.to_numeric(converter.convert_units(orig))
                     if converter.get_scale() == "log":
                         comp = np.log10(comp)
@@ -1161,7 +1167,7 @@ class VectorPlotter:
 
         # -- Verify the types of our x and y variables here.
         # This doesn't really make complete sense being here here, but it's a fine
-        # place for it, given  the current sytstem.
+        # place for it, given  the current system.
         # (Note that for some plots, there might be more complicated restrictions)
         # e.g. the categorical plots have their own check that as specific to the
         # non-categorical axis.

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -169,6 +169,12 @@ class _CategoricalPlotterNew(VectorPlotter):
         if self.var_types[axis] != "categorical":
             return
 
+        # We can infer the total number of categories (including those from previous
+        # plots that are not part of the plot we are currently making) from the number
+        # of ticks, which matplotlib sets up while doing unit conversion. This feels
+        # slightly risky, as if we are relying on something that may be a matplotlib
+        # implementation detail. But I cannot think of a better way to keep track of
+        # the state from previous categorical calls (see GH2516 for context)
         n = len(getattr(ax, f"get_{axis}ticks")())
 
         if axis == "x":

--- a/seaborn/tests/test_categorical.py
+++ b/seaborn/tests/test_categorical.py
@@ -1610,6 +1610,13 @@ class SharedAxesLevelTests:
         self.func(data=long_df, x="a", y="y", color="C3", ax=ax)
         assert self.get_last_color(ax) == to_rgba("C3")
 
+    def test_two_calls(self):
+
+        ax = plt.figure().subplots()
+        self.func(x=["a", "b", "c"], y=[1, 2, 3], ax=ax)
+        self.func(x=["e", "f"], y=[4, 5], ax=ax)
+        assert ax.get_xlim() == (-.5, 4.5)
+
 
 class SharedScatterTests(SharedAxesLevelTests):
     """Tests functionality common to stripplot and swarmplot."""


### PR DESCRIPTION
Fixes #2516

With the example from that issue:

```python
ax = sns.stripplot(x=["A", "B", "C"], y=[1, 3, 2])
ax = sns.stripplot(x=["E", "F"], y=[5, 2])
```
![image](https://user-images.githubusercontent.com/315810/117486123-3c9e4700-af37-11eb-98d3-8fe666e75de9.png)

This does make some assumptions about what matplotlib will be doing, namely that updating categorical unit data will add ticks to the matplotlib axis (even though it does not rescale the limits).

I also ran into a bunch of confusing issues when implementing this (apparently simple) fix. The internals relating to establishing/using the `var_levels` for categorical variables messy and confusing. I was able to get this working without rethinking/reimplementing everything, but I do think that doing so will ultimately be important for ongoing maintainability.