### PR TITLE
Make the legend markers have consistent style as those on the curve.

### DIFF
--- a/seaborn/relational.py
+++ b/seaborn/relational.py
@@ -590,6 +590,15 @@ class _ScatterPlotter(_RelationalPlotter):
             self.add_legend_data(ax)
             handles, _ = ax.get_legend_handles_labels()
             if handles:
+                for h in handles:
+                    if 'markersize' in kws:
+                        h.set_markersize(kws['markersize'])
+                    if 'markeredgewidth' in kws:
+                        h.set_markeredgewidth(kws['markeredgewidth'])
+                    if 'linewidth' in kws:
+                        h.set_linewidth(kws['linewidth'])
+                    if 'markeredgecolor' in kws:
+                        h.set_markeredgecolor(kws['markeredgecolor'])
                 legend = ax.legend(title=self.legend_title)
                 adjust_legend_subtitles(legend)
 


### PR DESCRIPTION
Before this PR, markers in the legend have a different style as those on the curves:
![image](https://user-images.githubusercontent.com/7333325/175115794-8ea75df0-89b2-434a-b5c9-725b5f2d7294.png)

After this PR, their styles are made consistent:
![image](https://user-images.githubusercontent.com/7333325/175115946-cfa1ab56-5864-4444-a0b7-3519b68a5214.png)

I think it is good to make them consistent. Matplotlib also has them consistent by default:
![image](https://user-images.githubusercontent.com/7333325/175116248-3a090fb8-68e2-4c8a-851e-ad1225ddabcc.png)
