### PR TITLE
docs: Fix a few typos

### DIFF
--- a/seaborn/_core/plot.py
+++ b/seaborn/_core/plot.py
@@ -409,7 +409,7 @@ class Plot:
         # TODO would like to add transpose=True, which would then draw
         # Plot(x=...).pair(y=[...]) across the rows
         # This may also be possible by setting `wrap=1`, although currently the axes
-        # are shared and the interior labels are disabeled (this is a bug either way)
+        # are shared and the interior labels are disabled (this is a bug either way)
 
         pair_spec: PairSpec = {}
 
@@ -900,7 +900,7 @@ class Plotter:
             self._scales[var] = scale._setup(var_df[var], prop)
 
             # Set up an empty series to receive the transformed values.
-            # We need this to handle piecemeal tranforms of categories -> floats.
+            # We need this to handle piecemeal transforms of categories -> floats.
             transformed_data = []
             for layer in layers:
                 index = layer["data"].frame.index

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -2216,7 +2216,7 @@ def jointplot(
     elif kind.startswith("hist"):
 
         # TODO process pair parameters for bins, etc. and pass
-        # to both jount and marginal plots
+        # to both joint and marginal plots
 
         joint_kws.setdefault("color", color)
         grid.plot_joint(histplot, **joint_kws)


### PR DESCRIPTION
There are small typos in:
- seaborn/_core/plot.py
- seaborn/axisgrid.py

Fixes:
- Should read `transforms` rather than `tranforms`.
- Should read `joint` rather than `jount`.
- Should read `disabled` rather than `disabeled`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md