### PR TITLE
Add rudimentary themeing support

### DIFF
--- a/seaborn/_core/plot.py
+++ b/seaborn/_core/plot.py
@@ -679,13 +679,13 @@ class Plot:
 
         return new
 
-    def save(self, fname, **kwargs) -> Plot:
+    def save(self, loc, **kwargs) -> Plot:
         """
         Compile the plot and write it to a buffer or file on disk.
 
         Parameters
         ----------
-        fname : str, path, or buffer
+        loc : str, path, or buffer
             Location on disk to save the figure, or a buffer to write into.
         kwargs
             Other keyword arguments are passed through to
@@ -694,7 +694,7 @@ class Plot:
         """
         # TODO expose important keyword arguments in our signature?
         with theme_context(self._theme_with_defaults()):
-            self._plot().save(fname, **kwargs)
+            self._plot().save(loc, **kwargs)
         return self
 
     def show(self, **kwargs) -> None:

--- a/tests/_core/test_plot.py
+++ b/tests/_core/test_plot.py
@@ -1,12 +1,14 @@
+import io
+import xml
 import functools
 import itertools
 import warnings
-import imghdr
 
 import numpy as np
 import pandas as pd
 import matplotlib as mpl
 import matplotlib.pyplot as plt
+from PIL import Image
 
 import pytest
 from pandas.testing import assert_frame_equal, assert_series_equal
@@ -864,11 +866,17 @@ class TestPlotting:
         p = Plot().plot()
         assert mpl.colors.same_color(p._figure.axes[0].get_facecolor(), "#EAEAF2")
 
-    def test_theme(self):
+    def test_theme_params(self):
 
         color = "r"
         p = Plot().theme({"axes.facecolor": color}).plot()
         assert mpl.colors.same_color(p._figure.axes[0].get_facecolor(), color)
+
+    def test_theme_error(self):
+
+        p = Plot()
+        with pytest.raises(TypeError, match=r"theme\(\) takes 1 positional"):
+            p.theme("arg1", "arg2")
 
     def test_move(self, long_df):
 
@@ -960,21 +968,31 @@ class TestPlotting:
         if not gui_backend:
             assert msg
 
-    def test_png_representation(self):
+    def test_png_repr(self):
 
         p = Plot()
         data, metadata = p._repr_png_()
+        img = Image.open(io.BytesIO(data))
 
         assert not hasattr(p, "_figure")
         assert isinstance(data, bytes)
-        assert imghdr.what("", data) == "png"
+        assert img.format == "PNG"
         assert sorted(metadata) == ["height", "width"]
         # TODO test retina scaling
 
-    @pytest.mark.xfail(reason="Plot.save not yet implemented")
     def test_save(self):
 
-        Plot().save()
+        buf = io.BytesIO()
+
+        p = Plot().save(buf)
+        assert isinstance(p, Plot)
+        img = Image.open(buf)
+        assert img.format == "PNG"
+
+        buf = io.StringIO()
+        Plot().save(buf, format="svg")
+        tag = xml.etree.ElementTree.fromstring(buf.getvalue()).tag
+        assert tag == "{http://www.w3.org/2000/svg}svg"
 
     def test_on_axes(self):
 

--- a/tests/_core/test_plot.py
+++ b/tests/_core/test_plot.py
@@ -859,6 +859,17 @@ class TestPlotting:
             assert_vector_equal(data["x"], long_df.loc[rows, x_i])
             assert_vector_equal(data["y"], long_df.loc[rows, y])
 
+    def test_theme_default(self):
+
+        p = Plot().plot()
+        assert mpl.colors.same_color(p._figure.axes[0].get_facecolor(), "#EAEAF2")
+
+    def test_theme(self):
+
+        color = "r"
+        p = Plot().theme({"axes.facecolor": color}).plot()
+        assert mpl.colors.same_color(p._figure.axes[0].get_facecolor(), color)
+
     def test_move(self, long_df):
 
         orig_df = long_df.copy(deep=True)

--- a/tests/_marks/test_lines.py
+++ b/tests/_marks/test_lines.py
@@ -119,18 +119,17 @@ class TestPath:
         x = y = [1, 2]
         rc = {"lines.solid_capstyle": "projecting", "lines.dash_capstyle": "round"}
 
-        with mpl.rc_context(rc):
-            p = Plot(x, y).add(Path()).plot()
-            line, = p._figure.axes[0].get_lines()
-            assert line.get_dash_capstyle() == "projecting"
+        p = Plot(x, y).add(Path()).theme(rc).plot()
+        line, = p._figure.axes[0].get_lines()
+        assert line.get_dash_capstyle() == "projecting"
 
-            p = Plot(x, y).add(Path(linestyle="--")).plot()
-            line, = p._figure.axes[0].get_lines()
-            assert line.get_dash_capstyle() == "round"
+        p = Plot(x, y).add(Path(linestyle="--")).theme(rc).plot()
+        line, = p._figure.axes[0].get_lines()
+        assert line.get_dash_capstyle() == "round"
 
-            p = Plot(x, y).add(Path({"solid_capstyle": "butt"})).plot()
-            line, = p._figure.axes[0].get_lines()
-            assert line.get_solid_capstyle() == "butt"
+        p = Plot(x, y).add(Path({"solid_capstyle": "butt"})).theme(rc).plot()
+        line, = p._figure.axes[0].get_lines()
+        assert line.get_solid_capstyle() == "butt"
 
 
 class TestLine:


### PR DESCRIPTION
This PR adds a `Plot.theme` method for controlling the appearance of data-independent plot elements, using matplotlib rc parameters.

**This is a provisional approach for the initial release and will be improved over time.**

Currently, `Plot.theme` accepts one positional-only argument, which should be a dictionary of rc parameters. To use "seaborn themes", you can call the relevant functions in the `seaborn` namespace (`sns`):

```python
(
    so.Plot(diamonds, "clarity")
    .add(so.Bar(), so.Hist())
    .theme({**sns.axes_style("whitegrid"), "patch.linewidth": 3})
)
```
<img width="417" alt="image" src="https://user-images.githubusercontent.com/315810/182052302-969456b2-4af4-4bd3-ba27-32935109bc79.png">

This is a little clunky; I do expect that it will become possible to use "named' themes more directly, but I am not sure what that interface should look like yet.

This also makes the default theme *independent of other matplotlib rc manipulations*, including ones performed by `seaborn.set_*` functions. The default theme does match what you'd get when you call `sns.set_theme()` with no arguments. There was an attempt to distinguish between "stylistic" rcparams and "logical" params and continue to let matplotlib respect the latter, but the exact set may change in the future.

Currently there is no way to change the default for all plots. I expect that will be added later, I am thinking something along the lines of

```python
so.Plot.default.theme = {...}
```

rather than functions that magically change global state, as currently works with matplotlib.

Why is this feature in a partially-finished state? There are some tricky API decisions here and  I am not ready to commit to more complex implementation, do not want to block the initial release, and do want to provide some capacity for customization.