### PR TITLE
Improve FacetGrid axis labeling

### DIFF
--- a/doc/docstrings/FacetGrid.ipynb
+++ b/doc/docstrings/FacetGrid.ipynb
@@ -120,7 +120,7 @@
    "cell_type": "raw",
    "metadata": {},
    "source": [
-    "When ``hue`` is set on the :class:`FacetGrid`, however, a separate plot is drawn for each level of the variable. If the plotting function understands ``hue``, it is better to let it handle that logic. But t is important to ensure that each facet will use the same hue mapping. In the sample ``tips`` data, the ``sex`` column has a categorical datatype, which ensures this. Otherwise, you may want to use the `hue_order` or similar parameter:"
+    "When ``hue`` is set on the :class:`FacetGrid`, however, a separate plot is drawn for each level of the variable. If the plotting function understands ``hue``, it is better to let it handle that logic. But it is important to ensure that each facet will use the same hue mapping. In the sample ``tips`` data, the ``sex`` column has a categorical datatype, which ensures this. Otherwise, you may want to use the `hue_order` or similar parameter:"
    ]
   },
   {

--- a/doc/docstrings/FacetGrid.ipynb
+++ b/doc/docstrings/FacetGrid.ipynb
@@ -85,24 +85,6 @@
    "cell_type": "raw",
    "metadata": {},
    "source": [
-    "One difference between the two methods is that :meth:`FacetGrid.map_dataframe` does not add axis labels. There is a dedicated method to do that:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "g = sns.FacetGrid(tips, col=\"time\",  row=\"sex\")\n",
-    "g.map_dataframe(sns.histplot, x=\"total_bill\")\n",
-    "g.set_axis_labels(\"Total bill\", \"Count\")"
-   ]
-  },
-  {
-   "cell_type": "raw",
-   "metadata": {},
-   "source": [
     "Notice how the bins have different widths in each facet. A separate plot is drawn on each facet, so if the plotting function derives any parameters from the data, they may not be shared across facets. You can pass additional keyword arguments to synchronize them. But when possible, using a figure-level function like :func:`displot` will take care of this bookkeeping for you:"
    ]
   },
@@ -113,8 +95,7 @@
    "outputs": [],
    "source": [
     "g = sns.FacetGrid(tips, col=\"time\", row=\"sex\")\n",
-    "g.map_dataframe(sns.histplot, x=\"total_bill\", binwidth=2)\n",
-    "g.set_axis_labels(\"Total bill\", \"Count\")"
+    "g.map_dataframe(sns.histplot, x=\"total_bill\", binwidth=2, binrange=(0, 60))"
    ]
   },
   {
@@ -132,7 +113,6 @@
    "source": [
     "g = sns.FacetGrid(tips, col=\"time\", hue=\"sex\")\n",
     "g.map_dataframe(sns.scatterplot, x=\"total_bill\", y=\"tip\")\n",
-    "g.set_axis_labels(\"Total bill\", \"Tip\")\n",
     "g.add_legend()"
    ]
   },
@@ -140,7 +120,7 @@
    "cell_type": "raw",
    "metadata": {},
    "source": [
-    "When ``hue`` is set on the :class:`FacetGrid`, however, a separate plot is drawn for each level of the variable. If the plotting function understands ``hue``, it is better to let it handle that logic. It is important, however, to ensure that each facet will use the same hue mapping. In the sample ``tips`` data, the ``sex`` column has a categorical datatype, which ensures this:"
+    "When ``hue`` is set on the :class:`FacetGrid`, however, a separate plot is drawn for each level of the variable. If the plotting function understands ``hue``, it is better to let it handle that logic. But t is important to ensure that each facet will use the same hue mapping. In the sample ``tips`` data, the ``sex`` column has a categorical datatype, which ensures this. Otherwise, you may want to use the `hue_order` or similar parameter:"
    ]
   },
   {
@@ -151,7 +131,6 @@
    "source": [
     "g = sns.FacetGrid(tips, col=\"time\")\n",
     "g.map_dataframe(sns.scatterplot, x=\"total_bill\", y=\"tip\", hue=\"sex\")\n",
-    "g.set_axis_labels(\"Total bill\", \"Tip\")\n",
     "g.add_legend()"
    ]
   },
@@ -160,13 +139,6 @@
    "metadata": {},
    "source": [
     "The size and shape of the plot is specified at the level of each subplot using the ``height`` and ``aspect`` parameters:"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Change the height and aspect ratio of each facet:"
    ]
   },
   {
@@ -192,7 +164,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "g = sns.FacetGrid(tips, col=\"size\", height=2, col_wrap=3)\n",
+    "g = sns.FacetGrid(tips, col=\"size\", height=2.5, col_wrap=3)\n",
     "g.map(sns.histplot, \"total_bill\")"
    ]
   },
@@ -217,7 +189,6 @@
     "\n",
     "g = sns.FacetGrid(tips, col=\"time\")\n",
     "g.map_dataframe(sns.scatterplot, x=\"total_bill\", y=\"tip\")\n",
-    "g.set_axis_labels(\"Total bill\", \"Tip\")\n",
     "g.map_dataframe(annotate)"
    ]
   },
