### PR TITLE
Avoid scatter edgecolor warning

### DIFF
--- a/seaborn/relational.py
+++ b/seaborn/relational.py
@@ -553,9 +553,6 @@ class _ScatterPlotter(_RelationalPlotter):
         x = data.get("x", empty)
         y = data.get("y", empty)
 
-        # Set defaults for other visual attributes
-        kws.setdefault("edgecolor", "w")
-
         if "style" in self.variables:
             # Use a representative marker so scatter sets the edgecolor
             # properly for line art markers. We currently enforce either
@@ -563,6 +560,14 @@ class _ScatterPlotter(_RelationalPlotter):
             example_level = self._style_map.levels[0]
             example_marker = self._style_map(example_level, "marker")
             kws.setdefault("marker", example_marker)
+
+        # Conditionally set the marker edgecolor based on whether the marker is "filled"
+        # See https://github.com/matplotlib/matplotlib/issues/17849 for context
+        m = kws.get("marker", mpl.rcParams.get("marker", "o"))
+        if not isinstance(m, mpl.markers.MarkerStyle):
+            m = mpl.markers.MarkerStyle(m)
+        if m.is_filled():
+            kws.setdefault("edgecolor", "w")
 
         # TODO this makes it impossible to vary alpha with hue which might
         # otherwise be useful? Should we just pass None?

--- a/seaborn/tests/test_axisgrid.py
+++ b/seaborn/tests/test_axisgrid.py
@@ -1609,6 +1609,7 @@ class TestJointGrid:
         npt.assert_array_equal(g.ax_joint.lines[-1].get_xydata(), hline)
         assert len(g.ax_marg_x.lines) == len(g.ax_marg_y.lines)
 
+
 class TestJointPlot:
 
     rs = np.random.RandomState(sum(map(ord, "jointplot")))

--- a/seaborn/tests/test_relational.py
+++ b/seaborn/tests/test_relational.py
@@ -1693,6 +1693,12 @@ class TestScatterPlotter(SharedAxesLevelTests, Helpers):
         # https://github.com/matplotlib/matplotlib/issues/17586
         ax.get_xlim()[0] > ax.xaxis.convert_units(np.datetime64("2002-01-01"))
 
+    def test_unfilled_marker_edgecolor_warning(self, long_df):  # GH2636
+
+        with pytest.warns(None) as record:
+            scatterplot(data=long_df, x="x", y="y", marker="+")
+        assert not record
+
     def test_scatterplot_vs_relplot(self, long_df, long_semantics):
 
         ax = scatterplot(data=long_df, **long_semantics)


### PR DESCRIPTION
Matplotlib added a warning when passing an `edgecolor` parameter with an unfilled `scatter` marker. See https://github.com/matplotlib/matplotlib/issues/17849 and subsequent matplotlib PR  for details.

seaborn wasn't doing anything wrong here, but on newer matplotlibs it will now spew warnings; this change avoids them.