### PR TITLE
Mention pointplot additional kwargs removal in the release notes

### DIFF
--- a/doc/releases/v0.12.0.txt
+++ b/doc/releases/v0.12.0.txt
@@ -104,4 +104,4 @@ Other updates
 
 - |API| Removed the previously-deprecated `factorplot` along with several previously-deprecated utility functions (`iqr`, `percentiles`, `pmf_hist`, and `sort_df`).
 
-- |API| removed the previously-unused option to pass additional keyword arguments to `pointplot`.
+- |API| Removed the (previously-unused) option to pass additional keyword arguments to :func:`pointplot`.

--- a/doc/releases/v0.12.0.txt
+++ b/doc/releases/v0.12.0.txt
@@ -103,3 +103,5 @@ Other updates
 - |Dependencies| The unit test suite is no longer part of the source or wheel distribution. Seaborn has never had a runtime API for exercising the tests, so this should not have workflow implications (:pr:`2833`).
 
 - |API| Removed the previously-deprecated `factorplot` along with several previously-deprecated utility functions (`iqr`, `percentiles`, `pmf_hist`, and `sort_df`).
+
+- |API| removed the previously-unused option to pass additional keyword arguments to `pointplot`.


### PR DESCRIPTION
Commit 533b6005bf1e8d85616fc10be9460b6afca7d791 removed the option to pass additional keyword arguments to `pointplot`. This PR adds this API change to the v0.12.0 release notes. 