@@ -236,7 +207,7 @@
    "source": [
     "g = sns.FacetGrid(tips, col=\"sex\", row=\"time\", margin_titles=True)\n",
     "g.map_dataframe(sns.scatterplot, x=\"total_bill\", y=\"tip\")\n",
-    "g.set_axis_labels(\"Total bill\", \"Tip\")\n",
+    "g.set_axis_labels(\"Total bill ($)\", \"Tip ($)\")\n",
     "g.set_titles(col_template=\"{col_name} patrons\", row_template=\"{row_name}\")\n",
     "g.set(xlim=(0, 60), ylim=(0, 12), xticks=[10, 30, 50], yticks=[2, 6, 10])\n",
     "g.tight_layout()\n",
@@ -273,7 +244,6 @@
    "source": [
     "g = sns.FacetGrid(tips, col=\"sex\", row=\"time\", margin_titles=True, despine=False)\n",
     "g.map_dataframe(sns.scatterplot, x=\"total_bill\", y=\"tip\")\n",
-    "g.set_axis_labels(\"Total bill\", \"Tip\")\n",
     "g.fig.subplots_adjust(wspace=0, hspace=0)\n",
     "for (row_val, col_val), ax in g.axes_dict.items():\n",
     "    if row_val == \"Lunch\" and col_val == \"Female\":\n",

--- a/doc/releases/v0.12.0.txt
+++ b/doc/releases/v0.12.0.txt
@@ -26,6 +26,8 @@ A paper describing seaborn was published in the `Journal of Open Source Software
 
 - |Enhancement| In :class:`FacetGrid`, :class:`PairGrid`, and functions that use them, the matplotlib `figure.autolayout` parameter is disabled to avoid having the legend overlap the plot (:pr:`2571`).
 
+- |Enhancement| In :class:`FacetGrid` and functions that use it, the visibility of interior axis labels is now disabled, and exterior axis labels are no longer erased when adding additional layers (:pr:`2583`).
+
 - |Enhancement| |Fix| Improved integration with the matplotlib color cycle in most axes-level functions (:pr:`2449`).
 
 - |API| In :func:`lmplot`, the `sharex`, `sharey`, and `legend_out` parameters have been deprecated from the function signature, but they can be passed using the new `facet_kws` parameter (:pr:`2576`).

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -746,8 +746,12 @@ class FacetGrid(Grid):
             # Draw the plot
             self._facet_plot(func, ax, args, kwargs)
 
-        # Finalize the annotations and layout
-        self._finalize_grid(args[:2])
+        # For axis labels, prefer to use positional args for backcompat
+        # but also extract the x/y kwargs and use if no corresponding arg
+        axis_labels = [kwargs.get("x", None), kwargs.get("y", None)]
+        for i, val in enumerate(args[:2]):
+            axis_labels[i] = val
+        self._finalize_grid(axis_labels)
 
         return self
 

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -166,16 +166,12 @@ class Grid:
 
         return self
 
-    def _clean_axis(self, ax):
-        """Turn off axis labels and legend."""
-        ax.set_xlabel("")
-        ax.set_ylabel("")
-        ax.legend_ = None
-        return self
-
     def _update_legend_data(self, ax):
         """Extract the legend data from an axes object and save it."""
         data = {}
+
+        # Get data directly from the legend, which is necessary
+        # for newer functions that don't add labeled proxy artists
         if ax.legend_ is not None and self._extract_legend_handles:
             handles = ax.legend_.legendHandles
             labels = [t.get_text() for t in ax.legend_.texts]
@@ -185,6 +181,9 @@ class Grid:
         data.update({l: h for h, l in zip(handles, labels)})
 
         self._legend_data.update(data)
+
+        # Now clear the legend
+        ax.legend_ = None
 
     def _get_palette(self, data, hue, hue_order, palette):
         """Get a list of colors for the hue variable."""
@@ -463,12 +462,14 @@ class FacetGrid(Grid):
                 for label in ax.get_xticklabels():
                     label.set_visible(False)
                 ax.xaxis.offsetText.set_visible(False)
+                ax.xaxis.label.set_visible(False)
 
         if sharey in [True, 'row']:
             for ax in self._not_left_axes:
                 for label in ax.get_yticklabels():
                     label.set_visible(False)
                 ax.yaxis.offsetText.set_visible(False)
+                ax.yaxis.label.set_visible(False)
 
     __init__.__doc__ = dedent("""\
         Initialize the matplotlib figure and FacetGrid object.
@@ -777,7 +778,6 @@ class FacetGrid(Grid):
 
         # Sort out the supporting information
         self._update_legend_data(ax)
-        self._clean_axis(ax)
 
     def _finalize_grid(self, axlabels):
         """Finalize the annotations and layout."""
@@ -1404,7 +1404,6 @@ class PairGrid(Grid):
             plot_kwargs.setdefault("hue_order", self._hue_order)
             plot_kwargs.setdefault("palette", self._orig_palette)
             func(x=vector, **plot_kwargs)
-            self._clean_axis(ax)
 
         self._add_axis_labels()
         return self
@@ -1443,8 +1442,6 @@ class PairGrid(Grid):
                     func(x=data_k, label=label_k, color=color, **plot_kwargs)
                 else:
                     func(data_k, label=label_k, color=color, **plot_kwargs)
-
-            self._clean_axis(ax)
 
         self._add_axis_labels()
 
@@ -1509,7 +1506,6 @@ class PairGrid(Grid):
         func(x=x, y=y, **kwargs)
 
         self._update_legend_data(ax)
-        self._clean_axis(ax)
 
     def _plot_bivariate_iter_hue(self, x_var, y_var, ax, func, **kwargs):
         """Draw a bivariate plot while iterating over hue subsets."""
@@ -1554,7 +1550,6 @@ class PairGrid(Grid):
                 func(x, y, **kws)
 
         self._update_legend_data(ax)
-        self._clean_axis(ax)
 
     def _add_axis_labels(self):
         """Add labels to the left and bottom Axes."""


### PR DESCRIPTION
A few small changes to make custom `FacetGrid` plotting a little easier:

- Disable the visibility of interior axis label objects (closes #2493)
- No longer remove axis labels after mapping a function (closes #2456)
- Use the `x` and `y` kwargs passed to `map_dataframe` for axis labels