### PR TITLE
fix bug in size_norm extrapolation beyond data range 

### DIFF
--- a/seaborn/_core.py
+++ b/seaborn/_core.py
@@ -334,6 +334,8 @@ class SizeMapping(SemanticMapping):
             normed = self.norm(key)
             if np.ma.is_masked(normed):
                 normed = np.nan
+            if self.sizes is None:
+                self.sizes = self.plotter._default_size_range
             value = self.sizes[0] + normed * np.ptp(self.sizes)
         return value
 

--- a/seaborn/_core.py
+++ b/seaborn/_core.py
@@ -334,9 +334,7 @@ class SizeMapping(SemanticMapping):
             normed = self.norm(key)
             if np.ma.is_masked(normed):
                 normed = np.nan
-            size_values = self.lookup_table.values()
-            size_range = min(size_values), max(size_values)
-            value = size_range[0] + normed * np.ptp(size_range)
+            value = self.sizes[0] + normed * np.ptp(self.sizes)
         return value
 
     def categorical_mapping(self, data, sizes, order):


### PR DESCRIPTION
## Original Issue
- https://github.com/mwaskom/seaborn/issues/2539

## Behavior 
```
import numpy as np
import pandas as pd
import seaborn as sns
from matplotlib import pyplot as plt

np.random.seed(12345)
df = pd.DataFrame({'x': np.random.rand(60),
                   'y': np.random.rand(60),
                   'sz': np.append(np.random.randint(0, 2500, 30), np.random.randint(2500, 6000, 30))})

fig, axs = plt.subplots(ncols=2, figsize=(10, 4), sharex=True, sharey=True)
sns.scatterplot(data=df[:30], x='x', y='y', size='sz', sizes=(0.01, 200), size_norm=(0, 6000), ax=axs[0])
sns.scatterplot(data=df, x='x', y='y', size='sz', sizes=(0.01, 200), size_norm=(0, 6000), ax=axs[1])
```
- Before
![スクリーンショット 2021-05-10 18 33 06](https://user-images.githubusercontent.com/33516104/117639144-906e9180-b1be-11eb-8344-53141be6cedf.png)

- After 
![スクリーンショット 2021-05-10 18 31 40](https://user-images.githubusercontent.com/33516104/117639148-919fbe80-b1be-11eb-9392-de4bb3ec7c2a.png)



