### PR TITLE
conftest.py: Fix Pandas deprecation warnings

### DIFF
--- a/seaborn/conftest.py
+++ b/seaborn/conftest.py
@@ -64,7 +64,7 @@ def rng():
 def wide_df(rng):
 
     columns = list("abc")
-    index = pd.Int64Index(np.arange(10, 50, 2), name="wide_index")
+    index = pd.RangeIndex(10, 50, 2, name="wide_index")
     values = rng.normal(size=(len(index), len(columns)))
     return pd.DataFrame(values, index=index, columns=columns)
 
@@ -78,7 +78,7 @@ def wide_array(wide_df):
 @pytest.fixture
 def flat_series(rng):
 
-    index = pd.Int64Index(np.arange(10, 30), name="t")
+    index = pd.RangeIndex(10, 30, name="t")
     return pd.Series(rng.normal(size=20), index, name="s")
 
 
@@ -97,7 +97,7 @@ def flat_list(flat_series):
 @pytest.fixture(params=["series", "array", "list"])
 def flat_data(rng, request):
 
-    index = pd.Int64Index(np.arange(10, 30), name="t")
+    index = pd.RangeIndex(10, 30, name="t")
     series = pd.Series(rng.normal(size=20), index, name="s")
     if request.param == "series":
         data = series


### PR DESCRIPTION
Starting from Pandas 1.4.0, [pandas.Int64Index](https://pandas.pydata.org/docs/reference/api/pandas.Int64Index.html) is depreciated, this PR replaces 3 cases of them in _conftest.py_ with an even more appropriate [RangeIndex](https://pandas.pydata.org/docs/reference/api/pandas.RangeIndex.html#pandas.RangeIndex), which is more concise and faster.

The errors are [here](https://github.com/mwaskom/seaborn/runs/6380973404?check_suite_focus=true#step:6:81) in the latest CI run on the master branch, and gone in the [CI run](https://github.com/mwaskom/seaborn/runs/6423254991?check_suite_focus=true) of this PR.