### PR TITLE
Add Grid.figure to (eventually) replace Grid.fig

### DIFF
--- a/doc/docstrings/FacetGrid.ipynb
+++ b/doc/docstrings/FacetGrid.ipynb
@@ -262,7 +262,7 @@
    "source": [
     "g = sns.FacetGrid(tips, col=\"sex\", row=\"time\", margin_titles=True, despine=False)\n",
     "g.map_dataframe(sns.scatterplot, x=\"total_bill\", y=\"tip\")\n",
-    "g.fig.subplots_adjust(wspace=0, hspace=0)\n",
+    "g.figure.subplots_adjust(wspace=0, hspace=0)\n",
     "for (row_val, col_val), ax in g.axes_dict.items():\n",
     "    if row_val == \"Lunch\" and col_val == \"Female\":\n",
     "        ax.set_facecolor(\".95\")\n",

--- a/doc/introduction.ipynb
+++ b/doc/introduction.ipynb
@@ -417,7 +417,7 @@
     ")\n",
     "g.set_axis_labels(\"Bill length (mm)\", \"Bill depth (mm)\", labelpad=10)\n",
     "g.legend.set_title(\"Body mass (g)\")\n",
-    "g.fig.set_size_inches(6.5, 4.5)\n",
+    "g.figure.set_size_inches(6.5, 4.5)\n",
     "g.ax.margins(.15)\n",
     "g.despine(trim=True)"
    ]

--- a/doc/releases/v0.11.2.txt
+++ b/doc/releases/v0.11.2.txt
@@ -12,9 +12,11 @@ This is a minor release that addresses issues in the v0.11 series and adds a sma
 
 - |Feature| In :func:`kdeplot`, added the `warn_singular` parameter to silence the warning about data with zero variance (:pr:`2566`).
 
-- |Enhancement| In :class:`FacetGrid` and functions that use it, visibility of the interior axis labels is now disabled, and exterior axis labels are no longer erased when adding additional layers. This produces the same results for plots made by seaborn functions, but it may produce different (better, in most cases) results for customized facet plots (:pr:`2583`).
-
 - |Enhancement| In :func:`histplot`, improved performance with large datasets and many groupings/facets (:pr:`2559`, :pr:`2570`).
+
+- |Enhancement| The :class:`FacetGrid` and :class:`PairGrid` objects now reference the underlying matplotlib figure with a `.figure` attribute. The existing `.fig` attribute still exists but is discouraged and may eventually be deprecated. The effect is that you can now call `obj.figure` on the return value from any seaborn function (:pr:`2639`).
+
+- |Enhancement| In :class:`FacetGrid` and functions that use it, visibility of the interior axis labels is now disabled, and exterior axis labels are no longer erased when adding additional layers. This produces the same results for plots made by seaborn functions, but it may produce different (better, in most cases) results for customized facet plots (:pr:`2583`).
 
 - |Enhancement| In :class:`FacetGrid`, :class:`PairGrid`, and functions that use them, the matplotlib `figure.autolayout` parameter is disabled to avoid having the legend overlap the plot (:pr:`2571`).
 

--- a/doc/releases/v0.11.2.txt
+++ b/doc/releases/v0.11.2.txt
@@ -14,7 +14,7 @@ This is a minor release that addresses issues in the v0.11 series and adds a sma
 
 - |Enhancement| In :func:`histplot`, improved performance with large datasets and many groupings/facets (:pr:`2559`, :pr:`2570`).
 
-- |Enhancement| The :class:`FacetGrid` and :class:`PairGrid` objects now reference the underlying matplotlib figure with a `.figure` attribute. The existing `.fig` attribute still exists but is discouraged and may eventually be deprecated. The effect is that you can now call `obj.figure` on the return value from any seaborn function (:pr:`2639`).
+- |Enhancement| The :class:`FacetGrid`, :class:`PairGrid`, and :class:`JointGrid` objects now reference the underlying matplotlib figure with a `.figure` attribute. The existing `.fig` attribute still exists but is discouraged and may eventually be deprecated. The effect is that you can now call `obj.figure` on the return value from any seaborn function to access the matplotlib object (:pr:`2639`).
 
 - |Enhancement| In :class:`FacetGrid` and functions that use it, visibility of the interior axis labels is now disabled, and exterior axis labels are no longer erased when adding additional layers. This produces the same results for plots made by seaborn functions, but it may produce different (better, in most cases) results for customized facet plots (:pr:`2583`).
 

