### PR TITLE
Fix: shifting margins caused by multiple rugplots

### DIFF
--- a/doc/whatsnew/v0.12.0.rst
+++ b/doc/whatsnew/v0.12.0.rst
@@ -100,6 +100,8 @@ Other updates
 
 - |Fix| Improved robustness to numerical errors in :func:`kdeplot` (:pr:`2862`).
 
+- |Fix| Fixed a bug where :func:`rugplot` was ignoring expand_margins=False (:pr:`2953`).
+
 - |Defaults| The `patch.facecolor` rc param is no longer set by :func:`set_palette` (or :func:`set_theme`). This should have no general effect, because the matplotlib default is now `"C0"` (:pr:`2906`).
 
 - |Deps| Made `scipy` an optional dependency and added `pip install seaborn[stats]` as a method for ensuring the availability of compatible `scipy` and `statsmodels` libraries at install time. This has a few minor implications for existing code, which are explained in the Github pull request (:pr:`2398`).

--- a/seaborn/utils.py
+++ b/seaborn/utils.py
@@ -100,7 +100,7 @@ def _default_color(method, hue, color, kws):
 
     elif method.__name__ == "plot":
 
-        scout, = method([], [], **kws)
+        scout, = method([], [], scalex=False, scaley=False, **kws)
         color = scout.get_color()
         scout.remove()
 

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -305,17 +305,15 @@ class TestRugPlot(SharedAxesLevelTests):
         assert x1 == x2
         assert y1 + height * 2 == pytest.approx(y2)
 
-    def test_multiple_rugs(self, long_df):
+    def test_multiple_rugs(self):
 
         values = np.linspace(start=0, stop=1, num=5)
-        ax = lineplot(x=values, y=values)
-        rugplot(x=values, ax=ax)
+        ax = rugplot(x=values)
         ylim = ax.get_ylim()
 
-        for j in range(4):
-            rugplot(x=values, ax=ax, expand_margins=False)
+        rugplot(x=values, ax=ax, expand_margins=False)
 
-        assert_array_equal(ylim, ax.get_ylim())
+        assert ylim == ax.get_ylim()
 
     def test_matplotlib_kwargs(self, flat_series):
 

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -31,6 +31,9 @@ from seaborn.distributions import (
     kdeplot,
     rugplot,
 )
+from seaborn.relational import (
+    lineplot,
+)
 from seaborn.external.version import Version
 from seaborn.axisgrid import FacetGrid
 from seaborn._testing import (
@@ -301,6 +304,18 @@ class TestRugPlot(SharedAxesLevelTests):
         x2, y2 = ax.margins()
         assert x1 == x2
         assert y1 + height * 2 == pytest.approx(y2)
+
+    def test_multiple_rugs(self, long_df):
+
+        values = np.linspace(start=0, stop=1, num=5)
+        ax = lineplot(x=values, y=values)
+        rugplot(x=values, ax=ax)
+        ylim = ax.get_ylim()
+
+        for j in range(4):
+            rugplot(x=values, ax=ax, expand_margins=False)
+
+        assert_array_equal(ylim, ax.get_ylim())
 
     def test_matplotlib_kwargs(self, flat_series):
 

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -31,9 +31,6 @@ from seaborn.distributions import (
     kdeplot,
     rugplot,
 )
-from seaborn.relational import (
-    lineplot,
-)
 from seaborn.external.version import Version
 from seaborn.axisgrid import FacetGrid
 from seaborn._testing import (


### PR DESCRIPTION
This fix prevents margins from increasing when multiple rugplots are
added to the same `ax`, even if `expand_margins` is `False`.

<img width="1102" alt="Screenshot 2022-08-12 at 22 11 42" src="https://user-images.githubusercontent.com/33420535/184435490-b3a349b9-c3c7-4a7b-ac34-35360cd2da86.png">

As a minimum reproducible example (which is similar to the added unit test):

```py
import seaborn as sns; sns.set()
import numpy as np
import matplotlib.pyplot as plt

values = np.linspace(start=0, stop=1, num=5)
ax = sns.lineplot(x=values, y=values)
sns.rugplot(x=values, ax=ax)

ylim = ax.get_ylim()

for _ in range(4):
    sns.rugplot(x=values, ax=ax, expand_margins=False)

if not all(a == b for a, b in zip(ylim, ax.get_ylim())):
    print(f'{ylim} != {ax.get_ylim()}')
plt.suptitle("Example showing that multiple rugplots cause issues")
plt.show()
```

Running the above code:

```sh
$ pip install seaborn numpy matplotlib; python3 test.py
(-0.1, 1.1) != (-0.61051, 1.14641)
```

This bug was caused by how seaborn detects the correct colors to use. In
`seaborn/utils.py`, in method `_default_color`, the following line used
to resolve to `ax.plot([], [], **kws)`:

```py
scout, = method([], [], **kws)
```
But matplotlib has the parameters `scalex` and `scaley` of `ax.plot` set
to `True` by default. Matplotlib would see that the rug was already on
the `ax` from the previous call to `sns.rugplot`, and so it would
rescale the x and y axes. This caused the content of the plot to take up
less and less space, with larger and larger margins as more rugplots
were added.

The fix sets `scalex` and `scaley` both to `False`, since this plot
method is a null-plot and is only used to check what colours should be
used:
```py
scout, = method([], [], scalex=False, scaley=False, **kws)
```

The above line is within an if-elif-else branch, but the other branches
do not suffer this bug and so no change is needed for them.

An additional unit test was also added to catch this bug:
`test_multiple_rugs`.