### PR TITLE
Allow Plot.label to control title(s)

### DIFF
--- a/seaborn/_core/plot.py
+++ b/seaborn/_core/plot.py
@@ -858,15 +858,17 @@ class Plotter:
 
         return common_data, layers
 
-    def _resolve_label(self, p: Plot, var: str, auto_label: str | None) -> str | None:
+    def _resolve_label(self, p: Plot, var: str, auto_label: str | None) -> str:
 
-        label: str | None
+        label: str
         if var in p._labels:
             manual_label = p._labels[var]
             if callable(manual_label) and auto_label is not None:
                 label = manual_label(auto_label)
             else:
                 label = cast(str, manual_label)
+        elif auto_label is None:
+            label = ""
         else:
             label = auto_label
         return label
@@ -1456,7 +1458,7 @@ class Plotter:
 
         # First pass: Identify the values that will be shown for each variable
         schema: list[tuple[
-            tuple[str | None, str | int], list[str], tuple[list, list[str]]
+            tuple[str, str | int], list[str], tuple[list, list[str]]
         ]] = []
         schema = []
         for var in legend_vars:
@@ -1469,8 +1471,7 @@ class Plotter:
                         part_vars.append(var)
                         break
                 else:
-                    auto_title = data.names[var]
-                    title = self._resolve_label(p, var, auto_title)
+                    title = self._resolve_label(p, var, data.names[var])
                     entry = (title, data.ids[var]), [var], (values, labels)
                     schema.append(entry)
 
@@ -1490,7 +1491,7 @@ class Plotter:
         # Input list has an entry for each distinct variable in each layer
         # Output dict has an entry for each distinct variable
         merged_contents: dict[
-            tuple[str | None, str | int], tuple[list[Artist], list[str]],
+            tuple[str, str | int], tuple[list[Artist], list[str]],
         ] = {}
         for key, artists, labels in self._legend_contents:
             # Key is (name, id); we need the id to resolve variable uniqueness,
@@ -1514,7 +1515,7 @@ class Plotter:
                 self._figure,
                 handles,
                 labels,
-                title="" if name is None else name,
+                title=name,
                 loc="center left",
                 bbox_to_anchor=(.98, .55),
             )

--- a/seaborn/_core/plot.py
+++ b/seaborn/_core/plot.py
@@ -937,8 +937,7 @@ class Plotter:
             title_parts = []
             for dim in ["row", "col"]:
                 if sub[dim] is not None:
-                    name = common.names.get(dim)  # TODO None = val looks bad
-                    title_parts.append(f"{name} = {sub[dim]}")
+                    title_parts.append(f"{sub[dim]}")
 
             has_col = sub["col"] is not None
             has_row = sub["row"] is not None

--- a/seaborn/_core/plot.py
+++ b/seaborn/_core/plot.py
@@ -945,7 +945,7 @@ class Plotter:
                     val = self._resolve_label(p, "title", f"{sub[dim]}")
                     if dim in p._labels:
                         key = self._resolve_label(p, dim, common.names.get(dim))
-                        val = f"{key}: {val}"
+                        val = f"{key} {val}"
                     title_parts.append(val)
 
             has_col = sub["col"] is not None

--- a/seaborn/_core/plot.py
+++ b/seaborn/_core/plot.py
@@ -176,6 +176,7 @@ class Plot:
             raise TypeError(err)
 
         self._data = PlotData(data, variables)
+
         self._layers = []
 
         self._scales = {}
@@ -249,8 +250,9 @@ class Plot:
         new._layers.extend(self._layers)
 
         new._scales.update(self._scales)
-        new._labels.update(self._labels)
         new._limits.update(self._limits)
+        new._labels.update(self._labels)
+        new._theme.update(self._theme)
 
         new._facet_spec.update(self._facet_spec)
         new._pair_spec.update(self._pair_spec)
