### PR TITLE
Fix histplot dodge bar widths with log scale

### DIFF
--- a/doc/releases/v0.12.0.txt
+++ b/doc/releases/v0.12.0.txt
@@ -63,11 +63,13 @@ Other updates
 
 - |Fix| Fixed a bug in :func:`scatterplot` where an error would be raised when `hue_order` was a subset of the hue levels (:pr:`2848`).
 
-- |Fix| Subplot titles will no longer be reset when calling :meth:`FacetGrid.map` or :meth:`FacetGrid.map_dataframe` (:pr:`2705`).
+- |Fix| Fixed a bug in :func:`histplot` where dodged bars would have different widths on a log scale (:pr:`2849`).
 
 - |Fix| In :func:`lineplot`, allowed the `dashes` keyword to set the style of a line without mapping a `style` variable (:pr:`2449`).
 
 - |Fix| Improved support in :func:`relplot` for "wide" data and for faceting variables passed as non-pandas objects (:pr:`2846`).
+
+- |Fix| Subplot titles will no longer be reset when calling :meth:`FacetGrid.map` or :meth:`FacetGrid.map_dataframe` (:pr:`2705`).
 
 - |Dependencies| Made `scipy` an optional dependency and added `pip install seaborn[all]` as a method for ensuring the availability of compatible `scipy` and `statsmodels` libraries at install time. This has a few minor implications for existing code, which are explained in the Github pull request (:pr:`2398`).
 

--- a/seaborn/distributions.py
+++ b/seaborn/distributions.py
@@ -280,8 +280,18 @@ class _DistributionPlotter(VectorPlotter):
             for key in curves:
                 level = dict(key)["hue"]
                 hist = curves[key].reset_index(name="heights")
-                hist["widths"] /= n
-                hist["edges"] += hue_levels.index(level) * hist["widths"]
+                if self._log_scaled(self.data_variable):
+                    level_idx = hue_levels.index(level)
+                    left_scaled = np.log10(hist["edges"])
+                    right_scaled = np.log10(hist["edges"] + hist["widths"])
+                    w_scaled = (right_scaled - left_scaled) / n
+                    new_left = np.power(10, left_scaled + level_idx * w_scaled)
+                    new_right = np.power(10, left_scaled + (level_idx + 1) * w_scaled)
+                    hist["widths"] = new_right - new_left
+                    hist["edges"] = new_left
+                else:
+                    hist["widths"] /= n
+                    hist["edges"] += hue_levels.index(level) * hist["widths"]
 
                 curves[key] = hist.set_index(["edges", "widths"])["heights"]
 

--- a/seaborn/distributions.py
+++ b/seaborn/distributions.py
@@ -280,18 +280,18 @@ class _DistributionPlotter(VectorPlotter):
             for key in curves:
                 level = dict(key)["hue"]
                 hist = curves[key].reset_index(name="heights")
+                level_idx = hue_levels.index(level)
                 if self._log_scaled(self.data_variable):
-                    level_idx = hue_levels.index(level)
-                    left_scaled = np.log10(hist["edges"])
-                    right_scaled = np.log10(hist["edges"] + hist["widths"])
-                    w_scaled = (right_scaled - left_scaled) / n
-                    new_left = np.power(10, left_scaled + level_idx * w_scaled)
-                    new_right = np.power(10, left_scaled + (level_idx + 1) * w_scaled)
-                    hist["widths"] = new_right - new_left
-                    hist["edges"] = new_left
+                    log_min = np.log10(hist["edges"])
+                    log_max = np.log10(hist["edges"] + hist["widths"])
+                    log_width = (log_max - log_min) / n
+                    new_min = np.power(10, log_min + level_idx * log_width)
+                    new_max = np.power(10, log_min + (level_idx + 1) * log_width)
+                    hist["widths"] = new_max - new_min
+                    hist["edges"] = new_min
                 else:
                     hist["widths"] /= n
-                    hist["edges"] += hue_levels.index(level) * hist["widths"]
+                    hist["edges"] += level_idx * hist["widths"]
 
                 curves[key] = hist.set_index(["edges", "widths"])["heights"]
 

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -1722,6 +1722,15 @@ class TestHistPlotUnivariate(SharedAxesLevelTests):
         steps = np.divide(bar_widths[1:], bar_widths[:-1])
         assert np.allclose(steps, 10)
 
+    def test_log_scale_dodge(self, rng):
+
+        x = rng.lognormal(0, 2, 100)
+        hue = np.repeat(["a", "b"], 50)
+        ax = histplot(x=x, hue=hue, bins=5, log_scale=True, multiple="dodge")
+        x_min = np.log([b.get_x() for b in ax.patches])
+        x_max = np.log([b.get_x() + b.get_width() for b in ax.patches])
+        assert np.unique(np.round(x_max - x_min, 10)).size == 1
+
     @pytest.mark.parametrize(
         "fill", [True, False],
     )


### PR DESCRIPTION
Closes #2819 by adding a test and fixes #2820 

![image](https://user-images.githubusercontent.com/315810/173204016-db2aa79f-58d0-4c3f-bc1a-8da2207fffe0.png)
