### PR TITLE
Workaround for matplotlib rc_context issue

### DIFF
--- a/doc/whatsnew/v0.12.0.rst
+++ b/doc/whatsnew/v0.12.0.rst
@@ -92,6 +92,8 @@ Other updates
 
 - |Fix| Subplot titles will no longer be reset when calling :meth:`FacetGrid.map` or :meth:`FacetGrid.map_dataframe` (:pr:`2705`).
 
+- |Fix| Added a workaround for a matplotlib issue that caused figure-level functions to freeze when `plt.show` was called (:pr:`2925`).
+
 - |Fix| Improved robustness to numerical errors in :func:`kdeplot` (:pr:`2862`).
 
 - |Defaults| The `patch.facecolor` rc param is no longer set by :func:`set_palette` (or :func:`set_theme`). This should have no general effect, because the matplotlib default is now `"C0"` (:pr:`2906`).

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -11,7 +11,9 @@ import matplotlib.pyplot as plt
 
 from ._oldcore import VectorPlotter, variable_type, categorical_order
 from . import utils
-from .utils import _check_argument, adjust_legend_subtitles, _draw_figure
+from .utils import (
+    adjust_legend_subtitles, _check_argument, _draw_figure, _disable_autolayout
+)
 from .palettes import color_palette, blend_palette
 from ._docstrings import (
     DocstringComponents,
@@ -389,8 +391,7 @@ class FacetGrid(Grid):
 
         # --- Initialize the subplot grid
 
-        # Disable autolayout so legend_out works properly
-        with mpl.rc_context({"figure.autolayout": False}):
+        with _disable_autolayout():
             fig = plt.figure(figsize=figsize)
 
         if col_wrap is None:
@@ -1215,8 +1216,7 @@ class PairGrid(Grid):
         # Create the figure and the array of subplots
         figsize = len(x_vars) * height * aspect, len(y_vars) * height
 
-        # Disable autolayout so legend_out works
-        with mpl.rc_context({"figure.autolayout": False}):
+        with _disable_autolayout():
             fig = plt.figure(figsize=figsize)
 
         axes = fig.subplots(len(y_vars), len(x_vars),

--- a/seaborn/utils.py
+++ b/seaborn/utils.py
@@ -4,6 +4,7 @@ import re
 import inspect
 import warnings
 import colorsys
+from contextlib import contextmanager
 from urllib.request import urlopen, urlretrieve
 
 import numpy as np
@@ -782,7 +783,7 @@ def _assign_default_kwargs(kws, call_func, source_func):
     # This exists so that axes-level functions and figure-level functions can
     # both call a Plotter method while having the default kwargs be defined in
     # the signature of the axes-level function.
-    # An alternative would be to  have a decorator on the method that sets its
+    # An alternative would be to have a decorator on the method that sets its
     # defaults based on those defined in the axes-level function.
     # Then the figure-level function would not need to worry about defaults.
     # I am not sure which is better.
@@ -797,7 +798,12 @@ def _assign_default_kwargs(kws, call_func, source_func):
 
 
 def adjust_legend_subtitles(legend):
-    """Make invisible-handle "subtitles" entries look more like titles."""
+    """
+    Make invisible-handle "subtitles" entries look more like titles.
+
+    Note: This function is not part of the public API and may be changed or removed.
+
+    """
     # Legend title not in rcParams until 3.0
     font_size = plt.rcParams.get("legend.title_fontsize", None)
     hpackers = legend.findobj(mpl.offsetbox.VPacker)[0].get_children()
@@ -834,3 +840,16 @@ def _deprecate_ci(errorbar, ci):
         warnings.warn(msg, FutureWarning, stacklevel=3)
 
     return errorbar
+
+
+@contextmanager
+def _disable_autolayout():
+    """Context manager for preventing rc-controlled auto-layout behavior."""
+    # This is a workaround for an issue in matplotlib, for details see
+    # https://github.com/mwaskom/seaborn/issues/2914
+    orig_val = mpl.rcParams["figure.autolayout"]
+    try:
+        mpl.rcParams["figure.autolayout"] = False
+        yield
+    finally:
+        mpl.rcParams["figure.autolayout"] = orig_val

--- a/seaborn/utils.py
+++ b/seaborn/utils.py
@@ -847,6 +847,12 @@ def _disable_autolayout():
     """Context manager for preventing rc-controlled auto-layout behavior."""
     # This is a workaround for an issue in matplotlib, for details see
     # https://github.com/mwaskom/seaborn/issues/2914
+    # The only affect of this rcParam is to set the default value for
+    # layout= in plt.figure, so we could just do that instead.
+    # But then we would need to own the complexity of the transition
+    # from tight_layout=True -> layout="tight". This seems easier,
+    # but can be removed when (if) that is simpler on the matplotlib side,
+    # or if the layout algorithms are improved to handle figure legends.
     orig_val = mpl.rcParams["figure.autolayout"]
     try:
         mpl.rcParams["figure.autolayout"] = False


### PR DESCRIPTION
It's not necessary to use `rc_context` because we know exactly what parameter we want to change (although it does require implementing a custom context manager).

The only effect of this rcparam is to toggle the layout parameter of `plt.figure()` (actually `mpl.figure.Figure`), so really we could just pass a parameter there. But matplotlib is in the middle of a dance with the `tight_layout`/`layout` parameters, so handling the various forwards/backwards compatibility issues seems too complicated for now.

Fixes #2914
More context at https://github.com/matplotlib/matplotlib/issues/23298