### PR TITLE
Fix: typos in nextgen docs

### DIFF
--- a/doc/nextgen/demo.ipynb
+++ b/doc/nextgen/demo.ipynb
@@ -25,7 +25,7 @@
    "source": [
     "## The basic interface\n",
     "\n",
-    "The new interface exists as a set of classes that can be acessed through a single namespace import:"
+    "The new interface exists as a set of classes that can be accessed through a single namespace import:"
    ]
   },
   {
@@ -498,7 +498,7 @@
     "\n",
     "### Semantic mapping: the Scale\n",
     "\n",
-    "The declarative interface allows users to represent dataset variables with visual properites such as position, color or size. A complete plot can be made without doing anything more defining the mappings: users need not be concerned with converting their data into units that matplotlib understands. But what if one wants to alter the mapping that seaborn chooses? This is accomplished through the concept of a `Scale`.\n",
+    "The declarative interface allows users to represent dataset variables with visual properties such as position, color or size. A complete plot can be made without doing anything more defining the mappings: users need not be concerned with converting their data into units that matplotlib understands. But what if one wants to alter the mapping that seaborn chooses? This is accomplished through the concept of a `Scale`.\n",
     "\n",
     "The notion of scaling will probably not be unfamiliar; as in matplotlib, seaborn allows one to apply a mathematical transformation, such as `log`, to the coordinate variables:"
    ]
@@ -680,7 +680,7 @@
    "id": "92c1a0fd-873f-476b-9e88-d6a2c4f49807",
    "metadata": {},
    "source": [
-    "Seaborn's faceting functionality (drawing subsets of the data on distinct subplots) is built into the `Plot` object and works interchangably with any `Mark`/`Stat`/`Move`/`Scale` spec:"
+    "Seaborn's faceting functionality (drawing subsets of the data on distinct subplots) is built into the `Plot` object and works interchangeably with any `Mark`/`Stat`/`Move`/`Scale` spec:"
    ]
   },
   {
@@ -836,7 +836,7 @@
    "id": "354b2395-4cad-40c0-a558-60368d5b435f",
    "metadata": {},
    "source": [
-    "It is possible (and in fact the deafult behavior) to be completely pyplot-free, and all the drawing is done by directly hooking into Jupyter's rich display system. Unlike in normal usage of the inline backend, writing code in a cell to define a plot is indendent from showing it:"
+    "It is possible (and in fact the default behavior) to be completely pyplot-free, and all the drawing is done by directly hooking into Jupyter's rich display system. Unlike in normal usage of the inline backend, writing code in a cell to define a plot is independent from showing it:"
    ]
   },
   {
@@ -956,7 +956,7 @@
     "\n",
     "## Matplotlib integration\n",
     "\n",
-    "It's always been a design aim in seaborn to allow complicated seaborn plots to coexist within the context of a larger matplotlib figure. This is acheived within the \"axes-level\" functions, which accept an `ax=` parameter. The `Plot` object *will* provide a similar functionality:"
+    "It's always been a design aim in seaborn to allow complicated seaborn plots to coexist within the context of a larger matplotlib figure. This is achieved within the \"axes-level\" functions, which accept an `ax=` parameter. The `Plot` object *will* provide a similar functionality:"
    ]
   },
   {


### PR DESCRIPTION
I wasn't sure about the API change at first, but having gone through the demonstration I'm so excited now. Anyway, here's some typos I found.