### PR TITLE
Address issues with new categorical scatterplots

### DIFF
--- a/seaborn/_oldcore.py
+++ b/seaborn/_oldcore.py
@@ -93,7 +93,11 @@ class HueMapping(SemanticMapping):
 
         data = plotter.plot_data.get("hue", pd.Series(dtype=float))
 
-        if data.notna().any():
+        if data.isna().all():
+            if palette is not None:
+                msg = "Ignoring `palette` because no `hue` variable has been assigned."
+                warnings.warn(msg, stacklevel=4)
+        else:
 
             map_type = self.infer_map_type(
                 palette, norm, plotter.input_format, plotter.var_types["hue"]

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -352,19 +352,18 @@ class _CategoricalPlotterNew(_RelationalPlotter):
                 points.set_edgecolors(edgecolor)
 
             if not sub_data.empty:
-                point_collections[sub_data[self.cat_axis].iloc[0]] = points
+                point_collections[(ax, sub_data[self.cat_axis].iloc[0])] = points
 
         beeswarm = Beeswarm(
             width=width, orient=self.orient, warn_thresh=warn_thresh,
         )
-        for center, points in point_collections.items():
+        for (ax, center), points in point_collections.items():
             if points.get_offsets().shape[0] > 1:
 
                 def draw(points, renderer, *, center=center):
 
                     beeswarm(points, center)
 
-                    ax = points.axes
                     if self.orient == "h":
                         scalex = False
                         scaley = ax.get_autoscaley_on()

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -167,6 +167,18 @@ class _CategoricalPlotterNew(_RelationalPlotter):
 
         return palette, hue_order
 
+    def _palette_without_hue_backcompat(self, palette, hue_order):
+        """Provide one cycle where palette= implies hue= when not provided"""
+        if "hue" not in self.variables and palette is not None:
+            msg = "Passing `palette` without assigning `hue` is deprecated."
+            warnings.warn(msg, FutureWarning, stacklevel=3)
+            self.legend = False
+            self.plot_data["hue"] = self.plot_data[self.cat_axis]
+            self.variables["hue"] = self.variables.get(self.cat_axis)
+            self.var_types["hue"] = self.var_types.get(self.cat_axis)
+            hue_order = self.var_levels.get(self.cat_axis)
+        return hue_order
+
     @property
     def cat_axis(self):
         return {"v": "x", "h": "y"}[self.orient]
@@ -2797,6 +2809,7 @@ def stripplot(
 
     p._attach(ax)
 
+    hue_order = p._palette_without_hue_backcompat(palette, hue_order)
     palette, hue_order = p._hue_backcompat(color, palette, hue_order)
 
     color = _default_color(ax.scatter, hue, color, kwargs)
@@ -2925,6 +2938,7 @@ def swarmplot(
 
     color = _default_color(ax.scatter, hue, color, kwargs)
 
+    hue_order = p._palette_without_hue_backcompat(palette, hue_order)
     p.map_hue(palette=palette, order=hue_order, norm=hue_norm)
 
     # XXX Copying possibly bad default decisions from original code for now

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -3659,6 +3659,11 @@ def catplot(
         palette, hue_order = p._hue_backcompat(color, palette, hue_order)
         p.map_hue(palette=palette, order=hue_order, norm=hue_norm)
 
+        # Set a default color
+        # Otherwise each artist will be plotted separately and trip the color cycle
+        if hue is None and color is None:
+            color = "C0"
+
         if kind == "strip":
 
             # TODO get these defaults programmatically?

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -2934,11 +2934,11 @@ def swarmplot(
     if not p.has_xy_data:
         return ax
 
+    hue_order = p._palette_without_hue_backcompat(palette, hue_order)
     palette, hue_order = p._hue_backcompat(color, palette, hue_order)
 
     color = _default_color(ax.scatter, hue, color, kwargs)
 
-    hue_order = p._palette_without_hue_backcompat(palette, hue_order)
     p.map_hue(palette=palette, order=hue_order, norm=hue_norm)
 
     # XXX Copying possibly bad default decisions from original code for now
@@ -3669,6 +3669,7 @@ def catplot(
         if not has_xy_data:
             return g
 
+        hue_order = p._palette_without_hue_backcompat(palette, hue_order)
         palette, hue_order = p._hue_backcompat(color, palette, hue_order)
         p.map_hue(palette=palette, order=hue_order, norm=hue_norm)
 

--- a/tests/test_categorical.py
+++ b/tests/test_categorical.py
@@ -2813,6 +2813,8 @@ class TestCatPlot(CategoricalFixture):
         g = cat.catplot(x="g", y="y", data=self.df, kind="strip")
         want_elements = self.g.unique().size
         assert len(g.ax.collections) == want_elements
+        for strip in g.ax.collections:
+            assert same_color(strip.get_facecolors(), "C0")
 
         g = cat.catplot(x="g", y="y", hue="h", data=self.df, kind="strip")
         want_elements = self.g.unique().size + self.h.unique().size

--- a/tests/test_categorical.py
+++ b/tests/test_categorical.py
@@ -2054,6 +2054,15 @@ class SharedScatterTests(SharedAxesLevelTests):
         for point_color in points.get_facecolors():
             assert to_rgb(point_color) in palette
 
+    def test_palette_with_hue_deprecation(self, long_df):
+        palette = "Blues"
+        with pytest.warns(FutureWarning, match="Passing `palette` without"):
+            ax = self.func(data=long_df, x="a", y=long_df["y"], palette=palette)
+        strips = ax.collections
+        colors = color_palette(palette, len(strips))
+        for strip, color in zip(strips, colors):
+            assert same_color(strip.get_facecolor()[0], color)
+
     def test_log_scale(self):
 
         x = [1, 10, 100, 1000]

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -316,6 +316,12 @@ class TestHueMapping:
         with pytest.raises(ValueError):
             HueMapping(p, norm="not a norm")
 
+    def test_hue_map_without_hue_dataa(self, long_df):
+
+        p = VectorPlotter(data=long_df, variables=dict(x="x", y="y"))
+        with pytest.warns(UserWarning, match="Ignoring `palette`"):
+            HueMapping(p, palette="viridis")
+
 
 class TestSizeMapping:
 


### PR DESCRIPTION
Fixes #2835 

- Fixes a simple bug introduced in the refactor (#2429) where `catplot(..., kind="swarm")` would only have points in the final axes swarmed.
- Fixes a bug where `catplot()` with either scatterplot option was using the color cycle for each categorical level.
- Added a warning and some backwards compatibility for cases where `palette=` is passed without `hue=` in the refactored categorical scatterplots. I thought I had done this during the refactor, but apparently not. While we are changing the default behavior, it seems reasonable to honor this explicit ask for multiple colors with a warning / smoother deprecation.