### PR TITLE
Add Plot.label method

### DIFF
--- a/seaborn/_core/plot.py
+++ b/seaborn/_core/plot.py
@@ -10,7 +10,7 @@ import itertools
 import textwrap
 from collections import abc
 from collections.abc import Callable, Generator, Hashable
-from typing import Any, cast
+from typing import Any, Optional, cast
 
 import pandas as pd
 from pandas import DataFrame, Series, Index
@@ -832,10 +832,12 @@ class Plotter:
                 auto_label = next((name for name in names if name is not None), None)
                 if axis_key in p._labels:
                     manual_label = p._labels[axis_key]
-                    if callable(manual_label):
+                    label: str | None
+                    if callable(manual_label) and auto_label is not None:
                         label = manual_label(auto_label)
                     else:
-                        label = manual_label
+                        # mypy needs a lot of help here, I'm not sure why
+                        label = cast(Optional[str], manual_label)
                 else:
                     label = auto_label
                 ax.set(**{f"{axis}label": label})
@@ -1422,10 +1424,12 @@ class Plotter:
                     auto_title = data.names[var]
                     if var in titles:
                         manual_title = titles[var]
-                        if callable(manual_title):
+                        title: str | None
+                        if callable(manual_title) and auto_title is not None:
                             title = manual_title(auto_title)
                         else:
-                            title = manual_title
+                            # mypy needs a lot of help here, I'm not sure why
+                            title = cast(Optional[str], manual_title)
                     else:
                         title = auto_title
                     entry = (title, data.ids[var]), [var], (values, labels)

--- a/tests/_core/test_plot.py
+++ b/tests/_core/test_plot.py
@@ -1012,6 +1012,18 @@ class TestPlotting:
         ax = p._figure.axes[0]
         assert ax.get_xlim() == (0.5, 2.5)
 
+    def test_labels(self, long_df):
+
+        label = "Y axis"
+        p = Plot(long_df, x="x", y="y").label(y=label).plot()
+        ax1 = p._figure.axes[0]
+        assert ax1.get_ylabel() == label
+
+        label = str.capitalize
+        p = Plot(long_df, x="x", y="y").label(y=label).plot()
+        ax = p._figure.axes[0]
+        assert ax.get_ylabel() == "Y"
+
 
 class TestFacetInterface:
 
@@ -1405,6 +1417,13 @@ class TestPairInterface:
         p = Plot(long_df, y="y").pair(x=["x", "z"]).limit(x1=limit).plot()
         ax1 = p._figure.axes[1]
         assert ax1.get_xlim() == limit
+
+    def test_labels(self, long_df):
+
+        label = "Z"
+        p = Plot(long_df, y="y").pair(x=["x", "z"]).label(x1=label).plot()
+        ax1 = p._figure.axes[1]
+        assert ax1.get_xlabel() == label
 
 
 class TestLabelVisibility:

--- a/tests/_core/test_plot.py
+++ b/tests/_core/test_plot.py
@@ -999,8 +999,8 @@ class TestPlotting:
 
         limit = (-2, 24)
         p = Plot(long_df, x="x", y="y").limit(x=limit).plot()
-        ax1 = p._figure.axes[0]
-        assert ax1.get_xlim() == limit
+        ax = p._figure.axes[0]
+        assert ax.get_xlim() == limit
 
         limit = (np.datetime64("2005-01-01"), np.datetime64("2008-01-01"))
         p = Plot(long_df, x="d", y="y").limit(x=limit).plot()
@@ -1012,17 +1012,29 @@ class TestPlotting:
         ax = p._figure.axes[0]
         assert ax.get_xlim() == (0.5, 2.5)
 
-    def test_labels(self, long_df):
+    def test_labels_axis(self, long_df):
 
         label = "Y axis"
         p = Plot(long_df, x="x", y="y").label(y=label).plot()
-        ax1 = p._figure.axes[0]
-        assert ax1.get_ylabel() == label
+        ax = p._figure.axes[0]
+        assert ax.get_ylabel() == label
 
         label = str.capitalize
         p = Plot(long_df, x="x", y="y").label(y=label).plot()
         ax = p._figure.axes[0]
         assert ax.get_ylabel() == "Y"
+
+    def test_labels_legend(self, long_df):
+
+        m = MockMark()
+
+        label = "A"
+        p = Plot(long_df, x="x", y="y", color="a").add(m).label(color=label).plot()
+        assert p._figure.legends[0].get_title().get_text() == label
+
+        func = str.capitalize
+        p = Plot(long_df, x="x", y="y", color="a").add(m).label(color=func).plot()
+        assert p._figure.legends[0].get_title().get_text() == label
 
 
 class TestFacetInterface:


### PR DESCRIPTION
Another specific configuration method. Like `Plot.limit`, also subject to changes before release on the name (and on whether it should be a distinct function) but status quo bias is strong.

Accepts a string, a function, or `None`:

```
(
    so.Plot(tips, "day", "total_bill", color="sex")
    .add(so.Bar(), so.Agg(), so.Dodge())
    .label(x=str.capitalize, y="Total bill ($)", color=None)
)
```
![image](https://user-images.githubusercontent.com/315810/178619561-d830b7ac-9f5d-4920-b493-3f137eec514d.png)

This API will entail a separation between the text of the labels and any other configuration of them, and I am not sure where other configuration should live as of the moment.