--- a/doc/tutorial/axis_grids.ipynb
+++ b/doc/tutorial/axis_grids.ipynb
@@ -245,14 +245,14 @@
     "g.map(sns.scatterplot, \"total_bill\", \"tip\", color=\"#334488\")\n",
     "g.set_axis_labels(\"Total bill (US Dollars)\", \"Tip\")\n",
     "g.set(xticks=[10, 30, 50], yticks=[2, 6, 10])\n",
-    "g.fig.subplots_adjust(wspace=.02, hspace=.02)"
+    "g.figure.subplots_adjust(wspace=.02, hspace=.02)"
    ]
   },
   {
    "cell_type": "raw",
    "metadata": {},
    "source": [
-    "For even more customization, you can  work directly with the underling matplotlib ``Figure`` and ``Axes`` objects, which are stored as member attributes at ``fig`` and ``axes`` (a two-dimensional array), respectively. When making a figure without row or column faceting, you can also use the ``ax`` attribute to directly access the single axes."
+    "For even more customization, you can  work directly with the underling matplotlib ``Figure`` and ``Axes`` objects, which are stored as member attributes at ``figure`` and ``axes_dict``, respectively. When making a figure without row or column faceting, you can also use the ``ax`` attribute to directly access the single axes."
    ]
   },
   {
@@ -263,7 +263,7 @@
    "source": [
     "g = sns.FacetGrid(tips, col=\"smoker\", margin_titles=True, height=4)\n",
     "g.map(plt.scatter, \"total_bill\", \"tip\", color=\"#338844\", edgecolor=\"white\", s=50, lw=1)\n",
-    "for ax in g.axes.flat:\n",
+    "for ax in g.axes_dict.values():\n",
     "    ax.axline((0, 0), slope=.2, c=\".2\", ls=\"--\", zorder=0)\n",
     "g.set(xlim=(0, 60), ylim=(0, 14))"
    ]

--- a/doc/tutorial/relational.ipynb
+++ b/doc/tutorial/relational.ipynb
@@ -224,7 +224,7 @@
     "df = pd.DataFrame(dict(time=np.arange(500),\n",
     "                       value=np.random.randn(500).cumsum()))\n",
     "g = sns.relplot(x=\"time\", y=\"value\", kind=\"line\", data=df)\n",
-    "g.fig.autofmt_xdate()"
+    "g.figure.autofmt_xdate()"
    ]
   },
   {
@@ -519,7 +519,7 @@
     "df = pd.DataFrame(dict(time=pd.date_range(\"2017-1-1\", periods=500),\n",
     "                       value=np.random.randn(500).cumsum()))\n",
     "g = sns.relplot(x=\"time\", y=\"value\", kind=\"line\", data=df)\n",
-    "g.fig.autofmt_xdate()"
+    "g.figure.autofmt_xdate()"
    ]
   },
   {

--- a/examples/joint_histogram.py
+++ b/examples/joint_histogram.py
@@ -16,7 +16,7 @@ g = sns.JointGrid(data=planets, x="year", y="distance", marginal_ticks=True)
 g.ax_joint.set(yscale="log")
 
 # Create an inset legend for the histogram colorbar
-cax = g.fig.add_axes([.15, .55, .02, .2])
+cax = g.figure.add_axes([.15, .55, .02, .2])
 
 # Add the joint and marginal histogram plots
 g.plot_joint(

--- a/examples/kde_ridgeplot.py
+++ b/examples/kde_ridgeplot.py
@@ -42,7 +42,7 @@ def label(x, color, label):
 g.map(label, "x")
 
 # Set the subplots to overlap
-g.fig.subplots_adjust(hspace=-.25)
+g.figure.subplots_adjust(hspace=-.25)
 
 # Remove axes details that don't play well with overlap
 g.set_titles("")

--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -811,7 +811,7 @@ class ClusterGrid(Grid):
 
         self.mask = _matrix_mask(self.data2d, mask)
 
-        self.fig = plt.figure(figsize=figsize)
+        self._figure = plt.figure(figsize=figsize)
 
         self.row_colors, self.row_color_labels = \
             self._preprocess_colors(data, row_colors, axis=0)
@@ -842,8 +842,8 @@ class ClusterGrid(Grid):
                                     width_ratios=width_ratios,
                                     height_ratios=height_ratios)
 
-        self.ax_row_dendrogram = self.fig.add_subplot(self.gs[-1, 0])
-        self.ax_col_dendrogram = self.fig.add_subplot(self.gs[0, -1])
+        self.ax_row_dendrogram = self._figure.add_subplot(self.gs[-1, 0])
+        self.ax_col_dendrogram = self._figure.add_subplot(self.gs[0, -1])
         self.ax_row_dendrogram.set_axis_off()
         self.ax_col_dendrogram.set_axis_off()
 
@@ -851,19 +851,19 @@ class ClusterGrid(Grid):
         self.ax_col_colors = None
 
         if self.row_colors is not None:
-            self.ax_row_colors = self.fig.add_subplot(
+            self.ax_row_colors = self._figure.add_subplot(
                 self.gs[-1, 1])
         if self.col_colors is not None:
-            self.ax_col_colors = self.fig.add_subplot(
+            self.ax_col_colors = self._figure.add_subplot(
                 self.gs[1, -1])
 
-        self.ax_heatmap = self.fig.add_subplot(self.gs[-1, -1])
+        self.ax_heatmap = self._figure.add_subplot(self.gs[-1, -1])
         if cbar_pos is None:
             self.ax_cbar = self.cax = None
         else:
             # Initialize the colorbar axes in the gridspec so that tight_layout
             # works. We will move it where it belongs later. This is a hack.
-            self.ax_cbar = self.fig.add_subplot(self.gs[0, 0])
+            self.ax_cbar = self._figure.add_subplot(self.gs[0, 0])
             self.cax = self.ax_cbar  # Backwards compatibility
         self.cbar_pos = cbar_pos
 
@@ -1066,11 +1066,6 @@ class ClusterGrid(Grid):
         cmap = mpl.colors.ListedColormap(list(unique_colors))
         return matrix, cmap
 
-    def savefig(self, *args, **kwargs):
-        if 'bbox_inches' not in kwargs:
-            kwargs['bbox_inches'] = 'tight'
-        self.fig.savefig(*args, **kwargs)
-
     def plot_dendrograms(self, row_cluster, col_cluster, metric, method,
                          row_linkage, col_linkage, tree_kws):
         # Plot the row dendrogram
@@ -1208,13 +1203,13 @@ class ClusterGrid(Grid):
 
         tight_params = dict(h_pad=.02, w_pad=.02)
         if self.ax_cbar is None:
-            self.fig.tight_layout(**tight_params)
+            self._figure.tight_layout(**tight_params)
         else:
             # Turn the colorbar axes off for tight layout so that its
             # ticks don't interfere with the rest of the plot layout.
             # Then move it.
             self.ax_cbar.set_axis_off()
-            self.fig.tight_layout(**tight_params)
+            self._figure.tight_layout(**tight_params)
             self.ax_cbar.set_axis_on()
             self.ax_cbar.set_position(self.cbar_pos)
 

--- a/seaborn/tests/test_axisgrid.py
+++ b/seaborn/tests/test_axisgrid.py
@@ -40,10 +40,11 @@ class TestFacetGrid:
         g = ag.FacetGrid(self.df)
         assert g.data is self.df
 
-    def test_self_fig(self):
+    def test_self_figure(self):
 
         g = ag.FacetGrid(self.df)
-        assert isinstance(g.fig, plt.Figure)
+        assert isinstance(g.figure, plt.Figure)
+        assert g.figure is g._figure
 
     def test_self_axes(self):
 
@@ -695,10 +696,11 @@ class TestPairGrid:
         expected = df.drop('date', axis=1)
         tm.assert_frame_equal(result, expected)
 
-    def test_self_fig(self):
+    def test_self_figure(self):
 
         g = ag.PairGrid(self.df)
-        assert isinstance(g.fig, plt.Figure)
+        assert isinstance(g.figure, plt.Figure)
+        assert g.figure is g._figure
 
     def test_self_axes(self):
 

--- a/seaborn/tests/test_axisgrid.py
+++ b/seaborn/tests/test_axisgrid.py
@@ -190,26 +190,26 @@ class TestFacetGrid:
     def test_figure_size(self):
 
         g = ag.FacetGrid(self.df, row="a", col="b")
-        npt.assert_array_equal(g.fig.get_size_inches(), (6, 9))
+        npt.assert_array_equal(g.figure.get_size_inches(), (6, 9))
 
         g = ag.FacetGrid(self.df, row="a", col="b", height=6)
-        npt.assert_array_equal(g.fig.get_size_inches(), (12, 18))
+        npt.assert_array_equal(g.figure.get_size_inches(), (12, 18))
 
         g = ag.FacetGrid(self.df, col="c", height=4, aspect=.5)
-        npt.assert_array_equal(g.fig.get_size_inches(), (6, 4))
+        npt.assert_array_equal(g.figure.get_size_inches(), (6, 4))
 
     def test_figure_size_with_legend(self):
 
         g = ag.FacetGrid(self.df, col="a", hue="c", height=4, aspect=.5)
-        npt.assert_array_equal(g.fig.get_size_inches(), (6, 4))
+        npt.assert_array_equal(g.figure.get_size_inches(), (6, 4))
         g.add_legend()
-        assert g.fig.get_size_inches()[0] > 6
+        assert g.figure.get_size_inches()[0] > 6
 
         g = ag.FacetGrid(self.df, col="a", hue="c", height=4, aspect=.5,
                          legend_out=False)
-        npt.assert_array_equal(g.fig.get_size_inches(), (6, 4))
+        npt.assert_array_equal(g.figure.get_size_inches(), (6, 4))
         g.add_legend()
-        npt.assert_array_equal(g.fig.get_size_inches(), (6, 4))
+        npt.assert_array_equal(g.figure.get_size_inches(), (6, 4))
 
     def test_legend_data(self):
 
@@ -343,7 +343,7 @@ class TestFacetGrid:
             ax.set_xticks([])
             ax.set_yticks([])
 
-        g.fig.tight_layout()
+        g.figure.tight_layout()
 
         for (l, m, r) in g.axes:
             assert l.get_position().width > m.get_position().width
@@ -758,10 +758,10 @@ class TestPairGrid:
         plot_vars = ["x", "y", "z"]
         g = ag.PairGrid(self.df, vars=plot_vars, corner=True)
         corner_size = sum([i + 1 for i in range(len(plot_vars))])
-        assert len(g.fig.axes) == corner_size
+        assert len(g.figure.axes) == corner_size
 
         g.map_diag(plt.hist)
-        assert len(g.fig.axes) == (corner_size + len(plot_vars))
+        assert len(g.figure.axes) == (corner_size + len(plot_vars))
 
         for ax in np.diag(g.axes):
             assert not ax.yaxis.get_visible()
@@ -770,7 +770,7 @@ class TestPairGrid:
         plot_vars = ["x", "y", "z"]
         g = ag.PairGrid(self.df, vars=plot_vars, corner=True)
         g.map(scatterplot)
-        assert len(g.fig.axes) == corner_size
+        assert len(g.figure.axes) == corner_size
 
     def test_size(self):
 


### PR DESCRIPTION
The advantage of this change is that you will be able to do

    obj = sns.<func>()
    obj.figure.<method>

regardless of whether `<func>` is figure-level or axes-level.

The `Grid.fig` methods are being soft-deprecated: discouraged in the
attribute documentation but not (currently) issuing a warning when used.