### PR TITLE
Renaming: Ribbon -> Band, Interval -> Range

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -31,11 +31,11 @@ Mark objects
     Bars
     Dot
     Dots
-    Interval
-    Path
-    Paths
     Line
     Lines
+    Path
+    Paths
+    Range
 
 Stat objects
 ~~~~~~~~~~~~

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -26,6 +26,7 @@ Mark objects
     :nosignatures:
 
     Area
+    Band
     Bar
     Bars
     Dot
@@ -35,7 +36,6 @@ Mark objects
     Paths
     Line
     Lines
-    Ribbon
 
 Stat objects
 ~~~~~~~~~~~~

--- a/doc/nextgen/api.rst
+++ b/doc/nextgen/api.rst
@@ -35,13 +35,13 @@ Marks
     :nosignatures:
 
     Area
+    Band
     Bar
     Dot
     Line
     Lines
     Path
     Paths
-    Ribbon
     Scatter
 
 Stats

--- a/doc/nextgen/api.rst
+++ b/doc/nextgen/api.rst
@@ -37,12 +37,14 @@ Marks
     Area
     Band
     Bar
+    Bars
     Dot
+    Dots
     Line
     Lines
     Path
     Paths
-    Scatter
+    Range
 
 Stats
 -----

--- a/doc/nextgen/demo.ipynb
+++ b/doc/nextgen/demo.ipynb
@@ -363,7 +363,7 @@
     "    .describe()\n",
     "    .pipe(so.Plot, x=\"timepoint\")\n",
     "    .add(so.Line(), y=\"mean\")\n",
-    "    .add(so.Ribbon(alpha=.2), ymin=\"min\", ymax=\"max\")\n",
+    "    .add(so.Band(alpha=.2), ymin=\"min\", ymax=\"max\")\n",
     ")"
    ]
   },

--- a/seaborn/_marks/area.py
+++ b/seaborn/_marks/area.py
@@ -126,7 +126,7 @@ class Area(AreaBase, Mark):
 
 
 @dataclass
-class Ribbon(AreaBase, Mark):
+class Band(AreaBase, Mark):
     """
     An interval mark that fills between minimum and maximum values.
     """

--- a/seaborn/_marks/line.py
+++ b/seaborn/_marks/line.py
@@ -201,7 +201,7 @@ class Lines(Paths):
 
 
 @dataclass
-class Interval(Paths):
+class Range(Paths):
     """
     An oriented line mark drawn between min/max values.
     """

--- a/seaborn/objects.py
+++ b/seaborn/objects.py
@@ -31,7 +31,7 @@ from seaborn._core.plot import Plot  # noqa: F401
 from seaborn._marks.base import Mark  # noqa: F401
 from seaborn._marks.area import Area, Band  # noqa: F401
 from seaborn._marks.bar import Bar, Bars  # noqa: F401
-from seaborn._marks.line import Line, Lines, Path, Paths, Interval  # noqa: F401
+from seaborn._marks.line import Line, Lines, Path, Paths, Range  # noqa: F401
 from seaborn._marks.dot import Dot, Dots  # noqa: F401
 
 from seaborn._stats.base import Stat  # noqa: F401

--- a/seaborn/objects.py
+++ b/seaborn/objects.py
@@ -29,7 +29,7 @@ ways that a plot can be enhanced and customized.
 from seaborn._core.plot import Plot  # noqa: F401
 
 from seaborn._marks.base import Mark  # noqa: F401
-from seaborn._marks.area import Area, Ribbon  # noqa: F401
+from seaborn._marks.area import Area, Band  # noqa: F401
 from seaborn._marks.bar import Bar, Bars  # noqa: F401
 from seaborn._marks.line import Line, Lines, Path, Paths, Interval  # noqa: F401
 from seaborn._marks.dot import Dot, Dots  # noqa: F401

--- a/tests/_marks/test_area.py
+++ b/tests/_marks/test_area.py
@@ -5,7 +5,7 @@ from matplotlib.colors import to_rgba, to_rgba_array
 from numpy.testing import assert_array_equal
 
 from seaborn._core.plot import Plot
-from seaborn._marks.area import Area, Ribbon
+from seaborn._marks.area import Area, Band
 
 
 class TestAreaMarks:
@@ -94,10 +94,10 @@ class TestAreaMarks:
         poly = ax.patches[0]
         assert poly.get_facecolor() == to_rgba("C0", 0)
 
-    def test_ribbon(self):
+    def test_band(self):
 
         x, ymin, ymax = [1, 2, 4], [2, 1, 4], [3, 3, 5]
-        p = Plot(x=x, ymin=ymin, ymax=ymax).add(Ribbon()).plot()
+        p = Plot(x=x, ymin=ymin, ymax=ymax).add(Band()).plot()
         ax = p._figure.axes[0]
         verts = ax.patches[0].get_path().vertices.T
 

--- a/tests/_marks/test_line.py
+++ b/tests/_marks/test_line.py
@@ -6,7 +6,7 @@ from matplotlib.colors import same_color, to_rgba
 from numpy.testing import assert_array_equal
 
 from seaborn._core.plot import Plot
-from seaborn._marks.line import Line, Path, Lines, Paths, Interval
+from seaborn._marks.line import Line, Path, Lines, Paths, Range
 
 
 class TestPath:
@@ -244,7 +244,7 @@ class TestLines:
         assert_array_equal(verts[1], [3, 4])
 
 
-class TestInterval:
+class TestRange:
 
     def test_xy_data(self):
 
@@ -252,7 +252,7 @@ class TestInterval:
         ymin = [1, 4]
         ymax = [2, 3]
 
-        p = Plot(x=x, ymin=ymin, ymax=ymax).add(Interval()).plot()
+        p = Plot(x=x, ymin=ymin, ymax=ymax).add(Range()).plot()
         lines, = p._figure.axes[0].collections
 
         for i, path in enumerate(lines.get_paths()):
@@ -267,7 +267,7 @@ class TestInterval:
         ymax = [2, 3, 1, 4]
         group = ["a", "a", "b", "b"]
 
-        p = Plot(x=x, ymin=ymin, ymax=ymax, color=group).add(Interval()).plot()
+        p = Plot(x=x, ymin=ymin, ymax=ymax, color=group).add(Range()).plot()
         lines, = p._figure.axes[0].collections
 
         for i, path in enumerate(lines.get_paths()):
@@ -282,7 +282,7 @@ class TestInterval:
         ymin = [1, 4]
         ymax = [2, 3]
 
-        m = Interval(color="r", linewidth=4)
+        m = Range(color="r", linewidth=4)
         p = Plot(x=x, ymin=ymin, ymax=ymax).add(m).plot()
         lines, = p._figure.axes[0].collections
 


### PR DESCRIPTION
- `Band` is more consistent with `err_style="band"` in the existing `lineplot` and is shorter
- `Range` is more about brevity than consistency, but `Interval` could be useful as a stat in the future. I went back and forth on this one a lot, `Span` could also work but I think that will be held in reserve for a bar-type interval mark. FWIW `Range` is consistent with `geom_pointrange`/`geom_linerange`.