### PR TITLE
Make scale config apply to variables computed by the stat transform

### DIFF
--- a/seaborn/_compat.py
+++ b/seaborn/_compat.py
@@ -121,5 +121,7 @@ def set_scale_obj(ax, axis, scale):
             trans = scale.get_transform()
             kws["functions"] = (trans._forward, trans._inverse)
         method(scale.name, **kws)
+        axis_obj = getattr(ax, f"{axis}axis")
+        scale.set_default_locators_and_formatters(axis_obj)
     else:
         ax.set(**{f"{axis}scale": scale})

--- a/seaborn/_core/plot.py
+++ b/seaborn/_core/plot.py
@@ -1143,18 +1143,20 @@ class Plotter:
                 if isinstance(prop, Coordinate):
                     # If we have a coordinate here, we didn't assign a scale for it
                     # in _transform_coords, which means it was added during compute_stat
-                    # This allows downstream orientation inference to work properly.
-                    # But it feels a little hacky, so perhaps revisit.
                     share = self._subplots.subplot_spec[f"share{axis}"]
                     views = [view for view in self._subplots if view[axis] == var]
                     for view in views:
                         axis_obj = getattr(view["ax"], f"{axis}axis")
                         seed_values = self._get_subplot_data(var_df, var, view, share)
-                        scale = scale._setup(seed_values, prop, axis=axis_obj)
-                        set_scale_obj(view["ax"], axis, scale._matplotlib_scale)
+                        view_scale = scale._setup(seed_values, prop, axis=axis_obj)
+                        set_scale_obj(view["ax"], axis, view_scale._matplotlib_scale)
 
                 scale = scale._setup(var_df[var], prop)
+
+                # This allows downstream orientation inference to work properly.
+                # But it feels a little hacky, so perhaps revisit.
                 scale._priority = 0  # type: ignore
+
                 self._scales[var] = scale
 
     def _plot_layer(self, p: Plot, layer: Layer) -> None:

--- a/seaborn/_core/plot.py
+++ b/seaborn/_core/plot.py
@@ -1110,10 +1110,7 @@ class Plotter:
                 else:
                     parts.append(layer["data"].frame.filter(cols))
 
-            if parts:
-                var_df = pd.concat(parts, ignore_index=True)
-            else:
-                var_df = pd.DataFrame(columns=cols)
+            var_df = pd.concat(parts, ignore_index=True)
 
             # Determine whether this is an coordinate variable
             # (i.e., x/y, paired x/y, or derivative such as xmax)

--- a/seaborn/_core/plot.py
+++ b/seaborn/_core/plot.py
@@ -1091,8 +1091,13 @@ class Plotter:
 
         for var in variables:
 
+            if var in ["col", "row"]:
+                # There's not currently a concept of "scale" for faceting variables
+                continue
+
             if var in self._scales:
-                # Scales for coordinate variables added in _transform_coords
+                # Scales for coordinate variables have already been added
+                # in _transform_coords so there's nothing to do here
                 continue
 
             # Get the data all the distinct appearances of this variable.

--- a/tests/_core/test_plot.py
+++ b/tests/_core/test_plot.py
@@ -2,7 +2,6 @@ import functools
 import itertools
 import warnings
 import imghdr
-from xml.dom.minidom import Identified
 
 import numpy as np
 import pandas as pd

--- a/tests/_core/test_plot.py
+++ b/tests/_core/test_plot.py
@@ -2,6 +2,7 @@ import functools
 import itertools
 import warnings
 import imghdr
+from xml.dom.minidom import Identified
 
 import numpy as np
 import pandas as pd
@@ -438,6 +439,31 @@ class TestScaling:
             expected = expected + mpl.dates.date2num(np.datetime64('0000-12-31'))
 
         assert_vector_equal(m.passed_data[0]["x"], expected)
+
+    def test_computed_var_ticks(self, long_df):
+
+        class Identity(Stat):
+            def __call__(self, df, groupby, orient, scales):
+                other = {"x": "y", "y": "x"}[orient]
+                return df.assign(**{other: df[orient]})
+
+        tick_locs = [1, 2, 5]
+        scale = Continuous().tick(at=tick_locs)
+        p = Plot(long_df, "x").add(MockMark(), Identity()).scale(y=scale).plot()
+        ax = p._figure.axes[0]
+        assert_array_equal(ax.get_yticks(), tick_locs)
+
+    def test_computed_var_transform(self, long_df):
+
+        class Identity(Stat):
+            def __call__(self, df, groupby, orient, scales):
+                other = {"x": "y", "y": "x"}[orient]
+                return df.assign(**{other: df[orient]})
+
+        p = Plot(long_df, "x").add(MockMark(), Identity()).scale(y="log").plot()
+        ax = p._figure.axes[0]
+        xfm = ax.yaxis.get_transform().transform
+        assert_array_equal(xfm([1, 10, 100]), [0, 1, 2])
 
     def test_facet_categories(self):
 

--- a/tests/_core/test_plot.py
+++ b/tests/_core/test_plot.py
@@ -464,6 +464,27 @@ class TestScaling:
         xfm = ax.yaxis.get_transform().transform
         assert_array_equal(xfm([1, 10, 100]), [0, 1, 2])
 
+    def test_explicit_range_with_axis_scaling(self):
+
+        x = [1, 2, 3]
+        ymin = [10, 100, 1000]
+        ymax = [20, 200, 2000]
+        m = MockMark()
+        Plot(x=x, ymin=ymin, ymax=ymax).add(m).scale(y="log").plot()
+        assert_vector_equal(m.passed_data[0]["ymax"], pd.Series(ymax, dtype=float))
+
+    def test_derived_range_with_axis_scaling(self):
+
+        class AddOne(Stat):
+            def __call__(self, df, *args):
+                return df.assign(ymax=df["y"] + 1)
+
+        x = y = [1, 10, 100]
+
+        m = MockMark()
+        Plot(x, y).add(m, AddOne()).scale(y="log").plot()
+        assert_vector_equal(m.passed_data[0]["ymax"], pd.Series([10., 100., 1000.]))
+
     def test_facet_categories(self):
 
         m = MockMark()


### PR DESCRIPTION
- Refactors `_transform_coords` and `_setup_scales` into one method.
- Properly handles scale config for coordinate variables that are computed during the stat
- Properly handles scale config when only coordinate ranges are defined

Fixes #2908, fixes #2885