### PR TITLE
setup.py: Update runtime error to correct minimal Python version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,8 +68,8 @@ if __name__ == "__main__":
     from setuptools import setup
 
     import sys
-    if sys.version_info[:2] < (3, 6):
-        raise RuntimeError("seaborn requires python >= 3.6.")
+    if sys.version_info[:2] < (3, 7):
+        raise RuntimeError("seaborn requires python >= 3.7.")
 
     setup(
         name=DISTNAME,


### PR DESCRIPTION
Small nitpick after #2396: Also update the runtime error to list Python 3.7 as minimal version