### PR TITLE
Fix histplot/kdeplot normalization with weights

### DIFF
--- a/doc/releases/v0.12.0.txt
+++ b/doc/releases/v0.12.0.txt
@@ -51,9 +51,11 @@ Other updates
 
 - |Enhancement| Example datasets are now stored in an OS-specific cache location (as determined by `appdirs`) rather than in the user's home directory. Users should feel free to remove `~/seaborn-data` if desired (:pr:`2773`).
 
-- |Fix| FacetGrid subplot titles will no longer be reset when calling :meth:`FacetGrid.map` or :meth:`FacetGrid.map_dataframe` after :meth:`FacetGrid.set_titles` (:pr:`2705`).
-
 - |Fix| Fixed a regression in 0.11.2 that caused some functions to stall indefinitely or raise when the input data had a duplicate index (:pr:`2776`).
+
+- |Fix| Fixed a bug in :func:`histplot` and :func:`kdeplot` where weights were not factored into the normalization (:pr:`2812`).
+
+- |Fix| FacetGrid subplot titles will no longer be reset when calling :meth:`FacetGrid.map` or :meth:`FacetGrid.map_dataframe` after :meth:`FacetGrid.set_titles` (:pr:`2705`).
 
 - |Fix| In :func:`lineplot`, allowed the `dashes` keyword to set the style of a line without mapping a `style` variable (:pr:`2449`).
 

--- a/seaborn/distributions.py
+++ b/seaborn/distributions.py
@@ -315,7 +315,7 @@ class _DistributionPlotter(VectorPlotter):
         if common_norm and "weights" in all_data:
             whole_weight = all_data["weights"].sum()
         else:
-            whole_weight = len(self.plot_data)
+            whole_weight = len(all_data)
 
         densities = {}
 
@@ -414,23 +414,21 @@ class _DistributionPlotter(VectorPlotter):
         histograms = {}
 
         # Do pre-compute housekeeping related to multiple groups
-        # TODO best way to account for facet/semantic?
         all_data = self.comp_data.dropna()
-        if set(self.variables) - {"x", "y"}:
-            if common_bins:
-                all_observations = all_data[self.data_variable]
-                estimator.define_bin_params(
-                    all_observations,
-                    weights=all_data.get("weights", None),
-                )
+        all_weights = all_data.get("weights", None)
 
+        if set(self.variables) - {"x", "y"}:  # Check if we'll have multiple histograms
+            if common_bins:
+                estimator.define_bin_params(
+                    all_data[self.data_variable], weights=all_weights
+                )
         else:
             common_norm = False
 
-        if common_norm and "weights" in all_data:
-            whole_weight = all_data["weights"].sum()
+        if common_norm and all_weights is not None:
+            whole_weight = all_weights.sum()
         else:
-            whole_weight = len(self.plot_data)
+            whole_weight = len(all_data)
 
         # Estimate the smoothed kernel densities, for use later
         if kde:

--- a/seaborn/tests/test_distributions.py
+++ b/seaborn/tests/test_distributions.py
@@ -823,6 +823,19 @@ class TestKDEPlotUnivariate(SharedAxesLevelTests):
 
         assert y1 == pytest.approx(2 * y2)
 
+    def test_weight_norm(self, rng):
+
+        vals = rng.normal(0, 1, 50)
+        x = np.concatenate([vals, vals])
+        w = np.repeat([1, 2], 50)
+        ax = kdeplot(x=x, weights=w, hue=w, common_norm=True)
+
+        # Recall that artists are added in reverse of hue order
+        x1, y1 = ax.lines[0].get_xydata().T
+        x2, y2 = ax.lines[1].get_xydata().T
+
+        assert integrate(y1, x1) == pytest.approx(2 * integrate(y2, x2))
+
     def test_sticky_edges(self, long_df):
 
         f, (ax1, ax2) = plt.subplots(ncols=2)
@@ -1396,6 +1409,21 @@ class TestHistPlotUnivariate(SharedAxesLevelTests):
         bar_heights = [bar.get_height() for bar in ax.patches]
         total_weight = missing_df[["x", "s"]].dropna()["s"].sum()
         assert sum(bar_heights) == pytest.approx(total_weight)
+
+    def test_weight_norm(self, rng):
+
+        vals = rng.normal(0, 1, 50)
+        x = np.concatenate([vals, vals])
+        w = np.repeat([1, 2], 50)
+        ax = histplot(
+            x=x, weights=w, hue=w, common_norm=True, stat="density", bins=5
+        )
+
+        # Recall that artists are added in reverse of hue order
+        y1 = [bar.get_height() for bar in ax.patches[:5]]
+        y2 = [bar.get_height() for bar in ax.patches[5:]]
+
+        assert sum(y1) == 2 * sum(y2)
 
     def test_discrete(self, long_df):
 


### PR DESCRIPTION
Fixes #2655

With the example from that issue:

```python
f, axs = plt.subplots(2, 2, constrained_layout=True, figsize=(7, 6))
params = dict(x=[1, 2, 3], weights=[1, 2, 2], discrete=True)
sns.histplot(**params, ax=axs.flat[0])
sns.histplot(**params, hue=["a", "b", "b"], ax=axs.flat[1])
sns.histplot(**params, hue=["a", "b", "b"], stat="proportion", ax=axs.flat[2])
sns.histplot(**params, hue=["a", "b", "b"], stat="proportion", common_norm=False, ax=axs.flat[3])
```

![image](https://user-images.githubusercontent.com/315810/168716013-404a4ffe-b72f-4ae0-a416-4f3825c4a004.png)
