### PR TITLE
Rename Plot.configure -> Plot.layout, add Plot.share, and modify Plot.layout parameters

### DIFF
--- a/doc/nextgen/api.rst
+++ b/doc/nextgen/api.rst
@@ -18,13 +18,14 @@ Plot interface
 
     Plot
     Plot.add
-    Plot.scale
     Plot.facet
     Plot.pair
-    Plot.configure
+    Plot.layout
     Plot.on
     Plot.plot
     Plot.save
+    Plot.scale
+    Plot.share
     Plot.show
 
 Marks

--- a/doc/nextgen/demo.ipynb
+++ b/doc/nextgen/demo.ipynb
@@ -717,7 +717,7 @@
     "    .facet(col=\"day\")\n",
     "    .add(so.Dots(color=\".75\"), col=None)\n",
     "    .add(so.Dots(), color=\"day\")\n",
-    "    .configure(figsize=(7, 3))\n",
+    "    .layout(size=(7, 3))\n",
     ")"
    ]
   },
@@ -808,7 +808,7 @@
     "(\n",
     "    so.Plot(tips)\n",
     "    .pair(x=tips.columns, wrap=3)\n",
-    "    .configure(sharey=False)\n",
+    "    .share(y=False)\n",
     "    .add(so.Bar(), so.Hist())\n",
     ")"
    ]

--- a/doc/nextgen/index.ipynb
+++ b/doc/nextgen/index.ipynb
@@ -20,7 +20,6 @@
    "outputs": [],
    "source": [
     "import seaborn as sns\n",
-    "sns.set_theme()\n",
     "tips = sns.load_dataset(\"tips\")\n",
     "\n",
     "import seaborn.objects as so\n",
@@ -31,7 +30,7 @@
     "    )\n",
     "    .facet(\"time\")\n",
     "    .add(so.Dots())\n",
-    "    .configure(figsize=(7, 4))\n",
+    "    .layout(size=(7, 4))\n",
     ")"
    ]
   },

--- a/seaborn/_core/plot.py
+++ b/seaborn/_core/plot.py
@@ -631,7 +631,7 @@ class Plot:
         self,
         *,
         figsize: tuple[float, float] | None = None,  # TODO change to size
-        algo: str = "tight",  # TODO document
+        algo: str | None = "tight",  # TODO document
         sharex: bool | str | None = None,
         sharey: bool | str | None = None,
     ) -> Plot:
@@ -640,8 +640,10 @@ class Plot:
 
         Parameters
         ----------
-        figsize: (width, height)
+        figsize : (width, height)
             Size of the resulting figure, in inches.
+        algo : {{"tight", "constrained", None}}
+            Name of algorithm for automatically adjusting the layout to remove overlap.
         sharex, sharey : bool, "row", or "col"
             Whether axis limits should be shared across subplots. Boolean values apply
             across the entire grid, whereas `"row"` or `"col"` have a smaller scope.

--- a/seaborn/_core/plot.py
+++ b/seaborn/_core/plot.py
@@ -630,7 +630,7 @@ class Plot:
     def layout(
         self,
         *,
-        figsize: tuple[float, float] | None = None,  # TODO change to size
+        size: tuple[float, float] | None = None,
         algo: str | None = "tight",  # TODO document
         sharex: bool | str | None = None,
         sharey: bool | str | None = None,
@@ -640,8 +640,9 @@ class Plot:
 
         Parameters
         ----------
-        figsize : (width, height)
-            Size of the resulting figure, in inches.
+        size : (width, height)
+            Size of the resulting figure, in inches. Size is inclusive of legend when
+            using pyplot, but not otherwise.
         algo : {{"tight", "constrained", None}}
             Name of algorithm for automatically adjusting the layout to remove overlap.
         sharex, sharey : bool, "row", or "col"
@@ -657,7 +658,7 @@ class Plot:
 
         new = self._clone()
 
-        new._figure_spec["figsize"] = figsize
+        new._figure_spec["figsize"] = size
 
         if sharex is not None:
             new._subplot_spec["sharex"] = sharex

--- a/tests/_core/test_plot.py
+++ b/tests/_core/test_plot.py
@@ -1248,6 +1248,9 @@ class TestFacetInterface:
     @pytest.mark.parametrize("algo", ["tight", "constrained"])
     def test_layout_algo(self, algo):
 
+        if algo == "constrained" and Version(mpl.__version__) < Version("3.3.0"):
+            pytest.skip("constrained_layout requires matplotlib>=3.3")
+
         p = Plot().facet(["a", "b"]).limit(x=(.1, .9))
 
         p1 = p.layout(algo=algo).plot()

--- a/tests/_core/test_plot.py
+++ b/tests/_core/test_plot.py
@@ -503,7 +503,7 @@ class TestScaling:
         p = (
             Plot(x=["a", "b", "a", "c"])
             .facet(col=["x", "x", "y", "y"])
-            .configure(sharex=False)
+            .layout(sharex=False)
             .add(m)
             .plot()
         )
@@ -527,7 +527,7 @@ class TestScaling:
             Plot(df, x="x")
             .facet(row="row", col="col")
             .add(m)
-            .configure(sharex="row")
+            .layout(sharex="row")
             .plot()
         )
 
