### PR TITLE
Use f-strings for string formatting

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -68,7 +68,7 @@ master_doc = 'index'
 # General information about the project.
 project = u'seaborn'
 import time
-copyright = u'2012-{}'.format(time.strftime("%Y"))
+copyright = f"2012-{time.strftime('%Y')}"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/doc/sphinxext/gallery_generator.py
+++ b/doc/sphinxext/gallery_generator.py
@@ -185,7 +185,7 @@ class ExampleGenerator(object):
         if not op.exists(outfilename) or op.getmtime(outfilename) < file_mtime:
             self.exec_file()
         else:
-            print("skipping {0}".format(self.filename))
+            print(f"skipping {self.filename}")
 
     @property
     def dirname(self):
@@ -299,7 +299,7 @@ class ExampleGenerator(object):
         self.end_line = erow + 1 + start_row
 
     def exec_file(self):
-        print("running {0}".format(self.filename))
+        print(f"running {self.filename}")
 
         plt.close('all')
         my_globals = {'pl': plt,
@@ -310,14 +310,14 @@ class ExampleGenerator(object):
         fig.canvas.draw()
         pngfile = op.join(self.target_dir, self.pngfilename)
         thumbfile = op.join("example_thumbs", self.thumbfilename)
-        self.html = "<img src=../%s>" % self.pngfilename
+        self.html = f"<img src=../{self.pngfilename}>"
         fig.savefig(pngfile, dpi=75, bbox_inches="tight")
 
         cx, cy = self.thumbloc
         create_thumbnail(pngfile, thumbfile, cx=cx, cy=cy)
 
     def toctree_entry(self):
-        return "   ./%s\n\n" % op.splitext(self.htmlfilename)[0]
+        return f"   ./{op.splitext(self.htmlfilename)[0]}\n\n"
 
     def contents_entry(self):
         return (".. raw:: html\n\n"

--- a/seaborn/_core.py
+++ b/seaborn/_core.py
@@ -51,7 +51,7 @@ class SemanticMapping:
 
     def map(cls, plotter, *args, **kwargs):
         # This method is assigned the __init__ docstring
-        method_name = "_{}_map".format(cls.__name__[:-7].lower())
+        method_name = f"_{cls.__name__[:-7].lower()}_map"
         setattr(plotter, method_name, cls(plotter, *args, **kwargs))
         return plotter
 

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -2073,8 +2073,7 @@ def pairplot(
 
     if not isinstance(data, pd.DataFrame):
         raise TypeError(
-            "'data' must be pandas DataFrame object, not: {typefound}".format(
-                typefound=type(data)))
+            f"'data' must be pandas DataFrame object, not: {type(data)}")
 
     plot_kws = {} if plot_kws is None else plot_kws.copy()
     diag_kws = {} if diag_kws is None else diag_kws.copy()

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -498,7 +498,7 @@ class _CategoricalPlotter(object):
             # Validate the inputs
             for var in [x, y, hue, units]:
                 if isinstance(var, str):
-                    err = "Could not interpret input '{}'".format(var)
+                    err = f"Could not interpret input '{var}'"
                     raise ValueError(err)
 
             # Figure out the plotting orientation
@@ -872,7 +872,7 @@ class _ViolinPlotter(_CategoricalPlotter):
                         inner.startswith("box"),
                         inner.startswith("stick"),
                         inner.startswith("point")]):
-                err = "Inner style '{}' not recognized".format(inner)
+                err = f"Inner style '{inner}' not recognized"
                 raise ValueError(err)
         self.inner = inner
 
@@ -1004,7 +1004,7 @@ class _ViolinPlotter(_CategoricalPlotter):
             self.scale_count(density, counts, scale_hue)
 
         else:
-            raise ValueError("scale method '{}' not recognized".format(scale))
+            raise ValueError(f"scale method '{scale}' not recognized")
 
         # Set object attributes that will be used while plotting
         self.support = support
@@ -3592,7 +3592,7 @@ def catplot(
     try:
         plot_func = globals()[kind + "plot"]
     except KeyError:
-        err = "Plot kind '{}' is not recognized".format(kind)
+        err = f"Plot kind '{kind}' is not recognized"
         raise ValueError(err)
 
     # Check for attempt to plot onto specific axes and warn

--- a/seaborn/external/appdirs.py
+++ b/seaborn/external/appdirs.py
@@ -620,24 +620,24 @@ if __name__ == "__main__":
              "site_data_dir",
              "site_config_dir")
 
