### PR TITLE
Add Bars for more efficient bar plots and improve Bar as well

### DIFF
--- a/seaborn/_marks/bars.py
+++ b/seaborn/_marks/bars.py
@@ -207,6 +207,9 @@ class Bars(BarBase):
 
         if "edgewidth" not in scales and isinstance(self.edgewidth, Mappable):
 
+            for ax in collections:
+                ax.autoscale_view()
+
             def get_dimensions(collection):
                 edges, widths = [], []
                 for verts in (path.vertices for path in collection.get_paths()):
@@ -216,7 +219,6 @@ class Bars(BarBase):
 
             min_width = np.inf
             for ax, col in collections.items():
-                ax.autoscale_view()
                 edges, widths = get_dimensions(col)
                 points = 72 / ax.figure.dpi * abs(
                     ax.transData.transform([edges + widths] * 2)

--- a/seaborn/_marks/bars.py
+++ b/seaborn/_marks/bars.py
@@ -188,11 +188,21 @@ class Bars(BarBase):
         for _, data, ax in split_gen():
 
             bars, _ = self._make_patches(data, scales, orient)
+            ax.autoscale_view()
 
             collection = mpl.collections.PatchCollection(bars, match_original=True)
             collection.sticky_edges[val_idx][:] = (0, np.inf)
             collections[ax].append(collection)
-            ax.add_collection(collection)
+            ax.add_collection(collection, autolim=False)
+
+            # Workaround for matplotlib autoscaling bug
+            # https://github.com/matplotlib/matplotlib/issues/11898
+            # https://github.com/matplotlib/matplotlib/issues/23129
+            xy = np.vstack([bar.get_verts() for bar in bars])
+            ax.dataLim.update_from_data_xy(
+                xy, ax.ignore_existing_data_limits,
+                updatex=True, updatey=True
+            )
 
         def get_dimensions(collection):
 

--- a/seaborn/_marks/bars.py
+++ b/seaborn/_marks/bars.py
@@ -204,23 +204,21 @@ class Bars(BarBase):
                 updatex=True, updatey=True
             )
 
-        def get_dimensions(collection):
-
-            edges = []
-            widths = []
-            for path in collection.get_paths():
-                verts = path.vertices
-                edges.append(min(verts[:, ori_idx]))
-                widths.append(np.ptp(verts[:, ori_idx]))
-
-            return np.array(edges), np.array(widths)
-
         if "edgewidth" not in scales and isinstance(self.edgewidth, Mappable):
+
+            def get_dimensions(collection):
+
+                edges = []
+                widths = []
+                for path in collection.get_paths():
+                    verts = path.vertices
+                    edges.append(min(verts[:, ori_idx]))
+                    widths.append(np.ptp(verts[:, ori_idx]))
+                return np.array(edges), np.array(widths)
 
             min_width = np.inf
 
             for ax, ax_collections in collections.items():
-                ax.autoscale_view()
                 for collection in ax_collections:
                     edges, widths = get_dimensions(collection)
                     points = 72 / ax.figure.dpi * abs(
@@ -228,8 +226,6 @@ class Bars(BarBase):
                         - ax.transData.transform([edges] * 2)
                     )
                     min_width = min(min_width, min(points[ori_idx]))
-
-            # TODO handle infinit width
 
             auto_linewidth = min(.1 * min_width, mpl.rcParams["patch.linewidth"])
 

--- a/seaborn/_marks/bars.py
+++ b/seaborn/_marks/bars.py
@@ -23,22 +23,61 @@ if TYPE_CHECKING:
     from seaborn._core.scales import Scale
 
 
-@dataclass
-class Bar(Mark):
-    """
-    An interval mark drawn between baseline and data values with a width.
-    """
-    color: MappableColor = Mappable("C0")
-    alpha: MappableFloat = Mappable(.7)
-    fill: MappableBool = Mappable(True)
-    edgecolor: MappableColor = Mappable(depend="color")
-    edgealpha: MappableFloat = Mappable(1)
-    edgewidth: MappableFloat = Mappable(rc="patch.linewidth")
-    edgestyle: MappableStyle = Mappable("-")
-    # pattern: MappableString = Mappable(None)  # TODO no Property yet
+class BarBase(Mark):
 
