### PR TITLE
Downgrade exception on mapping list length mismatch to warning

### DIFF
--- a/seaborn/_oldcore.py
+++ b/seaborn/_oldcore.py
@@ -74,7 +74,6 @@ class SemanticMapping:
             ])
             values = values[:len(levels)]
 
-        # TODO look into custom PlotSpecWarning with better formatting
         if message:
             warnings.warn(message, UserWarning)
 
@@ -90,6 +89,7 @@ class SemanticMapping:
             return [self._lookup_single(k, *args, **kwargs) for k in key]
         else:
             return self._lookup_single(key, *args, **kwargs)
+
 
 @share_init_params_with_map
 class HueMapping(SemanticMapping):

--- a/seaborn/_oldcore.py
+++ b/seaborn/_oldcore.py
@@ -75,7 +75,7 @@ class SemanticMapping:
             values = values[:len(levels)]
 
         if message:
-            warnings.warn(message, UserWarning)
+            warnings.warn(message, UserWarning, stacklevel=6)
 
         return values
 

--- a/tests/test_axisgrid.py
+++ b/tests/test_axisgrid.py
@@ -1385,7 +1385,7 @@ class TestPairGrid:
         m2 = g._legend.legendHandles[1].get_paths()[0]
         assert m1 != m2
 
-        with pytest.raises(ValueError):
+        with pytest.warns(UserWarning):
             g = ag.pairplot(self.df, hue="a", vars=vars, markers=markers[:-2])
 
     def test_corner_despine(self):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -151,7 +151,7 @@ class TestHueMapping:
 
         # Test list with wrong number of colors
         palette = colors[:-1]
-        with pytest.raises(ValueError):
+        with pytest.warns(UserWarning):
             HueMapping(p, palette=palette)
 
         # Test hue order
@@ -296,7 +296,7 @@ class TestHueMapping:
         assert m.lookup_table == dict(zip(hue_levels, palette))
 
         palette = color_palette("Blues", len(hue_levels) + 1)
-        with pytest.raises(ValueError):
+        with pytest.warns(UserWarning):
             HueMapping(p, palette=palette)
 
         # Test dictionary of colors
@@ -460,7 +460,7 @@ class TestSizeMapping:
 
         # Test sizes list with wrong length
         sizes = list(np.random.rand(len(levels) + 1))
-        with pytest.raises(ValueError):
+        with pytest.warns(UserWarning):
             SizeMapping(p, sizes=sizes)
 
         # Test sizes dict with missing levels
@@ -578,13 +578,13 @@ class TestStyleMapping:
             assert_array_equal(m(key, "path").vertices, path.vertices)
 
         # Test too many levels with style lists
-        with pytest.raises(ValueError):
+        with pytest.warns(UserWarning):
             StyleMapping(p, markers=["o", "s"], dashes=False)
 
-        with pytest.raises(ValueError):
+        with pytest.warns(UserWarning):
             StyleMapping(p, markers=False, dashes=[(2, 1)])
 
-        # Test too many levels with style dicts
+        # Test missing keys with style dicts
         markers, dashes = {"a": "o", "b": "s"}, False
         with pytest.raises(ValueError):
             StyleMapping(p, markers=markers, dashes=dashes)


### PR DESCRIPTION
Closes #2662 

This makes the current behavior of functions that use the old core machinery consistent with the objects interface, so there should be a smooth transition once they are refactored.