-    print("-- app dirs %s --" % __version__)
+    print(f"-- app dirs {__version__} --")
 
     print("-- app dirs (with optional 'version')")
     dirs = AppDirs(appname, appauthor, version="1.0")
     for prop in props:
-        print("%s: %s" % (prop, getattr(dirs, prop)))
+        print(f"{prop}: {getattr(dirs, prop)}")
 
     print("\n-- app dirs (without optional 'version')")
     dirs = AppDirs(appname, appauthor)
     for prop in props:
-        print("%s: %s" % (prop, getattr(dirs, prop)))
+        print(f"{prop}: {getattr(dirs, prop)}")
 
     print("\n-- app dirs (without optional 'appauthor')")
     dirs = AppDirs(appname)
     for prop in props:
-        print("%s: %s" % (prop, getattr(dirs, prop)))
+        print(f"{prop}: {getattr(dirs, prop)}")
 
     print("\n-- app dirs (with disabled 'appauthor')")
     dirs = AppDirs(appname, appauthor=False)
     for prop in props:
-        print("%s: %s" % (prop, getattr(dirs, prop)))
+        print(f"{prop}: {getattr(dirs, prop)}")

--- a/seaborn/external/docscrape.py
+++ b/seaborn/external/docscrape.py
@@ -126,7 +126,7 @@ class ParseError(Exception):
     def __str__(self):
         message = self.args[0]
         if hasattr(self, 'docstring'):
-            message = "%s in %r" % (message, self.docstring)
+            message = f"{message} in {self.docstring!r}"
         return message
 
 
@@ -179,7 +179,7 @@ class NumpyDocString(Mapping):
 
     def __setitem__(self, key, val):
         if key not in self._parsed_data:
-            self._error_location("Unknown section %s" % key, error=False)
+            self._error_location(f"Unknown section {key}", error=False)
         else:
             self._parsed_data[key] = val
 
@@ -311,7 +311,7 @@ class NumpyDocString(Mapping):
             """Match ':role:`name`' or 'name'."""
             m = self._func_rgx.match(text)
             if not m:
-                raise ParseError("%s is not a item name" % text)
+                raise ParseError(f"{text} is not a item name")
             role = m.group('role')
             name = m.group('name') if role else m.group('name2')
             return name, role, m.end()
@@ -346,7 +346,7 @@ class NumpyDocString(Mapping):
                 rest = list(filter(None, [description]))
                 items.append((funcs, rest))
             else:
-                raise ParseError("%s is not a item name" % line)
+                raise ParseError(f"{line} is not a item name")
         return items
 
     def _parse_index(self, section, content):
@@ -412,8 +412,7 @@ class NumpyDocString(Mapping):
                 section = (s.capitalize() for s in section.split(' '))
                 section = ' '.join(section)
                 if self.get(section):
-                    self._error_location("The section %s appears twice"
-                                         % section)
+                    self._error_location(f"The section {section} appears twice")
 
             if section in ('Parameters', 'Other Parameters', 'Attributes',
                            'Methods'):
@@ -435,8 +434,7 @@ class NumpyDocString(Mapping):
                 filename = inspect.getsourcefile(self._obj)
             except TypeError:
                 filename = None
-            msg = msg + (" in the docstring of %s in %s."
-                         % (self._obj, filename))
+            msg = msg + f" in the docstring of {self._obj} in {filename}."
         if error:
             raise ValueError(msg)
         else:
@@ -507,11 +505,11 @@ class NumpyDocString(Mapping):
             links = []
             for func, role in funcs:
                 if role:
-                    link = ':%s:`%s`' % (role, func)
+                    link = f':{role}:`{func}`'
                 elif func_role:
-                    link = ':%s:`%s`' % (func_role, func)
+                    link = f':{func_role}:`{func}`'
                 else:
-                    link = "`%s`_" % func
+                    link = f"`{func}`_"
                 links.append(link)
             link = ', '.join(links)
             out += [link]
