### PR TITLE
Include empty example_thumbs directory in repository

### DIFF
--- a/doc/.gitignore
+++ b/doc/.gitignore
@@ -2,7 +2,7 @@
 _build/
 generated/
 examples/
-example_thumbs/
+example_thumbs/*.png
 introduction.rst
 tutorial/*.rst
 docstrings/*.rst

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -164,9 +164,6 @@ html_favicon = "_static/favicon.ico"
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static', 'example_thumbs']
-for path in html_static_path:
-    if not os.path.exists(path):
-        os.makedirs(path)
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.


### PR DESCRIPTION
As an alternative to creating the directory in conf.py

Cf #2572