### PR TITLE
Improve legend for categorical scatterplots

### DIFF
--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -39,6 +39,8 @@ __all__ = [
 ]
 
 
+# Subclassing _RelationalPlotter for the legend machinery,
+# but probably should move that more centrally
 class _CategoricalPlotterNew(_RelationalPlotter):
 
     semantics = "x", "y", "hue", "units"
@@ -3582,7 +3584,6 @@ def catplot(
     refactored_kinds = [
         "strip", "swarm",
     ]
-
     if kind in refactored_kinds:
 
         p = _CategoricalFacetPlotter(
@@ -3620,12 +3621,17 @@ def catplot(
             **facet_kws,
         )
 
+        # Capture this here because scale_categorical is going to insert a (null)
+        # x variable even if it is empty. It's not clear whether that needs to
+        # happen or if disabling that is the cleaner solution.
+        has_xy_data = p.has_xy_data
+
         if not native_scale or p.var_types[p.cat_axis] == "categorical":
             p.scale_categorical(p.cat_axis, order=order, formatter=formatter)
 
         p._attach(g)
 
-        if not p.has_xy_data:
+        if not has_xy_data:
             return g
 
         palette, hue_order = p._hue_backcompat(color, palette, hue_order)

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -279,7 +279,6 @@ class _CategoricalPlotterNew(_RelationalPlotter):
                 points.set_edgecolors(edgecolor)
 
         # Finalize the axes details
-        self._add_axis_labels(ax)
         if self.legend and not self._redundant_hue and self.input_format != "wide":
             self.add_legend_data(ax)
             handles, _ = ax.get_legend_handles_labels()
@@ -368,7 +367,6 @@ class _CategoricalPlotterNew(_RelationalPlotter):
         _draw_figure(ax.figure)
 
         # Finalize the axes details
-        self._add_axis_labels(ax)
         if self.legend and not self._redundant_hue and self.input_format != "wide":
             self.add_legend_data(ax)
             handles, _ = ax.get_legend_handles_labels()

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -286,7 +286,12 @@ class _CategoricalPlotterNew(_RelationalPlotter):
                 points.set_edgecolors(edgecolor)
 
         # Finalize the axes details
-        if self.legend and not self._redundant_hue and self.input_format != "wide":
+        if self.legend == "auto":
+            show_legend = not self._redundant_hue and self.input_format != "wide"
+        else:
+            show_legend = bool(self.legend)
+
+        if show_legend:
             self.add_legend_data(ax)
             handles, _ = ax.get_legend_handles_labels()
             if handles:
@@ -374,7 +379,12 @@ class _CategoricalPlotterNew(_RelationalPlotter):
         _draw_figure(ax.figure)
 
         # Finalize the axes details
-        if self.legend and not self._redundant_hue and self.input_format != "wide":
+        if self.legend == "auto":
+            show_legend = not self._redundant_hue and self.input_format != "wide"
+        else:
+            show_legend = bool(self.legend)
+
+        if show_legend:
             self.add_legend_data(ax)
             handles, _ = ax.get_legend_handles_labels()
             if handles:

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -180,6 +180,12 @@ class _CategoricalPlotterNew(_RelationalPlotter):
         if self.var_types[axis] != "categorical":
             return
 
+        # If both x/y data are empty, the correct way to set up the plot is
+        # somewhat undefined; because we don't add null category data to the plot in
+        # this case we don't *have* a categorical axis (yet), so best to just bail.
+        if self.plot_data[axis].empty:
+            return
+
         # We can infer the total number of categories (including those from previous
         # plots that are not part of the plot we are currently making) from the number
         # of ticks, which matplotlib sets up while doing unit conversion. This feels

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -79,6 +79,8 @@ class _CategoricalPlotterNew(_RelationalPlotter):
             require_numeric=require_numeric,
         )
 
+        self.legend = legend
+
         # Short-circuit in the case of an empty plot
         if not self.has_xy_data:
             return
@@ -104,8 +106,6 @@ class _CategoricalPlotterNew(_RelationalPlotter):
         # Categorical variables have discrete levels that we need to track
         cat_levels = categorical_order(self.plot_data[self.cat_axis], order)
         self.var_levels[self.cat_axis] = cat_levels
-
-        self.legend = legend
 
     def _hue_backcompat(self, color, palette, hue_order, force_hue=False):
         """Implement backwards compatibility for hue parametrization.

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -262,8 +262,7 @@ class _CategoricalPlotterNew(_RelationalPlotter):
         for sub_vars, sub_data in self.iter_data(iter_vars,
                                                  from_comp_data=True,
                                                  allow_empty=True):
-
-            if offsets is not None:
+            if offsets is not None and (offsets != 0).any():
                 dodge_move = offsets[sub_data["hue"].map(self._hue_map.levels.index)]
 
             jitter_move = jitterer(size=len(sub_data)) if len(sub_data) > 1 else 0

--- a/seaborn/relational.py
+++ b/seaborn/relational.py
@@ -524,7 +524,7 @@ class _ScatterPlotter(_RelationalPlotter):
         legend=None
     ):
 
-        # TODO this is messy, we want the mapping to be agnoistic about
+        # TODO this is messy, we want the mapping to be agnostic about
         # the kind of plot to draw, but for the time being we need to set
         # this information so the SizeMapping can use it
         self._default_size_range = (

--- a/seaborn/tests/test_categorical.py
+++ b/seaborn/tests/test_categorical.py
@@ -2028,6 +2028,24 @@ class SharedScatterTests(SharedAxesLevelTests):
         for point_color in ax.collections[0].get_facecolor():
             assert tuple(point_color) == to_rgba("C0")
 
+    def test_legend_categorical(self, long_df):
+
+        ax = self.func(data=long_df, x="y", y="a", hue="b")
+        legend_texts = [t.get_text() for t in ax.legend_.texts]
+        expected = categorical_order(long_df["b"])
+        assert legend_texts == expected
+
+    def test_legend_numeric(self, long_df):
+
+        ax = self.func(data=long_df, x="y", y="a", hue="z")
+        vals = [float(t.get_text()) for t in ax.legend_.texts]
+        assert (vals[1] - vals[0]) == pytest.approx(vals[2] - vals[1])
+
+    def test_legend_disabled(self, long_df):
+
+        ax = self.func(data=long_df, x="y", y="a", hue="b", legend=False)
+        assert ax.legend_ is None
+
     def test_palette_from_color_deprecation(self, long_df):
 
         color = (.9, .4, .5)
@@ -2085,9 +2103,8 @@ class SharedScatterTests(SharedAxesLevelTests):
             dict(data="wide", orient="h"),
             dict(data="long", x="x", color="C3"),
             dict(data="long", y="y", hue="a", jitter=False),
-            # TODO XXX full numeric hue legend crashes pinned mpl, disabling for now
-            # dict(data="long", x="a", y="y", hue="z", edgecolor="w", linewidth=.5),
-            # dict(data="long", x="a_cat", y="y", hue="z"),
+            dict(data="long", x="a", y="y", hue="z", edgecolor="w", linewidth=.5),
+            dict(data="long", x="a_cat", y="y", hue="z"),
             dict(data="long", x="y", y="s", hue="c", orient="h", dodge=True),
             dict(data="long", x="s", y="y", hue="c", native_scale=True),
         ]


### PR DESCRIPTION
This ties up some loose ends from #2413 and #2447, which allowed them to apply a continuous mapping to the hue variable without upgrading the legend machinery to properly show a colorbar-like legend. Now that works as expected:

```python
sns.catplot(diamonds, x="cut", y="price", hue="carat", jitter=.4, s=5)
```
![image](https://user-images.githubusercontent.com/315810/171396619-f11b35fa-fd23-427c-b732-85f1867c58a3.png)

The solution is a bit of a shortcut, simply making `_CategoricalPlotterNew` subclass `_RelationalPlotter`, where the relevant method for creating legend artists lives. Probably that method should be moved down to the base class level to keep a cleaner division between the modules (but also, the `distributions` module has a different approach altogether). Legends remain a mess.