@@ -562,7 +562,7 @@ class TestScaling:
         data = [("a", "a"), ("b", "c")]
         df = pd.DataFrame(data, columns=["x1", "x2"]).assign(y=1)
         m = MockMark()
-        p = Plot(df, y="y").pair(x=["x1", "x2"]).add(m).configure(sharex=True).plot()
+        p = Plot(df, y="y").pair(x=["x1", "x2"]).add(m).layout(sharex=True).plot()
 
         for ax in p._figure.axes:
             assert ax.get_xticks() == [0, 1, 2]
@@ -1242,7 +1242,7 @@ class TestFacetInterface:
     def test_figsize(self):
 
         figsize = (4, 2)
-        p = Plot().configure(figsize=figsize).plot()
+        p = Plot().layout(figsize=figsize).plot()
         assert tuple(p._figure.get_size_inches()) == figsize
 
     def test_axis_sharing(self, long_df):
@@ -1257,13 +1257,13 @@ class TestFacetInterface:
             shareset = getattr(root, f"get_shared_{axis}_axes")()
             assert all(shareset.joined(root, ax) for ax in other)
 
-        p2 = p.configure(sharex=False, sharey=False).plot()
+        p2 = p.layout(sharex=False, sharey=False).plot()
         root, *other = p2._figure.axes
         for axis in "xy":
             shareset = getattr(root, f"get_shared_{axis}_axes")()
             assert not any(shareset.joined(root, ax) for ax in other)
 
-        p3 = p.configure(sharex="col", sharey="row").plot()
+        p3 = p.layout(sharex="col", sharey="row").plot()
         shape = (
             len(categorical_order(long_df[variables["row"]])),
             len(categorical_order(long_df[variables["col"]])),
@@ -1448,7 +1448,7 @@ class TestPairInterface:
             y_shareset = getattr(root, "get_shared_y_axes")()
             assert not any(y_shareset.joined(root, ax) for ax in other)
 
-        p2 = p.configure(sharex=False, sharey=False).plot()
+        p2 = p.layout(sharex=False, sharey=False).plot()
         root, *other = p2._figure.axes
         for axis in "xy":
             shareset = getattr(root, f"get_shared_{axis}_axes")()
@@ -1712,7 +1712,7 @@ class TestLabelVisibility:
         p = (
             Plot()
             .facet(col=["a", "b"], row=["x", "y"])
-            .configure(sharex=False, sharey=False)
+            .layout(sharex=False, sharey=False)
             .plot()
         )
         subplots = list(p._subplots)

--- a/tests/_core/test_plot.py
+++ b/tests/_core/test_plot.py
@@ -1239,11 +1239,11 @@ class TestFacetInterface:
         p = Plot(long_df).facet(**variables, order=order)
         self.check_facet_results_2d(p, long_df, variables, order)
 
-    def test_figsize(self):
+    def test_layout_size(self):
 
-        figsize = (4, 2)
-        p = Plot().layout(figsize=figsize).plot()
-        assert tuple(p._figure.get_size_inches()) == figsize
+        size = (4, 2)
+        p = Plot().layout(size=size).plot()
+        assert tuple(p._figure.get_size_inches()) == size
 
     def test_layout_algo(self):
 

--- a/tests/_core/test_plot.py
+++ b/tests/_core/test_plot.py
@@ -1245,6 +1245,24 @@ class TestFacetInterface:
         p = Plot().layout(figsize=figsize).plot()
         assert tuple(p._figure.get_size_inches()) == figsize
 
+    def test_layout_algo(self):
+
+        p = Plot().facet(["a", "b"]).limit(x=(.1, .9))
+
+        p1 = p.plot()
+        p2 = p.layout(algo=None).plot()
+
+        # Force a draw (we probably need a method for this)
+        p1.save(io.BytesIO())
+        p2.save(io.BytesIO())
+
+        bb11, bb12 = [ax.get_position() for ax in p1._figure.axes]
+        bb21, bb22 = [ax.get_position() for ax in p2._figure.axes]
+
+        sep1 = bb12.corners()[0, 0] - bb11.corners()[2, 0]
+        sep2 = bb22.corners()[0, 0] - bb21.corners()[2, 0]
+        assert sep1 < sep2
+
     def test_axis_sharing(self, long_df):
 
         variables = {"row": "a", "col": "c"}

--- a/tests/_core/test_plot.py
+++ b/tests/_core/test_plot.py
@@ -994,6 +994,12 @@ class TestPlotting:
         tag = xml.etree.ElementTree.fromstring(buf.getvalue()).tag
         assert tag == "{http://www.w3.org/2000/svg}svg"
 
+    def test_layout_size(self):
+
+        size = (4, 2)
+        p = Plot().layout(size=size).plot()
+        assert tuple(p._figure.get_size_inches()) == size
+
     def test_on_axes(self):
 
         ax = mpl.figure.Figure().subplots()
@@ -1239,17 +1245,12 @@ class TestFacetInterface:
         p = Plot(long_df).facet(**variables, order=order)
         self.check_facet_results_2d(p, long_df, variables, order)
 
-    def test_layout_size(self):
-
-        size = (4, 2)
-        p = Plot().layout(size=size).plot()
-        assert tuple(p._figure.get_size_inches()) == size
-
-    def test_layout_algo(self):
+    @pytest.mark.parametrize("algo", ["tight", "constrained"])
+    def test_layout_algo(self, algo):
 
         p = Plot().facet(["a", "b"]).limit(x=(.1, .9))
 
-        p1 = p.plot()
+        p1 = p.layout(algo=algo).plot()
         p2 = p.layout(algo=None).plot()
 
         # Force a draw (we probably need a method for this)

--- a/tests/_core/test_plot.py
+++ b/tests/_core/test_plot.py
@@ -503,7 +503,7 @@ class TestScaling:
         p = (
             Plot(x=["a", "b", "a", "c"])
             .facet(col=["x", "x", "y", "y"])
-            .layout(sharex=False)
+            .share(x=False)
             .add(m)
             .plot()
         )
@@ -527,7 +527,7 @@ class TestScaling:
             Plot(df, x="x")
             .facet(row="row", col="col")
             .add(m)
-            .layout(sharex="row")
+            .share(x="row")
             .plot()
         )
 