-    width: MappableFloat = Mappable(.8, grouping=False)
-    baseline: MappableFloat = Mappable(0, grouping=False)  # TODO *is* this mappable?
+    def _make_patches(self, data, scales, orient):
+
+        kws = self._resolve_properties(data, scales)
+        if orient == "x":
+            kws["x"] = (data["x"] - data["width"] / 2).to_numpy()
+            kws["y"] = data["baseline"].to_numpy()
+            kws["w"] = data["width"].to_numpy()
+            kws["h"] = (data["y"] - data["baseline"]).to_numpy()
+        else:
+            kws["x"] = data["baseline"].to_numpy()
+            kws["y"] = (data["y"] - data["width"] / 2).to_numpy()
+            kws["w"] = (data["x"] - data["baseline"]).to_numpy()
+            kws["h"] = data["width"].to_numpy()
+
+        kws.pop("width", None)
+        kws.pop("baseline", None)
+
+        val_dim = {"x": "h", "y": "w"}[orient]
+        bars, vals = [], []
+
+        for i in range(len(data)):
+
+            row = {k: v[i] for k, v in kws.items()}
+
+            # Skip bars with no value. It's possible we'll want to make this
+            # an option (i.e so you have an artist for animating or annotating),
+            # but let's keep things simple for now.
+            if not np.nan_to_num(row[val_dim]):
+                continue
+
+            # Because we are clipping the artist (see below), the edges end up
+            # looking half as wide as they actually are. I don't love this clumsy
+            # workaround, which is going to cause surprises if you work with the
+            # artists directly. We may need to revisit after feedback.
+            linewidth = row["edgewidth"] * 2
+            linestyle = row["edgestyle"]
+            if linestyle[1]:
+                linestyle = (linestyle[0], tuple(x / 2 for x in linestyle[1]))
+
+            bar = mpl.patches.Rectangle(
+                xy=(row["x"], row["y"]),
+                width=row["w"],
+                height=row["h"],
+                facecolor=row["facecolor"],
+                edgecolor=row["edgecolor"],
+                linestyle=linestyle,
+                linewidth=linewidth,
+                **self.artist_kws,
+            )
+            bars.append(bar)
+            vals.append(row[val_dim])
+
+        return bars, vals
 
     def _resolve_properties(self, data, scales):
 
@@ -56,83 +95,6 @@ class Bar(Mark):
 
         return resolved
 
-    def _plot(self, split_gen, scales, orient):
-
-        val_dim = {"x": "h", "y": "w"}[orient]
-        val_idx = ["y", "x"].index(orient)
-
-        for _, data, ax in split_gen():
-
-            kws = self._resolve_properties(data, scales)
-            if orient == "x":
-                kws["x"] = (data["x"] - data["width"] / 2).to_numpy()
-                kws["y"] = data["baseline"].to_numpy()
-                kws["w"] = data["width"].to_numpy()
-                kws["h"] = (data["y"] - data["baseline"]).to_numpy()
-            else:
-                kws["x"] = data["baseline"].to_numpy()
-                kws["y"] = (data["y"] - data["width"] / 2).to_numpy()
-                kws["w"] = (data["x"] - data["baseline"]).to_numpy()
-                kws["h"] = data["width"].to_numpy()
-
-            kws.pop("width", None)
-            kws.pop("baseline", None)
-
-            bars, vals = [], []
-            for i in range(len(data)):
-
-                row = {k: v[i] for k, v in kws.items()}
-
-                # Skip bars with no value. It's possible we'll want to make this
-                # an option (i.e so you have an artist for animating or annotating),
-                # but let's keep things simple for now.
-                if not np.nan_to_num(row[val_dim]):
-                    continue
-
-                # Because we are clipping the artist (see below), the edges end up
-                # looking half as wide as they actually are. I don't love this clumsy
-                # workaround, which is going to cause surprises if you work with the
-                # artists directly. We may need to revisit after feedback.
-                linewidth = row["edgewidth"] * 2
-                linestyle = row["edgestyle"]
-                if linestyle[1]:
-                    linestyle = (linestyle[0], tuple(x / 2 for x in linestyle[1]))
-
-                bar = mpl.patches.Rectangle(
-                    xy=(row["x"], row["y"]),
-                    width=row["w"],
-                    height=row["h"],
-                    facecolor=row["facecolor"],
-                    edgecolor=row["edgecolor"],
-                    linestyle=linestyle,
-                    linewidth=linewidth,
-                    **self.artist_kws,
-                )
-
-                # This is a bit of a hack to handle the fact that the edge lines are
-                # centered on the actual extents of the bar, and overlap when bars are
-                # stacked or dodged. We may discover that this causes problems and needs
-                # to be revisited at some point. Also it should be faster to clip with
-                # a bbox than a path, but I cant't work out how to get the intersection
-                # with the axes bbox.
-                bar.set_clip_path(bar.get_path(), bar.get_transform() + ax.transData)
-                if self.artist_kws.get("clip_on", True):
-                    # It seems the above hack undoes the default axes clipping
-                    bar.set_clip_box(ax.bbox)
-                bar.sticky_edges[val_idx][:] = (0, np.inf)
-                ax.add_patch(bar)
-                bars.append(bar)
-                vals.append(row[val_dim])
-
-            # Add a container which is useful for, e.g. Axes.bar_label
-            if Version(mpl.__version__) >= Version("3.4.0"):
-                orientation = {"x": "vertical", "y": "horizontal"}[orient]
-                container_kws = dict(datavalues=vals, orientation=orientation)
-            else:
-                container_kws = {}
-            container = mpl.container.BarContainer(bars, **container_kws)
-            ax.add_container(container)
-
     def _legend_artist(
         self, variables: list[str], value: Any, scales: dict[str, Scale],
     ) -> Artist:
