### PR TITLE
Add Scale.label interface for formatting ticks

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,0 @@
-[pytest]
-filterwarnings =
-;   Warnings raised from within patsy imports
-    ignore:Using or importing the ABCs:DeprecationWarning
-junit_family=xunit1

--- a/seaborn/_core/plot.py
+++ b/seaborn/_core/plot.py
@@ -23,7 +23,7 @@ from seaborn._marks.base import Mark
 from seaborn._stats.base import Stat
 from seaborn._core.data import PlotData
 from seaborn._core.moves import Move
-from seaborn._core.scales import Scale, ScaleTransform
+from seaborn._core.scales import Scale
 from seaborn._core.subplots import Subplots
 from seaborn._core.groupby import GroupBy
 from seaborn._core.properties import PROPERTIES, Property, Coordinate
@@ -677,7 +677,7 @@ class Plotter:
         self._legend_contents: list[
             tuple[str, str | int], list[Artist], list[str],
         ] = []
-        self._scales: dict[str, ScaleTransform] = {}
+        self._scales: dict[str, Scale] = {}
 
     def save(self, loc, **kwargs) -> Plotter:  # TODO type args
         kwargs.setdefault("dpi", 96)
@@ -873,7 +873,7 @@ class Plotter:
                 var_df = pd.DataFrame(columns=cols)
 
             prop = Coordinate(axis)
-            scale_spec = self._get_scale(p, prefix, prop, var_df[var])
+            scale = self._get_scale(p, prefix, prop, var_df[var])
 
             # Shared categorical axes are broken on matplotlib<3.4.0.
             # https://github.com/matplotlib/matplotlib/pull/18308
@@ -882,7 +882,7 @@ class Plotter:
             if Version(mpl.__version__) < Version("3.4.0"):
                 from seaborn._core.scales import Nominal
                 paired_axis = axis in p._pair_spec
-                cat_scale = isinstance(scale_spec, Nominal)
+                cat_scale = isinstance(scale, Nominal)
                 ok_dim = {"x": "col", "y": "row"}[axis]
                 shared_axes = share_state not in [False, "none", ok_dim]
                 if paired_axis and cat_scale and shared_axes:
@@ -897,7 +897,7 @@ class Plotter:
             # Setup the scale on all of the data and plug it into self._scales
             # We do this because by the time we do self._setup_scales, coordinate data
             # will have been converted to floats already, so scale inference fails
-            self._scales[var] = scale_spec.setup(var_df[var], prop)
+            self._scales[var] = scale._setup(var_df[var], prop)
 
             # Set up an empty series to receive the transformed values.
             # We need this to handle piecemeal tranforms of categories -> floats.
@@ -927,7 +927,7 @@ class Plotter:
 
                     seed_values = var_df.loc[idx, var]
 
-                scale = scale_spec.setup(seed_values, prop, axis=axis_obj)
+                scale = scale._setup(seed_values, prop, axis=axis_obj)
 
                 for layer, new_series in zip(layers, transformed_data):
                     layer_df = layer["data"].frame
@@ -936,7 +936,7 @@ class Plotter:
                         new_series.loc[idx] = scale(layer_df.loc[idx, var])
 
                 # TODO need decision about whether to do this or modify axis transform
-                set_scale_obj(view["ax"], axis, scale.matplotlib_scale)
+                set_scale_obj(view["ax"], axis, scale._matplotlib_scale)
 
             # Now the transformed data series are complete, set update the layer data
             for layer, new_series in zip(layers, transformed_data):
@@ -1052,12 +1052,12 @@ class Plotter:
                 axis = m["axis"]
 
             prop = PROPERTIES.get(var if axis is None else axis, Property())
-            scale_spec = self._get_scale(p, var, prop, var_values)
+            scale = self._get_scale(p, var, prop, var_values)
 
             # Initialize the data-dependent parameters of the scale
             # Note that this returns a copy and does not mutate the original
             # This dictionary is used by the semantic mappings
-            if scale_spec is None:
+            if scale is None:
                 # TODO what is the cleanest way to implement identity scale?
                 # We don't really need a Scale, and Identity() will be
                 # overloaded anyway (but maybe a general Identity object
@@ -1065,18 +1065,16 @@ class Plotter:
                 # Note that this may not be the right spacer to use
                 # (but that is only relevant for coordinates, where identity scale
                 # doesn't make sense or is poorly defined, since we don't use pixels.)
-                self._scales[var] = ScaleTransform(
-                    [], lambda x: x, None, "identity", None
-                )
+                self._scales[var] = Scale._identity()
             else:
-                scale = scale_spec.setup(var_values, prop)
+                transform = scale._setup(var_values, prop)
                 if isinstance(prop, Coordinate):
                     # If we have a coordinate here, we didn't assign a scale for it
                     # in _transform_coords, which means it was added during compute_stat
                     # This allows downstream orientation inference to work properly.
                     # But it feels a little hacky, so perhaps revisit.
-                    scale.scale_type = "computed"
-                self._scales[var] = scale
+                    transform._priority = 0
+                self._scales[var] = transform
 
     def _plot_layer(self, p: Plot, layer: Layer) -> None:
 
@@ -1106,7 +1104,7 @@ class Plotter:
             else:
                 width = df.get("width", 0.8)  # TODO what default
             if orient in df:
-                df["width"] = width * scales[orient].spacing(df[orient])
+                df["width"] = width * scales[orient]._spacing(df[orient])
 
             if "baseline" in mark._mappable_props:
                 # TODO what marks should have this?
@@ -1207,7 +1205,7 @@ class Plotter:
     def _generate_pairings(
         self, data: PlotData, pair_variables: dict,
     ) -> Generator[
-        tuple[list[dict], DataFrame, dict[str, ScaleTransform]], None, None
+        tuple[list[dict], DataFrame, dict[str, Scale]], None, None
     ]:
         # TODO retype return with subplot_spec or similar
 
@@ -1279,7 +1277,7 @@ class Plotter:
             v for v in grouping_vars if v in df and v not in ["col", "row"]
         ]
         for var in grouping_vars:
-            order = self._scales[var].order
+            order = getattr(self._scales[var], "order", None)
             if order is None:
                 order = categorical_order(df[var])
             grouping_keys.append(order)
@@ -1343,7 +1341,7 @@ class Plotter:
         return split_generator
 
     def _update_legend_contents(
-        self, mark: Mark, data: PlotData, scales: dict[str, ScaleTransform]
+        self, mark: Mark, data: PlotData, scales: dict[str, Scale]
     ) -> None:
         """Add legend artists / labels for one layer in the plot."""
         if data.frame.empty and data.frames:
@@ -1359,7 +1357,7 @@ class Plotter:
         ]] = []
         schema = []
         for var in legend_vars:
-            var_legend = scales[var].legend
+            var_legend = scales[var]._legend
             if var_legend is not None:
                 values, labels = var_legend
                 for (_, part_id), part_vars, _ in schema:

--- a/seaborn/_core/plot.py
+++ b/seaborn/_core/plot.py
@@ -1073,7 +1073,7 @@ class Plotter:
                     # in _transform_coords, which means it was added during compute_stat
                     # This allows downstream orientation inference to work properly.
                     # But it feels a little hacky, so perhaps revisit.
-                    scale._priority = 0
+                    scale._priority = 0  # type: ignore
                 self._scales[var] = scale
 
     def _plot_layer(self, p: Plot, layer: Layer) -> None:

--- a/seaborn/_core/plot.py
+++ b/seaborn/_core/plot.py
@@ -1067,14 +1067,14 @@ class Plotter:
                 # doesn't make sense or is poorly defined, since we don't use pixels.)
                 self._scales[var] = Scale._identity()
             else:
-                transform = scale._setup(var_values, prop)
+                scale = scale._setup(var_values, prop)
                 if isinstance(prop, Coordinate):
                     # If we have a coordinate here, we didn't assign a scale for it
                     # in _transform_coords, which means it was added during compute_stat
                     # This allows downstream orientation inference to work properly.
                     # But it feels a little hacky, so perhaps revisit.
-                    transform._priority = 0
-                self._scales[var] = transform
+                    scale._priority = 0
+                self._scales[var] = scale
 
     def _plot_layer(self, p: Plot, layer: Layer) -> None:
 

