### PR TITLE
Fix FacetGrid.data on object returned from relplot and displot

### DIFF
--- a/doc/releases/v0.12.0.txt
+++ b/doc/releases/v0.12.0.txt
@@ -32,7 +32,7 @@ A paper describing seaborn was published in the `Journal of Open Source Software
 
 - |Feature| Added a ``refline`` method to :class:`FacetGrid` and :class:`JointGrid` for including horizontal and/or vertical reference lines using :meth:`matplotlib.axes.Axes.axhline`/:meth:`matplotlib.axes.Axes.axvline` (:pr:`2620`).
 
-- |API| In :func:`lmplot`, the `sharex`, `sharey`, and `legend_out` parameters have been deprecated from the function signature, but they can be passed using the new `facet_kws` parameter (:pr:`2576`).
+- |API| |Enhancement| In :func:`lmplot`, added a new `facet_kws` parameter and deprecated the `sharex`, `sharey`, and `legend_out` parameters from the function signature; pass them in the `facet_kws` dictionary (:pr:`2576`).
 
 - |Fix| In :func:`lineplot, allowed the `dashes` keyword to set the style of a line without mapping a `style` variable (:pr:`2449`).
 
@@ -43,6 +43,8 @@ A paper describing seaborn was published in the `Journal of Open Source Software
 - |Fix| In :func:`lmplot`, fixed a bug where `sharey=False` did not always work as expected (:pr:`2576`).
 
 - |Fix| In the relational plots, fixed a bug where legend entries for the `size` semantic were incorrect when `size_norm` extrapolated beyond the range of the data (:pr:`2580`).
+
+- |Fix| In :func:`relplot` and :func:`displot`, fixed a bug where the dataframe attached to the returned `FacetGrid` object dropped columns that were not used in the plot (:pr:`2623`).
 
 - |Fix| In :func:`relplot`, fixed an error that would be raised when a column used to facet shared a name with one of the plot variables (:pr:`2581`).
 

--- a/seaborn/distributions.py
+++ b/seaborn/distributions.py
@@ -2312,6 +2312,8 @@ def displot(
     g.tight_layout()
 
     if data is not None and (x is not None or y is not None):
+        if not isinstance(data, pd.DataFrame):
+            data = pd.DataFrame(data)
         g.data = pd.merge(
             data,
             g.data[g.data.columns.difference(data.columns)],

--- a/seaborn/distributions.py
+++ b/seaborn/distributions.py
@@ -2177,8 +2177,8 @@ def displot(
             p.variables[var] = f"_{var}_"
 
     # Adapt the plot_data dataframe for use with FacetGrid
-    data = p.plot_data.rename(columns=p.variables)
-    data = data.loc[:, ~data.columns.duplicated()]
+    grid_data = p.plot_data.rename(columns=p.variables)
+    grid_data = grid_data.loc[:, ~grid_data.columns.duplicated()]
 
     col_name = p.variables.get("col", None)
     row_name = p.variables.get("row", None)
@@ -2187,7 +2187,7 @@ def displot(
         facet_kws = {}
 
     g = FacetGrid(
-        data=data, row=row_name, col=col_name,
+        data=grid_data, row=row_name, col=col_name,
         col_wrap=col_wrap, row_order=row_order,
         col_order=col_order, height=height,
         aspect=aspect,
@@ -2310,6 +2310,19 @@ def displot(
     )
     g.set_titles()
     g.tight_layout()
+
+    if data is not None and (x is not None or y is not None):
+        g.data = pd.merge(
+            data,
+            g.data[g.data.columns.difference(data.columns)],
+            left_index=True,
+            right_index=True,
+        )
+    else:
+        wide_cols = {
+            k: f"_{k}_" if v is None else v for k, v in p.variables.items()
+        }
+        g.data = p.plot_data.rename(columns=wide_cols)
 
     return g
 

--- a/seaborn/relational.py
+++ b/seaborn/relational.py
@@ -1005,6 +1005,8 @@ def relplot(
     }
     grid_data = g.data.rename(columns=orig_cols)
     if data is not None and (x is not None or y is not None):
+        if not isinstance(data, pd.DataFrame):
+            data = pd.DataFrame(data)
         g.data = pd.merge(
             data,
             grid_data[grid_data.columns.difference(data.columns)],

--- a/seaborn/relational.py
+++ b/seaborn/relational.py
@@ -1,6 +1,7 @@
 import warnings
 
 import numpy as np
+import pandas as pd
 import matplotlib as mpl
 import matplotlib.pyplot as plt
 
@@ -1002,7 +1003,16 @@ def relplot(
     orig_cols = {
         f"_{k}": f"_{k}_" if v is None else v for k, v in variables.items()
     }
-    g.data = g.data.rename(columns=orig_cols)
+    grid_data = g.data.rename(columns=orig_cols)
+    if data is not None and (x is not None or y is not None):
+        g.data = pd.merge(
+            data,
+            grid_data[grid_data.columns.difference(data.columns)],
+            left_index=True,
+            right_index=True,
+        )
+    else:
+        g.data = grid_data
 
     return g
 

--- a/seaborn/tests/test_distributions.py
+++ b/seaborn/tests/test_distributions.py
@@ -2320,6 +2320,19 @@ class TestDisPlot:
         clim2 = g.axes.flat[1].collections[0].get_clim()
         assert clim1[1] > clim2[1]
 
+    def test_facetgrid_data(self, long_df):
+
+        g = displot(
+            data=long_df,
+            x="z",
+            hue=long_df["a"].rename("hue_var"),
+            col=long_df["c"].to_numpy(),
+        )
+        expected_cols = set(long_df.columns.to_list() + ["hue_var", "_col_"])
+        assert set(g.data.columns) == expected_cols
+        assert_array_equal(g.data["hue_var"], long_df["a"])
+        assert_array_equal(g.data["_col_"], long_df["c"])
+
 
 def integrate(y, x):
     """"Simple numerical integration for testing KDE code."""

--- a/seaborn/tests/test_distributions.py
+++ b/seaborn/tests/test_distributions.py
@@ -2323,7 +2323,7 @@ class TestDisPlot:
     def test_facetgrid_data(self, long_df):
 
         g = displot(
-            data=long_df.to_dict(),
+            data=long_df.to_dict(orient="list"),
             x="z",
             hue=long_df["a"].rename("hue_var"),
             col=long_df["c"].to_numpy(),

--- a/seaborn/tests/test_distributions.py
+++ b/seaborn/tests/test_distributions.py
@@ -2323,7 +2323,7 @@ class TestDisPlot:
     def test_facetgrid_data(self, long_df):
 
         g = displot(
-            data=long_df,
+            data=long_df.to_dict(),
             x="z",
             hue=long_df["a"].rename("hue_var"),
             col=long_df["c"].to_numpy(),

--- a/seaborn/tests/test_relational.py
+++ b/seaborn/tests/test_relational.py
@@ -620,9 +620,11 @@ class TestRelationalPlotter(Helpers):
     def test_relplot_data(self, long_df):
 
         g = relplot(
-            data=long_df.to_dict(),
-            x="x", y=long_df["y"].rename("y_var"),
-            hue=long_df["a"].to_numpy(), col="c"
+            data=long_df.to_dict(orient="list"),
+            x="x",
+            y=long_df["y"].rename("y_var"),
+            hue=long_df["a"].to_numpy(),
+            col="c",
         )
         expected_cols = set(long_df.columns.to_list() + ["_hue_", "y_var"])
         assert set(g.data.columns) == expected_cols

--- a/seaborn/tests/test_relational.py
+++ b/seaborn/tests/test_relational.py
@@ -620,7 +620,7 @@ class TestRelationalPlotter(Helpers):
     def test_relplot_data(self, long_df):
 
         g = relplot(
-            data=long_df,
+            data=long_df.to_dict(),
             x="x", y=long_df["y"].rename("y_var"),
             hue=long_df["a"].to_numpy(), col="c"
         )

--- a/seaborn/tests/test_relational.py
+++ b/seaborn/tests/test_relational.py
@@ -617,15 +617,17 @@ class TestRelationalPlotter(Helpers):
         for line, color in zip(lines, palette):
             assert line.get_color() == color
 
-    def test_relplot_data_columns(self, long_df):
+    def test_relplot_data(self, long_df):
 
-        long_df = long_df.assign(x_var=long_df["x"], y_var=long_df["y"])
         g = relplot(
             data=long_df,
-            x="x_var", y="y_var",
+            x="x", y=long_df["y"].rename("y_var"),
             hue=long_df["a"].to_numpy(), col="c"
         )
-        assert g.data.columns.to_list() == ["x_var", "y_var", "_hue_", "c"]
+        expected_cols = set(long_df.columns.to_list() + ["_hue_", "y_var"])
+        assert set(g.data.columns) == expected_cols
+        assert_array_equal(g.data["y_var"], long_df["y"])
+        assert_array_equal(g.data["_hue_"], long_df["a"])
 
     def test_facet_variable_collision(self, long_df):
 


### PR DESCRIPTION
Fixes #2622 

Context: `relplot` and `displot` no longer use the original approach of "set up a `FacetGrid`, map an axes-level function" such that the `FacetGrid` owns the data. This is because they can handle wide data and data passed directly as vectors, using the relevant module-level plotting class to parse the inputs. But as a consequence, the `.data` attribute on the `FacetGrid` that they return does not have all the columns that were passed into the function.

This  PR attempts to improve that situation by merging the input dataframe with the processed dataframe used internally (which handles, e.g. the transform from wide data or vectors that were passed directly to plot kwargs, often without names).

Because input data specification is so flexible, this is a little tricky, and there may be some corner cases. For instance, if you pass a series object to one of the plot variables and it shares a name with one of the columns in the input dataframe, its data won't be represented in the output data. It may be possible to handle weird cases like that, but for now I am going to aim for simplicity / consistency with what was originally possible.

### Test case with `displot`

```python
g = sns.displot(
    data=tips.to_dict(orient="list"),
    x="total_bill",
    hue=tips["smoker"].rename("y_var"),
    col=tips["time"].to_numpy(),
)
print(g.data.head())
```

v0.11.1:
```
   total_bill y_var   _col_