@@ -146,3 +108,53 @@ class Bar(Mark):
             linestyle=key["edgestyle"],
         )
         return artist
+
+
+@dataclass
+class Bar(BarBase):
+    """
+    An interval mark drawn between baseline and data values with a width.
+    """
+    color: MappableColor = Mappable("C0")
+    alpha: MappableFloat = Mappable(.7)
+    fill: MappableBool = Mappable(True)
+    edgecolor: MappableColor = Mappable(depend="color")
+    edgealpha: MappableFloat = Mappable(1)
+    edgewidth: MappableFloat = Mappable(rc="patch.linewidth")
+    edgestyle: MappableStyle = Mappable("-")
+    # pattern: MappableString = Mappable(None)  # TODO no Property yet
+
+    width: MappableFloat = Mappable(.8, grouping=False)
+    baseline: MappableFloat = Mappable(0, grouping=False)  # TODO *is* this mappable?
+
+    def _plot(self, split_gen, scales, orient):
+
+        val_idx = ["y", "x"].index(orient)
+
+        for _, data, ax in split_gen():
+
+            bars, vals = self._make_patches(data, scales, orient)
+
+            for bar in bars:
+
+                # This is a bit of a hack to handle the fact that the edge lines are
+                # centered on the actual extents of the bar, and overlap when bars are
+                # stacked or dodged. We may discover that this causes problems and needs
+                # to be revisited at some point. Also it should be faster to clip with
+                # a bbox than a path, but I cant't work out how to get the intersection
+                # with the axes bbox.
+                bar.set_clip_path(bar.get_path(), bar.get_transform() + ax.transData)
+                if self.artist_kws.get("clip_on", True):
+                    # It seems the above hack undoes the default axes clipping
+                    bar.set_clip_box(ax.bbox)
+                bar.sticky_edges[val_idx][:] = (0, np.inf)
+                ax.add_patch(bar)
+
+            # Add a container which is useful for, e.g. Axes.bar_label
+            if Version(mpl.__version__) >= Version("3.4.0"):
+                orientation = {"x": "vertical", "y": "horizontal"}[orient]
+                container_kws = dict(datavalues=vals, orientation=orientation)
+            else:
+                container_kws = {}
+            container = mpl.container.BarContainer(bars, **container_kws)
+            ax.add_container(container)

--- a/seaborn/_marks/bars.py
+++ b/seaborn/_marks/bars.py
@@ -222,7 +222,7 @@ class Bars(BarBase):
                     ax.transData.transform([edges + widths] * 2)
                     - ax.transData.transform([edges] * 2)
                 )
-                min_width = min(min_width, min(points[ori_idx]))
+                min_width = min(min_width, min(points[:, ori_idx]))
 
             linewidth = min(.1 * min_width, mpl.rcParams["patch.linewidth"])
             for _, col in collections.items():