--- a/seaborn/_core/plot.py
+++ b/seaborn/_core/plot.py
@@ -1097,7 +1097,7 @@ class Plotter:
                 # sorted unique numbers will correctly reconstruct intended order
                 # TODO This is tricky, make sure we add some tests for this
                 if var not in "xy" and var in scales:
-                    return scales[var].order
+                    return getattr(scales[var], "order", None)
 
             if "width" in mark._mappable_props:
                 width = mark._resolve(df, "width", None)

--- a/seaborn/_core/properties.py
+++ b/seaborn/_core/properties.py
@@ -86,7 +86,7 @@ class Property:
         if isinstance(arg, str):
             if any(arg.startswith(k) for k in trans_args):
                 # TODO validate numeric type? That should happen centrally somewhere
-                return Continuous(transform=arg)
+                return Continuous(trans=arg)
             else:
                 msg = f"Unknown magic arg for {self.variable} scale: '{arg}'."
                 raise ValueError(msg)

--- a/seaborn/_core/properties.py
+++ b/seaborn/_core/properties.py
@@ -8,7 +8,7 @@ import matplotlib as mpl
 from matplotlib.colors import to_rgb, to_rgba, to_rgba_array
 from matplotlib.path import Path
 
-from seaborn._core.scales import ScaleSpec, Nominal, Continuous, Temporal
+from seaborn._core.scales import Scale, Nominal, Continuous, Temporal
 from seaborn._core.rules import categorical_order, variable_type
 from seaborn._compat import MarkerStyle
 from seaborn.palettes import QUAL_PALETTES, color_palette, blend_palette
@@ -59,7 +59,7 @@ class Property:
             variable = self.__class__.__name__.lower()
         self.variable = variable
 
-    def default_scale(self, data: Series) -> ScaleSpec:
+    def default_scale(self, data: Series) -> Scale:
         """Given data, initialize appropriate scale class."""
         # TODO allow variable_type to be "boolean" if that's a scale?
         # TODO how will this handle data with units that can be treated as numeric
@@ -75,7 +75,7 @@ class Property:
         else:
             return Nominal()
 
-    def infer_scale(self, arg: Any, data: Series) -> ScaleSpec:
+    def infer_scale(self, arg: Any, data: Series) -> Scale:
         """Given data and a scaling argument, initialize appropriate scale class."""
         # TODO put these somewhere external for validation
         # TODO putting this here won't pick it up if subclasses define infer_scale
@@ -96,7 +96,7 @@ class Property:
             raise TypeError(msg)
 
     def get_mapping(
-        self, scale: ScaleSpec, data: Series
+        self, scale: Scale, data: Series
     ) -> Callable[[ArrayLike], ArrayLike]:
         """Return a function that maps from data domain to property range."""
         def identity(x):
@@ -176,7 +176,7 @@ class IntervalProperty(Property):
         """Transform applied to results of mapping that returns to native values."""
         return values
 
-    def infer_scale(self, arg: Any, data: Series) -> ScaleSpec:
+    def infer_scale(self, arg: Any, data: Series) -> Scale:
         """Given data and a scaling argument, initialize appropriate scale class."""
 
         # TODO infer continuous based on log/sqrt etc?
@@ -192,7 +192,7 @@ class IntervalProperty(Property):
             return Continuous(arg)
 
     def get_mapping(
-        self, scale: ScaleSpec, data: ArrayLike
+        self, scale: Scale, data: ArrayLike
     ) -> Callable[[ArrayLike], ArrayLike]:
         """Return a function that maps from data domain to property range."""
         if isinstance(scale, Nominal):
@@ -325,7 +325,7 @@ class ObjectProperty(Property):
         return Nominal(arg)
 
     def get_mapping(
-        self, scale: ScaleSpec, data: Series,
+        self, scale: Scale, data: Series,
     ) -> Callable[[ArrayLike], list]:
         """Define mapping as lookup into list of object values."""
         order = getattr(scale, "order", None)
@@ -532,7 +532,7 @@ class Color(Property):
         else:
             return to_rgba_array(colors)[:, :3]
 
-    def infer_scale(self, arg: Any, data: Series) -> ScaleSpec:
+    def infer_scale(self, arg: Any, data: Series) -> Scale:
         # TODO when inferring Continuous without data, verify type
 
         # TODO need to rethink the variable type system
@@ -617,7 +617,7 @@ class Color(Property):
         return mapping
 
     def get_mapping(
-        self, scale: ScaleSpec, data: Series
+        self, scale: Scale, data: Series
     ) -> Callable[[ArrayLike], ArrayLike]:
         """Return a function that maps from data domain to color values."""
         # TODO what is best way to do this conditional?
@@ -690,13 +690,13 @@ class Fill(Property):
         """Given data, initialize appropriate scale class."""
         return Nominal()
 
-    def infer_scale(self, arg: Any, data: Series) -> ScaleSpec:
+    def infer_scale(self, arg: Any, data: Series) -> Scale:
         """Given data and a scaling argument, initialize appropriate scale class."""
         # TODO infer Boolean where possible?
         return Nominal(arg)
 
     def get_mapping(
-        self, scale: ScaleSpec, data: Series
+        self, scale: Scale, data: Series
     ) -> Callable[[ArrayLike], ArrayLike]:
         """Return a function that maps each data value to True or False."""
         # TODO categorical_order is going to return [False, True] for booleans,

--- a/seaborn/_core/scales.py
+++ b/seaborn/_core/scales.py
@@ -4,7 +4,7 @@ from copy import copy
 from collections.abc import Sequence
 from dataclasses import dataclass
 from functools import partial
-from typing import Any, Callable, Tuple, Optional, Union
+from typing import Any, Callable, Tuple, Optional, Union, ClassVar
 
 import numpy as np
 import matplotlib as mpl
@@ -52,7 +52,7 @@ class Scale:
 
     values: tuple | str | list | dict | None
 
-    _priority: int
+    _priority: ClassVar[int]
     _pipeline: Pipeline
     _matplotlib_scale: ScaleBase
     _spacer: staticmethod
@@ -138,7 +138,7 @@ class Nominal(Scale):
     values: tuple | str | list | dict | None = None
     order: list | None = None
 
