### PR TITLE
Add width parameter to barplot

### DIFF
--- a/doc/releases/v0.12.0.txt
+++ b/doc/releases/v0.12.0.txt
@@ -51,6 +51,8 @@ Other updates
 
 - |Enhancement| Example datasets are now stored in an OS-specific cache location (as determined by `appdirs`) rather than in the user's home directory. Users should feel free to remove `~/seaborn-data` if desired (:pr:`2773`).
 
+- |Enhancement| Added a `width` parameter to :func:`barplot` (:pr:`2860`).
+
 - |Enhancement| Error bars in :func:`regplot` now inherit the alpha value of the points they correspond to (:pr:`2540`).
 
 - |Enhancement| When using :func:`pairplot` with `corner=True` and `diag_kind=None`, the top left y axis label is no longer hidden (:pr:2850`).

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -1576,8 +1576,8 @@ class _BarPlotter(_CategoricalStatPlotter):
 
     def __init__(self, x, y, hue, data, order, hue_order,
                  estimator, ci, n_boot, units, seed,
-                 orient, color, palette, saturation, errcolor,
-                 errwidth, capsize, dodge):
+                 orient, color, palette, saturation, width,
+                 errcolor, errwidth, capsize, dodge):
         """Initialize the plotter."""
         self.establish_variables(x, y, hue, data, orient,
                                  order, hue_order, units)
@@ -1585,6 +1585,7 @@ class _BarPlotter(_CategoricalStatPlotter):
         self.estimate_statistic(estimator, ci, n_boot, seed)
 
         self.dodge = dodge
+        self.width = width
 
         self.errcolor = errcolor
         self.errwidth = errwidth
@@ -2743,7 +2744,7 @@ swarmplot.__doc__ = dedent("""\
 def barplot(
     data=None, *, x=None, y=None, hue=None, order=None, hue_order=None,
     estimator=np.mean, ci=95, n_boot=1000, units=None, seed=None,
-    orient=None, color=None, palette=None, saturation=.75,
+    orient=None, color=None, palette=None, saturation=.75, width=.8,
     errcolor=".26", errwidth=None, capsize=None, dodge=True,
     ax=None,
     **kwargs,
@@ -2752,7 +2753,7 @@ def barplot(
     plotter = _BarPlotter(x, y, hue, data, order, hue_order,
                           estimator, ci, n_boot, units, seed,
                           orient, color, palette, saturation,
-                          errcolor, errwidth, capsize, dodge)
+                          width, errcolor, errwidth, capsize, dodge)
 
     if ax is None:
         ax = plt.gca()
@@ -2793,6 +2794,7 @@ barplot.__doc__ = dedent("""\
     {color}
     {palette}
     {saturation}
+    {width}
     errcolor : matplotlib color
         Color used for the error bar lines.
     {errwidth}

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -2912,7 +2912,7 @@ pointplot.__doc__ = dedent("""\
 
 def countplot(
     data=None, *, x=None, y=None, hue=None, order=None, hue_order=None,
-    orient=None, color=None, palette=None, saturation=.75,
+    orient=None, color=None, palette=None, saturation=.75, width=.8,
     dodge=True, ax=None, **kwargs
 ):
 
@@ -2938,7 +2938,7 @@ def countplot(
         x, y, hue, data, order, hue_order,
         estimator, ci, n_boot, units, seed,
         orient, color, palette, saturation,
-        errcolor, errwidth, capsize, dodge
+        width, errcolor, errwidth, capsize, dodge
     )
 
     plotter.value_label = "count"

--- a/tests/test_categorical.py
+++ b/tests/test_categorical.py
@@ -2209,20 +2209,20 @@ class TestBarPlotter(CategoricalFixture):
 
     def test_nested_width(self):
 
-        kws = self.default_kws.copy()
+        ax = cat.barplot(data=self.df, x="g", y="y", hue="h")
+        for bar in ax.patches:
+            assert bar.get_width() == pytest.approx(.8 / 2)
+        ax.clear()
 
-        p = cat._BarPlotter(**kws)
-        p.establish_variables("g", "y", hue="h", data=self.df)
-        assert p.nested_width == .8 / 2
+        ax = cat.barplot(data=self.df, x="g", y="y", hue="g", width=.5)
+        for bar in ax.patches:
+            assert bar.get_width() == pytest.approx(.5 / 3)
+        ax.clear()
 
-        p = cat._BarPlotter(**kws)
-        p.establish_variables("h", "y", "g", data=self.df)
-        assert p.nested_width == .8 / 3
-
-        kws["dodge"] = False
-        p = cat._BarPlotter(**kws)
-        p.establish_variables("h", "y", "g", data=self.df)
-        assert p.nested_width == .8
+        ax = cat.barplot(data=self.df, x="g", y="y", hue="g", dodge=False)
+        for bar in ax.patches:
+            assert bar.get_width() == pytest.approx(.8)
+        ax.clear()
 
     def test_draw_vertical_bars(self):
 

--- a/tests/test_categorical.py
+++ b/tests/test_categorical.py
@@ -2203,7 +2203,8 @@ class TestBarPlotter(CategoricalFixture):
         estimator=np.mean, ci=95, n_boot=100, units=None, seed=None,
         order=None, hue_order=None,
         orient=None, color=None, palette=None,
-        saturation=.75, errcolor=".26", errwidth=None,
+        saturation=.75, width=0.8,
+        errcolor=".26", errwidth=None,
         capsize=None, dodge=True
     )
 


### PR DESCRIPTION
Closes #2508, see also #1878, #824

```python
sns.barplot(tips, x="size", y="tip", hue="sex", width=.4)
```

![image](https://user-images.githubusercontent.com/315810/173713268-f4f121a3-9956-49ba-aa0e-62f8ba555a4d.png)
