### PR TITLE
Implement orient= in lineplot for sorting / aggregating on the y axis

### DIFF
--- a/doc/docstrings/lineplot.ipynb
+++ b/doc/docstrings/lineplot.ipynb
@@ -153,6 +153,22 @@
    "cell_type": "raw",
    "metadata": {},
    "source": [
+    "Use the `orient` paramter to aggregate and sort along the vertical dimension of the plot:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sns.lineplot(data=flights, x=\"passengers\", y=\"year\", orient=\"y\")"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
     "Each semantic variable can also represent a different column. For that, we'll need a more complex dataset:"
    ]
   },
@@ -411,10 +427,13 @@
   }
  ],
  "metadata": {
+  "interpreter": {
+   "hash": "8bdfc9d9da1e36addfcfc8a3409187c45d33387af0f87d0d91e99e8d6403f1c3"
+  },
   "kernelspec": {
-   "display_name": "seaborn-py38-latest",
+   "display_name": "Python 3.9.9 ('seaborn-py39-latest')",
    "language": "python",
-   "name": "seaborn-py38-latest"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -426,7 +445,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.9.9"
   }
  },
  "nbformat": 4,

--- a/doc/releases/v0.12.0.txt
+++ b/doc/releases/v0.12.0.txt
@@ -47,13 +47,15 @@ Other updates
 
 - |Feature| Increased the flexibility of what can be shown by the internally-calculated errorbars for :func:`lineplot`. With the new `errorbar` parameter, it is now possible to select bootstrap confidence intervals, percentile / predictive intervals, or intervals formed by scaled standard deviations or standard errors. As a consequence of this change, the `ci` parameter has been deprecated. Similar changes will be made to other functions that aggregate data points in future releases. (:pr:`2407`).
 
-- |Enhancement| Improved integration with the matplotlib color cycle in most axes-level functions (:pr:`2449`).
+- |Feature| It is now possible to aggregate / sort a :func:`lineplot` along the y axis using `orient="y"` (:pr:`2854`).
 
 - |Enhancement| Example datasets are now stored in an OS-specific cache location (as determined by `appdirs`) rather than in the user's home directory. Users should feel free to remove `~/seaborn-data` if desired (:pr:`2773`).
 
