### PR TITLE
Add apply and pipe methods to Grid objects for fluent customization

### DIFF
--- a/doc/whatsnew/v0.12.0.rst
+++ b/doc/whatsnew/v0.12.0.rst
@@ -60,9 +60,11 @@ Other updates
 
 - |Feature| It is now possible to aggregate / sort a :func:`lineplot` along the y axis using `orient="y"` (:pr:`2854`).
 
-- |Feature| It is now possible to specify `estimator` as a string in :func:`barplot` and :func:`pointplot`, in addition to a callable (:pr:`2866`).
+- |Feature| Made it easier to customize :class:`FacetGrid` with a fluent (method-chained) style by adding :meth:`FacetGrid.apply` / :meth:`FacetGrid.pipe` and fixing :meth:`FacetGrid.tight_layout` / :meth:`FacetGrid.refline` so that they return `self` (:pr:`2926`).
 
 - |Enhancement| Added a `width` parameter to :func:`barplot` (:pr:`2860`).
+
+- |Enhancement| It is now possible to specify `estimator` as a string in :func:`barplot` and :func:`pointplot`, in addition to a callable (:pr:`2866`).
 
 - |Enhancement| Error bars in :func:`regplot` now inherit the alpha value of the points they correspond to (:pr:`2540`).
 

--- a/doc/whatsnew/v0.12.0.rst
+++ b/doc/whatsnew/v0.12.0.rst
@@ -60,7 +60,7 @@ Other updates
 
 - |Feature| It is now possible to aggregate / sort a :func:`lineplot` along the y axis using `orient="y"` (:pr:`2854`).
 
-- |Feature| Made it easier to customize :class:`FacetGrid` with a fluent (method-chained) style by adding :meth:`FacetGrid.apply` / :meth:`FacetGrid.pipe` and fixing :meth:`FacetGrid.tight_layout` / :meth:`FacetGrid.refline` so that they return `self` (:pr:`2926`).
+- |Feature| Made it easier to customize :class:`FacetGrid` / :class:`PairGrid` / :class:`JointGrid` with a fluent (method-chained) style by adding `apply`/ `pipe` methods. Additionally, fixed the `tight_layout` and `refline` methods so that they return `self` (:pr:`2926`).
 
 - |Enhancement| Added a `width` parameter to :func:`barplot` (:pr:`2860`).
 

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -52,7 +52,7 @@ class _BaseGrid:
 
     def apply(self, func, *args, **kwargs):
         """
-        Customize the grid with a user-supplied function and return self.
+        Pass the grid to a user-supplied function and return self.
 
         The `func` must accept an object of this type for its first
         positional argument. Additional arguments are passed through.
@@ -67,7 +67,7 @@ class _BaseGrid:
 
     def pipe(self, func, *args, **kwargs):
         """
-        Customize the grid with a user-supplied function and return its value.
+        Pass the grid to a user-supplied function and return its value.
 
         The `func` must accept an object of this type for its first
         positional argument. Additional arguments are passed through.

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -50,6 +50,35 @@ class _BaseGrid:
         """Access the :class:`matplotlib.figure.Figure` object underlying the grid."""
         return self._figure
 
