### PR TITLE
Adding Grid.tick_params() method.

### DIFF
--- a/doc/whatsnew/v0.12.0.rst
+++ b/doc/whatsnew/v0.12.0.rst
@@ -62,6 +62,8 @@ Other updates
 
 - |Feature| Made it easier to customize :class:`FacetGrid` / :class:`PairGrid` / :class:`JointGrid` with a fluent (method-chained) style by adding `apply`/ `pipe` methods. Additionally, fixed the `tight_layout` and `refline` methods so that they return `self` (:pr:`2926`).
 
+- |Feature| Added :meth:`FacetGrid.tick_params` and :meth:`PairGrid.tick_params` to customize the appearance of the ticks, tick labels, and gridlines of all subplots at once (:pr:`2944`).
+
 - |Enhancement| Added a `width` parameter to :func:`barplot` (:pr:`2860`).
 
 - |Enhancement| It is now possible to specify `estimator` as a string in :func:`barplot` and :func:`pointplot`, in addition to a callable (:pr:`2866`).

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -278,6 +278,24 @@ class Grid(_BaseGrid):
         except AttributeError:
             return None
 
+    def tick_params(self, **kwargs):
+        """Modify the ticks, tick labels, and gridlines.
+
+        Parameters
+        ----------
+        **kwargs
+            Keyword arguments to pass to :meth:`matplotlib.axes.Axes.tick_params`.
+
+        Returns
+        -------
+        self : Grid instance
+            Returns self for easy chaining.
+
+        """
+        for ax in self.figure.axes:
+            ax.tick_params(**kwargs)
+        return self
+
 
 _facet_docs = dict(
 

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -278,13 +278,16 @@ class Grid(_BaseGrid):
         except AttributeError:
             return None
 
-    def tick_params(self, **kwargs):
+    def tick_params(self, axis='both', **kwargs):
         """Modify the ticks, tick labels, and gridlines.
 
         Parameters
         ----------
-        **kwargs
-            Keyword arguments to pass to :meth:`matplotlib.axes.Axes.tick_params`.
+        axis : {'x', 'y', 'both'}
+            The axis on which to apply the formatting.
+        kwargs : keyword arguments
+            Additional keyword arguments to pass to
+            :meth:`matplotlib.axes.Axes.tick_params`.
 
         Returns
         -------
@@ -293,7 +296,7 @@ class Grid(_BaseGrid):
 
         """
         for ax in self.figure.axes:
-            ax.tick_params(**kwargs)
+            ax.tick_params(axis=axis, **kwargs)
         return self
 
 

--- a/tests/test_axisgrid.py
+++ b/tests/test_axisgrid.py
@@ -699,15 +699,15 @@ class TestFacetGrid:
     def test_tick_params(self):
 
         g = ag.FacetGrid(self.df, row="a", col="b")
-        color = 'blue'
-        width = 2
-        g.tick_params(width=width, color=color)
+        color = "blue"
+        pad = 3
+        g.tick_params(pad=pad, color=color)
         for ax in g.axes.flat:
-            for axis in ['xaxis', 'yaxis']:
+            for axis in ["xaxis", "yaxis"]:
                 for tick in getattr(ax, axis).get_major_ticks():
                     assert mpl.colors.same_color(tick.tick1line.get_color(), color)
                     assert mpl.colors.same_color(tick.tick2line.get_color(), color)
-                    assert tick._width == width
+                    assert tick.get_pad() == pad
 
 
 class TestPairGrid:
@@ -1447,15 +1447,15 @@ class TestPairGrid:
     def test_tick_params(self):
 
         g = ag.PairGrid(self.df)
-        color = 'red'
-        width = 3
-        g.tick_params(width=width, color=color)
+        color = "red"
+        pad = 3
+        g.tick_params(pad=pad, color=color)
         for ax in g.axes.flat:
-            for axis in ['xaxis', 'yaxis']:
+            for axis in ["xaxis", "yaxis"]:
                 for tick in getattr(ax, axis).get_major_ticks():
                     assert mpl.colors.same_color(tick.tick1line.get_color(), color)
                     assert mpl.colors.same_color(tick.tick2line.get_color(), color)
-                    assert tick._width == width
+                    assert tick.get_pad() == pad
 
 
 class TestJointGrid:

--- a/tests/test_axisgrid.py
+++ b/tests/test_axisgrid.py
@@ -696,6 +696,19 @@ class TestFacetGrid:
         assert res == color
         assert g.figure.get_facecolor() == color
 
+    def test_tick_params(self):
+
+        g = ag.FacetGrid(self.df, row="a", col="b")
+        color = 'blue'
+        width = 2
+        g.tick_params(width=width, color=color)
+        for ax in g.axes.ravel():
+            for axis in ['xaxis', 'yaxis']:
+                for tick in getattr(ax, axis).get_major_ticks():
+                    assert tick.tick1line.get_color() == color
+                    assert tick.tick2line.get_color() == color
+                    assert tick._width == width
+
 
 class TestPairGrid:
 
@@ -1430,6 +1443,19 @@ class TestPairGrid:
 
         g2 = ag.pairplot(self.df)
         assert g2.legend is None
+
+    def test_tick_params(self):
+
+        g = ag.PairGrid(self.df)
+        color = 'red'
+        width = 3
+        g.tick_params(width=width, color=color)
+        for ax in g.axes.ravel():
+            for axis in ['xaxis', 'yaxis']:
+                for tick in getattr(ax, axis).get_major_ticks():
+                    assert tick.tick1line.get_color() == color
+                    assert tick.tick2line.get_color() == color
+                    assert tick._width == width
 
 
 class TestJointGrid:

--- a/tests/test_axisgrid.py
+++ b/tests/test_axisgrid.py
@@ -653,14 +653,14 @@ class TestFacetGrid:
 
         g = ag.FacetGrid(self.df, row="a", col="b")
         g.refline()
-        for ax in g.axes.ravel():
+        for ax in g.axes.flat:
             assert not ax.lines
 
         refx = refy = 0.5
         hline = np.array([[0, refy], [1, refy]])
         vline = np.array([[refx, 0], [refx, 1]])
         g.refline(x=refx, y=refy)
-        for ax in g.axes.ravel():
+        for ax in g.axes.flat:
             assert ax.lines[0].get_color() == '.5'
             assert ax.lines[0].get_linestyle() == '--'
             assert len(ax.lines) == 2
@@ -702,11 +702,11 @@ class TestFacetGrid:
         color = 'blue'
         width = 2
         g.tick_params(width=width, color=color)
-        for ax in g.axes.ravel():
+        for ax in g.axes.flat:
             for axis in ['xaxis', 'yaxis']:
                 for tick in getattr(ax, axis).get_major_ticks():
-                    assert tick.tick1line.get_color() == color
-                    assert tick.tick2line.get_color() == color
+                    assert mpl.colors.same_color(tick.tick1line.get_color(), color)
+                    assert mpl.colors.same_color(tick.tick2line.get_color(), color)
                     assert tick._width == width
 
 
@@ -1450,11 +1450,11 @@ class TestPairGrid:
         color = 'red'
         width = 3
         g.tick_params(width=width, color=color)
-        for ax in g.axes.ravel():
+        for ax in g.axes.flat:
             for axis in ['xaxis', 'yaxis']:
                 for tick in getattr(ax, axis).get_major_ticks():
-                    assert tick.tick1line.get_color() == color
-                    assert tick.tick2line.get_color() == color
+                    assert mpl.colors.same_color(tick.tick1line.get_color(), color)
+                    assert mpl.colors.same_color(tick.tick2line.get_color(), color)
                     assert tick._width == width
 
 


### PR DESCRIPTION
Closes https://github.com/mwaskom/seaborn/issues/2491

`FacetGrid` and `PairGrid` now have a `tick_params()` method, which will iterate over each `Axes` in the grid and call its `tick_params()` method. Some examples:

```python
import seaborn as sns

tips = sns.load_dataset('tips')

g = sns.FacetGrid(tips, col='time', row='sex')
g.map(sns.scatterplot, 'total_bill', 'tip')
g.tick_params(direction='in', length=6, width=2) # on both
g.tick_params(colors='blue', axis='x')
g.tick_params(colors='green', axis='y')
```
<img width="434" alt="Screen Shot 2022-08-07 at 10 51 44 AM" src="https://user-images.githubusercontent.com/24376333/183296876-efc260af-6cb7-4f0e-992a-09d58f951779.png">


```python
import seaborn as sns

penguins = sns.load_dataset('penguins')

g = sns.PairGrid(penguins, diag_sharey=False, corner=True)
g.map_lower(sns.scatterplot)
g.map_diag(sns.kdeplot)
g.tick_params(direction='in', length=6, width=2, color='blue')
```
<img width="673" alt="Screen Shot 2022-08-06 at 8 47 55 PM" src="https://user-images.githubusercontent.com/24376333/183270428-560914a3-08bf-4e82-b245-5b5dc48d26f6.png">