@@ -616,8 +618,6 @@ class Plot:
         When using a single subplot, `title=` sets its title.
 
         """
-        # TODO should col=... add a "label" to the facet titles?
-        # How does this interact with title=...?
         new = self._clone()
         if title is not None:
             new._labels["title"] = title

--- a/seaborn/_core/plot.py
+++ b/seaborn/_core/plot.py
@@ -779,7 +779,7 @@ class Plotter:
         self._pyplot = pyplot
         self._theme = theme
         self._legend_contents: list[tuple[
-            tuple[str | None, str | int], list[Artist], list[str],
+            tuple[str, str | int], list[Artist], list[str],
         ]] = []
         self._scales: dict[str, Scale] = {}
 

--- a/tests/_core/test_plot.py
+++ b/tests/_core/test_plot.py
@@ -1791,7 +1791,7 @@ class TestLegend:
 
         labels = list(np.unique(s))  # assumes sorted order
 
-        assert e[0] == (None, id(s))
+        assert e[0] == ("", id(s))
         assert e[-1] == labels
 
         artists = e[1]

--- a/tests/_core/test_plot.py
+++ b/tests/_core/test_plot.py
@@ -1131,7 +1131,7 @@ class TestPlotting:
         p = Plot(data).facet("a", "x").label(col=str.capitalize, row="$x$").plot()
         axs = np.reshape(p._figure.axes, (2, 2))
         for (i, j), ax in np.ndenumerate(axs):
-            expected = f"A: {data['a'][j]} | $x$: {data['x'][i]}"
+            expected = f"A {data['a'][j]} | $x$ {data['x'][i]}"
             assert ax.get_title() == expected
 
     def test_title_single(self):

--- a/tests/_core/test_plot.py
+++ b/tests/_core/test_plot.py
@@ -1125,6 +1125,34 @@ class TestPlotting:
         p = Plot(long_df, x="x", y="y", color="a").add(m).label(color=func).plot()
         assert p._figure.legends[0].get_title().get_text() == label
 
+    def test_labels_facets(self):
+
+        data = {"a": ["b", "c"], "x": ["y", "z"]}
+        p = Plot(data).facet("a", "x").label(col=str.capitalize, row="$x$").plot()
+        axs = np.reshape(p._figure.axes, (2, 2))
+        for (i, j), ax in np.ndenumerate(axs):
+            expected = f"A: {data['a'][j]} | $x$: {data['x'][i]}"
+            assert ax.get_title() == expected
+
+    def test_title_single(self):
+
+        label = "A"
+        p = Plot().label(title=label).plot()
+        assert p._figure.axes[0].get_title() == label
+
+    def test_title_facet_function(self):
+
+        titles = ["a", "b"]
+        p = Plot().facet(titles).label(title=str.capitalize).plot()
+        for i, ax in enumerate(p._figure.axes):
+            assert ax.get_title() == titles[i].upper()
+
+        cols, rows = ["a", "b"], ["x", "y"]
+        p = Plot().facet(cols, rows).label(title=str.capitalize).plot()
+        for i, ax in enumerate(p._figure.axes):
+            expected = " | ".join([cols[i % 2].upper(), rows[i // 2].upper()])
+            assert ax.get_title() == expected
+
 
 class TestFacetInterface:
 
@@ -1188,7 +1216,7 @@ class TestFacetInterface:
             assert subplot["row"] == row_level
             assert subplot["col"] == col_level
             assert subplot["axes"].get_title() == (
-                f"{row_level} | {col_level}"
+                f"{col_level} | {row_level}"
             )
             assert_gridspec_shape(
                 subplot["axes"], len(levels["row"]), len(levels["col"])

--- a/tests/_core/test_plot.py
+++ b/tests/_core/test_plot.py
@@ -1152,7 +1152,7 @@ class TestFacetInterface:
         for subplot, level in zip(p._subplots, order):
             assert subplot[dim] == level
             assert subplot[other_dim] is None
-            assert subplot["ax"].get_title() == f"{key} = {level}"
+            assert subplot["ax"].get_title() == f"{level}"
             assert_gridspec_shape(subplot["ax"], **{f"n{dim}s": len(order)})
 
     def test_1d(self, long_df, dim):
@@ -1188,7 +1188,7 @@ class TestFacetInterface:
             assert subplot["row"] == row_level
             assert subplot["col"] == col_level
             assert subplot["axes"].get_title() == (
-                f"{variables['row']} = {row_level} | {variables['col']} = {col_level}"
+                f"{row_level} | {col_level}"
             )
             assert_gridspec_shape(
                 subplot["axes"], len(levels["row"]), len(levels["col"])
@@ -1375,7 +1375,7 @@ class TestPairInterface:
             ax = subplot["ax"]
             assert ax.get_xlabel() == x
             assert ax.get_ylabel() == y_i
-            assert ax.get_title() == f"{col} = {col_i}"
+            assert ax.get_title() == f"{col_i}"
             assert_gridspec_shape(ax, len(y), len(facet_levels))
 
     @pytest.mark.parametrize("variables", [("rows", "y"), ("columns", "x")])


### PR DESCRIPTION
Following on #2919 to support titles. It expands the API in a few ways:

1. The `title=` parameter allows setting directly a title for a single-axes plot

```python
so.Plot().label(title="Here is a plot")
```
![image](https://user-images.githubusercontent.com/315810/182381709-084f46b1-a1dc-406e-bd54-96fb1f5e5322.png)

2. The `title=` parameter also can be passed a function that operates on the auto-titles in a faceting context

```python
so.Plot().facet(["a", "b"]).label(title=str.capitalize)
```
![image](https://user-images.githubusercontent.com/315810/182381900-fdfb85b6-8581-430f-8468-b3c10f529b1a.png)

3. The `col=` or `row=` parameters accept a string that adds a prefix to facet titles:

```python
so.Plot().facet(["a", "b"], ["x", "y"]).label(col="Column", row="Row")
```
![image](https://user-images.githubusercontent.com/315810/182382667-b51af850-8344-4e69-badd-c2f709379857.png)

Note two relevant changes from the way titles work in `FacetGrid`:

- A label for the variable name is not added by default
- The order of the titles is `{col} | {row}`, corresponding to the change in the order of positional arguments (column faceting is more useful than row faceting so it should be prioritized)

I would like to add, and probably default to "margin titles" for the row variable, but that isn't implemented yet.

The combination of the faceting variables is not currently customizable with a template akin to what `FacetGrid.set_titles` accepts, but you can customize a single dimension:

```python
so.Plot().facet([1, 2]).label(title="{}st column".format)
```
![image](https://user-images.githubusercontent.com/315810/182383428-d25f35f0-3b75-49b1-ad94-6e79c24a958c.png)

I see some potential for `title` vs `col`/`row` to be a little confusing so may revisit this during the experimental phase.

"Suptitles" and captions are likely in scope for this method too, but I don't want to commit to them yet because the interaction with matplotlib autolayouts is trickier.