### PR TITLE
Fix PairGrid with hue passed in map method

### DIFF
--- a/doc/releases/v0.12.0.txt
+++ b/doc/releases/v0.12.0.txt
@@ -59,6 +59,8 @@ Other updates
 
 - |Fix| Fixed a bug in :func:`violinplot` where inner boxes/points could be missing with unpaired split violins (:pr:`2814`).
 
+- |Fix| Fixed a bug in :class:`PairGrid` where and error would be raised when defining `hue` only in the mapping methods (:pr:`2847`).
+
 - |Fix| Subplot titles will no longer be reset when calling :meth:`FacetGrid.map` or :meth:`FacetGrid.map_dataframe` (:pr:`2705`).
 
 - |Fix| In :func:`lineplot`, allowed the `dashes` keyword to set the style of a line without mapping a `style` variable (:pr:`2449`).

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -1565,9 +1565,10 @@ class PairGrid(Grid):
         else:
             hue = data.get(self._hue_var)
 
-        kwargs.setdefault("hue", hue)
-        kwargs.setdefault("hue_order", self._hue_order)
-        kwargs.setdefault("palette", self._orig_palette)
+        if "hue" not in kwargs:
+            kwargs.update({
+                "hue": hue, "hue_order": self._hue_order, "palette": self._orig_palette,
+            })
         func(x=x, y=y, **kwargs)
 
         self._update_legend_data(ax)

--- a/tests/test_axisgrid.py
+++ b/tests/test_axisgrid.py
@@ -1170,6 +1170,14 @@ class TestPairGrid:
 
         plt.close("all")
 
+    def test_hue_in_map(self, long_df):
+
+        g = ag.PairGrid(long_df, vars=["x", "y"])
+        g.map(scatterplot, hue=long_df["a"])
+        ax = g.axes.flat[0]
+        points = ax.collections[0]
+        assert len(set(map(tuple, points.get_facecolors()))) == 3
+
     def test_nondefault_index(self):
 
         df = self.df.copy().set_index("b")


### PR DESCRIPTION
Fixes #2590.

With reprex from that issue:

```python
import seaborn as sns
iris = sns.load_dataset("iris")
g = sns.PairGrid(iris, y_vars=["sepal_length","sepal_width"], x_vars=["petal_length","petal_width"])
g.map(sns.scatterplot, hue=iris["species"])
g.map(sns.regplot, scatter=False)
```

![image](https://user-images.githubusercontent.com/315810/173198721-2f254735-2557-4a6f-b8ea-f613a62f1357.png)
