### PR TITLE
Housekeeping on relational plot parameters

### DIFF
--- a/seaborn/relational.py
+++ b/seaborn/relational.py
@@ -352,7 +352,7 @@ class _LinePlotter(_RelationalPlotter):
     def __init__(
         self, *,
         data=None, variables={},
-        estimator=None, ci=None, n_boot=None, seed=None, errorbar=None,
+        estimator=None, n_boot=None, seed=None, errorbar=None,
         sort=True, orient="x", err_style=None, err_kws=None, legend=None
     ):
 
@@ -367,7 +367,6 @@ class _LinePlotter(_RelationalPlotter):
 
         self.estimator = estimator
         self.errorbar = errorbar
-        self.ci = ci
         self.n_boot = n_boot
         self.seed = seed
         self.sort = sort
@@ -625,7 +624,7 @@ def lineplot(
     variables = _LinePlotter.get_semantics(locals())
     p = _LinePlotter(
         data=data, variables=variables,
-        estimator=estimator, ci=ci, n_boot=n_boot, seed=seed, errorbar=errorbar,
+        estimator=estimator, n_boot=n_boot, seed=seed, errorbar=errorbar,
         sort=sort, orient=orient, err_style=err_style, err_kws=err_kws,
         legend=legend,
     )

--- a/seaborn/relational.py
+++ b/seaborn/relational.py
@@ -1006,10 +1006,6 @@ should refer to the documentation for each to see kind-specific options.
 After plotting, the :class:`FacetGrid` with the plot is returned and can
 be used directly to tweak supporting plot details or add other layers.
 
-Note that, unlike when using the underlying plotting functions directly,
-data must be passed in a long-form DataFrame with variables specified by
-passing strings to ``x``, ``y``, and other parameters.
-
 Parameters
 ----------
 {params.core.data}

--- a/seaborn/relational.py
+++ b/seaborn/relational.py
@@ -521,14 +521,7 @@ class _ScatterPlotter(_RelationalPlotter):
     _legend_attributes = ["color", "s", "marker"]
     _legend_func = "scatter"
 
-    def __init__(
-        self, *,
-        data=None, variables={},
-        x_bins=None, y_bins=None,
-        estimator=None, ci=None, n_boot=None,
-        alpha=None, x_jitter=None, y_jitter=None,
-        legend=None
-    ):
+    def __init__(self, *, data=None, variables={}, legend=None):
 
         # TODO this is messy, we want the mapping to be agnostic about
         # the kind of plot to draw, but for the time being we need to set
@@ -539,7 +532,6 @@ class _ScatterPlotter(_RelationalPlotter):
 
         super().__init__(data=data, variables=variables)
 
-        self.alpha = alpha
         self.legend = legend
 
     def plot(self, ax, kws):
@@ -571,10 +563,6 @@ class _ScatterPlotter(_RelationalPlotter):
             m = mpl.markers.MarkerStyle(m)
         if m.is_filled():
             kws.setdefault("edgecolor", "w")
-
-        # TODO this makes it impossible to vary alpha with hue which might
-        # otherwise be useful? Should we just pass None?
-        kws["alpha"] = 1 if self.alpha == "auto" else self.alpha
 
         # Draw the scatter plot
         points = ax.scatter(x=x, y=y, **kws)
@@ -741,21 +729,12 @@ def scatterplot(
     x=None, y=None, hue=None, size=None, style=None,
     palette=None, hue_order=None, hue_norm=None,
     sizes=None, size_order=None, size_norm=None,
-    markers=True, style_order=None,
-    x_bins=None, y_bins=None,
-    units=None, estimator=None, ci=95, n_boot=1000,
-    alpha=None, x_jitter=None, y_jitter=None,
-    legend="auto", ax=None,
+    markers=True, style_order=None, legend="auto", ax=None,
     **kwargs
 ):
 
     variables = _ScatterPlotter.get_semantics(locals())
-    p = _ScatterPlotter(
-        data=data, variables=variables,
-        x_bins=x_bins, y_bins=y_bins,
-        estimator=estimator, ci=ci, n_boot=n_boot,
-        alpha=alpha, x_jitter=x_jitter, y_jitter=y_jitter, legend=legend,
-    )
+    p = _ScatterPlotter(data=data, variables=variables, legend=legend)
 
     p.map_hue(palette=palette, order=hue_order, norm=hue_norm)
     p.map_size(sizes=sizes, order=size_order, norm=size_norm)
@@ -809,20 +788,6 @@ style : vector or key in ``data``
 {params.rel.size_norm}
 {params.rel.markers}
 {params.rel.style_order}
-{{x,y}}_bins : lists or arrays or functions
-    *Currently non-functional.*
-{params.rel.units}
-    *Currently non-functional.*
-{params.rel.estimator}
-    *Currently non-functional.*
-{params.rel.ci}
-    *Currently non-functional.*
-{params.rel.n_boot}
-    *Currently non-functional.*
-alpha : float
-    Proportional opacity of the points.
-{{x,y}}_jitter : booleans or floats
-    *Currently non-functional.*
 {params.rel.legend}
 {params.core.ax}
 kwargs : key, value mappings

--- a/seaborn/utils.py
+++ b/seaborn/utils.py
@@ -828,9 +828,9 @@ def _deprecate_ci(errorbar, ci):
         else:
             errorbar = ("ci", ci)
         msg = (
-            "The `ci` parameter is deprecated; "
-            f"use `errorbar={repr(errorbar)}` for same effect."
+            "\n\nThe `ci` parameter is deprecated. "
+            f"Use `errorbar={repr(errorbar)}` for the same effect.\n"
         )
-        warnings.warn(msg, UserWarning)
+        warnings.warn(msg, FutureWarning, stacklevel=3)
 
     return errorbar

--- a/tests/test_relational.py
+++ b/tests/test_relational.py
@@ -1278,13 +1278,13 @@ class TestLinePlotter(SharedAxesLevelTests, Helpers):
 
         axs = plt.figure().subplots(2)
         lineplot(data=long_df, x="x", y="y", errorbar=("ci", 95), seed=0, ax=axs[0])
-        with pytest.warns(UserWarning, match="The `ci` parameter is deprecated"):
+        with pytest.warns(FutureWarning, match="\n\nThe `ci` parameter is deprecated"):
             lineplot(data=long_df, x="x", y="y", ci=95, seed=0, ax=axs[1])
         assert_plots_equal(*axs)
 
         axs = plt.figure().subplots(2)
         lineplot(data=long_df, x="x", y="y", errorbar="sd", ax=axs[0])
-        with pytest.warns(UserWarning, match="The `ci` parameter is deprecated"):
+        with pytest.warns(FutureWarning, match="\n\nThe `ci` parameter is deprecated"):
             lineplot(data=long_df, x="x", y="y", ci="sd", ax=axs[1])
         assert_plots_equal(*axs)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -560,16 +560,16 @@ def test_draw_figure():
 
 def test_deprecate_ci():
 
-    msg = "The `ci` parameter is deprecated; use `errorbar="
+    msg = "\n\nThe `ci` parameter is deprecated. Use `errorbar="
 
-    with pytest.warns(UserWarning, match=msg + "None"):
+    with pytest.warns(FutureWarning, match=msg + "None"):
         out = _deprecate_ci(None, None)
     assert out is None
 
-    with pytest.warns(UserWarning, match=msg + "'sd'"):
+    with pytest.warns(FutureWarning, match=msg + "'sd'"):
         out = _deprecate_ci(None, "sd")
     assert out == "sd"
 
-    with pytest.warns(UserWarning, match=msg + r"\('ci', 68\)"):
+    with pytest.warns(FutureWarning, match=msg + r"\('ci', 68\)"):
         out = _deprecate_ci(None, 68)
     assert out == ("ci", 68)


### PR DESCRIPTION
When originally implemented, `scatterplot` had some placeholder parameters for functionality that was originally planned. But that functionality (jittering, aggregation) will be redundant with the categorical plots once they support `native_scale=True`. And because we now enforce keyword arguments, it's no longer necessary to have placeholders that anticipate a future signature ... if we do plan to add these back in the future, they can simply be inserted in a sensible location in the parameter list.