### PR TITLE
Loosen doc/requirements.txt

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,6 +1,6 @@
-docutils<=0.17  # https://sourceforge.net/p/docutils/bugs/431/
-sphinx==3.3.1
-sphinx_bootstrap_theme==0.7.1
+docutils<0.18  # https://sourceforge.net/p/docutils/bugs/431/
+sphinx>=3.3.1
+sphinx_bootstrap_theme>=0.7.1
 numpydoc
 nbconvert
 ipykernel


### PR DESCRIPTION
Loosen the package requirements in `doc/requirements.txt`.
 - `docutils<0.18` allows docutils 0.17.1 and maybe a future 0.17.2
 - sphinx and sphinx_bootstrap_theme now only have minimal versions

This enables the docs to be build with Python 3.10.