### PR TITLE
Add Est stat and Interval mark to show error bars

### DIFF
--- a/seaborn/_core/plot.py
+++ b/seaborn/_core/plot.py
@@ -1354,10 +1354,11 @@ class Plotter:
                         # Matplotlib (usually?) masks nan data, so this should "work".
                         # Downstream code can also drop these rows, at some speed cost.
                         present = axes_df.notna().all(axis=1)
-                        axes_df = axes_df.assign(
-                            x=axes_df["x"].where(present),
-                            y=axes_df["y"].where(present),
-                        )
+                        nulled = {}
+                        for axis in "xy":
+                            if axis in axes_df:
+                                nulled[axis] = axes_df[axis].where(present)
+                        axes_df = axes_df.assign(**nulled)
                     else:
                         axes_df = axes_df.dropna()
 

--- a/seaborn/_core/scales.py
+++ b/seaborn/_core/scales.py
@@ -350,7 +350,10 @@ class ContinuousBase(Scale):
         ]
 
         def spacer(x):
-            return np.min(np.diff(np.sort(x.dropna().unique())))
+            x = x.dropna().unique()
+            if len(x) < 2:
+                return np.nan
+            return np.min(np.diff(np.sort(x)))
         new._spacer = spacer
 
         # TODO How to allow disabling of legend for all uses of property?

--- a/seaborn/_marks/bars.py
+++ b/seaborn/_marks/bars.py
@@ -200,10 +200,8 @@ class Bars(BarBase):
             # Workaround for matplotlib autoscaling bug
             # https://github.com/matplotlib/matplotlib/issues/11898
             # https://github.com/matplotlib/matplotlib/issues/23129
-            xy = np.vstack([path.vertices for path in col.get_paths()])
-            ax.dataLim.update_from_data_xy(
-                xy, ax.ignore_existing_data_limits, updatex=True, updatey=True
-            )
+            xys = np.vstack([path.vertices for path in col.get_paths()])
+            ax.update_datalim(xys)
 
         if "edgewidth" not in scales and isinstance(self.edgewidth, Mappable):
 

--- a/seaborn/_marks/lines.py
+++ b/seaborn/_marks/lines.py
@@ -203,7 +203,7 @@ class Lines(Paths):
 @dataclass
 class Interval(Paths):
     """
-    An oriented line mark drawn between min/max values on the other axis.
+    An oriented line mark drawn between min/max values.
     """
     def _setup_lines(self, split_gen, scales, orient):
 

--- a/seaborn/_marks/lines.py
+++ b/seaborn/_marks/lines.py
@@ -139,17 +139,12 @@ class Paths(Mark):
             line_data[ax]["linestyles"].append(vals["linestyle"])
 
         for ax, ax_data in line_data.items():
-            lines = mpl.collections.LineCollection(
-                **ax_data,
-                **self.artist_kws,
-            )
-            ax.add_collection(lines, autolim=False)
+            lines = mpl.collections.LineCollection(**ax_data, **self.artist_kws)
+            # Handle datalim update manually
             # https://github.com/matplotlib/matplotlib/issues/23129
-            # TODO get paths from lines object?
+            ax.add_collection(lines, autolim=False)
             xy = np.concatenate(ax_data["segments"])
-            ax.dataLim.update_from_data_xy(
-                xy, ax.ignore_existing_data_limits, updatex=True, updatey=True
-            )
+            ax.update_datalim(xy)
 
     def _legend_artist(self, variables, value, scales):
 

--- a/seaborn/_stats/aggregation.py
+++ b/seaborn/_stats/aggregation.py
@@ -1,14 +1,16 @@
 from __future__ import annotations
 from dataclasses import dataclass
-from typing import ClassVar
+from typing import ClassVar, Callable
+from numbers import Number
+
+import numpy as np
+import pandas as pd
 
 from seaborn._stats.base import Stat
+from seaborn.algorithms import bootstrap
+from seaborn.utils import _check_argument
 
-from typing import TYPE_CHECKING
-if TYPE_CHECKING:
-    from typing import Callable
-    from numbers import Number
-    from seaborn._core.typing import Vector
+from seaborn._core.typing import Vector
 
 
 @dataclass
