### PR TITLE
Inherit errorbar alpha from scatter points in regplot

### DIFF
--- a/doc/releases/v0.12.0.txt
+++ b/doc/releases/v0.12.0.txt
@@ -53,6 +53,8 @@ Other updates
 
 - |Enhancement| When using :func:`pairplot` with `corner=True` and `diag_kind=None`, the top left y axis label is no longer hidden (:pr:2850`).
 
+- |Enhancement| Error bars in :func:`regplot` now inherit the alpha value of the points they correspond to (:pr:`2540`).
+
 - |Fix| Fixed a regression in 0.11.2 that caused some functions to stall indefinitely or raise when the input data had a duplicate index (:pr:`2776`).
 
 - |Fix| Fixed a bug in :func:`histplot` and :func:`kdeplot` where weights were not factored into the normalization (:pr:`2812`).

--- a/seaborn/regression.py
+++ b/seaborn/regression.py
@@ -396,6 +396,8 @@ class _RegressionPlotter(_LinearPlotter):
         else:
             # TODO abstraction
             ci_kws = {"color": kws["color"]}
+            if "alpha" in kws:
+                ci_kws["alpha"] = kws["alpha"]
             ci_kws["linewidth"] = mpl.rcParams["lines.linewidth"] * 1.75
             kws.setdefault("s", 50)
 

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -522,6 +522,14 @@ class TestRegressionPlots:
                         scatter_kws={'color': color})
         assert ax.collections[0]._alpha == 0.8
 
+        f, ax = plt.subplots()
+        alpha = .3
+        ax = lm.regplot(x="x", y="y", data=self.df,
+                        x_bins=5, fit_reg=False,
+                        scatter_kws={"alpha": alpha})
+        for line in ax.lines:
+            assert line.get_alpha() == alpha
+
     def test_regplot_binned(self):
 
         ax = lm.regplot(x="x", y="y", data=self.df, x_bins=5)


### PR DESCRIPTION
Closes https://github.com/mwaskom/seaborn/pull/2540 by adding a test. Closes #2538.

```python
sns.regplot(
    tips, x="size", y="total_bill",
    x_estimator=np.mean, scatter_kws={"alpha": .5}
)
```
![image](https://user-images.githubusercontent.com/315810/173239061-5a6ace3a-4518-4a0e-935c-42733bfbd482.png)
