### PR TITLE
Add Plot.limit method

### DIFF
--- a/tests/_core/test_plot.py
+++ b/tests/_core/test_plot.py
@@ -995,6 +995,18 @@ class TestPlotting:
         assert ax.get_xlabel() == "a"
         assert ax.get_ylabel() == "b"
 
+    def test_limits(self, long_df):
+
+        limit = (-2, 24)
+        p = Plot(long_df, x="x", y="y").limit(x=limit).plot()
+        ax1 = p._figure.axes[0]
+        assert ax1.get_xlim() == limit
+
+        limit = tuple(np.array(["2005-01-01", "2008-01-01"], dtype="datetime64"))
+        p = Plot(long_df, x="d", y="y").limit(x=limit).plot()
+        ax1 = p._figure.axes[0]
+        assert ax1.get_xlim() == tuple(mpl.dates.date2num(limit))
+
 
 class TestFacetInterface:
 
@@ -1381,6 +1393,13 @@ class TestPairInterface:
         err = "When faceting on both col= and row=, passing `order`"
         with pytest.raises(RuntimeError, match=err):
             p.facet(col="a", row="b", order=["a", "b", "c"])
+
+    def test_limits(self, long_df):
+
+        limit = (-2, 24)
+        p = Plot(long_df, y="y").pair(x=["x", "z"]).limit(x1=limit).plot()
+        ax1 = p._figure.axes[1]
+        assert ax1.get_xlim() == limit
 
 
 class TestLabelVisibility:

--- a/tests/_core/test_plot.py
+++ b/tests/_core/test_plot.py
@@ -1002,10 +1002,15 @@ class TestPlotting:
         ax1 = p._figure.axes[0]
         assert ax1.get_xlim() == limit
 
-        limit = tuple(np.array(["2005-01-01", "2008-01-01"], dtype="datetime64"))
+        limit = (np.datetime64("2005-01-01"), np.datetime64("2008-01-01"))
         p = Plot(long_df, x="d", y="y").limit(x=limit).plot()
-        ax1 = p._figure.axes[0]
-        assert ax1.get_xlim() == tuple(mpl.dates.date2num(limit))
+        ax = p._figure.axes[0]
+        assert ax.get_xlim() == tuple(mpl.dates.date2num(limit))
+
+        limit = ("b", "c")
+        p = Plot(x=["a", "b", "c", "d"], y=[1, 2, 3, 4]).limit(x=limit).plot()
+        ax = p._figure.axes[0]
+        assert ax.get_xlim() == (0.5, 2.5)
 
 
 class TestFacetInterface:


### PR DESCRIPTION
I still feel slightly non-committal about this having its own distinct method, but I think this is probably the most straightforward approach.

This has the nice feature of accepting and converting various units, including on a Nominal scale:

```python
(
    so.Plot(diamonds, "price", "clarity")
    .add(so.Scatter(), move=so.Jitter(.8))
    .limit(x=(0, 20000), y=["VS1", "SI2"])
)
```
![image](https://user-images.githubusercontent.com/315810/178394498-fa6d61e1-f8b5-47f8-8c53-830cd6fe3182.png)

Closes #2871 