### PR TITLE
Option for kdeplot to interpret `levels` as densities.

### DIFF
--- a/examples/layered_bivariate_plot.py
+++ b/examples/layered_bivariate_plot.py
@@ -19,5 +19,8 @@ x, y = rng.multivariate_normal(mean, cov, n).T
 # Draw a combo histogram and scatterplot with density contours
 f, ax = plt.subplots(figsize=(6, 6))
 sns.scatterplot(x=x, y=y, s=5, color=".15")
-sns.histplot(x=x, y=y, bins=50, pthresh=.1, cmap="mako")
-sns.kdeplot(x=x, y=y, levels=5, color="w", linewidths=1)
+sns.histplot(x=x, y=y, bins=50, pthresh=.1, cmap="mako", cbar=True,
+    stat="density", vmin=0, vmax=0.40)
+sns.kdeplot(x=x, y=y,
+    levels=np.arange(0, 0.45, 0.05), levels_as_densities=True,
+    color="white", cbar=True, linestyles=['solid', 'dashed', 'dotted'])


### PR DESCRIPTION
The main motivation for this PR is that I wanted to improve the clarity of a histplot by adding lines from a kdeplot.
Those lines should be at know value that aproximately represent the histogram height (or, rather, the probability density).

Currently, the `levels` argument in `kdeplot` is interpreted as iso-proportions.
This PR proposes a `levels_as_densities` kwarg. This allows to specify `levels`
as iso-densities instead of iso-proportions.

This has  two advantages:
- lines (e.g. of matching styles) can be compared across different kdeplots.
- when enabeling a colorbar for kdeplot, the values can be compared to histplot. In principle, the two cbars can be combined.

I illustrated this in the layered_bivariate example, see below.

![sample](https://user-images.githubusercontent.com/12393119/137514139-dff86ad6-cca4-475d-ae70-3267906b1deb.jpg)