@@ -562,7 +562,7 @@ class TestScaling:
         data = [("a", "a"), ("b", "c")]
         df = pd.DataFrame(data, columns=["x1", "x2"]).assign(y=1)
         m = MockMark()
-        p = Plot(df, y="y").pair(x=["x1", "x2"]).add(m).layout(sharex=True).plot()
+        p = Plot(df, y="y").pair(x=["x1", "x2"]).add(m).share(x=True).plot()
 
         for ax in p._figure.axes:
             assert ax.get_xticks() == [0, 1, 2]
@@ -1275,13 +1275,13 @@ class TestFacetInterface:
             shareset = getattr(root, f"get_shared_{axis}_axes")()
             assert all(shareset.joined(root, ax) for ax in other)
 
-        p2 = p.layout(sharex=False, sharey=False).plot()
+        p2 = p.share(x=False, y=False).plot()
         root, *other = p2._figure.axes
         for axis in "xy":
             shareset = getattr(root, f"get_shared_{axis}_axes")()
             assert not any(shareset.joined(root, ax) for ax in other)
 
-        p3 = p.layout(sharex="col", sharey="row").plot()
+        p3 = p.share(x="col", y="row").plot()
         shape = (
             len(categorical_order(long_df[variables["row"]])),
             len(categorical_order(long_df[variables["col"]])),
@@ -1466,7 +1466,7 @@ class TestPairInterface:
             y_shareset = getattr(root, "get_shared_y_axes")()
             assert not any(y_shareset.joined(root, ax) for ax in other)
 
-        p2 = p.layout(sharex=False, sharey=False).plot()
+        p2 = p.share(x=False, y=False).plot()
         root, *other = p2._figure.axes
         for axis in "xy":
             shareset = getattr(root, f"get_shared_{axis}_axes")()
@@ -1730,7 +1730,7 @@ class TestLabelVisibility:
         p = (
             Plot()
             .facet(col=["a", "b"], row=["x", "y"])
-            .layout(sharex=False, sharey=False)
+            .share(x=False, y=False)
             .plot()
         )
         subplots = list(p._subplots)


### PR DESCRIPTION
A few important API changes here:

- `Plot.configure` has been renamed to `Plot.layout`. It's shorter and better focused on what this method is about.
- The `sharex`/`sharey` parameters have moved out of this method and into a new `Plot.share` method. I expect that this method will eventually generalize to other variables (i.e., allowing different color scales in subplots), but that's currently blocked on having a better story for legend configuration.
- The `figsize` parameter in `Plot.configure`/`Plot.layout` has been shortened to just `size`.
- An `algo` parameter has been added to `Plot.layout`, accepting `"tight"`, `"constrained"`, or `None`.

This PR has an additional tweak to fact that legends are currently not visible in an interactive pyplot window. When calling `Plot.show`, the legend will be right-aligned with the edge of the subplots, rather than left-aligned with it. This means that it will overlap the figure content, which is regrettable, but I don't know of a better non-hacky solution until matplotlib's layout algorithms understand figure legends.

When calling `Plot.save`,  it is currently necessary to manually specify `bbox_inches="tight"` if you have a legend.

I expect that some of these decisions are temporary. In particular:

- I hope that we have a better solution to controlling where the legend goes and whether it's visible by default in all relevant contexts.
- I would like there to be a better automatic sizing and perhaps more convenient (subplot-based) size parameters. That's something that could quite possibly change in backwards incompatible ways across future releases.
- I expect to add more parameters to `Plot.layout` for additional customization, but am not certain about the best API yet.