### PR TITLE
Pyupgrade 3.7: Update syntax with Python 3.7+ features

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # seaborn documentation build configuration file, created by
 # sphinx-quickstart on Mon Jul 29 23:25:46 2013.
@@ -66,7 +65,7 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'seaborn'
+project = 'seaborn'
 import time
 copyright = f"2012-{time.strftime('%Y')}"
 
@@ -226,8 +225,8 @@ latex_elements = {
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-  ('index', 'seaborn.tex', u'seaborn Documentation',
-   u'Michael Waskom', 'manual'),
+  ('index', 'seaborn.tex', 'seaborn Documentation',
+   'Michael Waskom', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -256,8 +255,8 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('index', 'seaborn', u'seaborn Documentation',
-     [u'Michael Waskom'], 1)
+    ('index', 'seaborn', 'seaborn Documentation',
+     ['Michael Waskom'], 1)
 ]
 
 # If true, show URL addresses after external links.
@@ -270,8 +269,8 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  ('index', 'seaborn', u'seaborn Documentation',
-   u'Michael Waskom', 'seaborn', 'One line description of project.',
+  ('index', 'seaborn', 'seaborn Documentation',
+   'Michael Waskom', 'seaborn', 'One line description of project.',
    'Miscellaneous'),
 ]
 

--- a/doc/sphinxext/gallery_generator.py
+++ b/doc/sphinxext/gallery_generator.py
@@ -167,14 +167,14 @@ def indent(s, N=4):
     return s.replace('\n', '\n' + N * ' ')
 
 
-class ExampleGenerator(object):
+class ExampleGenerator:
     """Tools for generating an example page from a file"""
     def __init__(self, filename, target_dir):
         self.filename = filename
         self.target_dir = target_dir
         self.thumbloc = .5, .5
         self.extract_docstring()
-        with open(filename, "r") as fid:
+        with open(filename) as fid:
             self.filetext = fid.read()
 
         outfilename = op.join(target_dir, self.rstfilename)
@@ -322,10 +322,10 @@ class ExampleGenerator(object):
     def contents_entry(self):
         return (".. raw:: html\n\n"
                 "    <div class='figure align-center'>\n"
-                "    <a href=./{0}>\n"
-                "    <img src=../_static/{1}>\n"
+                "    <a href=./{}>\n"
+                "    <img src=../_static/{}>\n"
                 "    <span class='figure-label'>\n"
-                "    <p>{2}</p>\n"
+                "    <p>{}</p>\n"
                 "    </span>\n"
                 "    </a>\n"
                 "    </div>\n\n"

--- a/doc/tools/set_nb_kernels.py
+++ b/doc/tools/set_nb_kernels.py
@@ -12,7 +12,7 @@ if __name__ == "__main__":
     nb_paths = glob("./**/*.ipynb", recursive=True)
     for path in nb_paths:
 
-        with open(path, "r") as f:
+        with open(path) as f:
             nb = nbformat.read(f, as_version=4)
 
         nb["metadata"]["kernelspec"]["name"] = kernel_name

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -318,7 +318,7 @@ class FacetGrid(Grid):
         gridspec_kws=None, size=None
     ):
 
-        super(FacetGrid, self).__init__()
+        super().__init__()
 
         # Handle deprecations
         if size is not None:
@@ -1190,7 +1190,7 @@ class PairGrid(Grid):
 
         """
 
-        super(PairGrid, self).__init__()
+        super().__init__()
 
         # Handle deprecations
         if size is not None:
@@ -2096,8 +2096,8 @@ def pairplot(
             if not isinstance(markers, list):
                 markers = [markers] * n_markers
             if len(markers) != n_markers:
-                raise ValueError(("markers must be a singleton or a list of "
-                                  "markers for each level of the hue variable"))
+                raise ValueError("markers must be a singleton or a list of "
+                                  "markers for each level of the hue variable")
             grid.hue_kws = {"marker": markers}
         elif kind == "scatter":
             if isinstance(markers, str):

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -375,7 +375,7 @@ class _CategoricalFacetPlotter(_CategoricalPlotterNew):
     semantics = _CategoricalPlotterNew.semantics + ("col", "row")
 
 
-class _CategoricalPlotter(object):
+class _CategoricalPlotter:
 
     width = .8
     default_palette = "light"
@@ -475,7 +475,7 @@ class _CategoricalPlotter(object):
                 plot_data = [np.asarray(d, float) for d in plot_data]
 
                 # The group names will just be numeric indices
-                group_names = list(range((len(plot_data))))
+                group_names = list(range(len(plot_data)))
 
             # Figure out the plotting orientation
             orient = "h" if str(orient).startswith("h") else "v"
@@ -1819,7 +1819,7 @@ class _LVPlotter(_CategoricalPlotter):
         elif self.k_depth == 'proportion':
             k = int(np.log2(n)) - int(np.log2(n * p)) + 1
         elif self.k_depth == 'trustworthy':
-            point_conf = 2 * _normal_quantile_func((1 - self.trust_alpha / 2)) ** 2
+            point_conf = 2 * _normal_quantile_func(1 - self.trust_alpha / 2) ** 2
             k = int(np.log2(n / point_conf)) + 1
         else:
             k = int(self.k_depth)  # allow having k as input

--- a/seaborn/external/appdirs.py
+++ b/seaborn/external/appdirs.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 # Copyright (c) 2005-2010 ActiveState Software Inc.
 # Copyright (c) 2013 Eddy Petrișor
 
@@ -442,7 +441,7 @@ def user_log_dir(appname=None, appauthor=None, version=None, opinion=True):
     return path
 
 
-class AppDirs(object):
+class AppDirs:
     """Convenience wrapper for getting application dirs."""
     def __init__(self, appname=None, appauthor=None, version=None,
             roaming=False, multipath=False):

--- a/seaborn/external/docscrape.py
+++ b/seaborn/external/docscrape.py
@@ -46,7 +46,7 @@ def strip_blank_lines(l):
     return l
 
 
-class Reader(object):
+class Reader:
     """A line-based string reader.
 
     """
@@ -395,7 +395,7 @@ class NumpyDocString(Mapping):
         self._parse_summary()
 
         sections = list(self._read_sections())
-        section_names = set([section for section, content in sections])
+        section_names = {section for section, content in sections}
 
         has_returns = 'Returns' in section_names
         has_yields = 'Yields' in section_names
@@ -627,7 +627,7 @@ class FunctionDoc(NumpyDocString):
                 print(f"Warning: invalid role {self._role}")
             out += f".. {roles.get(self._role, '')}:: {func_name}\n    \n\n"
 
-        out += super(FunctionDoc, self).__str__(func_role=self._role)
+        out += super().__str__(func_role=self._role)
         return out
 
 

--- a/seaborn/external/kde.py
+++ b/seaborn/external/kde.py
@@ -79,7 +79,7 @@ from numpy import linalg
 __all__ = ['gaussian_kde']
 
 
-class gaussian_kde(object):
+class gaussian_kde:
     """Representation of a kernel-density estimate using Gaussian kernels.
 
     Kernel density estimation is a way to estimate the probability density

--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -556,7 +556,7 @@ def heatmap(
     return ax
 
 
-class _DendrogramPlotter(object):
+class _DendrogramPlotter:
     """Object for drawing tree of similarities between data rows/columns"""
 
     def __init__(self, data, linkage, metric, method, axis, label, rotate):

--- a/seaborn/regression.py
+++ b/seaborn/regression.py
@@ -22,7 +22,7 @@ from .axisgrid import FacetGrid, _facet_docs
 __all__ = ["lmplot", "regplot", "residplot"]
 
 
-class _LinearPlotter(object):
+class _LinearPlotter:
     """Base class for plotting relational data in tidy format.
 
     To get anything useful done you'll have to inherit from this, but setup
@@ -617,8 +617,8 @@ def lmplot(
     if not isinstance(markers, list):
         markers = [markers] * n_markers
     if len(markers) != n_markers:
-        raise ValueError(("markers must be a singleton or a list of markers "
-                          "for each level of the hue variable"))
+        raise ValueError("markers must be a singleton or a list of markers "
+                          "for each level of the hue variable")
     facets.hue_kws = {"marker": markers}
 
     def update_datalim(data, x, y, ax, **kws):

--- a/seaborn/tests/test_axisgrid.py
+++ b/seaborn/tests/test_axisgrid.py
@@ -757,7 +757,7 @@ class TestPairGrid:
 
         plot_vars = ["x", "y", "z"]
         g = ag.PairGrid(self.df, vars=plot_vars, corner=True)
-        corner_size = sum([i + 1 for i in range(len(plot_vars))])
+        corner_size = sum(i + 1 for i in range(len(plot_vars)))
         assert len(g.figure.axes) == corner_size
 
         g.map_diag(plt.hist)
@@ -1226,7 +1226,7 @@ class TestPairGrid:
         g1.map_diag(histplot)
         for i, ax in enumerate(g1.diag_axes):
             var = plot_vars[i]
-            count = sum([p.get_height() for p in ax.patches])
+            count = sum(p.get_height() for p in ax.patches)
             assert count == df[var].notna().sum()
 
     def test_histplot_legend(self):

--- a/seaborn/tests/test_distributions.py
+++ b/seaborn/tests/test_distributions.py
@@ -60,7 +60,7 @@ def get_contour_color(c):
             return c.get_edgecolor()
 
 
-class TestDistPlot(object):
+class TestDistPlot:
 
     rs = np.random.RandomState(0)
     x = rs.randn(100)
@@ -942,8 +942,8 @@ class TestKDEPlotBivariate:
         kdeplot(x=x, y=y, hue=hue, common_norm=True, ax=ax1)
         kdeplot(x=x, y=y, hue=hue, common_norm=False, ax=ax2)
 
-        n_seg_1 = sum([len(get_contour_coords(c)) > 0 for c in ax1.collections])
-        n_seg_2 = sum([len(get_contour_coords(c)) > 0 for c in ax2.collections])
+        n_seg_1 = sum(len(get_contour_coords(c)) > 0 for c in ax1.collections)
+        n_seg_2 = sum(len(get_contour_coords(c)) > 0 for c in ax2.collections)
         assert n_seg_2 > n_seg_1
 
     def test_log_scale(self, rng):

--- a/seaborn/tests/test_utils.py
+++ b/seaborn/tests/test_utils.py
@@ -51,7 +51,7 @@ def _network(t=None, url="https://github.com"):
         # attempt to connect
         try:
             f = urlopen(url)
-        except (IOError, HTTPException):
+        except (OSError, HTTPException):
             pytest.skip("No internet connection")
         else:
             f.close()
@@ -121,7 +121,7 @@ def test_to_utf8(s, exp):
     assert u == exp
 
 
-class TestSpineUtils(object):
+class TestSpineUtils:
 
     sides = ["left", "right", "bottom", "top"]
     outer_sides = ["top", "right"]


### PR DESCRIPTION
This PR updates the Python code with Python 3.7+, removing old, depreciated and redundant code. The biggest advantage is increased readability of the code. [pyupgrade](https://github.com/asottile/pyupgrade) 2.32.1 was used with `--py37-plus`.

This includes:
- f-string formatting of strings ([PEP 498](https://www.python.org/dev/peps/pep-0498/), Python 3.6+)
- utf-8 encoding is now the default ([PEP 3120](https://www.python.org/dev/peps/pep-3120/), Python 3.0+)
- Replace list comprehensions by Generator Expressions ([PEP 289](https://www.python.org/dev/peps/pep-0289/), Python 2.4+)
- Replace `yield` loop by `yield from` ([PEP 380](https://www.python.org/dev/peps/pep-0380/), Python 3.3+)
- Replace the IOError alias by OSError ([PEP 3151](https://www.python.org/dev/peps/pep-3151/), Python 3.3+)
- Remove the default subclass `(object)` when defining a class
- Define sets with curly braces `{}` instead of `set()`
- Remove `"r"` parameter from open function, which is default