@@ -19,12 +21,10 @@ class Agg(Stat):
     Parameters
     ----------
     func
-        Name of a method understood by Pandas or an arbitrary vector -> scalar function.
+        Name of a :class:`pandas.Series` method or a vector -> scalar function.
 
     """
-    # TODO In current practice we will always have a numeric x/y variable,
-    # but they may represent non-numeric values. Needs clear documentation.
-    func: str | Callable[[Vector], Number] = "mean"
+    func: str | Callable[[Vector], float] = "mean"
 
     group_by_orient: ClassVar[bool] = True
 
@@ -44,18 +44,64 @@ class Agg(Stat):
 @dataclass
 class Est(Stat):
 
-    # TODO a string here must be a numpy ufunc?
-    func: str | Callable[[Vector], Number] = "mean"
-
-    # TODO type errorbar options with literal?
+    func: str | Callable[[Vector], float] = "mean"
     errorbar: str | tuple[str, float] = ("ci", 95)
+    n_boot: int = 1000
+    seed: int | None = None
 
     group_by_orient: ClassVar[bool] = True
 
+    def _process(self, data, var):
+
+        vals = data[var]
+
+        estimate = vals.agg(self.func)
+
+        # Options that produce no error bars
+        if self.error_method is None:
+            err_min = err_max = np.nan
+        elif len(data) <= 1:
+            err_min = err_max = np.nan
+
+        # Generic errorbars from user-supplied function
+        elif callable(self.error_method):
+            err_min, err_max = self.error_method(vals)
+
+        # Parametric options
+        elif self.error_method == "sd":
+            half_interval = vals.std() * self.error_level
+            err_min, err_max = estimate - half_interval, estimate + half_interval
+        elif self.error_method == "se":
+            half_interval = vals.sem() * self.error_level
+            err_min, err_max = estimate - half_interval, estimate + half_interval
+
+        # Nonparametric options
+        elif self.error_method == "pi":
+            err_min, err_max = _percentile_interval(vals, self.error_level)
+        elif self.error_method == "ci":
+            boot_kws = {"n_boot": self.n_boot, "seed": self.seed}
+            # units = data.get("units", None)  # TODO change to unit
+            units = None
+            boots = bootstrap(vals, units=units, func=self.func, **boot_kws)
+            err_min, err_max = _percentile_interval(boots, self.error_level)
+
+        res = {var: estimate, f"{var}min": err_min, f"{var}max": err_max}
+        return pd.DataFrame([res])
+
     def __call__(self, data, groupby, orient, scales):
 
-        # TODO port code over from _statistics
-        ...
+        method, level = _validate_errorbar_arg(self.errorbar)
+        self.error_method = method
+        self.error_level = level
+
+        var = {"x": "y", "y": "x"}.get(orient)
+        res = (
+            groupby
+            .apply(data, self._process, var)
+            .dropna()
+            .reset_index(drop=True)
+        )
+        return res
 
 
 @dataclass
@@ -64,3 +110,41 @@ class Rolling(Stat):
 
     def __call__(self, data, groupby, orient, scales):
         ...
+
+
+def _percentile_interval(data, width):
+    """Return a percentile interval from data of a given width."""
+    edge = (100 - width) / 2
+    percentiles = edge, 100 - edge
+    return np.nanpercentile(data, percentiles)
+
+
+def _validate_errorbar_arg(arg):
+    """Check type and value of errorbar argument and assign default level."""
+    DEFAULT_LEVELS = {
+        "ci": 95,
+        "pi": 95,
+        "se": 1,
+        "sd": 1,
+    }
+
+    usage = "`errorbar` must be a callable, string, or (string, number) tuple"
+
+    if arg is None:
+        return None, None
+    elif callable(arg):
+        return arg, None
+    elif isinstance(arg, str):
+        method = arg
+        level = DEFAULT_LEVELS.get(method, None)
+    else:
+        try:
+            method, level = arg
+        except (ValueError, TypeError) as err:
+            raise err.__class__(usage) from err
+
+    _check_argument("errorbar", list(DEFAULT_LEVELS), method)
+    if level is not None and not isinstance(level, Number):
+        raise TypeError(usage)
+
+    return method, level

--- a/seaborn/_stats/histograms.py
+++ b/seaborn/_stats/histograms.py
@@ -31,6 +31,9 @@ class Hist(Stat):
     # Q: would Discrete() scale imply binwidth=1 or bins centered on integers?
     discrete: bool = False
 
+    # TODO Note that these methods are mostly copied from _statistics.Histogram,
+    # but it only computes univariate histograms. We should reconcile the code.
+
     def _define_bin_edges(self, vals, weight, bins, binwidth, binrange, discrete):
         """Inner function that takes bin parameters as arguments."""
         vals = vals.dropna()

--- a/seaborn/objects.py
+++ b/seaborn/objects.py
@@ -1,5 +1,30 @@
 """
