### PR TITLE
Rename fixed_scale to native_scale and invert boolean

### DIFF
--- a/doc/docstrings/stripplot.ipynb
+++ b/doc/docstrings/stripplot.ipynb
@@ -230,7 +230,7 @@
    "cell_type": "raw",
    "metadata": {},
    "source": [
-    "To disable this behavior and use the original scale of the variable, set `fixed_scale=False`:"
+    "To disable this behavior and use the original scale of the variable, set `native_scale=True`:"
    ]
   },
   {
@@ -242,7 +242,7 @@
     "sns.stripplot(\n",
     "    data=tips.query(\"size in [2, 3, 5]\"),\n",
     "    x=\"total_bill\", y=\"size\", orient=\"h\",\n",
-    "    fixed_scale=False,\n",
+    "    native_scale=True,\n",
     ")"
    ]
   },

--- a/doc/docstrings/swarmplot.ipynb
+++ b/doc/docstrings/swarmplot.ipynb
@@ -198,7 +198,7 @@
    "cell_type": "raw",
    "metadata": {},
    "source": [
-    "To disable this behavior and use the original scale of the variable, set `fixed_scale=False` (notice how this also changes the order of the variables on the y axis):"
+    "To disable this behavior and use the original scale of the variable, set `native_scale=True` (notice how this also changes the order of the variables on the y axis):"
    ]
   },
   {
@@ -210,7 +210,7 @@
     "sns.swarmplot(\n",
     "    data=tips.query(\"size in [2, 3, 5]\"),\n",
     "    x=\"total_bill\", y=\"size\", orient=\"h\",\n",
-    "    fixed_scale=False,\n",
+    "    native_scale=True,\n",
     ")"
    ]
   },

--- a/doc/releases/v0.12.0.txt
+++ b/doc/releases/v0.12.0.txt
@@ -9,7 +9,7 @@ Modernization of categorical scatterplots
 
 This release begins the process of modernizing the :ref:`categorical plots <categorical_api>`, beginning with :func:`stripplot` and :func:`swarmplot`. These functions are sporting some enhancements that alleviate a few long-running frustrations (:pr:`2413`, :pr:`2447`):
 
-- |Feature| The new `fixed_scale` parameter allows numeric or datetime categories to be plotted with their original scale rather than converted to strings and plotted at fixed intervals.
+- |Feature| The new `native_scale` parameter allows numeric or datetime categories to be plotted with their original scale rather than converted to strings and plotted at fixed intervals.
 
 - |Feature| The new `formatter` parameter allows more control over the string representation of values on the categorical axis. There should also be improved defaults for some types, such as dates.
 

--- a/seaborn/tests/test_categorical.py
+++ b/seaborn/tests/test_categorical.py
@@ -1850,7 +1850,7 @@ class SharedScatterTests(SharedAxesLevelTests):
         if "stripplot" in str(self.func):  # can't use __name__ with partial
             kws["jitter"] = False
 
-        ax = self.func(data=long_df, x=cat_var, y="y", fixed_scale=False, **kws)
+        ax = self.func(data=long_df, x=cat_var, y="y", native_scale=True, **kws)
 
         for i, (cat_level, cat_data) in enumerate(long_df.groupby(cat_var)):
 
@@ -2051,7 +2051,7 @@ class SharedScatterTests(SharedAxesLevelTests):
 
         ax = plt.figure().subplots()
         ax.set_xscale("log")
-        self.func(x=x, y=y, fixed_scale=False)
+        self.func(x=x, y=y, native_scale=True)
         for i, point in enumerate(ax.collections):
             val = point.get_offsets()[0, 0]
             assert val == pytest.approx(x[i])
@@ -2067,7 +2067,7 @@ class SharedScatterTests(SharedAxesLevelTests):
 
         ax = plt.figure().subplots()
         ax.set_yscale("log")
-        self.func(x=x, y=y, orient="h", fixed_scale=False)
+        self.func(x=x, y=y, orient="h", native_scale=True)
         cat_points = ax.collections[0].get_offsets().copy()[:, 1]
         assert np.ptp(np.log10(cat_points)) <= .8
 
@@ -2082,7 +2082,7 @@ class SharedScatterTests(SharedAxesLevelTests):
             # dict(data="long", x="a", y="y", hue="z", edgecolor="w", linewidth=.5),
             # dict(data="long", x="a_cat", y="y", hue="z"),
             dict(data="long", x="y", y="s", hue="c", orient="h", dodge=True),
-            dict(data="long", x="s", y="y", hue="c", fixed_scale=False),
+            dict(data="long", x="s", y="y", hue="c", native_scale=True),
         ]
     )
     def test_vs_catplot(self, long_df, wide_df, kwargs):
@@ -2116,7 +2116,7 @@ class TestStripPlot(SharedScatterTests):
     def test_jitter_unfixed(self, long_df):
 
         ax1, ax2 = plt.figure().subplots(2)
-        kws = dict(data=long_df, x="y", orient="h", fixed_scale=False)
+        kws = dict(data=long_df, x="y", orient="h", native_scale=True)
 
         np.random.seed(0)
         stripplot(**kws, y="s", ax=ax1)


### PR DESCRIPTION
Potentially just bikeshedding, but feels maybe a bit more natural to affirmatively ask for the new behavior than to disable the old behavior.

Usage example:
```python
planets = sns.load_dataset("planets")
sns.stripplot(data=planets, x="year", y="mass", native_scale=True)
sns.lineplot(data=planets, x="year", y="mass")
```
![image](https://user-images.githubusercontent.com/315810/168440556-38ae5363-7a08-45ee-b3f8-63abb7e3d5c2.png)