+    def apply(self, func, *args, **kwargs):
+        """
+        Customize the grid with a user-supplied function and return self.
+
+        The `func` must accept an object of this type for its first
+        positional argument. Additional arguments are passed through.
+        The return value of `func` is ignored; this method returns self.
+        See the `pipe` method if you want the return value.
+
+        Added in v0.12.0.
+
+        """
+        func(self, *args, **kwargs)
+        return self
+
+    def pipe(self, func, *args, **kwargs):
+        """
+        Customize the grid with a user-supplied function and return its value.
+
+        The `func` must accept an object of this type for its first
+        positional argument. Additional arguments are passed through.
+        The return value of `func` becomes the return value of this method.
+        See the `apply` method if you want to return self instead.
+
+        Added in v0.12.0.
+
+        """
+        return func(self, *args, **kwargs)
+
     def savefig(self, *args, **kwargs):
         """
         Save an image of the plot.
@@ -774,35 +803,6 @@ class FacetGrid(Grid):
         self._finalize_grid(axis_labels)
 
         return self
-
-    def apply(self, func, *args, **kwargs):
-        """
-        Customize the grid with a user-supplied function and return self.
-
-        The `func` must accept a :class:`FacetGrid` object for its first
-        positional argument. Additional arguments are passed through.
-        The return value of `func` is ignored; this method returns self.
-        See :meth:`FacetGrid.pipe` if you want the return value.
-
-        Added in v0.12.0.
-
-        """
-        func(self, *args, **kwargs)
-        return self
-
-    def pipe(self, func, *args, **kwargs):
-        """
-        Customize the grid with a user-supplied function and return its value.
-
-        The `func` must accept a :class:`FacetGrid` object for its first
-        positional argument. Additional arguments are passed through.
-        The return value of `func` becomes the return value of this method.
-        See :meth:`FacetGrid.apply` if you want to return self instead.
-
-        Added in v0.12.0.
-
-        """
-        return func(self, *args, **kwargs)
 
     def _facet_color(self, hue_index, kw_color):
 

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -775,6 +775,35 @@ class FacetGrid(Grid):
 
         return self
 
+    def apply(self, func, *args, **kwargs):
+        """
+        Customize the grid with a user-supplied function and return self.
+
+        The `func` must accept a :class:`FacetGrid` object for its first
+        positional argument. Additional arguments are passed through.
+        The return value of `func` is ignored; this method returns self.
+        See :meth:`FacetGrid.pipe` if you want the return value.
+
+        Added in v0.12.0.
+
+        """
+        func(self, *args, **kwargs)
+        return self
+
+    def pipe(self, func, *args, **kwargs):
+        """
+        Customize the grid with a user-supplied function and return its value.
+
+        The `func` must accept a :class:`FacetGrid` object for its first
+        positional argument. Additional arguments are passed through.
+        The return value of `func` becomes the return value of this method.
+        See :meth:`FacetGrid.apply` if you want to return self instead.
+
+        Added in v0.12.0.
+
+        """
+        return func(self, *args, **kwargs)
+
     def _facet_color(self, hue_index, kw_color):
 
         color = self._colors[hue_index]

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -84,6 +84,7 @@ class Grid(_BaseGrid):
         if self._tight_layout_pad is not None:
             kwargs.setdefault("pad", self._tight_layout_pad)
         self._figure.tight_layout(*args, **kwargs)
+        return self
 
     def add_legend(self, legend_data=None, title=None, label_order=None,
                    adjust_subtitles=False, **kwargs):
@@ -1005,6 +1006,8 @@ class FacetGrid(Grid):
 
         if y is not None:
             self.map(plt.axhline, y=y, **line_kws)
+
+        return self
 
     # ------ Properties that are part of the public API and documented by Sphinx
 

--- a/tests/test_axisgrid.py
+++ b/tests/test_axisgrid.py
@@ -673,6 +673,29 @@ class TestFacetGrid:
         assert g.axes[0, 0].lines[-1].get_color() == color
         assert g.axes[0, 0].lines[-1].get_linestyle() == linestyle
 
+    def test_apply(self, long_df):
+
+        def f(grid, color):
+            grid.figure.set_facecolor(color)
+
+        color = (.1, .6, .3, .9)
+        g = ag.FacetGrid(long_df)
+        res = g.apply(f, color)
+        assert res is g
+        assert g.figure.get_facecolor() == color
+
+    def test_pipe(self, long_df):
+
+        def f(grid, color):
+            grid.figure.set_facecolor(color)
+            return color
+
+        color = (.1, .6, .3, .9)
+        g = ag.FacetGrid(long_df)
+        res = g.pipe(f, color)
+        assert res == color
+        assert g.figure.get_facecolor() == color
+
 
 class TestPairGrid:
 


### PR DESCRIPTION
These two methods accept an function that operates on a `Grid` object to do additional customization of the plot. The methods are very similar, but `apply` returns the `Grid` it is attached to while `pipe` returns the value from the passed function. The objective is to make it easier to do arbitrary customization without catching the return value and switching to an imperative programming style.

Example:

```python
def slopeline(grid, slope, **kwargs):
    grid.ax.axline((0, 0), slope=slope, **kwargs)

(
    sns.relplot(tips, x="total_bill", y="tip")
    .apply(slopeline, slope=.2, color=".6")
    .set_axis_labels("Total bill", "Tip")
)
```
![image](https://user-images.githubusercontent.com/315810/182002524-c3b64c0c-5e74-414b-bf0d-9e840dda2feb.png)

Additionally, fixed two methods (`tight_layout` and `refline`) that were not returning self.