### PR TITLE
Add Norm move class

### DIFF
--- a/seaborn/_core/moves.py
+++ b/seaborn/_core/moves.py
@@ -171,6 +171,7 @@ class Norm(Move):
     func: Union[Callable, str] = "max"
     where: Optional[str] = None
     by: Optional[list[str]] = None
+    percent: bool = False
 
     group_by_orient: ClassVar[bool] = False
 
@@ -181,6 +182,10 @@ class Norm(Move):
         else:
             denom_data = df.query(self.where)[var]
         df[var] = df[var] / denom_data.agg(self.func)
+
+        if self.percent:
+            df[var] = df[var] * 100
+
         return df
 
     def __call__(self, data: DataFrame, groupby: GroupBy, orient: str) -> DataFrame:

--- a/seaborn/_core/moves.py
+++ b/seaborn/_core/moves.py
@@ -1,18 +1,17 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import ClassVar, Callable, Optional, Union
 
 import numpy as np
+from pandas import DataFrame
 
 from seaborn._core.groupby import GroupBy
-
-from typing import TYPE_CHECKING
-if TYPE_CHECKING:
-    from typing import Optional
-    from pandas import DataFrame
 
 
 @dataclass
 class Move:
+
+    group_by_orient: ClassVar[bool] = True
 
     def __call__(self, data: DataFrame, groupby: GroupBy, orient: str) -> DataFrame:
         raise NotImplementedError
@@ -61,10 +60,12 @@ class Dodge(Move):
     """
     Displacement and narrowing of overlapping marks along orientation axis.
     """
-    empty: str = "keep"  # keep, drop, fill
+    empty: str = "keep"  # Options: keep, drop, fill
     gap: float = 0
 
     # TODO accept just a str here?
+    # TODO should this always be present?
+    # TODO should the default be an "all" singleton?
     by: Optional[list[str]] = None
 
     def __call__(self, data: DataFrame, groupby: GroupBy, orient: str) -> DataFrame:
@@ -117,7 +118,7 @@ class Stack(Move):
     """
     Displacement of overlapping bar or area marks along the value axis.
     """
-    # TODO center? (or should this be a different move?)
+    # TODO center? (or should this be a different move, eg. Stream())
 
     def _stack(self, df, orient):
 
@@ -140,6 +141,7 @@ class Stack(Move):
     def __call__(self, data: DataFrame, groupby: GroupBy, orient: str) -> DataFrame:
 
         # TODO where to ensure that other semantic variables are sorted properly?
+        # TODO why are we not using the passed in groupby here?
         groupers = ["col", "row", orient]
         return GroupBy(groupers).apply(data, self._stack, orient)
 
@@ -158,3 +160,36 @@ class Shift(Move):
         data["x"] = data["x"] + self.x
         data["y"] = data["y"] + self.y
         return data
+
+
+@dataclass
+class Norm(Move):
+    """
+    Divisive scaling on the value axis after aggregating within groups.
+    """
+
+    func: Union[Callable, str] = "max"
+    where: Optional[str] = None
+    by: Optional[list[str]] = None
+
+    group_by_orient: ClassVar[bool] = False
+
+    def _norm(self, df, var):
+
+        if self.where is None:
+            denom_data = df[var]
+        else:
+            denom_data = df.query(self.where)[var]
+        df[var] = df[var] / denom_data.agg(self.func)
+        return df
+
+    def __call__(self, data: DataFrame, groupby: GroupBy, orient: str) -> DataFrame:
+
+        other = {"x": "y", "y": "x"}[orient]
+        return groupby.apply(data, self._norm, other)
+
+
+# TODO
+# @dataclass
+# class Ridge(Move):
+#     ...

--- a/seaborn/_core/plot.py
+++ b/seaborn/_core/plot.py
@@ -1117,11 +1117,12 @@ class Plotter:
             if move is not None:
                 moves = move if isinstance(move, list) else [move]
                 for move_step in moves:
-                    move_groupers = [
-                        orient,
-                        *(getattr(move_step, "by", None) or grouping_properties),
-                        *default_grouping_vars,
-                    ]
+                    move_by = getattr(move_step, "by", None)
+                    if move_by is None:
+                        move_by = grouping_properties
+                    move_groupers = [*move_by, *default_grouping_vars]
+                    if move_step.group_by_orient:
+                        move_groupers.insert(0, orient)
                     order = {var: get_order(var) for var in move_groupers}
                     groupby = GroupBy(order)
                     df = move_step(df, groupby, orient)

--- a/seaborn/objects.py
+++ b/seaborn/objects.py
@@ -14,6 +14,6 @@ from seaborn._stats.aggregation import Agg  # noqa: F401
 from seaborn._stats.regression import OLSFit, PolyFit  # noqa: F401
 from seaborn._stats.histograms import Hist  # noqa: F401
 
-from seaborn._core.moves import Dodge, Jitter, Shift, Stack  # noqa: F401
+from seaborn._core.moves import Dodge, Jitter, Norm, Shift, Stack  # noqa: F401
 
 from seaborn._core.scales import Nominal, Continuous, Temporal  # noqa: F401

--- a/seaborn/tests/_core/test_moves.py
+++ b/seaborn/tests/_core/test_moves.py
@@ -350,3 +350,9 @@ class TestNorm(MoveFixtures):
         gb = GroupBy(["null"])
         res = Norm(where="x == 2")(df, gb, "x")
         assert res.loc[res["x"] == 2, "y"].max() == pytest.approx(1)
+
+    def test_percent(self, df):
+
+        gb = GroupBy(["null"])
+        res = Norm(percent=True)(df, gb, "x")
+        assert res["y"].max() == pytest.approx(100)


### PR DESCRIPTION
A simple `Move` operation (slightly stretching the functionality beyond "reduce over-plotting") that does a divisive normalization by an arbitrary function.:

```python
so.Plot(penguins, "bill_length_mm").add(so.Bar(), so.Hist(), so.Norm())
```
![Screen Shot 2022-05-31 at 8 31 48 PM](https://user-images.githubusercontent.com/315810/171305012-30534388-35c4-4344-af97-a93d5ddd2416.png)

The function and grouping are flexible, and it can be chained with other moves in interesting ways:

```python
(
    so.Plot(tips, x="day", y="total_bill", color="sex")
    .add(so.Bar(), so.Hist(), [so.Norm("sum", by=["x"]), so.Stack()])
)
```
![image](https://user-images.githubusercontent.com/315810/171305070-a3cf81f6-0ef1-4af2-98ab-2e18518b5d55.png)

There is also some flexibility to the domain across where the normalizer is computed:

```python
(
    so.Plot(gapminder, "year", "lifeExp", color="continent")
    .add(so.Line(), so.Agg(), so.Norm(where="x == 1977"))
)
```
![image](https://user-images.githubusercontent.com/315810/171305122-5341c1bf-ccf6-40c9-8f14-b9c1a0912ea8.png)