--- a/seaborn/_marks/base.py
+++ b/seaborn/_marks/base.py
@@ -27,6 +27,7 @@ class Mappable:
         val: Any = None,
         depend: str | None = None,
         rc: str | None = None,
+        auto: bool = False,
         grouping: bool = True,
     ):
         """
@@ -40,6 +41,8 @@ class Mappable:
             Use the value of this feature as the default.
         rc : str
             Use the value of this rcParam as the default.
+        auto : bool
+            The default value will depend on other parameters at compile time.
         grouping : bool
             If True, use the mapped variable to define groups.
 
@@ -52,6 +55,7 @@ class Mappable:
         self._val = val
         self._rc = rc
         self._depend = depend
+        self._auto = auto
         self._grouping = grouping
 
     def __repr__(self):
@@ -62,6 +66,8 @@ class Mappable:
             s = f"<depend:{self._depend}>"
         elif self._rc is not None:
             s = f"<rc:{self._rc}>"
+        elif self._auto:
+            s = "<auto>"
         else:
             s = "<undefined>"
         return s

--- a/seaborn/_marks/scatter.py
+++ b/seaborn/_marks/scatter.py
@@ -91,7 +91,7 @@ class Scatter(Mark):
         # (That should be solved upstream by defaulting to "" for unset x/y?)
         # (Be mindful of xmin/xmax, etc!)
 
-        for keys, data, ax in split_gen():
+        for _, data, ax in split_gen():
 
             offsets = np.column_stack([data["x"], data["y"]])
             data = self._resolve_properties(data, scales)

--- a/seaborn/objects.py
+++ b/seaborn/objects.py
@@ -5,7 +5,7 @@ from seaborn._core.plot import Plot  # noqa: F401
 
 from seaborn._marks.base import Mark  # noqa: F401
 from seaborn._marks.area import Area, Ribbon  # noqa: F401
-from seaborn._marks.bars import Bar  # noqa: F401
+from seaborn._marks.bars import Bar, Bars  # noqa: F401
 from seaborn._marks.lines import Line, Lines, Path, Paths  # noqa: F401
 from seaborn._marks.scatter import Dot, Scatter  # noqa: F401
 

--- a/tests/_marks/test_bars.py
+++ b/tests/_marks/test_bars.py
@@ -176,6 +176,19 @@ class TestBars:
         lws = ax.collections[0].get_linewidths()
         assert_array_equal(np.argsort(lws), np.argsort(y))
 
+    def test_auto_edgewidth(self):
+
+        x0 = np.arange(10)
+        x1 = np.arange(1000)
+
+        p0 = Plot(x0, x0).add(Bars()).plot()
+        p1 = Plot(x1, x1).add(Bars()).plot()
+
+        lw0 = p0._figure.axes[0].collections[0].get_linewidths()
+        lw1 = p1._figure.axes[0].collections[0].get_linewidths()
+
+        assert (lw0 > lw1).all()
+
     def test_unfilled(self, x, y):
 
         p = Plot(x, y).add(Bars(fill=False, edgecolor="C4")).plot()

--- a/tests/_marks/test_bars.py
+++ b/tests/_marks/test_bars.py
@@ -1,9 +1,13 @@
-import pytest
 
-from matplotlib.colors import to_rgba
+import numpy as np
+import pandas as pd
+from matplotlib.colors import to_rgba, to_rgba_array
+
+import pytest
+from numpy.testing import assert_array_equal
 
 from seaborn._core.plot import Plot
-from seaborn._marks.bars import Bar
+from seaborn._marks.bars import Bar, Bars
 
 
 class TestBar:
@@ -104,3 +108,79 @@ class TestBar:
         p = Plot(["a", "b"], [1, 2]).add(Bar({"clip_on": False})).plot()
         patch = p._figure.axes[0].patches[0]
         assert patch.clipbox is None
+
+
+class TestBars:
+
+    @pytest.fixture
+    def x(self):
+        return pd.Series([4, 5, 6, 7, 8], name="x")
+
+    @pytest.fixture
+    def y(self):
+        return pd.Series([2, 8, 3, 5, 9], name="y")
+
+    @pytest.fixture
+    def color(self):
+        return pd.Series(["a", "b", "c", "a", "c"], name="color")
+
+    def test_positions(self, x, y):
+
+        p = Plot(x, y).add(Bars()).plot()
+        ax = p._figure.axes[0]
+        paths = ax.collections[0].get_paths()
+        assert len(paths) == len(x)
+        for i, path in enumerate(paths):
+            verts = path.vertices
+            assert verts[0, 0] == pytest.approx(x[i] - .5)
+            assert verts[1, 0] == pytest.approx(x[i] + .5)
+            assert verts[0, 1] == 0
+            assert verts[3, 1] == y[i]
+
+    def test_positions_horizontal(self, x, y):
+
+        p = Plot(x=y, y=x).add(Bars(), orient="h").plot()
+        ax = p._figure.axes[0]
+        paths = ax.collections[0].get_paths()
+        assert len(paths) == len(x)
+        for i, path in enumerate(paths):
+            verts = path.vertices
+            assert verts[0, 1] == pytest.approx(x[i] - .5)
+            assert verts[3, 1] == pytest.approx(x[i] + .5)
+            assert verts[0, 0] == 0
+            assert verts[1, 0] == y[i]
+
+    def test_width(self, x, y):
+
+        p = Plot(x, y).add(Bars(width=.4)).plot()
+        ax = p._figure.axes[0]
+        paths = ax.collections[0].get_paths()
+        for i, path in enumerate(paths):
+            verts = path.vertices
+            assert verts[0, 0] == pytest.approx(x[i] - .2)
+            assert verts[1, 0] == pytest.approx(x[i] + .2)
+
+    def test_mapped_color_direct_alpha(self, x, y, color):
+
+        alpha = .5
+        p = Plot(x, y, color=color).add(Bars(alpha=alpha)).plot()
+        ax = p._figure.axes[0]
+        fcs = ax.collections[0].get_facecolors()
+        expected = to_rgba_array(["C0", "C1", "C2", "C0", "C2"], alpha)
+        assert_array_equal(fcs, expected)
+
+    def test_mapped_edgewidth(self, x, y):
+
+        p = Plot(x, y, edgewidth=y).add(Bars()).plot()
+        ax = p._figure.axes[0]
+        lws = ax.collections[0].get_linewidths()
+        assert_array_equal(np.argsort(lws), np.argsort(y))
+
+    def test_unfilled(self, x, y):
+
+        p = Plot(x, y).add(Bars(fill=False, edgecolor="C4")).plot()
+        ax = p._figure.axes[0]
+        fcs = ax.collections[0].get_facecolors()
+        ecs = ax.collections[0].get_edgecolors()
+        assert_array_equal(fcs, to_rgba_array(["C0"] * len(x), 0))
+        assert_array_equal(ecs, to_rgba_array(["C4"] * len(x), 1))

--- a/tests/_marks/test_base.py
+++ b/tests/_marks/test_base.py
@@ -32,6 +32,7 @@ class TestMappable:
         assert str(Mappable("CO")) == "<'CO'>"
         assert str(Mappable(rc="lines.linewidth")) == "<rc:lines.linewidth>"
         assert str(Mappable(depend="color")) == "<depend:color>"
+        assert str(Mappable(auto=True)) == "<auto>"
 
     def test_input_checks(self):
 


### PR DESCRIPTION
Similar to how we have `Line`/`Lines`, the `Bars` mark uses a `PatchCollection` for more efficient drawing. (Unlike with `Lines`, we don't need to reduce the mappable properties). This can have a substantial effect:

```python
x = np.linspace(-3, 3, 1000)
y = np.exp(-(x ** 2))

%time so.Plot(x, y, color=x).add(so.Bar()).save(io.BytesIO())
%time so.Plot(x, y, color=x).add(so.Bars()).save(io.BytesIO())
```
```
CPU times: user 2.66 s, sys: 20.3 ms, total: 2.68 s
Wall time: 1.65 s
CPU times: user 918 ms, sys: 12.3 ms, total: 930 ms
Wall time: 397 ms
```

The default property values for `Bars` are also a little different: `width` is set to 1, edges use the `patch.linecolor` rc parameter, and edge widths are automatically set using the same approach in `histplot` to scale down for a dense plot.

```python
so.Plot(diamonds, "price").add(so.Bars(), so.Hist())
```
<img width="418" alt="image" src="https://user-images.githubusercontent.com/315810/178165032-b98a73f8-0e33-4600-80ab-83c8cda27609.png">
