### PR TITLE
Fix inner box with unpaired split violins

### DIFF
--- a/doc/releases/v0.12.0.txt
+++ b/doc/releases/v0.12.0.txt
@@ -57,9 +57,12 @@ Other updates
 
 - |Fix| Fixed two edgecases in :func:`histplot` when only `binwidth` was provided (:pr:`2813').
 
-- |Fix| FacetGrid subplot titles will no longer be reset when calling :meth:`FacetGrid.map` or :meth:`FacetGrid.map_dataframe` after :meth:`FacetGrid.set_titles` (:pr:`2705`).
+- |Fix| Fixed a bug in :func:`violinplot` where inner boxes/points could be missing with unpaired split violins (:pr:`2814`).
+
+- |Fix| Subplot titles will no longer be reset when calling :meth:`FacetGrid.map` or :meth:`FacetGrid.map_dataframe` (:pr:`2705`).
 
 - |Fix| In :func:`lineplot`, allowed the `dashes` keyword to set the style of a line without mapping a `style` variable (:pr:`2449`).
+
 
 - |Dependencies| Made `scipy` an optional dependency and added `pip install seaborn[all]` as a method for ensuring the availability of compatible `scipy` and `statsmodels` libraries at install time. This has a few minor implications for existing code, which are explained in the Github pull request (:pr:`2398`).
 

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -1136,7 +1136,7 @@ class _ViolinPlotter(_CategoricalPlotter):
 
                 # Draw box and whisker information
                 if self.inner.startswith("box"):
-                    self.draw_box_lines(ax, violin_data, support, density, i)
+                    self.draw_box_lines(ax, violin_data, i)
 
                 # Draw quartile lines
                 elif self.inner.startswith("quart"):
@@ -1217,7 +1217,7 @@ class _ViolinPlotter(_CategoricalPlotter):
 
                         # The box and point interior plots are drawn for
                         # all data at the group level, so we just do that once
-                        if not j:
+                        if j and any(self.plot_hues[0] == hue_level):
                             continue
 
                         # Get the whole vector for this group level
@@ -1225,8 +1225,7 @@ class _ViolinPlotter(_CategoricalPlotter):
 
                         # Draw box and whisker information
                         if self.inner.startswith("box"):
-                            self.draw_box_lines(ax, violin_data,
-                                                support, density, i)
+                            self.draw_box_lines(ax, violin_data, i)
 
                         # Draw point observations
                         elif self.inner.startswith("point"):
@@ -1252,9 +1251,7 @@ class _ViolinPlotter(_CategoricalPlotter):
 
                         # Draw box and whisker information
                         if self.inner.startswith("box"):
-                            self.draw_box_lines(ax, violin_data,
-                                                support, density,
-                                                i + offsets[j])
+                            self.draw_box_lines(ax, violin_data, i + offsets[j])
 
                         # Draw quartile lines
                         elif self.inner.startswith("quart"):
@@ -1286,7 +1283,7 @@ class _ViolinPlotter(_CategoricalPlotter):
                     color=self.gray,
                     linewidth=self.linewidth)
 
-    def draw_box_lines(self, ax, data, support, density, center):
+    def draw_box_lines(self, ax, data, center):
         """Draw boxplot information at center of the density."""
         # Compute the boxplot statistics
         q25, q50, q75 = np.percentile(data, [25, 50, 75])

--- a/seaborn/tests/test_categorical.py
+++ b/seaborn/tests/test_categorical.py
@@ -1592,6 +1592,13 @@ class TestViolinPlotter(CategoricalFixture):
                            inner=inner, split=True)
             plt.close("all")
 
+    def test_split_one_each(self, rng):
+
+        x = np.repeat([0, 1], 5)
+        y = rng.normal(0, 1, 10)
+        ax = cat.violinplot(x=x, y=y, hue=x, split=True, inner="box")
+        assert len(ax.lines) == 4
+
 
 # ====================================================================================
 # ====================================================================================

--- a/seaborn/tests/test_categorical.py
+++ b/seaborn/tests/test_categorical.py
@@ -1324,7 +1324,7 @@ class TestViolinPlotter(CategoricalFixture):
         p = cat._ViolinPlotter(**kws)
 
         _, ax = plt.subplots()
-        p.draw_box_lines(ax, self.y, p.support[0], p.density[0], 0)
+        p.draw_box_lines(ax, self.y, 0)
         assert len(ax.lines) == 2
 
         q25, q50, q75 = np.percentile(self.y, [25, 50, 75])
@@ -1342,7 +1342,7 @@ class TestViolinPlotter(CategoricalFixture):
         p = cat._ViolinPlotter(**kws)
 
         _, ax = plt.subplots()
-        p.draw_box_lines(ax, self.y, p.support[0], p.density[0], 0)
+        p.draw_box_lines(ax, self.y, 0)
         assert len(ax.lines) == 2
 
         q25, q50, q75 = np.percentile(self.y, [25, 50, 75])


### PR DESCRIPTION
Fixes #2742

With the example from that issue:

```python
N = 30
np.random.seed(3)
data = np.random.normal(size=(N,))
df = pd.DataFrame({'Before': data,
                   'After': data + 1})
df_long = pd.melt(df, value_vars=['Before', 'After'])
ax = sns.violinplot(x='variable', y='value', data=df_long, hue='variable', split=True, inner='box', cut=1)
```
![image](https://user-images.githubusercontent.com/315810/169194510-ef3e934d-f8af-4916-a731-69b93a79215a.png)