-TODO Give this module a useful docstring
+A declarative, object-oriented interface for creating statistical graphics.
+
+The seaborn.objects namespace contains a number of classes that can be composed
+together to build a customized visualization.
+
+The main object is :class:`Plot`, which is the starting point for all figures.
+Pass :class:`Plot` a dataset and specify assignments from its variables to
+roles in the plot. Build up the visualization by calling its methods.
+
+There are four other general types of objects in this interface:
+
+- :class:`Mark` subclasses, which create matplotlib artists for visualization
+- :class:`Stat` subclasses, which apply statistical transforms before plotting
+- :class:`Move` subclasses, which make further adjustments to reduce overplotting
+
+These classes are passed to :meth:`Plot.add` to define a layer in the plot.
+Each layer has a :class:`Mark` and optional :class:`Stat` and/or :class:`Move`.
+Plots can have multiple layers.
+
+The other general type of object is a :class:`Scale` subclass, which provide an
+interface for controlling the mappings between data values and visual properties.
+Pass :class:`Scale` objects to :meth:`Plot.scale`.
+
+See the documentation for other :class:`Plot` methods to learn about the many
+ways that a plot can be enhanced and customized.
+
 """
 from seaborn._core.plot import Plot  # noqa: F401
 

--- a/seaborn/objects.py
+++ b/seaborn/objects.py
@@ -31,7 +31,7 @@ from seaborn._core.plot import Plot  # noqa: F401
 from seaborn._marks.base import Mark  # noqa: F401
 from seaborn._marks.area import Area, Ribbon  # noqa: F401
 from seaborn._marks.bars import Bar, Bars  # noqa: F401
-from seaborn._marks.lines import Line, Lines, Path, Paths  # noqa: F401
+from seaborn._marks.lines import Line, Lines, Path, Paths, Interval  # noqa: F401
 from seaborn._marks.scatter import Dot, Scatter  # noqa: F401
 
 from seaborn._stats.base import Stat  # noqa: F401

--- a/seaborn/objects.py
+++ b/seaborn/objects.py
@@ -35,7 +35,7 @@ from seaborn._marks.lines import Line, Lines, Path, Paths  # noqa: F401
 from seaborn._marks.scatter import Dot, Scatter  # noqa: F401
 
 from seaborn._stats.base import Stat  # noqa: F401
-from seaborn._stats.aggregation import Agg  # noqa: F401
+from seaborn._stats.aggregation import Agg, Est  # noqa: F401
 from seaborn._stats.regression import OLSFit, PolyFit  # noqa: F401
 from seaborn._stats.histograms import Hist  # noqa: F401
 

--- a/tests/_marks/test_lines.py
+++ b/tests/_marks/test_lines.py
@@ -1,5 +1,6 @@
 
 import numpy as np
+import matplotlib as mpl
 from matplotlib.colors import same_color, to_rgba
 
 from numpy.testing import assert_array_equal
@@ -113,6 +114,24 @@ class TestPath:
         # assert line1.get_linestyle() != line2.get_linestyle()
         assert line1.get_markersize() != line2.get_markersize()
 
+    def test_capstyle(self):
+
+        x = y = [1, 2]
+        rc = {"lines.solid_capstyle": "projecting", "lines.dash_capstyle": "round"}
+
+        with mpl.rc_context(rc):
+            p = Plot(x, y).add(Path()).plot()
+            line, = p._figure.axes[0].get_lines()
+            assert line.get_dash_capstyle() == "projecting"
+
+            p = Plot(x, y).add(Path(linestyle="--")).plot()
+            line, = p._figure.axes[0].get_lines()
+            assert line.get_dash_capstyle() == "round"
+
+            p = Plot(x, y).add(Path({"solid_capstyle": "butt"})).plot()
+            line, = p._figure.axes[0].get_lines()
+            assert line.get_solid_capstyle() == "butt"
+
 
 class TestLine:
 
@@ -187,6 +206,24 @@ class TestPaths:
         p = Plot(x=x, y=y).add(m).plot()
         lines, = p._figure.axes[0].collections
         assert same_color(lines.get_colors().squeeze(), to_rgba(m.color, m.alpha))
+
+    def test_capstyle(self):
+
+        x = y = [1, 2]
+        rc = {"lines.solid_capstyle": "projecting"}
+
+        with mpl.rc_context(rc):
+            p = Plot(x, y).add(Paths()).plot()
+            lines = p._figure.axes[0].collections[0]
+            assert lines.get_capstyle() == "projecting"
+
+            p = Plot(x, y).add(Paths(linestyle="--")).plot()
+            lines = p._figure.axes[0].collections[0]
+            assert lines.get_capstyle() == "projecting"
+
+            p = Plot(x, y).add(Paths({"capstyle": "butt"})).plot()
+            lines = p._figure.axes[0].collections[0]
+            assert lines.get_capstyle() == "butt"
 
 
 class TestLines:

--- a/tests/_marks/test_lines.py
+++ b/tests/_marks/test_lines.py
@@ -6,7 +6,7 @@ from matplotlib.colors import same_color, to_rgba
 from numpy.testing import assert_array_equal
 
 from seaborn._core.plot import Plot
-from seaborn._marks.lines import Line, Path, Lines, Paths
+from seaborn._marks.lines import Line, Path, Lines, Paths, Interval
 
 
 class TestPath:
@@ -243,3 +243,50 @@ class TestLines:
         verts = lines.get_paths()[1].vertices.T
         assert_array_equal(verts[0], [2, 5])
         assert_array_equal(verts[1], [3, 4])
+
+
+class TestInterval:
+
+    def test_xy_data(self):
+
+        x = [1, 2]
+        ymin = [1, 4]
+        ymax = [2, 3]
+
+        p = Plot(x=x, ymin=ymin, ymax=ymax).add(Interval()).plot()
+        lines, = p._figure.axes[0].collections
+
+        for i, path in enumerate(lines.get_paths()):
+            verts = path.vertices.T
+            assert_array_equal(verts[0], [x[i], x[i]])
+            assert_array_equal(verts[1], [ymin[i], ymax[i]])
+
+    def test_mapped_color(self):
+
+        x = [1, 2, 1, 2]
+        ymin = [1, 4, 3, 2]
+        ymax = [2, 3, 1, 4]
+        group = ["a", "a", "b", "b"]
+
+        p = Plot(x=x, ymin=ymin, ymax=ymax, color=group).add(Interval()).plot()
+        lines, = p._figure.axes[0].collections
+
+        for i, path in enumerate(lines.get_paths()):
+            verts = path.vertices.T
+            assert_array_equal(verts[0], [x[i], x[i]])
+            assert_array_equal(verts[1], [ymin[i], ymax[i]])
+            assert same_color(lines.get_colors()[i], f"C{i // 2}")
+
+    def test_direct_properties(self):
+
+        x = [1, 2]
+        ymin = [1, 4]
+        ymax = [2, 3]
+
+        m = Interval(color="r", linewidth=4)
+        p = Plot(x=x, ymin=ymin, ymax=ymax).add(m).plot()
+        lines, = p._figure.axes[0].collections
+
+        for i, path in enumerate(lines.get_paths()):
+            assert same_color(lines.get_colors()[i], m.color)
+            assert lines.get_linewidths()[i] == m.linewidth

--- a/tests/_stats/test_aggregation.py
+++ b/tests/_stats/test_aggregation.py
@@ -1,14 +1,15 @@
 
+import numpy as np
 import pandas as pd
 
 import pytest
 from pandas.testing import assert_frame_equal
 
 from seaborn._core.groupby import GroupBy
-from seaborn._stats.aggregation import Agg
+from seaborn._stats.aggregation import Agg, Est
 
 
-class TestAgg:
+class AggregationFixtures:
 
     @pytest.fixture
     def df(self, rng):
@@ -26,6 +27,9 @@ class TestAgg:
         other = {"x": "y", "y": "x"}[orient]
         cols = [c for c in df if c != other]
         return GroupBy(cols)
+
+
+class TestAgg(AggregationFixtures):
 
     def test_default(self, df):
 
@@ -69,3 +73,53 @@ class TestAgg:
 
         expected = df.groupby("x", as_index=False)["y"].agg(func)
         assert_frame_equal(res, expected)
+
+
+class TestEst(AggregationFixtures):
+
+    # Note: Most of the underlying code is exercised in tests/test_statistics
+
+    @pytest.mark.parametrize("func", [np.mean, "mean"])
+    def test_mean_sd(self, df, func):
+
+        ori = "x"
+        df = df[["x", "y"]]
+        gb = self.get_groupby(df, ori)
+        res = Est(func, "sd")(df, gb, ori, {})
+
+        grouped = df.groupby("x", as_index=False)["y"]
+        est = grouped.mean()
+        err = grouped.std()
+        expected = est.assign(ymin=est["y"] - err["y"], ymax=est["y"] + err["y"])
+        assert_frame_equal(res, expected)
+
+    def test_sd_single_obs(self):
+
+        y = 1.5
+        ori = "x"
+        df = pd.DataFrame([{"x": "a", "y": y}])
+        gb = self.get_groupby(df, ori)
+        res = Est("mean", "sd")(df, gb, ori, {})
+        expected = df.assign(ymin=y, ymax=y)
+        assert_frame_equal(res, expected)
+
+    def test_median_pi(self, df):
+
+        ori = "x"
+        df = df[["x", "y"]]
+        gb = self.get_groupby(df, ori)
+        res = Est("median", ("pi", 100))(df, gb, ori, {})
+
+        grouped = df.groupby("x", as_index=False)["y"]
+        est = grouped.median()
+        expected = est.assign(ymin=grouped.min()["y"], ymax=grouped.max()["y"])
+        assert_frame_equal(res, expected)
+
+    def test_seed(self, df):
+
+        ori = "x"
+        gb = self.get_groupby(df, ori)
+        args = df, gb, ori, {}
+        res1 = Est("mean", "ci", seed=99)(*args)
+        res2 = Est("mean", "ci", seed=99)(*args)
+        assert_frame_equal(res1, res2)

--- a/tests/_stats/test_aggregation.py
+++ b/tests/_stats/test_aggregation.py
@@ -89,7 +89,7 @@ class TestEst(AggregationFixtures):
 
         grouped = df.groupby("x", as_index=False)["y"]
         est = grouped.mean()
-        err = grouped.std()
+        err = grouped.std().fillna(0)  # fillna needed only on pinned tests
         expected = est.assign(ymin=est["y"] - err["y"], ymax=est["y"] + err["y"])
         assert_frame_equal(res, expected)
 


### PR DESCRIPTION
This PR adds a new mark and a new stat that together will add error bars to aggregations:

```python
(
    so.Plot(diamonds, x="carat", y="clarity")
    .add(so.Interval(), so.Est("mean", "sd"))
    .add(so.Dot(), so.Agg())
)
```
<img width="500" alt="image" src="https://user-images.githubusercontent.com/315810/179432134-9d37a83d-05f2-44f1-8437-daeebbc95890.png">

The `Est` stay has the same basic API for error bar selection as we'll be rolling out for the functional interface in 0.12 (i.e., `ci`/`se`/`pi`/`sd`, with an optional scale/level parameter.

Note that is currently necessary to add two layers to get a dot + interval; see #2911 for some ideas there

This PR also addresses some wrinkles relating to matplotlib capstyles in both the interval mark and existing line marks.