### PR TITLE
JointGrid reference lines

### DIFF
--- a/doc/docstrings/FacetGrid.ipynb
+++ b/doc/docstrings/FacetGrid.ipynb
@@ -169,6 +169,24 @@
    ]
   },
   {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "To add horizontal or vertical reference lines on every facet, use :meth:`FacetGrid.refline`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "g = sns.FacetGrid(tips, col=\"time\", margin_titles=True)\n",
+    "g.map_dataframe(sns.scatterplot, x=\"total_bill\", y=\"tip\")\n",
+    "g.refline(y=tips.tip.median())"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/doc/docstrings/FacetGrid.ipynb
+++ b/doc/docstrings/FacetGrid.ipynb
@@ -183,7 +183,7 @@
    "source": [
     "g = sns.FacetGrid(tips, col=\"time\", margin_titles=True)\n",
     "g.map_dataframe(sns.scatterplot, x=\"total_bill\", y=\"tip\")\n",
-    "g.refline(y=tips.tip.median())"
+    "g.refline(y=tips[\"tip\"].median())"
    ]
   },
   {

--- a/doc/docstrings/JointGrid.ipynb
+++ b/doc/docstrings/JointGrid.ipynb
@@ -154,6 +154,24 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Horizontal and/or vertical reference lines can be added to the joint and/or marginal axes using the ``refline()`` method:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "g = sns.JointGrid(data=penguins, x=\"bill_length_mm\", y=\"bill_depth_mm\")\n",
+    "g.plot(sns.scatterplot, sns.histplot)\n",
+    "g.refline(x=45, y=16)"
+   ]
+  },
+  {
    "cell_type": "raw",
    "metadata": {},
    "source": [

--- a/doc/docstrings/JointGrid.ipynb
+++ b/doc/docstrings/JointGrid.ipynb
@@ -157,7 +157,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Horizontal and/or vertical reference lines can be added to the joint and/or marginal axes using the ``refline()`` method:"
+    "Horizontal and/or vertical reference lines can be added to the joint and/or marginal axes using :meth:`JointGrid.refline`:"
    ]
   },
   {

--- a/doc/releases/v0.12.0.txt
+++ b/doc/releases/v0.12.0.txt
@@ -30,6 +30,8 @@ A paper describing seaborn was published in the `Journal of Open Source Software
 
 - |Enhancement| |Fix| Improved integration with the matplotlib color cycle in most axes-level functions (:pr:`2449`).
 
+- |Feature| Added a ``refline`` method to :class:`FacetGrid` and :class:`JointGrid` for including horizontal and/or vertical reference lines using :meth:`matplotlib.axes.Axes.axhline`/:meth:`matplotlib.axes.Axes.axvline` (:pr:`2620`).
+
 - |API| In :func:`lmplot`, the `sharex`, `sharey`, and `legend_out` parameters have been deprecated from the function signature, but they can be passed using the new `facet_kws` parameter (:pr:`2576`).
 
 - |Fix| In :func:`lineplot, allowed the `dashes` keyword to set the style of a line without mapping a `style` variable (:pr:`2449`).

--- a/examples/kde_ridgeplot.py
+++ b/examples/kde_ridgeplot.py
@@ -27,6 +27,8 @@ g.map(sns.kdeplot, "x",
       bw_adjust=.5, clip_on=False,
       fill=True, alpha=1, linewidth=1.5)
 g.map(sns.kdeplot, "x", clip_on=False, color="w", lw=2, bw_adjust=.5)
+
+# passing color=None to refline() uses the hue mapping
 g.refline(y=0, linewidth=2, linestyle="-", color=None, clip_on=False)
 
 

--- a/examples/kde_ridgeplot.py
+++ b/examples/kde_ridgeplot.py
@@ -27,7 +27,7 @@ g.map(sns.kdeplot, "x",
       bw_adjust=.5, clip_on=False,
       fill=True, alpha=1, linewidth=1.5)
 g.map(sns.kdeplot, "x", clip_on=False, color="w", lw=2, bw_adjust=.5)
-g.map(plt.axhline, y=0, lw=2, clip_on=False)
+g.refline(y=0, linewidth=2, linestyle="-", color=None, clip_on=False)
 
 
 # Define and use a simple function to label the plot in axes coordinates
@@ -44,5 +44,5 @@ g.fig.subplots_adjust(hspace=-.25)
 
 # Remove axes details that don't play well with overlap
 g.set_titles("")
-g.set(yticks=[])
+g.set(yticks=[], ylabel="")
 g.despine(bottom=True, left=True)

--- a/examples/many_facets.py
+++ b/examples/many_facets.py
@@ -26,7 +26,7 @@ grid = sns.FacetGrid(df, col="walk", hue="walk", palette="tab20c",
                      col_wrap=4, height=1.5)
 
 # Draw a horizontal line to show the starting point
-grid.refline(y=0, linestyle=":", color=".5")
+grid.refline(y=0, linestyle=":")
 
 # Draw a line plot to show the trajectory of each random walk
 grid.map(plt.plot, "step", "position", marker="o")

--- a/examples/many_facets.py
+++ b/examples/many_facets.py
@@ -26,7 +26,7 @@ grid = sns.FacetGrid(df, col="walk", hue="walk", palette="tab20c",
                      col_wrap=4, height=1.5)
 
 # Draw a horizontal line to show the starting point
-grid.map(plt.axhline, y=0, ls=":", c=".5")
+grid.refline(y=0, linestyle=":", color=".5")
 
 # Draw a line plot to show the trajectory of each random walk
 grid.map(plt.plot, "step", "position", marker="o")

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -1819,6 +1819,8 @@ class JointGrid(object):
         """
         if x is None and y is None:
             raise ValueError('Must provide ``x`` or ``y``')
+        elif x is not None and y is not None:
+            raise ValueError('Provide either ``x`` or ``y``, not both')
         elif x is not None:
             func = 'axvline'
             ax_marg = self.ax_marg_x

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -1807,7 +1807,7 @@ class JointGrid(object):
         orient : "v" | "h"
             Orientation for reference line.
         joint, marginal : bools
-            Whether to add the reference line to the joint and/or marginal axes.
+            Whether to add the reference line to the joint/marginal axes.
         kwargs : key, value mappings
             Other keyword arguments are passed to :meth:`matplotlib.axes.Axes.axhline`
             or :meth:`matplotlib.axes.Axes.axvline` depending on ``orient``.

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -1809,7 +1809,7 @@ class JointGrid(object):
             Value(s) to draw the line(s) at.
         joint, marginal : bools
             Whether to add the reference line(s) to the joint/marginal axes.
-        color : str or RGB tuple
+        color : :mod:`matplotlib color <matplotlib.colors>`
             Specifies the color of the reference line(s).
         linestyle : str
             Specifies the style of the reference line(s). Defaults to dashed.

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -1827,6 +1827,8 @@ class JointGrid(object):
         else:
             raise ValueError(f'"{orient}" is not a supported value for ``orient``')
 
+        if not any((joint, marginal)):
+            raise ValueError('At least one of ``joint`` and ``marginal`` must be True')
         if joint:
             getattr(self.ax_joint, func)(value, **kwargs)
         if marginal:

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -957,6 +957,37 @@ class FacetGrid(Grid):
                 self.axes.flat[i].set_title(title, **kwargs)
         return self
 
+    def refline(self, *, x=None, y=None, color='.5', linestyle='--', **line_kws):
+        """Add a reference line(s) to each facet.
+
+        Parameters
+        ----------
+        x, y : numeric
+            Value(s) to draw the line(s) at.
+        color : :mod:`matplotlib color <matplotlib.colors>`
+            Specifies the color of the reference line(s).
+        linestyle : str
+            Specifies the style of the reference line(s). Defaults to dashed.
+        line_kws : key, value mappings
+            Other keyword arguments are passed to :meth:`matplotlib.axes.Axes.axvline`
+            when ``x`` is not None and :meth:`matplotlib.axes.Axes.axhline` when ``y``
+            is not None.
+
+        Returns
+        -------
+        :class:`FacetGrid` instance
+            Returns ``self`` for easy method chaining.
+
+        """
+        line_kws['color'] = color
+        line_kws['linestyle'] = linestyle
+
+        if x is not None:
+            self.map(plt.axvline, x=x, **line_kws)
+
+        if y is not None:
+            self.map(plt.axhline, y=y, **line_kws)
+
     # ------ Properties that are part of the public API and documented by Sphinx
 
     @property

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -1797,6 +1797,42 @@ class JointGrid(object):
 
         return self
 
+    def plot_refline(self, *, value, orient, joint=True, marginal=True, **kwargs):
+        """Add a reference line to joint and/or marginal axes.
+
+        Parameters
+        ----------
+        value : numeric
+            Value to draw the line at.
+        orient : "v" | "h"
+            Orientation for reference line.
+        joint, marginal : bools
+            Whether to add the reference line to the joint and/or marginal axes.
+        kwargs : key, value mappings
+            Other keyword arguments are passed to :meth:`matplotlib.axes.Axes.axhline`
+            or :meth:`matplotlib.axes.Axes.axvline` depending on ``orient``.
+
+        Returns
+        -------
+        :class:`JointGrid` instance
+            Returns ``self`` for easy method chaining.
+
+        """
+        if orient == 'h':
+            func = 'axhline'
+            ax_marg = self.ax_marg_y
+        elif orient == 'v':
+            func = 'axvline'
+            ax_marg = self.ax_marg_x
+        else:
+            raise ValueError(f'"{orient}" is not a supported value for ``orient``')
+
+        if joint:
+            getattr(self.ax_joint, func)(value, **kwargs)
+        if marginal:
+            getattr(ax_marg, func)(value, **kwargs)
+        return self
+
     def set_axis_labels(self, xlabel="", ylabel="", **kwargs):
         """Set axis labels on the bivariate axes.
 

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -1797,7 +1797,10 @@ class JointGrid(object):
 
         return self
 
-    def refline(self, *, x=None, y=None, joint=True, marginal=True, **line_kws):
+    def refline(
+        self, *, x=None, y=None, joint=True, marginal=True,
+        color='.5', linestyle='--', **line_kws
+    ):
         """Add a reference line(s) to joint and/or marginal axes.
 
         Parameters
@@ -1806,6 +1809,10 @@ class JointGrid(object):
             Value(s) to draw the line(s) at.
         joint, marginal : bools
             Whether to add the reference line(s) to the joint/marginal axes.
+        color : str or RGB tuple
+            Specifies the color of the reference line(s).
+        linestyle : str
+            Specifies the style of the reference line(s). Defaults to dashed.
         line_kws : key, value mappings
             Other keyword arguments are passed to :meth:`matplotlib.axes.Axes.axvline`
             when ``x`` is not None and :meth:`matplotlib.axes.Axes.axhline` when ``y``
@@ -1817,6 +1824,9 @@ class JointGrid(object):
             Returns ``self`` for easy method chaining.
 
         """
+        line_kws['color'] = color
+        line_kws['linestyle'] = linestyle
+
         if x is not None:
             if joint:
                 self.ax_joint.axvline(x, **line_kws)

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -1798,17 +1798,17 @@ class JointGrid(object):
         return self
 
     def refline(self, *, x=None, y=None, joint=True, marginal=True, **line_kws):
-        """Add a reference line to joint and/or marginal axes.
+        """Add a reference line(s) to joint and/or marginal axes.
 
         Parameters
         ----------
         x, y : numeric
-            Value to draw the line at.
+            Value(s) to draw the line(s) at.
         joint, marginal : bools
-            Whether to add the reference line to the joint/marginal axes.
+            Whether to add the reference line(s) to the joint/marginal axes.
         line_kws : key, value mappings
             Other keyword arguments are passed to :meth:`matplotlib.axes.Axes.axvline`
-            when ``x`` is not None or :meth:`matplotlib.axes.Axes.axhline` when ``y``
+            when ``x`` is not None and :meth:`matplotlib.axes.Axes.axhline` when ``y``
             is not None.
 
         Returns
@@ -1817,25 +1817,18 @@ class JointGrid(object):
             Returns ``self`` for easy method chaining.
 
         """
-        if x is None and y is None:
-            raise ValueError('Must provide ``x`` or ``y``')
-        elif x is not None and y is not None:
-            raise ValueError('Provide either ``x`` or ``y``, not both')
-        elif x is not None:
-            func = 'axvline'
-            ax_marg = self.ax_marg_x
-            value = x
-        elif y is not None:
-            func = 'axhline'
-            ax_marg = self.ax_marg_y
-            value = y
+        if x is not None:
+            if joint:
+                self.ax_joint.axvline(x, **line_kws)
+            if marginal:
+                self.ax_marg_x.axvline(x, **line_kws)
 
-        if not any((joint, marginal)):
-            raise ValueError('At least one of ``joint`` and ``marginal`` must be True')
-        if joint:
-            getattr(self.ax_joint, func)(value, **line_kws)
-        if marginal:
-            getattr(ax_marg, func)(value, **line_kws)
+        if y is not None:
+            if joint:
+                self.ax_joint.axhline(y, **line_kws)
+            if marginal:
+                self.ax_marg_y.axhline(y, **line_kws)
+
         return self
 
     def set_axis_labels(self, xlabel="", ylabel="", **kwargs):

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -1797,20 +1797,19 @@ class JointGrid(object):
 
         return self
 
-    def plot_refline(self, *, value, orient, joint=True, marginal=True, **kwargs):
+    def refline(self, *, x=None, y=None, joint=True, marginal=True, **line_kws):
         """Add a reference line to joint and/or marginal axes.
 
         Parameters
         ----------
-        value : numeric
+        x, y : numeric
             Value to draw the line at.
-        orient : "v" | "h"
-            Orientation for reference line.
         joint, marginal : bools
             Whether to add the reference line to the joint/marginal axes.
-        kwargs : key, value mappings
-            Other keyword arguments are passed to :meth:`matplotlib.axes.Axes.axhline`
-            or :meth:`matplotlib.axes.Axes.axvline` depending on ``orient``.
+        line_kws : key, value mappings
+            Other keyword arguments are passed to :meth:`matplotlib.axes.Axes.axvline`
+            when ``x`` is not None or :meth:`matplotlib.axes.Axes.axhline` when ``y``
+            is not None.
 
         Returns
         -------
@@ -1818,21 +1817,23 @@ class JointGrid(object):
             Returns ``self`` for easy method chaining.
 
         """
-        if orient == 'h':
-            func = 'axhline'
-            ax_marg = self.ax_marg_y
-        elif orient == 'v':
+        if x is None and y is None:
+            raise ValueError('Must provide ``x`` or ``y``')
+        elif x is not None:
             func = 'axvline'
             ax_marg = self.ax_marg_x
-        else:
-            raise ValueError(f'"{orient}" is not a supported value for ``orient``')
+            value = x
+        elif y is not None:
+            func = 'axhline'
+            ax_marg = self.ax_marg_y
+            value = y
 
         if not any((joint, marginal)):
             raise ValueError('At least one of ``joint`` and ``marginal`` must be True')
         if joint:
-            getattr(self.ax_joint, func)(value, **kwargs)
+            getattr(self.ax_joint, func)(value, **line_kws)
         if marginal:
-            getattr(ax_marg, func)(value, **kwargs)
+            getattr(ax_marg, func)(value, **line_kws)
         return self
 
     def set_axis_labels(self, xlabel="", ylabel="", **kwargs):

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -965,9 +965,10 @@ class FacetGrid(Grid):
         x, y : numeric
             Value(s) to draw the line(s) at.
         color : :mod:`matplotlib color <matplotlib.colors>`
-            Specifies the color of the reference line(s).
+            Specifies the color of the reference line(s). Pass ``color=None`` to
+            use ``hue`` mapping.
         linestyle : str
-            Specifies the style of the reference line(s). Defaults to dashed.
+            Specifies the style of the reference line(s).
         line_kws : key, value mappings
             Other keyword arguments are passed to :meth:`matplotlib.axes.Axes.axvline`
             when ``x`` is not None and :meth:`matplotlib.axes.Axes.axhline` when ``y``
@@ -1843,7 +1844,7 @@ class JointGrid(object):
         color : :mod:`matplotlib color <matplotlib.colors>`
             Specifies the color of the reference line(s).
         linestyle : str
-            Specifies the style of the reference line(s). Defaults to dashed.
+            Specifies the style of the reference line(s).
         line_kws : key, value mappings
             Other keyword arguments are passed to :meth:`matplotlib.axes.Axes.axvline`
             when ``x`` is not None and :meth:`matplotlib.axes.Axes.axhline` when ``y``

--- a/seaborn/tests/test_axisgrid.py
+++ b/seaborn/tests/test_axisgrid.py
@@ -648,6 +648,30 @@ class TestFacetGrid:
         with pytest.warns(UserWarning):
             g.map(pointplot, "b", "x")
 
+    def test_refline(self):
+
+        g = ag.FacetGrid(self.df, row="a", col="b")
+        g.refline()
+        for ax in g.axes.ravel():
+            assert not ax.lines
+
+        refx = refy = 0.5
+        hline = np.array([[0, refy], [1, refy]])
+        vline = np.array([[refx, 0], [refx, 1]])
+        g.refline(x=refx, y=refy)
+        for ax in g.axes.ravel():
+            assert ax.lines[0].get_color() == '.5'
+            assert ax.lines[0].get_linestyle() == '--'
+            assert len(ax.lines) == 2
+            npt.assert_array_equal(ax.lines[0].get_xydata(), vline)
+            npt.assert_array_equal(ax.lines[1].get_xydata(), hline)
+
+        color, linestyle = 'red', '-'
+        g.refline(x=refx, color=color, linestyle=linestyle)
+        npt.assert_array_equal(g.axes[0, 0].lines[-1].get_xydata(), vline)
+        assert g.axes[0, 0].lines[-1].get_color() == color
+        assert g.axes[0, 0].lines[-1].get_linestyle() == linestyle
+
 
 class TestPairGrid:
 

--- a/seaborn/tests/test_axisgrid.py
+++ b/seaborn/tests/test_axisgrid.py
@@ -1542,6 +1542,48 @@ class TestJointGrid:
         assert_plots_equal(g.ax_marg_x, g2.ax_marg_x, labels=False)
         assert_plots_equal(g.ax_marg_y, g2.ax_marg_y, labels=False)
 
+    def test_refline(self):
+
+        g = ag.JointGrid(x="x", y="y", data=self.data)
+        g.plot(scatterplot, histplot)
+        g.refline()
+        assert not g.ax_joint.lines and not g.ax_marg_x.lines and not g.ax_marg_y.lines
+
+        refx = refy = 0.5
+        hline = np.array([[0, refy], [1, refy]])
+        vline = np.array([[refx, 0], [refx, 1]])
+        g.refline(x=refx, y=refy, joint=False, marginal=False)
+        assert not g.ax_joint.lines and not g.ax_marg_x.lines and not g.ax_marg_y.lines
+
+        g.refline(x=refx, y=refy)
+        assert g.ax_joint.lines[0].get_color() == '.5'
+        assert g.ax_joint.lines[0].get_linestyle() == '--'
+        assert len(g.ax_joint.lines) == 2
+        assert len(g.ax_marg_x.lines) == 1
+        assert len(g.ax_marg_y.lines) == 1
+        npt.assert_array_equal(g.ax_joint.lines[0].get_xydata(), vline)
+        npt.assert_array_equal(g.ax_joint.lines[1].get_xydata(), hline)
+        npt.assert_array_equal(g.ax_marg_x.lines[0].get_xydata(), vline)
+        npt.assert_array_equal(g.ax_marg_y.lines[0].get_xydata(), hline)
+
+        color, linestyle = 'red', '-'
+        g.refline(x=refx, marginal=False, color=color, linestyle=linestyle)
+        npt.assert_array_equal(g.ax_joint.lines[-1].get_xydata(), vline)
+        assert g.ax_joint.lines[-1].get_color() == color
+        assert g.ax_joint.lines[-1].get_linestyle() == linestyle
+        assert len(g.ax_marg_x.lines) == len(g.ax_marg_y.lines)
+
+        g.refline(x=refx, joint=False)
+        npt.assert_array_equal(g.ax_marg_x.lines[-1].get_xydata(), vline)
+        assert len(g.ax_marg_x.lines) == len(g.ax_marg_y.lines) + 1
+
+        g.refline(y=refy, joint=False)
+        npt.assert_array_equal(g.ax_marg_y.lines[-1].get_xydata(), hline)
+        assert len(g.ax_marg_x.lines) == len(g.ax_marg_y.lines)
+
+        g.refline(y=refy, marginal=False)
+        npt.assert_array_equal(g.ax_joint.lines[-1].get_xydata(), hline)
+        assert len(g.ax_marg_x.lines) == len(g.ax_marg_y.lines)
 
 class TestJointPlot:
 


### PR DESCRIPTION
Closes #2249 &ndash; Adds new `JointGrid.refline()` method: 
```python
JointGrid.refline(self, *, x=None, y=None, joint=True, marginal=True, **line_kws)
```

Example usage:
```python
import seaborn as sns

penguins = sns.load_dataset('penguins')
g = sns.jointplot(data=penguins, x='bill_length_mm', y='bill_depth_mm')

# by default plot on both the marginal and joint axes
g.refline(y=16, linestyle='dashed', color='gray')

# only on joint
g.refline(x=45, marginal=False, linestyle='dotted', color='red')

# only on marginal
g.refline(x=55, joint=False, linestyle='dashed', color='blue')
```

Needs:

- [X] Test
- [X] Documentation in the JointGrid and FacetGrid API examples
- [X] Mention in release notes