### PR TITLE
Improve support for nonstandard data representation in relplot

### DIFF
--- a/doc/releases/v0.12.0.txt
+++ b/doc/releases/v0.12.0.txt
@@ -63,6 +63,8 @@ Other updates
 
 - |Fix| In :func:`lineplot`, allowed the `dashes` keyword to set the style of a line without mapping a `style` variable (:pr:`2449`).
 
+- |Fix| Improved support in :func:`relplot` for "wide" data and for faceting variables passed as non-pandas objects (:pr:`2846`).
+
 - |Dependencies| Made `scipy` an optional dependency and added `pip install seaborn[all]` as a method for ensuring the availability of compatible `scipy` and `statsmodels` libraries at install time. This has a few minor implications for existing code, which are explained in the Github pull request (:pr:`2398`).
 
 - |Dependencies| Following `NEP29 <https://numpy.org/neps/nep-0029-deprecation_policy.html>`_, dropped support for Python 3.6 and bumped the minimally-supported versions of the library dependencies.

--- a/seaborn/distributions.py
+++ b/seaborn/distributions.py
@@ -2137,8 +2137,8 @@ def displot(
     grid_data = p.plot_data.rename(columns=p.variables)
     grid_data = grid_data.loc[:, ~grid_data.columns.duplicated()]
 
-    col_name = p.variables.get("col", None)
-    row_name = p.variables.get("row", None)
+    col_name = p.variables.get("col")
+    row_name = p.variables.get("row")
 
     if facet_kws is None:
         facet_kws = {}

--- a/seaborn/relational.py
+++ b/seaborn/relational.py
@@ -951,7 +951,11 @@ def relplot(
 
     # Pass the row/col variables to FacetGrid with their original
     # names so that the axes titles render correctly
-    grid_kws = {v: p.variables.get(v, None) for v in grid_semantics}
+    for var in ["row", "col"]:
+        # Handle faceting variables that lack name information
+        if var in p.variables and p.variables[var] is None:
+            p.variables[var] = f"_{var}_"
+    grid_kws = {v: p.variables.get(v) for v in grid_semantics}
 
     # Rename the columns of the plot_data structure appropriately
     new_cols = plot_variables.copy()

--- a/seaborn/relational.py
+++ b/seaborn/relational.py
@@ -971,10 +971,8 @@ def relplot(
     # Draw the plot
     g.map_dataframe(func, **plot_kws)
 
-    # Label the axes
-    g.set_axis_labels(
-        variables.get("x", None), variables.get("y", None)
-    )
+    # Label the axes, using the original variables
+    g.set(xlabel=variables.get("x"), ylabel=variables.get("y"))
 
     # Show the legend
     if legend:

--- a/tests/test_relational.py
+++ b/tests/test_relational.py
@@ -507,6 +507,7 @@ class TestRelationalPlotter(Helpers):
         kws = {key: long_df[val] for key, val in semantics.items()}
         g = relplot(data=long_df, **kws)
         grouped = long_df.groupby("c")
+        assert len(g.axes_dict) == len(grouped)
         for (_, grp_df), ax in zip(grouped, g.axes.flat):
             x, y = ax.collections[0].get_offsets().T
             assert_array_equal(x, grp_df["x"])

--- a/tests/test_relational.py
+++ b/tests/test_relational.py
@@ -517,6 +517,7 @@ class TestRelationalPlotter(Helpers):
         g = relplot(data=wide_df)
         x, y = g.ax.collections[0].get_offsets().T
         assert_array_equal(y, wide_df.to_numpy().T.ravel())
+        assert not g.ax.get_ylabel()
 
     def test_relplot_hues(self, long_df):
 

--- a/tests/test_relational.py
+++ b/tests/test_relational.py
@@ -497,14 +497,15 @@ class TestRelationalPlotter(Helpers):
                 assert_array_equal(x, grp_df["x"])
                 assert_array_equal(y, grp_df["y"])
 
-    @pytest.mark.parametrize(
-        "vector_type",
-        ["series", "numpy", "list"],
-    )
+    @pytest.mark.parametrize("vector_type", ["series", "numpy", "list"])
     def test_relplot_vectors(self, long_df, vector_type):
 
         semantics = dict(x="x", y="y", hue="f", col="c")
         kws = {key: long_df[val] for key, val in semantics.items()}
+        if vector_type == "numpy":
+            kws = {k: v.to_numpy() for k, v in kws.items()}
+        elif vector_type == "list":
+            kws = {k: v.to_list() for k, v in kws.items()}
         g = relplot(data=long_df, **kws)
         grouped = long_df.groupby("c")
         assert len(g.axes_dict) == len(grouped)


### PR DESCRIPTION
- Suppress internal names for anonymous vector objects from appearing as axis labels (fixes #2712)
- Support anonymous vector objects as faceting variables (fixes #2624)