### PR TITLE
Add a move_legend convenience function

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -184,10 +184,11 @@ Utility functions
     :toctree: generated/
     :nosignatures:
 
+    despine
+    move_legend
+    saturate
+    desaturate
+    set_hls_values
     load_dataset
     get_dataset_names
     get_data_home
-    despine
-    desaturate
-    saturate
-    set_hls_values

--- a/doc/docstrings/move_legend.ipynb
+++ b/doc/docstrings/move_legend.ipynb
@@ -1,0 +1,156 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8ec46ad8-bc4c-4ee0-9626-271088c702f9",
+   "metadata": {
+    "tags": [
+     "hide"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "import seaborn as sns\n",
+    "sns.set_theme()\n",
+    "penguins = sns.load_dataset(\"penguins\")"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "008bdd98-88cb-4a81-9f50-9b0e5a357305",
+   "metadata": {},
+   "source": [
+    "For axes-level functions, pass the :class:`matplotlib.axes.Axes` object and provide a new location."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b82e58f9-b15d-4554-bee5-de6a689344a6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ax = sns.histplot(penguins, x=\"bill_length_mm\", hue=\"species\")\n",
+    "sns.move_legend(ax, \"center right\")"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "4f2a7f5d-ab39-46c7-87f4-532e607adf0b",
+   "metadata": {},
+   "source": [
+    "Use the `bbox_to_anchor` parameter for more fine-grained control, including moving the legend outside of the axes:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ed610a98-447a-4459-8342-48abc80330f0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ax = sns.histplot(penguins, x=\"bill_length_mm\", hue=\"species\")\n",
+    "sns.move_legend(ax, \"upper left\", bbox_to_anchor=(1, 1))"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "9d2fd766-a806-45d9-949d-1572991cf512",
+   "metadata": {},
+   "source": [
+    "Pass additional :meth:`matplotlib.axes.Axes.legend` parameters to update other properties:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5ad4342c-c46e-49e9-98a2-6c88c6fb4c54",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ax = sns.histplot(penguins, x=\"bill_length_mm\", hue=\"species\")\n",
+    "sns.move_legend(\n",
+    "    ax, \"lower center\",\n",
+    "    bbox_to_anchor=(.5, 1), ncol=3, title=None, frameon=False,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "0d573092-46fd-4a95-b7ed-7e6833823adc",
+   "metadata": {},
+   "source": [
+    "It's also possible to move the legend created by a figure-level function. But when fine-tuning the position, you must bear in mind that the figure will have extra blank space on the right:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b258a9b8-69e5-4d4a-94cb-5b6baddc402b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "g = sns.displot(\n",
+    "    penguins,\n",
+    "    x=\"bill_length_mm\", hue=\"species\",\n",
+    "    col=\"island\", col_wrap=2, height=3,\n",
+    ")\n",
+    "sns.move_legend(g, \"upper left\", bbox_to_anchor=(.55, .45))"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "c9dc54e2-2c66-412f-ab2a-4f2bc2cb5782",
+   "metadata": {},
+   "source": [
+    "One way to avoid this would be to set `legend_out=False` on the :class:`seaborn.FacetGrid`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "06cff408-4cdf-47af-8def-176f3e70ec5a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "g = sns.displot(\n",
+    "    penguins,\n",
+    "    x=\"bill_length_mm\", hue=\"species\",\n",
+    "    col=\"island\", col_wrap=2, height=3,\n",
+    "    facet_kws=dict(legend_out=False),\n",
+    ")\n",
+    "sns.move_legend(g, \"upper left\", bbox_to_anchor=(.55, .45), frameon=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b170f20d-22a9-4f7d-917a-d09e10b1f08c",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "seaborn-py38-latest",
+   "language": "python",
+   "name": "seaborn-py38-latest"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/doc/docstrings/move_legend.ipynb
+++ b/doc/docstrings/move_legend.ipynb
@@ -104,7 +104,7 @@
    "id": "c9dc54e2-2c66-412f-ab2a-4f2bc2cb5782",
    "metadata": {},
    "source": [
-    "One way to avoid this would be to set `legend_out=False` on the :class:`seaborn.FacetGrid`:"
+    "One way to avoid this would be to set `legend_out=False` on the :class:`FacetGrid`:"
    ]
   },
   {

--- a/doc/releases/v0.11.2.txt
+++ b/doc/releases/v0.11.2.txt
@@ -6,11 +6,13 @@ This is a minor release that addresses issues in the v0.11 series and adds a sma
 
 - |API| |Enhancement| In :func:`lmplot`, added a new `facet_kws` parameter and deprecated the `sharex`, `sharey`, and `legend_out` parameters from the function signature; pass them in a `facet_kws` dictionary instead (:pr:`2576`).
 
+- |Feature| Added a :func:`move_legend` convenience function for repositioning the legend on an existing axes or figure, along with updating its properties. This function should be preferred over calling `ax.legend` with no legend data, which does not reliably work across seaborn plot types (:pr:`2643`).
+
 - |Feature| In :func:`histplot`, added `stat="percent"` as an option for normalization such that bar heights sum to 100 and `stat="proportion"` as an alias for the existing `stat="probability"`: (:pr:`2461`, :pr:`2634`).
 
 - |Feature| Added a ``refline`` method to :class:`FacetGrid` and :class:`JointGrid` for adding horizontal and/or vertical reference lines to every subplot in one step (:pr:`2620`).
 
-- |Feature| In :func:`kdeplot`, added the `warn_singular` parameter to silence the warning about data with zero variance (:pr:`2566`).
+- |Feature| In :func:`kdeplot`, added a `warn_singular` parameter to silence the warning about data with zero variance (:pr:`2566`).
 
 - |Enhancement| In :func:`histplot`, improved performance with large datasets and many groupings/facets (:pr:`2559`, :pr:`2570`).
 


### PR DESCRIPTION
This addresses issues discussed in #2280, along with some of the issues in #2231

It is a somewhat hack-ish solution. Because matplotlib legends don't offer public
control over their location, this copies data from an existing legend to a new
object, and then removes the original legend. I am hopeful that there will be
upstream changes that make legend repositioning more natural, but this is
a reasonable stopgap measure to alleviate a common seaborn pain-point.

It is also in a sense more powerful than the name suggests, because it lets one
update other legend parameters, which is also not otherwise possible with
public methods on an existing legend object.

Example in action:

```python
ax = sns.histplot(penguins, x="bill_length_mm", hue="species")
sns.move_legend(ax, "lower center", bbox_to_anchor=(.5, 1), ncol=3)
```
![image](https://user-images.githubusercontent.com/315810/129489906-5f655cbd-28d5-4791-95ca-fa04924068e6.png)
