### PR TITLE
Document the legend argument of categorical scatterplots

### DIFF
--- a/doc/_docstrings/stripplot.ipynb
+++ b/doc/_docstrings/stripplot.ipynb
@@ -76,7 +76,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.stripplot(data=tips, x=\"total_bill\", y=\"day\", hue=\"day\")"
+    "sns.stripplot(data=tips, x=\"total_bill\", y=\"day\", hue=\"day\", legend=False)"
    ]
   },
   {

--- a/doc/_docstrings/swarmplot.ipynb
+++ b/doc/_docstrings/swarmplot.ipynb
@@ -76,7 +76,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.swarmplot(data=tips, x=\"total_bill\", y=\"day\", hue=\"day\")"
+    "sns.swarmplot(data=tips, x=\"total_bill\", y=\"day\", hue=\"day\", legend=False)"
    ]
   },
   {

--- a/examples/jitter_stripplot.py
+++ b/examples/jitter_stripplot.py
@@ -19,7 +19,8 @@ sns.despine(bottom=True, left=True)
 
 # Show each observation with a scatterplot
 sns.stripplot(x="value", y="measurement", hue="species",
-              data=iris, dodge=True, alpha=.25, zorder=1)
+              data=iris, dodge=True, alpha=.25, zorder=1,
+              legend=False)
 
 # Show the conditional means, aligning each pointplot in the
 # center of the strips by adjusting the width allotted to each
@@ -30,7 +31,6 @@ sns.pointplot(x="value", y="measurement", hue="species",
               markers="d", scale=.75, ci=None)
 
 # Improve the legend
-handles, labels = ax.get_legend_handles_labels()
-ax.legend(handles[3:], labels[3:], title="species",
-          handletextpad=0, columnspacing=1,
-          loc="lower right", ncol=3, frameon=True)
+sns.move_legend(
+    ax, loc="lower right", ncol=3, frameon=True, columnspacing=1, handletextpad=0
+)

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -2134,8 +2134,12 @@ _categorical_docs = dict(
         and tick labels.\
     """),
     legend=dedent("""\
-    legend : str or bool, optional
-        If `False` or an empty string and `hue` is used, don't draw a legend.
+legend : "auto", "brief", "full", or False
+    How to draw the legend. If "brief", numeric `hue` and `size`
+    variables will be represented with a sample of evenly spaced values.
+    If "full", every group will get an entry in the legend. If "auto",
+    choose between brief or full representation based on number of levels.
+    If `False`, no legend data is added and no legend is drawn.
     """),
     ax_in=dedent("""\
     ax : matplotlib Axes, optional

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -3283,7 +3283,8 @@ catplot.__doc__ = dedent("""\
     {palette}
     {hue_norm}
     legend : str or bool, optional
-        If ``True`` and there is a ``hue`` variable, draw a legend on the plot.
+        Set to `False` to disable the legend. With `strip` or `swarm` plots,
+        this also accepts a string, as described in the axes-level docstrings.
     {legend_out}
     {share_xy}
     {margin_titles}

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -2133,6 +2133,10 @@ _categorical_docs = dict(
         Function for converting categorical data into strings. Affects both grouping
         and tick labels.\
     """),
+    legend=dedent("""\
+    legend : str or bool, optional
+        If `False` or an empty string and `hue` is used, don't draw a legend.
+    """),
     ax_in=dedent("""\
     ax : matplotlib Axes, optional
         Axes object to draw the plot onto, otherwise uses the current Axes.\
@@ -2542,6 +2546,7 @@ stripplot.__doc__ = dedent("""\
     {linewidth}
     {native_scale}
     {formatter}
+    {legend}
     {ax_in}
     kwargs : key, value mappings
         Other keyword arguments are passed through to
@@ -2663,6 +2668,7 @@ swarmplot.__doc__ = dedent("""\
     {linewidth}
     {native_scale}
     {formatter}
+    {legend}
     {ax_in}
     kwargs : key, value mappings
         Other keyword arguments are passed through to
@@ -3272,7 +3278,7 @@ catplot.__doc__ = dedent("""\
     {color}
     {palette}
     {hue_norm}
-    legend : bool, optional
+    legend : str or bool, optional
         If ``True`` and there is a ``hue`` variable, draw a legend on the plot.
     {legend_out}
     {share_xy}


### PR DESCRIPTION
The `legend` argument was added in #2828 but is not documented (it is mentioned in the release notes). This PR documents this argument, and uses it in the docstrings and one `stripplot` example.