@@ -534,12 +532,12 @@ class NumpyDocString(Mapping):
         default_index = idx.get('default', '')
         if default_index:
             output_index = True
-        out += ['.. index:: %s' % default_index]
+        out += [f'.. index:: {default_index}']
         for section, references in idx.items():
             if section == 'default':
                 continue
             output_index = True
-            out += ['   :%s: %s' % (section, ', '.join(references))]
+            out += [f"   :{section}: {', '.join(references)}"]
         if output_index:
             return out
         else:
@@ -603,9 +601,9 @@ class FunctionDoc(NumpyDocString):
                     else:
                         argspec = inspect.getargspec(func)
                     signature = inspect.formatargspec(*argspec)
-                signature = '%s%s' % (func_name, signature)
+                signature = f'{func_name}{signature}'
             except TypeError:
-                signature = '%s()' % func_name
+                signature = f'{func_name}()'
             self['Signature'] = signature
 
     def get_func(self):
@@ -626,9 +624,8 @@ class FunctionDoc(NumpyDocString):
 
         if self._role:
             if self._role not in roles:
-                print("Warning: invalid role %s" % self._role)
-            out += '.. %s:: %s\n    \n\n' % (roles.get(self._role, ''),
-                                             func_name)
+                print(f"Warning: invalid role {self._role}")
+            out += f".. {roles.get(self._role, '')}:: {func_name}\n    \n\n"
 
         out += super(FunctionDoc, self).__str__(func_role=self._role)
         return out
@@ -641,7 +638,7 @@ class ClassDoc(NumpyDocString):
     def __init__(self, cls, doc=None, modulename='', func_doc=FunctionDoc,
                  config={}):
         if not inspect.isclass(cls) and cls is not None:
-            raise ValueError("Expected a class or None, but got %r" % cls)
+            raise ValueError(f"Expected a class or None, but got {cls!r}")
         self._cls = cls
 
         if 'sphinx' in sys.modules:

--- a/seaborn/external/husl.py
+++ b/seaborn/external/husl.py
@@ -159,7 +159,7 @@ def rgb_prepare(triple):
         ch = round(ch, 3)
 
         if ch < -0.0001 or ch > 1.0001:
-            raise Exception("Illegal RGB value %f" % ch)
+            raise Exception(f"Illegal RGB value {ch:f}")
 
         if ch < 0:
             ch = 0

--- a/seaborn/external/kde.py
+++ b/seaborn/external/kde.py
@@ -239,8 +239,7 @@ class gaussian_kde(object):
                 points = reshape(points, (self.d, 1))
                 m = 1
             else:
-                msg = "points have dimension %s, dataset has dimension %s" % (d,
-                    self.d)
+                msg = f"points have dimension {d}, dataset has dimension {self.d}"
                 raise ValueError(msg)
 
         output_dtype = np.common_type(self.covariance, points)

--- a/seaborn/palettes.py
+++ b/seaborn/palettes.py
@@ -205,7 +205,7 @@ def color_palette(palette=None, n_colors=None, desat=None, as_cmap=False):
                 # Perhaps a named matplotlib colormap?
                 palette = mpl_palette(palette, n_colors, as_cmap=as_cmap)
             except ValueError:
-                raise ValueError("%s is not a valid palette name" % palette)
+                raise ValueError(f"{palette} is not a valid palette name")
 
     if desat is not None:
         palette = [desaturate(c, desat) for c in palette]
@@ -1029,7 +1029,7 @@ def set_color_codes(palette="deep"):
             palette = palette + "6"
         colors = SEABORN_PALETTES[palette] + [(.1, .1, .1)]
     else:
-        err = "Cannot set colors with palette '{}'".format(palette)
+        err = f"Cannot set colors with palette '{palette}'"
         raise ValueError(err)
 
     for code, color in zip("bgrmyck", colors):

--- a/seaborn/rcmod.py
+++ b/seaborn/rcmod.py
@@ -185,7 +185,7 @@ def axes_style(style=None, rc=None):
     else:
         styles = ["white", "dark", "whitegrid", "darkgrid", "ticks"]
         if style not in styles:
-            raise ValueError("style must be one of %s" % ", ".join(styles))
+            raise ValueError(f"style must be one of {', '.join(styles)}")
 
         # Define colors here
         dark_gray = ".15"
