### PR TITLE
Don't remove top left ylabel from corner pairplot with normal diagonal

### DIFF
--- a/doc/releases/v0.12.0.txt
+++ b/doc/releases/v0.12.0.txt
@@ -51,6 +51,8 @@ Other updates
 
 - |Enhancement| Example datasets are now stored in an OS-specific cache location (as determined by `appdirs`) rather than in the user's home directory. Users should feel free to remove `~/seaborn-data` if desired (:pr:`2773`).
 
+- |Enhancement| When using :func:`pairplot` with `corner=True` and `diag_kind=None`, the top left y axis label is no longer hidden (:pr:2850`).
+
 - |Fix| Fixed a regression in 0.11.2 that caused some functions to stall indefinitely or raise when the input data had a duplicate index (:pr:`2776`).
 
 - |Fix| Fixed a bug in :func:`histplot` and :func:`kdeplot` where weights were not factored into the normalization (:pr:`2812`).

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -1623,8 +1623,6 @@ class PairGrid(Grid):
             ax.set_xlabel(label)
         for ax, label in zip(self.axes[:, 0], self.y_vars):
             ax.set_ylabel(label)
-        if self._corner:
-            self.axes[0, 0].set_ylabel("")
 
     def _find_numeric_cols(self, data):
         """Find which variables in a DataFrame are numeric."""

--- a/tests/test_axisgrid.py
+++ b/tests/test_axisgrid.py
@@ -765,12 +765,12 @@ class TestPairGrid:
 
         for ax in np.diag(g.axes):
             assert not ax.yaxis.get_visible()
-            assert not g.axes[0, 0].get_ylabel()
 
         plot_vars = ["x", "y", "z"]
         g = ag.PairGrid(self.df, vars=plot_vars, corner=True)
         g.map(scatterplot)
         assert len(g.figure.axes) == corner_size
+        assert g.axes[0, 0].get_ylabel() == "x"
 
     def test_size(self):
 


### PR DESCRIPTION
Closes #2772. Because `PairGrid.map_diag` has logic to disable the y axis visibility when `corner=True`, there's no reason to remove the y axis label when setting up the plot.