-    _priority: int = 3  # TODO need to hide from dataclass
+    _priority: ClassVar[int] = 3
 
     def _setup(
         self, data: Series, prop: Property, axis: Axis | None = None,
@@ -379,7 +379,7 @@ class Continuous(ContinuousBase):
     # TODO Add this to deal with outliers?
     # outside: Literal["keep", "drop", "clip"] = "keep"
 
-    _priority: int = 1
+    _priority: ClassVar[int] = 1
 
     def tick(
         self,
@@ -614,7 +614,7 @@ class Temporal(ContinuousBase):
 
     transform = None
 
-    _priority: int = 2
+    _priority: ClassVar[int] = 2
 
     def tick(
         self, locator: Locator | None = None, *, upto: int | None = None,

--- a/seaborn/_core/scales.py
+++ b/seaborn/_core/scales.py
@@ -470,8 +470,32 @@ class Continuous(ContinuousBase):
         base: int | None = None,
         unit: str | None = None,
     ) -> Continuous:
+        """
+        Configure the appearance of tick labels for the scale's axis or legend.
 
-        # TODO input check on like
+        Parameters
+        ----------
+        formatter : matplotlib Formatter
+            Pre-configured formatter to use; other parameters will be ignored.
+        like : str or callable
+            Either a format pattern (e.g., `".2f"`), a format string with fields named
+            `x` and/or `pos` (e.g., `"${x.2f}"`), or a callable that consumes a number
+            and returns a string.
+        base : number
+            Use log formatter (with scientific notation) having this value as the base.
+        unit : str or (str, str) tuple
+            Use engineering formatter with SI units (e.g., tick values in the 1000s
+            with `unit="g"` will have a `"kg"` suffix). When a tuple, the first
+            element gives the seperator between the number and unit.
+
+        Returns
+        -------
+        Copy of self with new label configuration.
+
+        """
+        if like is not None and not isinstance(like, str) or callable(like):
+            msg = f"`like` must be a string or callable, not {type(like).__name__}."
+            raise TypeError(msg)
 
         new = copy(self)
         new._label_params = {
@@ -497,18 +521,16 @@ class Continuous(ContinuousBase):
             else:
                 formatter = FuncFormatter(like)
 
+        elif base is not None:
+            # We could add other log options if necessary
+            formatter = LogFormatterSciNotation(base)
+
         elif unit is not None:
-            # TODO use like with unit to set places=?
-            # TODO accept (sep, unit) tuple?
             if isinstance(unit, tuple):
                 sep, unit = unit
             else:
                 sep = " "
             formatter = EngFormatter(unit, sep=sep)
-
-        elif base is not None:
-            # TODO what about other log options?
-            formatter = LogFormatterSciNotation(base)
 
         else:
             formatter = ScalarFormatter()

--- a/seaborn/_core/scales.py
+++ b/seaborn/_core/scales.py
@@ -45,7 +45,7 @@ if TYPE_CHECKING:
     Pipeline = Sequence[Optional[Callable[[Union[Series, ArrayLike]], ArrayLike]]]
 
 
-class Scale:
+class ScaleTransform:
 
     def __init__(
         self,
@@ -104,7 +104,7 @@ class Scale:
 
 
 @dataclass
-class ScaleSpec:
+class Scale:
 
     values: tuple | str | list | dict | None = None
 
@@ -130,7 +130,7 @@ class ScaleSpec:
 
     def setup(
         self, data: Series, prop: Property, axis: Axis | None = None,
-    ) -> Scale:
+    ) -> ScaleTransform:
         ...
 
     # TODO typing
@@ -154,7 +154,7 @@ class ScaleSpec:
 
 
 @dataclass
-class Nominal(ScaleSpec):
+class Nominal(Scale):
     """
     A categorical scale without relative importance / magnitude.
     """
@@ -224,19 +224,19 @@ class Nominal(ScaleSpec):
 
 
 @dataclass
-class Ordinal(ScaleSpec):
+class Ordinal(Scale):
     # Categorical (convert to strings), sortable, can skip ticklabels
     ...
 
 
 @dataclass
-class Discrete(ScaleSpec):
+class Discrete(Scale):
     # Numeric, integral, can skip ticks/ticklabels
     ...
 
 
 @dataclass
-class ContinuousBase(ScaleSpec):
+class ContinuousBase(Scale):
 
     values: tuple | str | None = None
     norm: tuple | None = None
@@ -282,7 +282,7 @@ class ContinuousBase(ScaleSpec):
         def spacer(x):
             return np.min(np.diff(np.sort(x.dropna().unique())))
 
-        # TODO make legend optional on per-plot basis with ScaleSpec parameter?
+        # TODO make legend optional on per-plot basis with Scale parameter?
         if prop.legend:
             axis.set_view_interval(vmin, vmax)
             locs = axis.major.locator()
@@ -523,12 +523,12 @@ class Temporal(ContinuousBase):
 # ----------------------------------------------------------------------------------- #
 
 
-class Calendric(ScaleSpec):
+class Calendric(Scale):
     # TODO have this separate from Temporal or have Temporal(date=True) or similar?
     ...
 
 
-class Binned(ScaleSpec):
+class Binned(Scale):
     # Needed? Or handle this at layer (in stat or as param, eg binning=)
     ...
 

--- a/seaborn/_core/scales.py
+++ b/seaborn/_core/scales.py
@@ -368,7 +368,7 @@ class ContinuousBase(Scale):
 
     def _get_transform(self):
 
-        arg = self.transform
+        arg = self.trans
 
         def get_param(method, default):
             if arg == method:
@@ -407,7 +407,7 @@ class Continuous(ContinuousBase):
     A numeric scale supporting norms and functional transforms.
     """
     values: tuple | str | None = None
-    transform: str | Transforms | None = None
+    trans: str | Transforms | None = None
 
     # TODO Add this to deal with outliers?
     # outside: Literal["keep", "drop", "clip"] = "keep"
@@ -455,7 +455,7 @@ class Continuous(ContinuousBase):
                 f"Tick locator must be an instance of {Locator!r}, "
                 f"not {type(locator)!r}."
             )
-        log_base, symlog_thresh = self._parse_for_log_params(self.transform)
+        log_base, symlog_thresh = self._parse_for_log_params(self.trans)
         if log_base or symlog_thresh:
             if count is not None and between is None:
                 raise RuntimeError("`count` requires `between` with log transform.")
@@ -523,21 +523,23 @@ class Continuous(ContinuousBase):
         }
         return new
 
-    def _parse_for_log_params(self, transform):
+    def _parse_for_log_params(
+        self, trans: str | Transforms | None
+    ) -> tuple[float | None, float | None]:
 
         log_base = symlog_thresh = None
-        if isinstance(transform, str):
-            m = re.match(r"^log(\d*)", transform)
+        if isinstance(trans, str):
+            m = re.match(r"^log(\d*)", trans)
             if m is not None:
                 log_base = float(m[1] or 10)
-            m = re.match(r"symlog(\d*)", transform)
+            m = re.match(r"symlog(\d*)", trans)
             if m is not None:
                 symlog_thresh = float(m[1] or 1)
         return log_base, symlog_thresh
 
     def _get_locators(self, locator, at, upto, count, every, between, minor):
 
-        log_base, symlog_thresh = self._parse_for_log_params(self.transform)
+        log_base, symlog_thresh = self._parse_for_log_params(self.trans)
 
         if locator is not None:
             major_locator = locator
@@ -595,7 +597,7 @@ class Continuous(ContinuousBase):
 
     def _get_formatter(self, locator, formatter, like, base, unit):
 
-        log_base, symlog_thresh = self._parse_for_log_params(self.transform)
+        log_base, symlog_thresh = self._parse_for_log_params(self.trans)
         if base is None:
             if symlog_thresh:
                 log_base = 10
@@ -646,7 +648,7 @@ class Temporal(ContinuousBase):
     # those yet, and having a clear distinction betewen date(time) / time
     # may be more useful.
 
-    transform = None
+    trans = None
 
     _priority: ClassVar[int] = 2
 

--- a/seaborn/_core/scales.py
+++ b/seaborn/_core/scales.py
@@ -73,7 +73,7 @@ class Scale:
     def _get_locators(self):
         raise NotImplementedError()
 
-    def _get_formatter(self):
+    def _get_formatter(self, locator: Locator | None = None):
         raise NotImplementedError()
 
     def _get_scale(self, name: str, forward: Callable, inverse: Callable):

--- a/seaborn/_core/scales.py
+++ b/seaborn/_core/scales.py
@@ -467,8 +467,8 @@ class Continuous(ContinuousBase):
         self,
         formatter=None, *,
         like: str | Callable | None = None,
-        unit: str | None = None,
         base: int | None = None,
+        unit: str | None = None,
     ) -> Continuous:
 
         # TODO input check on like
@@ -477,12 +477,12 @@ class Continuous(ContinuousBase):
         new._label_params = {
             "formatter": formatter,
             "like": like,
-            "unit": unit,
             "base": base,
+            "unit": unit,
         }
         return new
 
-    def _get_formatter(self, locator, formatter, like, unit, base):
+    def _get_formatter(self, locator, formatter, like, base, unit):
 
         if formatter is not None:
             return formatter
@@ -500,7 +500,11 @@ class Continuous(ContinuousBase):
         elif unit is not None:
             # TODO use like with unit to set places=?
             # TODO accept (sep, unit) tuple?
-            formatter = EngFormatter(unit)
+            if isinstance(unit, tuple):
+                sep, unit = unit
+            else:
+                sep = " "
+            formatter = EngFormatter(unit, sep=sep)
 
         elif base is not None:
             # TODO what about other log options?

--- a/seaborn/_core/scales.py
+++ b/seaborn/_core/scales.py
@@ -471,7 +471,7 @@ class Continuous(ContinuousBase):
         base : number
             Use log formatter (with scientific notation) having this value as the base.
         unit : str or (str, str) tuple
-            Use engineering formatter with SI units (e.g., with `unit="g"`, a tick value
+            Use  SI prefixes with these units (e.g., with `unit="g"`, a tick value
             of 5000 will appear as `5 kg`). When a tuple, the first element gives the
             seperator between the number and unit.
 

--- a/seaborn/_core/scales.py
+++ b/seaborn/_core/scales.py
@@ -62,6 +62,8 @@ class Scale:
 
         # TODO clumsy way to set up defaults needed after we changed these
         # to not operate in place
+        # Alternatively, could we have _setup call the methods to get default
+        # values when they are unset? Might be cleaner
         new = self.tick().label()
         self._tick_params = new._tick_params
         self._label_params = new._label_params

--- a/seaborn/_marks/base.py
+++ b/seaborn/_marks/base.py
@@ -1,19 +1,24 @@
 from __future__ import annotations
 from dataclasses import dataclass, fields, field
+from typing import Any, Callable, Union
+from collections.abc import Generator
 
 import numpy as np
 import pandas as pd
 import matplotlib as mpl
 
-from seaborn._core.properties import PROPERTIES, Property
-
-from typing import Any, Callable, Union
-from collections.abc import Generator
 from numpy import ndarray
 from pandas import DataFrame
 from matplotlib.artist import Artist
-from seaborn._core.properties import RGBATuple, DashPattern, DashPatternWithOffset
+
 from seaborn._core.scales import Scale
+from seaborn._core.properties import (
+    PROPERTIES,
+    Property,
+    RGBATuple,
+    DashPattern,
+    DashPatternWithOffset,
+)
 
 
 class Mappable:
@@ -184,27 +189,11 @@ class Mark:
         # TODO rethink this to map from scale type to "DV priority" and use that?
         # e.g. Nominal > Discrete > Continuous
 
-        x_type = None if "x" not in scales else scales["x"].scale_type
-        y_type = None if "y" not in scales else scales["y"].scale_type
+        x = 0 if "x" not in scales else scales["x"]._priority
+        y = 0 if "y" not in scales else scales["y"]._priority
 
-        if x_type is None or x_type == "computed":
+        if y > x:
             return "y"
-
-        elif y_type is None or y_type == "computed":
-            return "x"
-
-        elif x_type != "nominal" and y_type == "nominal":
-            return "y"
-
-        elif x_type != "continuous" and y_type == "continuous":
-
-            # TODO should we try to orient based on number of unique values?
-
-            return "x"
-
-        elif x_type == "continuous" and y_type != "continuous":
-            return "y"
-
         else:
             return "x"
 

--- a/seaborn/_stats/histograms.py
+++ b/seaborn/_stats/histograms.py
@@ -117,7 +117,10 @@ class Hist(Stat):
 
     def __call__(self, data, groupby, orient, scales):
 
-        scale_type = scales[orient].scale_type
+        # TODO better to do this as an isinstance check?
+        # We are only asking about Nominal scales now,
+        # but presumably would apply to Ordinal too?
+        scale_type = scales[orient].__class__.__name__.lower()
         grouping_vars = [v for v in data if v in groupby.order]
         if not grouping_vars or self.common_bins is True:
             bin_kws = self._define_bin_params(data, orient, scale_type)

--- a/tests/_core/test_plot.py
+++ b/tests/_core/test_plot.py
@@ -319,10 +319,10 @@ class TestScaling:
 
     def test_inference(self, long_df):
 
-        for col, scale_type in zip("zat", ["continuous", "nominal", "temporal"]):
+        for col, scale_type in zip("zat", ["Continuous", "Nominal", "Temporal"]):
             p = Plot(long_df, x=col, y=col).add(MockMark()).plot()
             for var in "xy":
-                assert p._scales[var].scale_type == scale_type
+                assert p._scales[var].__class__.__name__ == scale_type
 
     def test_inference_from_layer_data(self):
 
@@ -551,7 +551,7 @@ class TestScaling:
         s = MockStat()
         y = ["a", "a", "b", "c"]
         Plot(y=y).add(MockMark(), s).plot()
-        assert s.scales["y"].scale_type == "nominal"
+        assert s.scales["y"].__class__.__name__ == "Nominal"
 
     # TODO where should RGB consistency be enforced?
     @pytest.mark.xfail(

--- a/tests/_core/test_scales.py
+++ b/tests/_core/test_scales.py
@@ -221,7 +221,7 @@ class TestContinuous:
 
     def test_label_like_pattern(self, x):
 
-        a, locs = self.setup_labels(x, like="4f")
+        a, locs = self.setup_labels(x, like=".4f")
         labels = a.major.formatter.format_ticks(locs)
         for text in labels:
             assert re.match(r"^\d\.\d{4}$", text)
@@ -260,6 +260,23 @@ class TestContinuous:
         labels = a.major.formatter.format_ticks(locs)
         for text in labels[1:-1]:
             assert re.match(r"^\d+mg$", text)
+
+    def test_label_base_from_transform(self, x):
+
+        s = Continuous(transform="log")
+        a = PseudoAxis(s._setup(x, Coordinate())._matplotlib_scale)
+        a.set_view_interval(10, 1000)
+        label, = a.major.formatter.format_ticks([100])
+        assert r"10^{2}" in label
+
+    def test_label_type_checks(self):
+
+        s = Continuous()
+        with pytest.raises(TypeError, match="Label formatter must be"):
+            s.label("{x}")
+
+        with pytest.raises(TypeError, match="`like` must be"):
+            s.label(like=2)
 
 
 class TestNominal:
@@ -568,10 +585,10 @@ class TestTemporal:
         assert isinstance(locator, mpl.dates.AutoDateLocator)
         assert isinstance(formatter, mpl.dates.AutoDateFormatter)
 
-    def test_concise_format(self, t, x):
+    def test_label_concise(self, t, x):
 
         ax = mpl.figure.Figure().subplots()
-        Temporal().format(concise=True)._setup(t, Coordinate(), ax.xaxis)
+        Temporal().label(concise=True)._setup(t, Coordinate(), ax.xaxis)
         formatter = ax.xaxis.get_major_formatter()
         assert isinstance(formatter, mpl.dates.ConciseDateFormatter)
 

--- a/tests/_core/test_scales.py
+++ b/tests/_core/test_scales.py
@@ -23,6 +23,7 @@ from seaborn._core.properties import (
     Fill,
 )
 from seaborn.palettes import color_palette
+from seaborn.external.version import Version
 
 
 class TestContinuous:
@@ -585,6 +586,10 @@ class TestTemporal:
         assert isinstance(locator, mpl.dates.AutoDateLocator)
         assert isinstance(formatter, mpl.dates.AutoDateFormatter)
 
+    @pytest.mark.skipif(
+        Version(mpl.__version__) < Version("3.3.0"),
+        reason="Test requires new matplotlib date epoch."
+    )
     def test_tick_locator(self, t):
 
         locator = mpl.dates.YearLocator(month=3, day=15)
@@ -601,13 +606,10 @@ class TestTemporal:
         locator = ax.xaxis.get_major_locator()
         assert set(locator.maxticks.values()) == {n}
 
-    def test_label_concise(self, t, x):
-
-        ax = mpl.figure.Figure().subplots()
-        Temporal().label(concise=True)._setup(t, Coordinate(), ax.xaxis)
-        formatter = ax.xaxis.get_major_formatter()
-        assert isinstance(formatter, mpl.dates.ConciseDateFormatter)
-
+    @pytest.mark.skipif(
+        Version(mpl.__version__) < Version("3.3.0"),
+        reason="Test requires new matplotlib date epoch."
+    )
     def test_label_formatter(self, t):
 
         formatter = mpl.dates.DateFormatter("%Y")
@@ -616,3 +618,10 @@ class TestTemporal:
         a.set_view_interval(10, 1000)
         label, = a.major.formatter.format_ticks([100])
         assert label == "1970"
+
+    def test_label_concise(self, t, x):
+
+        ax = mpl.figure.Figure().subplots()
+        Temporal().label(concise=True)._setup(t, Coordinate(), ax.xaxis)
+        formatter = ax.xaxis.get_major_formatter()
+        assert isinstance(formatter, mpl.dates.ConciseDateFormatter)

--- a/tests/_core/test_scales.py
+++ b/tests/_core/test_scales.py
@@ -32,88 +32,90 @@ class TestContinuous:
 
     def test_coordinate_defaults(self, x):
 
-        s = Continuous().setup(x, Coordinate())
+        s = Continuous()._setup(x, Coordinate())
         assert_series_equal(s(x), x)
-        assert_series_equal(s.invert_axis_transform(s(x)), x)
 
     def test_coordinate_transform(self, x):
 
-        s = Continuous(transform="log").setup(x, Coordinate())
+        s = Continuous(transform="log")._setup(x, Coordinate())
         assert_series_equal(s(x), np.log10(x))
-        assert_series_equal(s.invert_axis_transform(s(x)), x)
 
     def test_coordinate_transform_with_parameter(self, x):
 
-        s = Continuous(transform="pow3").setup(x, Coordinate())
+        s = Continuous(transform="pow3")._setup(x, Coordinate())
         assert_series_equal(s(x), np.power(x, 3))
-        assert_series_equal(s.invert_axis_transform(s(x)), x)
 
     def test_interval_defaults(self, x):
 
-        s = Continuous().setup(x, IntervalProperty())
+        s = Continuous()._setup(x, IntervalProperty())
         assert_array_equal(s(x), [0, .25, 1])
 
     def test_interval_with_range(self, x):
 
-        s = Continuous((1, 3)).setup(x, IntervalProperty())
+        s = Continuous((1, 3))._setup(x, IntervalProperty())
         assert_array_equal(s(x), [1, 1.5, 3])
 
     def test_interval_with_norm(self, x):
 
-        s = Continuous(norm=(3, 7)).setup(x, IntervalProperty())
+        s = Continuous(norm=(3, 7))._setup(x, IntervalProperty())
         assert_array_equal(s(x), [-.5, 0, 1.5])
 
     def test_interval_with_range_norm_and_transform(self, x):
 
         x = pd.Series([1, 10, 100])
         # TODO param order?
-        s = Continuous((2, 3), (10, 100), "log").setup(x, IntervalProperty())
+        s = Continuous((2, 3), (10, 100), "log")._setup(x, IntervalProperty())
         assert_array_equal(s(x), [1, 2, 3])
 
     def test_color_defaults(self, x):
 
         cmap = color_palette("ch:", as_cmap=True)
-        s = Continuous().setup(x, Color())
+        s = Continuous()._setup(x, Color())
         assert_array_equal(s(x), cmap([0, .25, 1])[:, :3])  # FIXME RGBA
 
     def test_color_named_values(self, x):
 
         cmap = color_palette("viridis", as_cmap=True)
-        s = Continuous("viridis").setup(x, Color())
+        s = Continuous("viridis")._setup(x, Color())
         assert_array_equal(s(x), cmap([0, .25, 1])[:, :3])  # FIXME RGBA
 
     def test_color_tuple_values(self, x):
 
         cmap = color_palette("blend:b,g", as_cmap=True)
-        s = Continuous(("b", "g")).setup(x, Color())
+        s = Continuous(("b", "g"))._setup(x, Color())
         assert_array_equal(s(x), cmap([0, .25, 1])[:, :3])  # FIXME RGBA
 
     def test_color_callable_values(self, x):
 
         cmap = color_palette("light:r", as_cmap=True)
-        s = Continuous(cmap).setup(x, Color())
+        s = Continuous(cmap)._setup(x, Color())
         assert_array_equal(s(x), cmap([0, .25, 1])[:, :3])  # FIXME RGBA
 
     def test_color_with_norm(self, x):
 
         cmap = color_palette("ch:", as_cmap=True)
-        s = Continuous(norm=(3, 7)).setup(x, Color())
+        s = Continuous(norm=(3, 7))._setup(x, Color())
         assert_array_equal(s(x), cmap([-.5, 0, 1.5])[:, :3])  # FIXME RGBA
 
     def test_color_with_transform(self, x):
 
         x = pd.Series([1, 10, 100], name="x", dtype=float)
         cmap = color_palette("ch:", as_cmap=True)
-        s = Continuous(transform="log").setup(x, Color())
+        s = Continuous(transform="log")._setup(x, Color())
         assert_array_equal(s(x), cmap([0, .5, 1])[:, :3])  # FIXME RGBA
+
+    def setup_ticks(self, x, *args, **kwargs):
+
+        s = Continuous().tick(*args, **kwargs)._setup(x, Coordinate())
+        a = PseudoAxis(s._matplotlib_scale)
+        a.set_view_interval(0, 1)
+        return a
 
     def test_tick_locator(self, x):
 
         locs = [.2, .5, .8]
         locator = mpl.ticker.FixedLocator(locs)
-        s = Continuous().tick(locator).setup(x, Coordinate())
-        a = PseudoAxis(s.matplotlib_scale)
-        a.set_view_interval(0, 1)
+        a = self.setup_ticks(x, locator)
         assert_array_equal(a.major.locator(), locs)
 
     def test_tick_locator_input_check(self, x):
@@ -125,60 +127,46 @@ class TestContinuous:
     def test_tick_upto(self, x):
 
         for n in [2, 5, 10]:
-            s = Continuous().tick(upto=n).setup(x, Coordinate())
-            a = PseudoAxis(s.matplotlib_scale)
-            a.set_view_interval(0, 1)
+            a = self.setup_ticks(x, upto=n)
             assert len(a.major.locator()) <= (n + 1)
 
     def test_tick_every(self, x):
 
         for d in [.05, .2, .5]:
-            s = Continuous().tick(every=d).setup(x, Coordinate())
-            a = PseudoAxis(s.matplotlib_scale)
-            a.set_view_interval(0, 1)
+            a = self.setup_ticks(x, every=d)
             assert np.allclose(np.diff(a.major.locator()), d)
 
     def test_tick_every_between(self, x):
 
         lo, hi = .2, .8
         for d in [.05, .2, .5]:
-            s = Continuous().tick(every=d, between=(lo, hi)).setup(x, Coordinate())
-            a = PseudoAxis(s.matplotlib_scale)
-            a.set_view_interval(0, 1)
+            a = self.setup_ticks(x, every=d, between=(lo, hi))
             expected = np.arange(lo, hi + d, d)
             assert_array_equal(a.major.locator(), expected)
 
     def test_tick_at(self, x):
 
         locs = [.2, .5, .9]
-        s = Continuous().tick(at=locs).setup(x, Coordinate())
-        a = PseudoAxis(s.matplotlib_scale)
-        a.set_view_interval(0, 1)
+        a = self.setup_ticks(x, at=locs)
         assert_array_equal(a.major.locator(), locs)
 
     def test_tick_count(self, x):
 
         n = 8
-        s = Continuous().tick(count=n).setup(x, Coordinate())
-        a = PseudoAxis(s.matplotlib_scale)
-        a.set_view_interval(0, 1)
+        a = self.setup_ticks(x, count=n)
         assert_array_equal(a.major.locator(), np.linspace(0, 1, n))
 
     def test_tick_count_between(self, x):
 
         n = 5
         lo, hi = .2, .7
-        s = Continuous().tick(count=n, between=(lo, hi)).setup(x, Coordinate())
-        a = PseudoAxis(s.matplotlib_scale)
-        a.set_view_interval(0, 1)
+        a = self.setup_ticks(x, count=n, between=(lo, hi))
         assert_array_equal(a.major.locator(), np.linspace(lo, hi, n))
 
     def test_tick_minor(self, x):
 
         n = 3
-        s = Continuous().tick(count=2, minor=n).setup(x, Coordinate())
-        a = PseudoAxis(s.matplotlib_scale)
-        a.set_view_interval(0, 1)
+        a = self.setup_ticks(x, count=2, minor=n)
         # I am not sure why matplotlib's minor ticks include the
         # largest major location but exclude the smalllest one ...
         expected = np.linspace(0, 1, n + 2)[1:]
@@ -186,8 +174,8 @@ class TestContinuous:
 
     def test_log_tick_default(self, x):
 
-        s = Continuous(transform="log").setup(x, Coordinate())
-        a = PseudoAxis(s.matplotlib_scale)
+        s = Continuous(transform="log")._setup(x, Coordinate())
+        a = PseudoAxis(s._matplotlib_scale)
         a.set_view_interval(.5, 1050)
         ticks = a.major.locator()
         assert np.allclose(np.diff(np.log10(ticks)), 1)
@@ -195,8 +183,8 @@ class TestContinuous:
     def test_log_tick_upto(self, x):
 
         n = 3
-        s = Continuous(transform="log").tick(upto=n).setup(x, Coordinate())
-        a = PseudoAxis(s.matplotlib_scale)
+        s = Continuous(transform="log").tick(upto=n)._setup(x, Coordinate())
+        a = PseudoAxis(s._matplotlib_scale)
         assert a.major.locator.numticks == n
 
     def test_log_tick_count(self, x):
@@ -205,7 +193,7 @@ class TestContinuous:
             Continuous(transform="log").tick(count=4)
 
         s = Continuous(transform="log").tick(count=4, between=(1, 1000))
-        a = PseudoAxis(s.setup(x, Coordinate()).matplotlib_scale)
+        a = PseudoAxis(s._setup(x, Coordinate())._matplotlib_scale)
         a.set_view_interval(.5, 1050)
         assert_array_equal(a.major.locator(), [1, 10, 100, 1000])
 
@@ -227,26 +215,23 @@ class TestNominal:
 
     def test_coordinate_defaults(self, x):
 
-        s = Nominal().setup(x, Coordinate())
+        s = Nominal()._setup(x, Coordinate())
         assert_array_equal(s(x), np.array([0, 1, 2, 1], float))
-        assert_array_equal(s.invert_axis_transform(s(x)), s(x))
 
     def test_coordinate_with_order(self, x):
 
-        s = Nominal(order=["a", "b", "c"]).setup(x, Coordinate())
+        s = Nominal(order=["a", "b", "c"])._setup(x, Coordinate())
         assert_array_equal(s(x), np.array([0, 2, 1, 2], float))
-        assert_array_equal(s.invert_axis_transform(s(x)), s(x))
 
     def test_coordinate_with_subset_order(self, x):
 
-        s = Nominal(order=["c", "a"]).setup(x, Coordinate())
+        s = Nominal(order=["c", "a"])._setup(x, Coordinate())
         assert_array_equal(s(x), np.array([1, 0, np.nan, 0], float))
-        assert_array_equal(s.invert_axis_transform(s(x)), s(x))
 
     def test_coordinate_axis(self, x):
 
         ax = mpl.figure.Figure().subplots()
-        s = Nominal().setup(x, Coordinate(), ax.xaxis)
+        s = Nominal()._setup(x, Coordinate(), ax.xaxis)
         assert_array_equal(s(x), np.array([0, 1, 2, 1], float))
         f = ax.xaxis.get_major_formatter()
         assert f.format_ticks([0, 1, 2]) == ["a", "c", "b"]
@@ -255,7 +240,7 @@ class TestNominal:
 
         order = ["a", "b", "c"]
         ax = mpl.figure.Figure().subplots()
-        s = Nominal(order=order).setup(x, Coordinate(), ax.xaxis)
+        s = Nominal(order=order)._setup(x, Coordinate(), ax.xaxis)
         assert_array_equal(s(x), np.array([0, 2, 1, 2], float))
         f = ax.xaxis.get_major_formatter()
         assert f.format_ticks([0, 1, 2]) == order
@@ -264,7 +249,7 @@ class TestNominal:
 
         order = ["c", "a"]
         ax = mpl.figure.Figure().subplots()
-        s = Nominal(order=order).setup(x, Coordinate(), ax.xaxis)
+        s = Nominal(order=order)._setup(x, Coordinate(), ax.xaxis)
         assert_array_equal(s(x), np.array([1, 0, np.nan, 0], float))
         f = ax.xaxis.get_major_formatter()
         assert f.format_ticks([0, 1, 2]) == [*order, ""]
@@ -274,7 +259,7 @@ class TestNominal:
         order = ["b", "a", "d", "c"]
         x = x.astype(pd.CategoricalDtype(order))
         ax = mpl.figure.Figure().subplots()
-        s = Nominal().setup(x, Coordinate(), ax.xaxis)
+        s = Nominal()._setup(x, Coordinate(), ax.xaxis)
         assert_array_equal(s(x), np.array([1, 3, 0, 3], float))
         f = ax.xaxis.get_major_formatter()
         assert f.format_ticks([0, 1, 2, 3]) == order
@@ -282,7 +267,7 @@ class TestNominal:
     def test_coordinate_numeric_data(self, y):
 
         ax = mpl.figure.Figure().subplots()
-        s = Nominal().setup(y, Coordinate(), ax.yaxis)
+        s = Nominal()._setup(y, Coordinate(), ax.yaxis)
         assert_array_equal(s(y), np.array([1, 0, 2, 0], float))
         f = ax.yaxis.get_major_formatter()
         assert f.format_ticks([0, 1, 2]) == ["-1.5", "1.0", "3.0"]
@@ -291,46 +276,46 @@ class TestNominal:
 
         order = [1, 4, -1.5]
         ax = mpl.figure.Figure().subplots()
-        s = Nominal(order=order).setup(y, Coordinate(), ax.yaxis)
+        s = Nominal(order=order)._setup(y, Coordinate(), ax.yaxis)
         assert_array_equal(s(y), np.array([0, 2, np.nan, 2], float))
         f = ax.yaxis.get_major_formatter()
         assert f.format_ticks([0, 1, 2]) == ["1.0", "4.0", "-1.5"]
 
     def test_color_defaults(self, x):
 
-        s = Nominal().setup(x, Color())
+        s = Nominal()._setup(x, Color())
         cs = color_palette()
         assert_array_equal(s(x), [cs[0], cs[1], cs[2], cs[1]])
 
     def test_color_named_palette(self, x):
 
         pal = "flare"
-        s = Nominal(pal).setup(x, Color())
+        s = Nominal(pal)._setup(x, Color())
         cs = color_palette(pal, 3)
         assert_array_equal(s(x), [cs[0], cs[1], cs[2], cs[1]])
 
     def test_color_list_palette(self, x):
 
         cs = color_palette("crest", 3)
-        s = Nominal(cs).setup(x, Color())
+        s = Nominal(cs)._setup(x, Color())
         assert_array_equal(s(x), [cs[0], cs[1], cs[2], cs[1]])
 
     def test_color_dict_palette(self, x):
 
         cs = color_palette("crest", 3)
         pal = dict(zip("bac", cs))
-        s = Nominal(pal).setup(x, Color())
+        s = Nominal(pal)._setup(x, Color())
         assert_array_equal(s(x), [cs[1], cs[2], cs[0], cs[2]])
 
     def test_color_numeric_data(self, y):
 
-        s = Nominal().setup(y, Color())
+        s = Nominal()._setup(y, Color())
         cs = color_palette()
         assert_array_equal(s(y), [cs[1], cs[0], cs[2], cs[0]])
 
     def test_color_numeric_with_order_subset(self, y):
 
-        s = Nominal(order=[-1.5, 1]).setup(y, Color())
+        s = Nominal(order=[-1.5, 1])._setup(y, Color())
         c1, c2 = color_palette(n_colors=2)
         null = (np.nan, np.nan, np.nan)
         assert_array_equal(s(y), [c2, c1, null, c1])
@@ -339,7 +324,7 @@ class TestNominal:
     def test_color_numeric_int_float_mix(self):
 
         z = pd.Series([1, 2], name="z")
-        s = Nominal(order=[1.0, 2]).setup(z, Color())
+        s = Nominal(order=[1.0, 2])._setup(z, Color())
         c1, c2 = color_palette(n_colors=2)
         null = (np.nan, np.nan, np.nan)
         assert_array_equal(s(z), [c1, null, c2])
@@ -347,7 +332,7 @@ class TestNominal:
     def test_color_alpha_in_palette(self, x):
 
         cs = [(.2, .2, .3, .5), (.1, .2, .3, 1), (.5, .6, .2, 0)]
-        s = Nominal(cs).setup(x, Color())
+        s = Nominal(cs)._setup(x, Color())
         assert_array_equal(s(x), [cs[0], cs[1], cs[2], cs[1]])
 
     def test_color_unknown_palette(self, x):
@@ -355,7 +340,7 @@ class TestNominal:
         pal = "not_a_palette"
         err = f"{pal} is not a valid palette name"
         with pytest.raises(ValueError, match=err):
-            Nominal(pal).setup(x, Color())
+            Nominal(pal)._setup(x, Color())
 
     def test_object_defaults(self, x):
 
@@ -363,62 +348,62 @@ class TestNominal:
             def _default_values(self, n):
                 return list("xyz"[:n])
 
-        s = Nominal().setup(x, MockProperty())
+        s = Nominal()._setup(x, MockProperty())
         assert s(x) == ["x", "y", "z", "y"]
 
     def test_object_list(self, x):
 
         vs = ["x", "y", "z"]
-        s = Nominal(vs).setup(x, ObjectProperty())
+        s = Nominal(vs)._setup(x, ObjectProperty())
         assert s(x) == ["x", "y", "z", "y"]
 
     def test_object_dict(self, x):
 
         vs = {"a": "x", "b": "y", "c": "z"}
-        s = Nominal(vs).setup(x, ObjectProperty())
+        s = Nominal(vs)._setup(x, ObjectProperty())
         assert s(x) == ["x", "z", "y", "z"]
 
     def test_object_order(self, x):
 
         vs = ["x", "y", "z"]
-        s = Nominal(vs, order=["c", "a", "b"]).setup(x, ObjectProperty())
+        s = Nominal(vs, order=["c", "a", "b"])._setup(x, ObjectProperty())
         assert s(x) == ["y", "x", "z", "x"]
 
     def test_object_order_subset(self, x):
 
         vs = ["x", "y"]
-        s = Nominal(vs, order=["a", "c"]).setup(x, ObjectProperty())
+        s = Nominal(vs, order=["a", "c"])._setup(x, ObjectProperty())
         assert s(x) == ["x", "y", None, "y"]
 
     def test_objects_that_are_weird(self, x):
 
         vs = [("x", 1), (None, None, 0), {}]
-        s = Nominal(vs).setup(x, ObjectProperty())
+        s = Nominal(vs)._setup(x, ObjectProperty())
         assert s(x) == [vs[0], vs[1], vs[2], vs[1]]
 
     def test_alpha_default(self, x):
 
-        s = Nominal().setup(x, Alpha())
+        s = Nominal()._setup(x, Alpha())
         assert_array_equal(s(x), [.95, .625, .3, .625])
 
     def test_fill(self):
 
         x = pd.Series(["a", "a", "b", "a"], name="x")
-        s = Nominal().setup(x, Fill())
+        s = Nominal()._setup(x, Fill())
         assert_array_equal(s(x), [True, True, False, True])
 
     def test_fill_dict(self):
 
         x = pd.Series(["a", "a", "b", "a"], name="x")
         vs = {"a": False, "b": True}
-        s = Nominal(vs).setup(x, Fill())
+        s = Nominal(vs)._setup(x, Fill())
         assert_array_equal(s(x), [False, False, True, False])
 
     def test_fill_nunique_warning(self):
 
         x = pd.Series(["a", "b", "c", "a", "b"], name="x")
         with pytest.warns(UserWarning, match="The variable assigned to fill"):
-            s = Nominal().setup(x, Fill())
+            s = Nominal()._setup(x, Fill())
         assert_array_equal(s(x), [True, False, True, True, False])
 
     def test_interval_defaults(self, x):
@@ -426,29 +411,29 @@ class TestNominal:
         class MockProperty(IntervalProperty):
             _default_range = (1, 2)
 
-        s = Nominal().setup(x, MockProperty())
+        s = Nominal()._setup(x, MockProperty())
         assert_array_equal(s(x), [2, 1.5, 1, 1.5])
 
     def test_interval_tuple(self, x):
 
-        s = Nominal((1, 2)).setup(x, IntervalProperty())
+        s = Nominal((1, 2))._setup(x, IntervalProperty())
         assert_array_equal(s(x), [2, 1.5, 1, 1.5])
 
     def test_interval_tuple_numeric(self, y):
 
-        s = Nominal((1, 2)).setup(y, IntervalProperty())
+        s = Nominal((1, 2))._setup(y, IntervalProperty())
         assert_array_equal(s(y), [1.5, 2, 1, 2])
 
     def test_interval_list(self, x):
 
         vs = [2, 5, 4]
-        s = Nominal(vs).setup(x, IntervalProperty())
+        s = Nominal(vs)._setup(x, IntervalProperty())
         assert_array_equal(s(x), [2, 5, 4, 5])
 
     def test_interval_dict(self, x):
 
         vs = {"a": 3, "b": 4, "c": 6}
-        s = Nominal(vs).setup(x, IntervalProperty())
+        s = Nominal(vs)._setup(x, IntervalProperty())
         assert_array_equal(s(x), [3, 6, 4, 6])
 
     def test_interval_with_transform(self, x):
@@ -457,7 +442,7 @@ class TestNominal:
             _forward = np.square
             _inverse = np.sqrt
 
-        s = Nominal((2, 4)).setup(x, MockProperty())
+        s = Nominal((2, 4))._setup(x, MockProperty())
         assert_array_equal(s(x), [4, np.sqrt(10), 2, np.sqrt(10)])
 
 
@@ -474,19 +459,19 @@ class TestTemporal:
 
     def test_coordinate_defaults(self, t, x):
 
-        s = Temporal().setup(t, Coordinate())
+        s = Temporal()._setup(t, Coordinate())
         assert_array_equal(s(t), x)
 
     def test_interval_defaults(self, t, x):
 
-        s = Temporal().setup(t, IntervalProperty())
+        s = Temporal()._setup(t, IntervalProperty())
         normed = (x - x.min()) / (x.max() - x.min())
         assert_array_equal(s(t), normed)
 
     def test_interval_with_range(self, t, x):
 
         values = (1, 3)
-        s = Temporal((1, 3)).setup(t, IntervalProperty())
+        s = Temporal((1, 3))._setup(t, IntervalProperty())
         normed = (x - x.min()) / (x.max() - x.min())
         expected = normed * (values[1] - values[0]) + values[0]
         assert_array_equal(s(t), expected)
@@ -494,7 +479,7 @@ class TestTemporal:
     def test_interval_with_norm(self, t, x):
 
         norm = t[1], t[2]
-        s = Temporal(norm=norm).setup(t, IntervalProperty())
+        s = Temporal(norm=norm)._setup(t, IntervalProperty())
         n = mpl.dates.date2num(norm)
         normed = (x - n[0]) / (n[1] - n[0])
         assert_array_equal(s(t), normed)
@@ -502,7 +487,7 @@ class TestTemporal:
     def test_color_defaults(self, t, x):
 
         cmap = color_palette("ch:", as_cmap=True)
-        s = Temporal().setup(t, Color())
+        s = Temporal()._setup(t, Color())
         normed = (x - x.min()) / (x.max() - x.min())
         assert_array_equal(s(t), cmap(normed)[:, :3])  # FIXME RGBA
 
@@ -510,14 +495,14 @@ class TestTemporal:
 
         name = "viridis"
         cmap = color_palette(name, as_cmap=True)
-        s = Temporal(name).setup(t, Color())
+        s = Temporal(name)._setup(t, Color())
         normed = (x - x.min()) / (x.max() - x.min())
         assert_array_equal(s(t), cmap(normed)[:, :3])  # FIXME RGBA
 
     def test_coordinate_axis(self, t, x):
 
         ax = mpl.figure.Figure().subplots()
-        s = Temporal().setup(t, Coordinate(), ax.xaxis)
+        s = Temporal()._setup(t, Coordinate(), ax.xaxis)
         assert_array_equal(s(t), x)
         locator = ax.xaxis.get_major_locator()
         formatter = ax.xaxis.get_major_formatter()
@@ -527,7 +512,7 @@ class TestTemporal:
     def test_concise_format(self, t, x):
 
         ax = mpl.figure.Figure().subplots()
-        Temporal().format(concise=True).setup(t, Coordinate(), ax.xaxis)
+        Temporal().format(concise=True)._setup(t, Coordinate(), ax.xaxis)
         formatter = ax.xaxis.get_major_formatter()
         assert isinstance(formatter, mpl.dates.ConciseDateFormatter)
 
@@ -535,6 +520,6 @@ class TestTemporal:
 
         n = 8
         ax = mpl.figure.Figure().subplots()
-        Temporal().tick(upto=n).setup(t, Coordinate(), ax.xaxis)
+        Temporal().tick(upto=n)._setup(t, Coordinate(), ax.xaxis)
         locator = ax.xaxis.get_major_locator()
         assert set(locator.maxticks.values()) == {n}

--- a/tests/_core/test_scales.py
+++ b/tests/_core/test_scales.py
@@ -62,6 +62,12 @@ class TestContinuous:
         s = Continuous(trans="pow3")._setup(x, Coordinate())
         assert_series_equal(s(x), np.power(x, 3))
 
+    def test_coordinate_transform_error(self, x):
+
+        s = Continuous(trans="bad")
+        with pytest.raises(ValueError, match="Unknown value provided"):
+            s._setup(x, Coordinate())
+
     def test_interval_defaults(self, x):
 
         s = Continuous()._setup(x, IntervalProperty())

--- a/tests/_core/test_scales.py
+++ b/tests/_core/test_scales.py
@@ -585,12 +585,13 @@ class TestTemporal:
         assert isinstance(locator, mpl.dates.AutoDateLocator)
         assert isinstance(formatter, mpl.dates.AutoDateFormatter)
 
-    def test_label_concise(self, t, x):
+    def test_tick_locator(self, t):
 
-        ax = mpl.figure.Figure().subplots()
-        Temporal().label(concise=True)._setup(t, Coordinate(), ax.xaxis)
-        formatter = ax.xaxis.get_major_formatter()
-        assert isinstance(formatter, mpl.dates.ConciseDateFormatter)
+        locator = mpl.dates.YearLocator(month=3, day=15)
+        s = Temporal().tick(locator)
+        a = PseudoAxis(s._setup(t, Coordinate())._matplotlib_scale)
+        a.set_view_interval(0, 365)
+        assert 73 in a.major.locator()
 
     def test_tick_upto(self, t, x):
 
@@ -599,3 +600,19 @@ class TestTemporal:
         Temporal().tick(upto=n)._setup(t, Coordinate(), ax.xaxis)
         locator = ax.xaxis.get_major_locator()
         assert set(locator.maxticks.values()) == {n}
+
+    def test_label_concise(self, t, x):
+
+        ax = mpl.figure.Figure().subplots()
+        Temporal().label(concise=True)._setup(t, Coordinate(), ax.xaxis)
+        formatter = ax.xaxis.get_major_formatter()
+        assert isinstance(formatter, mpl.dates.ConciseDateFormatter)
+
+    def test_label_formatter(self, t):
+
+        formatter = mpl.dates.DateFormatter("%Y")
+        s = Temporal().label(formatter)
+        a = PseudoAxis(s._setup(t, Coordinate())._matplotlib_scale)
+        a.set_view_interval(10, 1000)
+        label, = a.major.formatter.format_ticks([100])
+        assert label == "1970"

--- a/tests/_core/test_scales.py
+++ b/tests/_core/test_scales.py
@@ -212,6 +212,17 @@ class TestContinuous:
         with pytest.raises(RuntimeError, match="`every` not supported"):
             Continuous(transform="log").tick(every=2)
 
+    def test_symlog_tick_default(self, x):
+
+        s = Continuous(transform="symlog")._setup(x, Coordinate())
+        a = PseudoAxis(s._matplotlib_scale)
+        a.set_view_interval(-1050, 1050)
+        ticks = a.major.locator()
+        assert ticks[0] == -ticks[-1]
+        pos_ticks = np.sort(np.unique(np.abs(ticks)))
+        assert np.allclose(np.diff(np.log10(pos_ticks[1:])), 1)
+        assert pos_ticks[0] == 0
+
     def test_label_formatter(self, x):
 
         fmt = mpl.ticker.FormatStrFormatter("%.3f")

--- a/tests/_core/test_scales.py
+++ b/tests/_core/test_scales.py
@@ -54,12 +54,12 @@ class TestContinuous:
 
     def test_coordinate_transform(self, x):
 
-        s = Continuous(transform="log")._setup(x, Coordinate())
+        s = Continuous(trans="log")._setup(x, Coordinate())
         assert_series_equal(s(x), np.log10(x))
 
     def test_coordinate_transform_with_parameter(self, x):
 
-        s = Continuous(transform="pow3")._setup(x, Coordinate())
+        s = Continuous(trans="pow3")._setup(x, Coordinate())
         assert_series_equal(s(x), np.power(x, 3))
 
     def test_interval_defaults(self, x):
@@ -118,7 +118,7 @@ class TestContinuous:
 
         x = pd.Series([1, 10, 100], name="x", dtype=float)
         cmap = color_palette("ch:", as_cmap=True)
-        s = Continuous(transform="log")._setup(x, Color())
+        s = Continuous(trans="log")._setup(x, Color())
         assert_array_equal(s(x), cmap([0, .5, 1])[:, :3])  # FIXME RGBA
 
     def test_tick_locator(self, x):
@@ -184,7 +184,7 @@ class TestContinuous:
 
     def test_log_tick_default(self, x):
 
-        s = Continuous(transform="log")._setup(x, Coordinate())
+        s = Continuous(trans="log")._setup(x, Coordinate())
         a = PseudoAxis(s._matplotlib_scale)
         a.set_view_interval(.5, 1050)
         ticks = a.major.locator()
@@ -193,16 +193,16 @@ class TestContinuous:
     def test_log_tick_upto(self, x):
 
         n = 3
-        s = Continuous(transform="log").tick(upto=n)._setup(x, Coordinate())
+        s = Continuous(trans="log").tick(upto=n)._setup(x, Coordinate())
         a = PseudoAxis(s._matplotlib_scale)
         assert a.major.locator.numticks == n
 
     def test_log_tick_count(self, x):
 
         with pytest.raises(RuntimeError, match="`count` requires"):
-            Continuous(transform="log").tick(count=4)
+            Continuous(trans="log").tick(count=4)
 
-        s = Continuous(transform="log").tick(count=4, between=(1, 1000))
+        s = Continuous(trans="log").tick(count=4, between=(1, 1000))
         a = PseudoAxis(s._setup(x, Coordinate())._matplotlib_scale)
         a.set_view_interval(.5, 1050)
         assert_array_equal(a.major.locator(), [1, 10, 100, 1000])
@@ -210,11 +210,11 @@ class TestContinuous:
     def test_log_tick_every(self, x):
 
         with pytest.raises(RuntimeError, match="`every` not supported"):
-            Continuous(transform="log").tick(every=2)
+            Continuous(trans="log").tick(every=2)
 
     def test_symlog_tick_default(self, x):
 
-        s = Continuous(transform="symlog")._setup(x, Coordinate())
+        s = Continuous(trans="symlog")._setup(x, Coordinate())
         a = PseudoAxis(s._matplotlib_scale)
         a.set_view_interval(-1050, 1050)
         ticks = a.major.locator()
@@ -275,7 +275,7 @@ class TestContinuous:
 
     def test_label_base_from_transform(self, x):
 
-        s = Continuous(transform="log")
+        s = Continuous(trans="log")
         a = PseudoAxis(s._setup(x, Coordinate())._matplotlib_scale)
         a.set_view_interval(10, 1000)
         label, = a.major.formatter.format_ticks([100])

--- a/tests/test_categorical.py
+++ b/tests/test_categorical.py
@@ -1952,7 +1952,7 @@ class SharedScatterTests(SharedAxesLevelTests):
 
     @pytest.mark.parametrize(
         "val_var,val_col,hue_col",
-        itertools.product(["x", "y"], ["b", "y", "t"], [None, "a"]),
+        list(itertools.product(["x", "y"], ["b", "y", "t"], [None, "a"])),
     )
     def test_single(self, long_df, val_var, val_col, hue_col):
 


### PR DESCRIPTION
e.g.

```python
(
    so.Plot(tips, "total_bill")
    .add(so.Bar(), so.Hist())
    .scale(x=so.Continuous().label(like="${x:.0f}"))
)
```
![image](https://user-images.githubusercontent.com/315810/175790811-5d895794-d167-435a-b448-6a1cb91812c7.png)

```python
(
    so.Plot(planets, "distance")
    .add(so.Bar(), so.Hist())
    .scale(x=so.Continuous().label(unit="pc"))
)
```
![image](https://user-images.githubusercontent.com/315810/175791369-a9a846a7-b651-49c7-8ff4-4a908362e4e6.png)

This also makes log transformed scales default to a log formatter (closes #2840)

```python
(
    so.Plot(planets, "distance")
    .add(so.Bar(), so.Hist())
    .scale(x="log")
)
```
![image](https://user-images.githubusercontent.com/315810/175791420-ddcd72b7-d4fd-4cc3-81d3-22c986bd787d.png)

This also shortens the `transform` `Scale` parameter to `trans`, as testing revealed that typing out `transform` is a little cumbersome.