@@ -380,7 +380,7 @@ def plotting_context(context=None, font_scale=1, rc=None):
 
         contexts = ["paper", "notebook", "talk", "poster"]
         if context not in contexts:
-            raise ValueError("context must be in %s" % ", ".join(contexts))
+            raise ValueError(f"context must be in {', '.join(contexts)}")
 
         # Set up dictionary of default parameters
         texts_base_context = {

--- a/seaborn/relational.py
+++ b/seaborn/relational.py
@@ -882,7 +882,7 @@ def relplot(
         dashes = True if dashes is None else dashes
 
     else:
-        err = "Plot kind {} not recognized".format(kind)
+        err = f"Plot kind {kind} not recognized"
         raise ValueError(err)
 
     # Check for attempt to plot onto specific axes and warn

--- a/seaborn/tests/test_matrix.py
+++ b/seaborn/tests/test_matrix.py
@@ -303,7 +303,7 @@ class TestHeatmap:
         ax = mat.heatmap(self.df_norm, annot=True, fmt=".1f",
                          annot_kws={"fontsize": 14})
         for val, text in zip(self.x_norm.flat, ax.texts):
-            assert text.get_text() == "{:.1f}".format(val)
+            assert text.get_text() == f"{val:.1f}"
             assert text.get_fontsize() == 14
 
     def test_heatmap_annotation_overwrite_kws(self):
@@ -326,7 +326,7 @@ class TestHeatmap:
         ax = mat.heatmap(df, annot=True, fmt='.1f', mask=mask)
         assert len(df_masked.compressed()) == len(ax.texts)
         for val, text in zip(df_masked.compressed(), ax.texts):
-            assert "{:.1f}".format(val) == text.get_text()
+            assert f"{val:.1f}" == text.get_text()
 
     def test_heatmap_annotation_mesh_colors(self):
 
@@ -343,14 +343,14 @@ class TestHeatmap:
                          annot_kws={"fontsize": 14})
 
         for val, text in zip(annot_data.values.flat, ax.texts):
-            assert text.get_text() == "{:.1f}".format(val)
+            assert text.get_text() == f"{val:.1f}"
             assert text.get_fontsize() == 14
 
     def test_heatmap_annotation_with_limited_ticklabels(self):
         ax = mat.heatmap(self.df_norm, fmt=".2f", annot=True,
                          xticklabels=False, yticklabels=False)
         for val, text in zip(self.x_norm.flat, ax.texts):
-            assert text.get_text() == "{:.2f}".format(val)
+            assert text.get_text() == f"{val:.2f}"
 
     def test_heatmap_cbar(self):
 
@@ -1305,11 +1305,11 @@ class TestClustermap:
 
         g = mat.clustermap(self.df_norm, annot=True, fmt=".1f")
         for val, text in zip(np.asarray(g.data2d).flat, g.ax_heatmap.texts):
-            assert text.get_text() == "{:.1f}".format(val)
+            assert text.get_text() == f"{val:.1f}"
 
         g = mat.clustermap(self.df_norm, annot=self.df_norm, fmt=".1f")
         for val, text in zip(np.asarray(g.data2d).flat, g.ax_heatmap.texts):
-            assert text.get_text() == "{:.1f}".format(val)
+            assert text.get_text() == f"{val:.1f}"
 
     def test_tree_kws(self):
 


### PR DESCRIPTION
Reformats all the text from the old "%-formatted" and .format(...) format to the newer f-string format, as defined in [PEP 498](https://www.python.org/dev/peps/pep-0498/). This requires Python 3.6+.

[Flynt](https://github.com/ikamensh/flynt) 0.76 was used to reformat the strings. 45 f-strings were created in 13 files.

F-strings are in general more readable, concise and performant. See also: [PEP 498#Rationale](https://www.python.org/dev/peps/pep-0498/#rationale)

```
Running flynt v.0.76

Flynt run has finished. Stats:

Execution time:                            2.066s
Files checked:                             102
Files modified:                            13
Character count reduction:                 411 (0.03%)

Per expression type:
Old style (`%`) expressions attempted:     28/30 (93.3%)
`.format(...)` calls attempted:            23/33 (69.7%)
No concatenations attempted.
F-string expressions created:              45
```