+- |Enhancement| Error bars in :func:`regplot` now inherit the alpha value of the points they correspond to (:pr:`2540`).
+
 - |Enhancement| When using :func:`pairplot` with `corner=True` and `diag_kind=None`, the top left y axis label is no longer hidden (:pr:2850`).
 
-- |Enhancement| Error bars in :func:`regplot` now inherit the alpha value of the points they correspond to (:pr:`2540`).
+- |Enhancement| |Fix| Improved integration with the matplotlib color cycle in most axes-level functions (:pr:`2449`).
 
 - |Fix| Fixed a regression in 0.11.2 that caused some functions to stall indefinitely or raise when the input data had a duplicate index (:pr:`2776`).
 

--- a/seaborn/relational.py
+++ b/seaborn/relational.py
@@ -353,7 +353,7 @@ class _LinePlotter(_RelationalPlotter):
         self, *,
         data=None, variables={},
         estimator=None, ci=None, n_boot=None, seed=None, errorbar=None,
-        sort=True, sort_dim="x", err_style=None, err_kws=None, legend=None
+        sort=True, orient="x", err_style=None, err_kws=None, legend=None
     ):
 
         # TODO this is messy, we want the mapping to be agnostic about
@@ -371,7 +371,7 @@ class _LinePlotter(_RelationalPlotter):
         self.n_boot = n_boot
         self.seed = seed
         self.sort = sort
-        self.sort_dim = sort_dim
+        self.orient = orient
         self.err_style = err_style
         self.err_kws = {} if err_kws is None else err_kws
 
@@ -408,8 +408,11 @@ class _LinePlotter(_RelationalPlotter):
         )
 
         # TODO abstract variable to aggregate over here-ish. Better name?
-        agg_var = "y"
-        grouper = ["x"]
+        orient = self.orient
+        if orient not in {"x", "y"}:
+            err = f"`orient` must be either 'x' or 'y', not {orient!r}."
+            raise ValueError(err)
+        other = {"x": "y", "y": "x"}[orient]
 
         # TODO How to handle NA? We don't want NA to propagate through to the
         # estimate/CI when some values are present, but we would also like
@@ -422,13 +425,7 @@ class _LinePlotter(_RelationalPlotter):
         for sub_vars, sub_data in self.iter_data(grouping_vars, from_comp_data=True):
 
             if self.sort:
-                if self.sort_dim == "x":
-                    sort_vars = ["units", "x", "y"]
-                elif self.sort_dim == "y":
-                    sort_vars = ["units", "y", "x"]
-                else:
-                    err = "`sort_dim` must be 'x' or 'y', not {}"
-                    raise ValueError(err.format(self.sort_dim))
+                sort_vars = ["units", orient, other]
                 sort_cols = [var for var in sort_vars if var in self.variables]
                 sub_data = sub_data.sort_values(sort_cols)
 
@@ -437,10 +434,10 @@ class _LinePlotter(_RelationalPlotter):
                     # TODO eventually relax this constraint
                     err = "estimator must be None when specifying units"
                     raise ValueError(err)
-                grouped = sub_data.groupby(grouper, sort=self.sort)
+                grouped = sub_data.groupby(orient, sort=self.sort)
                 # Could pass as_index=False instead of reset_index,
                 # but that fails on a corner case with older pandas.
-                sub_data = grouped.apply(agg, agg_var).reset_index()
+                sub_data = grouped.apply(agg, other).reset_index()
 
             # TODO this is pretty ad hoc ; see GH2409
             for var in "xy":
@@ -484,19 +481,23 @@ class _LinePlotter(_RelationalPlotter):
 
                 if self.err_style == "band":
 
-                    ax.fill_between(
-                        sub_data["x"], sub_data["ymin"], sub_data["ymax"],
+                    func = {"x": ax.fill_between, "y": ax.fill_betweenx}[orient]
+                    func(
+                        sub_data[orient],
+                        sub_data[f"{other}min"], sub_data[f"{other}max"],
                         color=line_color, **err_kws
                     )
 
                 elif self.err_style == "bars":
 
-                    error_deltas = (
-                        sub_data["y"] - sub_data["ymin"],
-                        sub_data["ymax"] - sub_data["y"],
-                    )
+                    error_param = {
+                        f"{other}err": (
+                            sub_data[other] - sub_data[f"{other}min"],
+                            sub_data[f"{other}max"] - sub_data[other],
+                        )
+                    }
                     ebars = ax.errorbar(
-                        sub_data["x"], sub_data["y"], error_deltas,
+                        sub_data["x"], sub_data["y"], **error_param,
                         linestyle="", color=line_color, alpha=line_alpha,
                         **err_kws
                     )
@@ -614,7 +615,7 @@ def lineplot(
     sizes=None, size_order=None, size_norm=None,
     dashes=True, markers=None, style_order=None,
     estimator="mean", errorbar=("ci", 95), n_boot=1000, seed=None,
-    sort=True, sort_dim="x", err_style="band", err_kws=None,
+    orient="x", sort=True, err_style="band", err_kws=None,
     legend="auto", ci="deprecated", ax=None, **kwargs
 ):
 
@@ -625,7 +626,7 @@ def lineplot(
     p = _LinePlotter(
         data=data, variables=variables,
         estimator=estimator, ci=ci, n_boot=n_boot, seed=seed, errorbar=errorbar,
-        sort=sort, sort_dim=sort_dim, err_style=err_style, err_kws=err_kws,
+        sort=sort, orient=orient, err_style=err_style, err_kws=err_kws,
         legend=legend,
     )
 
@@ -694,12 +695,12 @@ style : vector or key in ``data``
 {params.stat.errorbar}
 {params.rel.n_boot}
 {params.rel.seed}
+orient : "x" or "y"
+    Dimension along which the data are sorted / aggregated. Equivalently,
+    the "independent variable" of the resulting function.
 sort : boolean
     If True, the data will be sorted by the x and y variables, otherwise
     lines will connect points in the order they appear in the dataset.
-sort_dim : "x" or "y"
-    Dimension to be sorted first. If the y-variable is drawn as a function
-    of the x-variable, use "x". If it is vice versa, use "y".
 err_style : "band" or "bars"
     Whether to draw the confidence intervals with translucent error bands
     or discrete error bars.

--- a/seaborn/relational.py
+++ b/seaborn/relational.py
@@ -352,9 +352,8 @@ class _LinePlotter(_RelationalPlotter):
     def __init__(
         self, *,
         data=None, variables={},
-        estimator=None, ci=None, n_boot=None, seed=None,
-        sort=True, err_style=None, err_kws=None, legend=None,
-        errorbar=None,
+        estimator=None, ci=None, n_boot=None, seed=None, errorbar=None,
+        sort=True, sort_dim="x", err_style=None, err_kws=None, legend=None
     ):
 
         # TODO this is messy, we want the mapping to be agnostic about
@@ -372,6 +371,7 @@ class _LinePlotter(_RelationalPlotter):
         self.n_boot = n_boot
         self.seed = seed
         self.sort = sort
+        self.sort_dim = sort_dim
         self.err_style = err_style
         self.err_kws = {} if err_kws is None else err_kws
 
@@ -422,7 +422,13 @@ class _LinePlotter(_RelationalPlotter):
         for sub_vars, sub_data in self.iter_data(grouping_vars, from_comp_data=True):
 
             if self.sort:
-                sort_vars = ["units", "x", "y"]
+                if self.sort_dim == "x":
+                    sort_vars = ["units", "x", "y"]
+                elif self.sort_dim == "y":
+                    sort_vars = ["units", "y", "x"]
+                else:
+                    err = "`sort_dim` must be 'x' or 'y', not {}"
+                    raise ValueError(err.format(self.sort_dim))
                 sort_cols = [var for var in sort_vars if var in self.variables]
                 sub_data = sub_data.sort_values(sort_cols)
 
@@ -608,8 +614,8 @@ def lineplot(
     sizes=None, size_order=None, size_norm=None,
     dashes=True, markers=None, style_order=None,
     estimator="mean", errorbar=("ci", 95), n_boot=1000, seed=None,
-    sort=True, err_style="band", err_kws=None, ci="deprecated",
-    legend="auto", ax=None, **kwargs
+    sort=True, sort_dim="x", err_style="band", err_kws=None,
+    legend="auto", ci="deprecated", ax=None, **kwargs
 ):
 
     # Handle deprecation of ci parameter
@@ -618,9 +624,9 @@ def lineplot(
     variables = _LinePlotter.get_semantics(locals())
     p = _LinePlotter(
         data=data, variables=variables,
-        estimator=estimator, ci=ci, n_boot=n_boot, seed=seed,
-        sort=sort, err_style=err_style, err_kws=err_kws, legend=legend,
-        errorbar=errorbar,
+        estimator=estimator, ci=ci, n_boot=n_boot, seed=seed, errorbar=errorbar,
+        sort=sort, sort_dim=sort_dim, err_style=err_style, err_kws=err_kws,
+        legend=legend,
     )
 
     p.map_hue(palette=palette, order=hue_order, norm=hue_norm)
@@ -691,6 +697,9 @@ style : vector or key in ``data``
 sort : boolean
     If True, the data will be sorted by the x and y variables, otherwise
     lines will connect points in the order they appear in the dataset.
+sort_dim : "x" or "y"
+    Dimension to be sorted first. If the y-variable is drawn as a function
+    of the x-variable, use "x". If it is vice versa, use "y".
 err_style : "band" or "bars"
     Whether to draw the confidence intervals with translucent error bands
     or discrete error bars.

--- a/tests/test_relational.py
+++ b/tests/test_relational.py
@@ -5,7 +5,7 @@ import matplotlib.pyplot as plt
 from matplotlib.colors import same_color, to_rgba
 
 import pytest
-from numpy.testing import assert_array_equal
+from numpy.testing import assert_array_equal, assert_array_almost_equal
 
 from seaborn.external.version import Version
 from seaborn.palettes import color_palette
@@ -1001,48 +1001,6 @@ class TestLinePlotter(SharedAxesLevelTests, Helpers):
             assert isinstance(c, mpl.collections.LineCollection)
 
         p = _LinePlotter(
-            data=long_df,
-            variables=dict(x="y", y="x", hue="a"),
-            sort_dim="y",
-            estimator="mean", err_style="band", ci="sd"
-        )
-
-        ax.clear()
-        p.plot(ax, {})
-        assert len(ax.lines) == len(ax.collections) == len(p._hue_map.levels)
-        for c in ax.collections:
-            assert isinstance(c, mpl.collections.PolyCollection)
-        for line in ax.lines:
-            x, y = line.get_data()
-            assert((y == sorted(y)).all())
-
-        p = _LinePlotter(
-            data=long_df,
-            variables=dict(x="y", y="x", hue="a"),
-            sort_dim="y",
-            estimator="mean", err_style="bars", ci="sd"
-        )
-
-        ax.clear()
-        p.plot(ax, {})
-        n_lines = len(ax.lines)
-        assert n_lines / 2 == len(ax.collections) == len(p._hue_map.levels)
-        assert len(ax.collections) == len(p._hue_map.levels)
-        for c in ax.collections:
-            assert isinstance(c, mpl.collections.LineCollection)
-        for line in ax.lines:
-            x, y = line.get_data()
-            assert((y == sorted(y)).all())
-
-        with pytest.raises(ValueError):
-            p = _LinePlotter(
-                data=long_df,
-                variables=dict(x="y", y="x", hue="a"),
-                sort_dim="bad"
-            )
-            p.plot(ax, {})
-
-        p = _LinePlotter(
             data=repeated_df,
             variables=dict(x="x", y="y", units="u"),
             estimator=None
@@ -1108,6 +1066,31 @@ class TestLinePlotter(SharedAxesLevelTests, Helpers):
         )
         ax.clear()
         p.plot(ax, {})
+
+    def test_orient(self, long_df):
+
+        long_df = long_df.drop("x", axis=1).rename(columns={"s": "y", "y": "x"})
+
+        ax1 = plt.figure().subplots()
+        lineplot(data=long_df, x="x", y="y", orient="y", errorbar="sd")
+        assert len(ax1.lines) == len(ax1.collections)
+        line, = ax1.lines
+        expected = long_df.groupby("y").agg({"x": "mean"}).reset_index()
+        assert_array_almost_equal(line.get_xdata(), expected["x"])
+        assert_array_almost_equal(line.get_ydata(), expected["y"])
+        ribbon_y = ax1.collections[0].get_paths()[0].vertices[:, 1]
+        assert_array_equal(np.unique(ribbon_y), long_df["y"].sort_values().unique())
+
+        ax2 = plt.figure().subplots()
+        lineplot(
+            data=long_df, x="x", y="y", orient="y", errorbar="sd", err_style="bars"
+        )
+        segments = ax2.collections[0].get_segments()
+        for i, val in enumerate(sorted(long_df["y"].unique())):
+            assert (segments[i][:, 1] == val).all()
+
+        with pytest.raises(ValueError, match="`orient` must be either 'x' or 'y'"):
+            lineplot(long_df, x="y", y="x", orient="bad")
 
     def test_log_scale(self):
 

--- a/tests/test_relational.py
+++ b/tests/test_relational.py
@@ -1001,6 +1001,48 @@ class TestLinePlotter(SharedAxesLevelTests, Helpers):
             assert isinstance(c, mpl.collections.LineCollection)
 
         p = _LinePlotter(
+            data=long_df,
+            variables=dict(x="y", y="x", hue="a"),
+            sort_dim="y",
+            estimator="mean", err_style="band", ci="sd"
+        )
+
+        ax.clear()
+        p.plot(ax, {})
+        assert len(ax.lines) == len(ax.collections) == len(p._hue_map.levels)
+        for c in ax.collections:
+            assert isinstance(c, mpl.collections.PolyCollection)
+        for line in ax.lines:
+            x, y = line.get_data()
+            assert((y == sorted(y)).all())
+
+        p = _LinePlotter(
+            data=long_df,
+            variables=dict(x="y", y="x", hue="a"),
+            sort_dim="y",
+            estimator="mean", err_style="bars", ci="sd"
+        )
+
+        ax.clear()
+        p.plot(ax, {})
+        n_lines = len(ax.lines)
+        assert n_lines / 2 == len(ax.collections) == len(p._hue_map.levels)
+        assert len(ax.collections) == len(p._hue_map.levels)
+        for c in ax.collections:
+            assert isinstance(c, mpl.collections.LineCollection)
+        for line in ax.lines:
+            x, y = line.get_data()
+            assert((y == sorted(y)).all())
+
+        with pytest.raises(ValueError):
+            p = _LinePlotter(
+                data=long_df,
+                variables=dict(x="y", y="x", hue="a"),
+                sort_dim="bad"
+            )
+            p.plot(ax, {})
+
+        p = _LinePlotter(
             data=repeated_df,
             variables=dict(x="x", y="y", units="u"),
             estimator=None


### PR DESCRIPTION
This builds on #1744 (thanks to @matzegoebel), handling a merge conflict with some abstractions that made the implementation a little simpler and changing the parameter name to "orient" to align with the objects interface.

Example:

```python
sns.lineplot(fmri, x="signal", y="timepoint", orient="y")
```
![image](https://user-images.githubusercontent.com/315810/173255437-9810dade-a26b-4fdc-b758-a561b548122f.png)

Closes #1744.