### PR TITLE
allowing hue_norm to be subclass of Normalize object

### DIFF
--- a/seaborn/_core.py
+++ b/seaborn/_core.py
@@ -244,7 +244,7 @@ class HueMapping(SemanticMapping):
                 norm = mpl.colors.Normalize()
             elif isinstance(norm, tuple):
                 norm = mpl.colors.Normalize(*norm)
-            elif not issubclass(norm, mpl.colors.Normalize):
+            elif not issubclass(type(norm), mpl.colors.Normalize):
                 err = "``hue_norm`` must be None, tuple, or subclass of Normalize object."
                 raise ValueError(err)
 

--- a/seaborn/_core.py
+++ b/seaborn/_core.py
@@ -244,7 +244,7 @@ class HueMapping(SemanticMapping):
                 norm = mpl.colors.Normalize()
             elif isinstance(norm, tuple):
                 norm = mpl.colors.Normalize(*norm)
-            elif not issubclass(type(norm), mpl.colors.Normalize):
+            elif not issubclass(norm, mpl.colors.Normalize):
                 err = "``hue_norm`` must be None, tuple, or subclass of Normalize object."
                 raise ValueError(err)
 

--- a/seaborn/_core.py
+++ b/seaborn/_core.py
@@ -244,8 +244,8 @@ class HueMapping(SemanticMapping):
                 norm = mpl.colors.Normalize()
             elif isinstance(norm, tuple):
                 norm = mpl.colors.Normalize(*norm)
-            elif not isinstance(norm, mpl.colors.Normalize):
-                err = "``hue_norm`` must be None, tuple, or Normalize object."
+            elif not issubclass(type(norm), mpl.colors.Normalize):
+                err = "``hue_norm`` must be None, tuple, or subclass of Normalize object."
                 raise ValueError(err)
 
             if not norm.scaled():


### PR DESCRIPTION
Explain with an example:
user wants to use matplotlib.colors.LogNorm and not the standard Normalize.

currently hue_norm only supports instance of Normalize object,
but it can work just fine with any subclass of it which implements the __call__ method (such as LogNorm)