### PR TITLE
Relax restriction on element type for discrete histplot

### DIFF
--- a/doc/releases/v0.12.0.txt
+++ b/doc/releases/v0.12.0.txt
@@ -57,6 +57,8 @@ Other updates
 
 - |Enhancement| |Fix| Improved integration with the matplotlib color cycle in most axes-level functions (:pr:`2449`).
 
+- |Enhancement| It is now possible to plot a discrete :func:`histplot` as a step function or polygon (:pr:`2859`).
+
 - |Fix| Fixed a regression in 0.11.2 that caused some functions to stall indefinitely or raise when the input data had a duplicate index (:pr:`2776`).
 
 - |Fix| Fixed a bug in :func:`histplot` and :func:`kdeplot` where weights were not factored into the normalization (:pr:`2812`).

--- a/seaborn/distributions.py
+++ b/seaborn/distributions.py
@@ -398,9 +398,6 @@ class _DistributionPlotter(VectorPlotter):
         _check_argument("multiple", ["layer", "stack", "fill", "dodge"], multiple)
         _check_argument("element", ["bars", "step", "poly"], element)
 
-        if estimate_kws["discrete"] and element != "bars":
-            raise ValueError("`element` must be 'bars' when `discrete` is True")
-
         auto_bins_with_weights = (
             "weights" in self.variables
             and estimate_kws["bins"] == "auto"

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -1449,11 +1449,6 @@ class TestHistPlotUnivariate(SharedAxesLevelTests):
         ymax, ymin = ax.get_ylim()
         assert ymax > ymin
 
-    def test_discrete_requires_bars(self, long_df):
-
-        with pytest.raises(ValueError, match="`element` must be 'bars'"):
-            histplot(long_df, x="s", discrete=True, element="poly")
-
     @pytest.mark.skipif(
         Version(np.__version__) < Version("1.17"),
         reason="Histogram over datetime64 requires numpy >= 1.17",


### PR DESCRIPTION
I don't recall if there was any rationale for this originally, but I cannot think of one now!

Fixes #2582