0       16.99    No  Dinner
1       10.34    No  Dinner
2       21.01    No  Dinner
3       23.68    No  Dinner
4       24.59    No  Dinner
```

This branch:
```
   total_bill   tip     sex smoker  day    time  size   _col_ y_var
0       16.99  1.01  Female     No  Sun  Dinner     2  Dinner    No
1       10.34  1.66    Male     No  Sun  Dinner     3  Dinner    No
2       21.01  3.50    Male     No  Sun  Dinner     3  Dinner    No
3       23.68  3.31    Male     No  Sun  Dinner     2  Dinner    No
4       24.59  3.61  Female     No  Sun  Dinner     4  Dinner    No
```

### Test case with `relplot`

```python
g = sns.relplot(
    data=tips,
    x="total_bill",
    y=tips["tip"].to_numpy(),
    col=tips["time"].rename("col_var"),
)
print(g.data.head())
```

v0.11.1:
```
       x     y   hue  size style units   NaN col_var
0  16.99  1.01  None  None  None  None  None  Dinner
1  10.34  1.66  None  None  None  None  None  Dinner
2  21.01  3.50  None  None  None  None  None  Dinner
3  23.68  3.31  None  None  None  None  None  Dinner
4  24.59  3.61  None  None  None  None  None  Dinner
```

This branch:
```
   total_bill   tip     sex smoker  day    time  size   _y_ col_var
0       16.99  1.01  Female     No  Sun  Dinner     2  1.01  Dinner
1       10.34  1.66    Male     No  Sun  Dinner     3  1.66  Dinner
2       21.01  3.50    Male     No  Sun  Dinner     3  3.50  Dinner
3       23.68  3.31    Male     No  Sun  Dinner     2  3.31  Dinner
4       24.59  3.61  Female     No  Sun  Dinner     4  3.61  Dinner
```

### TODO
- [x] Mention in release notes