### PR TITLE
Don't modify patch.facecolor in set_palette

### DIFF
--- a/doc/releases/v0.12.0.txt
+++ b/doc/releases/v0.12.0.txt
@@ -94,6 +94,8 @@ Other updates
 
 - |Fix| Improved robustness to numerical errors in :func:`kdeplot` (:pr:`2862`).
 
+- |Defaults| The `patch.facecolor` rc param is no longer set by :func:`set_palette` (or :func:`set_theme`). This should have no effect, because the matplotlib default is now `"C0"` (:pr:`2906`).
+
 - |Dependencies| Made `scipy` an optional dependency and added `pip install seaborn[all]` as a method for ensuring the availability of compatible `scipy` and `statsmodels` libraries at install time. This has a few minor implications for existing code, which are explained in the Github pull request (:pr:`2398`).
 
 - |Dependencies| Following `NEP29 <https://numpy.org/neps/nep-0029-deprecation_policy.html>`_, dropped support for Python 3.6 and bumped the minimally-supported versions of the library dependencies.

--- a/seaborn/rcmod.py
+++ b/seaborn/rcmod.py
@@ -508,8 +508,7 @@ def set_palette(palette, n_colors=None, desat=None, color_codes=False):
     Parameters
     ----------
     palette : seaborn color paltte | matplotlib colormap | hls | husl
-        Palette definition. Should be something that :func:`color_palette`
-        can process.
+        Palette definition. Should be something :func:`color_palette` can process.
     n_colors : int
         Number of colors in the cycle. The default number of colors will depend
         on the format of ``palette``, see the :func:`color_palette`
@@ -537,7 +536,6 @@ def set_palette(palette, n_colors=None, desat=None, color_codes=False):
     colors = palettes.color_palette(palette, n_colors, desat)
     cyl = cycler('color', colors)
     mpl.rcParams['axes.prop_cycle'] = cyl
-    mpl.rcParams["patch.facecolor"] = colors[0]
     if color_codes:
         try:
             palettes.set_color_codes(palette)

--- a/tests/test_rcmod.py
+++ b/tests/test_rcmod.py
@@ -260,6 +260,10 @@ class TestPalette:
         rcmod.set_palette("Set2", color_codes=True)
         assert utils.get_color_cycle() == palettes.color_palette("Set2", 8)
 
+        assert mpl.colors.same_color(
+            mpl.rcParams["patch.facecolor"], palettes.color_palette()[0]
+        )
+
 
 class TestFonts:
 


### PR DESCRIPTION
Matplotlib's default is now C0, so the facecolor should match the first
color in the cycle by default.

crossref: #2901