### PR TITLE
[DO NOT MERGE] Test pandas 1.4 release candidate

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,6 +44,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
 
         python: ['3.7.x', '3.8.x', '3.9.x']
@@ -85,6 +86,7 @@ jobs:
           if [[ ${{matrix.install}} == 'all' ]]; then EXTRAS='[all]'; fi
           if [[ ${{matrix.deps }} == 'pinned' ]]; then DEPS='-r ci/deps_pinned.txt'; fi
           pip install .$EXTRAS $DEPS -r ci/utils.txt
+          pip install --upgrade --pre pandas==1.4.0rc0
 
       - name: Cache datastes
         run: python ci/cache_test_datasets.py


### PR DESCRIPTION
Similarly as https://github.com/mwaskom/seaborn/pull/2608, not to merge, but just to test the pandas release candidate on your CI.