### PR TITLE
added loop variable to lineplot

### DIFF
--- a/seaborn/relational.py
+++ b/seaborn/relational.py
@@ -161,6 +161,10 @@ legend : "auto", "brief", "full", or False
     choose between brief or full representation based on number of levels.
     If `False`, no legend data is added and no legend is drawn.
     """,
+    loop="""
+loop : Boolean
+    If True, the ends of the line will be plotted as connected.
+    """,
     ax_in="""
 ax : matplotlib Axes
     Axes object to draw the plot onto, otherwise uses the current Axes.


### PR DESCRIPTION
If loop=True, the ends of the lineplot will connect. This is particularly useful for polar plots where the x-axis quantity of interest represents rotation.