### PR TITLE
Address breakage from matplotlib 3.6.0rc1

### DIFF
--- a/seaborn/_compat.py
+++ b/seaborn/_compat.py
@@ -135,9 +135,9 @@ def get_colormap(name):
         return mpl.cm.get_cmap(name)
 
 
-def register_colormap(cmap, name):
+def register_colormap(name, cmap):
     """Handle changes to matplotlib colormap interface in 3.6."""
     try:
-        mpl.colormaps.register_cmap(cmap, name)
+        mpl.colormaps.register(cmap, name=name)
     except AttributeError:
-        mpl.cm.register_cmap(cmap, name)
+        mpl.cm.register_cmap(name, cmap)

--- a/seaborn/_compat.py
+++ b/seaborn/_compat.py
@@ -138,7 +138,8 @@ def get_colormap(name):
 def register_colormap(name, cmap):
     """Handle changes to matplotlib colormap interface in 3.6."""
     try:
-        mpl.colormaps.register(cmap, name=name)
+        if name not in mpl.colormaps:
+            mpl.colormaps.register(cmap, name=name)
     except AttributeError:
         mpl.cm.register_cmap(name, cmap)
 

--- a/seaborn/_compat.py
+++ b/seaborn/_compat.py
@@ -141,3 +141,14 @@ def register_colormap(name, cmap):
         mpl.colormaps.register(cmap, name=name)
     except AttributeError:
         mpl.cm.register_cmap(name, cmap)
+
+
+def set_layout_engine(fig, algo):
+
+    if hasattr(fig, "set_layout_engine"):
+        fig.set_layout_engine(algo)
+    else:
+        if algo == "tight":
+            fig.set_tight_layout(True)
+        elif algo == "constrained":
+            fig.set_constrained_layout(True)

--- a/seaborn/_compat.py
+++ b/seaborn/_compat.py
@@ -144,7 +144,7 @@ def register_colormap(name, cmap):
 
 
 def set_layout_engine(fig, algo):
-
+    """Handle changes to auto layout engine interface in 3.6"""
     if hasattr(fig, "set_layout_engine"):
         fig.set_layout_engine(algo)
     else:
@@ -152,3 +152,12 @@ def set_layout_engine(fig, algo):
             fig.set_tight_layout(True)
         elif algo == "constrained":
             fig.set_constrained_layout(True)
+
+
+def share_axis(ax0, ax1, which):
+    """Handle changes to post-hoc axis sharing."""
+    if Version(mpl.__version__) < Version("3.5.0"):
+        group = getattr(ax0, f"get_shared_{which}_axes")()
+        group.join(ax1, ax0)
+    else:
+        getattr(ax1, f"share{which}")(ax0)

--- a/seaborn/_compat.py
+++ b/seaborn/_compat.py
@@ -125,3 +125,19 @@ def set_scale_obj(ax, axis, scale):
         scale.set_default_locators_and_formatters(axis_obj)
     else:
         ax.set(**{f"{axis}scale": scale})
+
+
+def get_colormap(name):
+    """Handle changes to matplotlib colormap interface in 3.6."""
+    try:
+        return mpl.colormaps[name]
+    except AttributeError:
+        return mpl.cm.get_cmap(name)
+
+
+def register_colormap(cmap, name):
+    """Handle changes to matplotlib colormap interface in 3.6."""
+    try:
+        mpl.colormaps.register_cmap(cmap, name)
+    except AttributeError:
+        mpl.cm.register_cmap(cmap, name)

--- a/seaborn/_core/plot.py
+++ b/seaborn/_core/plot.py
@@ -31,7 +31,7 @@ from seaborn._core.groupby import GroupBy
 from seaborn._core.properties import PROPERTIES, Property
 from seaborn._core.typing import DataSource, VariableSpec, VariableSpecList, OrderSpec
 from seaborn._core.rules import categorical_order
-from seaborn._compat import set_scale_obj
+from seaborn._compat import set_scale_obj, set_layout_engine
 from seaborn.rcmod import axes_style, plotting_context
 from seaborn.palettes import color_palette
 from seaborn.external.version import Version
@@ -1577,7 +1577,4 @@ class Plotter:
 
         algo_default = None if p._target is not None else "tight"
         layout_algo = p._layout_spec.get("algo", algo_default)
-        if layout_algo == "tight":
-            self._figure.set_tight_layout(True)
-        elif layout_algo == "constrained":
-            self._figure.set_constrained_layout(True)
+        set_layout_engine(self._figure, layout_algo)

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -10,6 +10,7 @@ import matplotlib as mpl
 import matplotlib.pyplot as plt
 
 from ._oldcore import VectorPlotter, variable_type, categorical_order
+from ._compat import share_axis
 from . import utils
 from .utils import (
     adjust_legend_subtitles, _check_argument, _draw_figure, _disable_autolayout
@@ -1468,11 +1469,8 @@ class PairGrid(Grid):
                             # when drawing a corner plot?
 
             if self.diag_sharey and diag_axes:
-                # This may change in future matplotlibs
-                # See https://github.com/matplotlib/matplotlib/pull/9923
-                group = diag_axes[0].get_shared_y_axes()
                 for ax in diag_axes[1:]:
-                    group.join(ax, diag_axes[0])
+                    share_axis(diag_axes[0], ax, "y")
 
             self.diag_vars = np.array(diag_vars, np.object_)
             self.diag_axes = np.array(diag_axes, np.object_)

--- a/seaborn/cm.py
+++ b/seaborn/cm.py
@@ -1,4 +1,5 @@
-from matplotlib import colors, cm as mpl_cm
+from matplotlib import colors
+from seaborn._compat import register_colormap
 
 
 _rocket_lut = [
@@ -1579,7 +1580,7 @@ for _name, _lut in _lut_dict.items():
     _cmap_r = colors.ListedColormap(_lut[::-1], _name + "_r")
     locals()[_name + "_r"] = _cmap_r
 
-    mpl_cm.register_cmap(_name, _cmap)
-    mpl_cm.register_cmap(_name + "_r", _cmap_r)
+    register_colormap(_name, _cmap)
+    register_colormap(_name + "_r", _cmap_r)
 
-del colors, mpl_cm
+del colors, register_colormap

--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -15,6 +15,7 @@ except ImportError:
 
 from . import cm
 from .axisgrid import Grid
+from ._compat import get_colormap
 from .utils import (
     despine,
     axis_ticklabels_overlap,
@@ -213,7 +214,7 @@ class _HeatMapper:
             else:
                 self.cmap = cm.icefire
         elif isinstance(cmap, str):
-            self.cmap = mpl.cm.get_cmap(cmap)
+            self.cmap = get_colormap(cmap)
         elif isinstance(cmap, list):
             self.cmap = mpl.colors.ListedColormap(cmap)
         else:

--- a/seaborn/palettes.py
+++ b/seaborn/palettes.py
@@ -205,7 +205,7 @@ def color_palette(palette=None, n_colors=None, desat=None, as_cmap=False):
             try:
                 # Perhaps a named matplotlib colormap?
                 palette = mpl_palette(palette, n_colors, as_cmap=as_cmap)
-            except (ValueError, KeyError):  # Error class changed in mpl36 
+            except (ValueError, KeyError):  # Error class changed in mpl36
                 raise ValueError(f"{palette} is not a valid palette name")
 
     if desat is not None:

--- a/seaborn/palettes.py
+++ b/seaborn/palettes.py
@@ -8,6 +8,7 @@ from .external import husl
 
 from .utils import desaturate, get_color_cycle
 from .colors import xkcd_rgb, crayons
+from ._compat import get_colormap
 
 
 __all__ = ["color_palette", "hls_palette", "husl_palette", "mpl_palette",
@@ -440,7 +441,7 @@ def mpl_palette(name, n_colors=6, as_cmap=False):
             pal = pal[::-1]
         cmap = blend_palette(pal, n_colors, as_cmap=True)
     else:
-        cmap = mpl.cm.get_cmap(name)
+        cmap = get_colormap(name)
 
     if name in MPL_QUAL_PALS:
         bins = np.linspace(0, 1, MPL_QUAL_PALS[name])[:n_colors]

--- a/seaborn/palettes.py
+++ b/seaborn/palettes.py
@@ -205,7 +205,7 @@ def color_palette(palette=None, n_colors=None, desat=None, as_cmap=False):
             try:
                 # Perhaps a named matplotlib colormap?
                 palette = mpl_palette(palette, n_colors, as_cmap=as_cmap)
-            except ValueError:
+            except (ValueError, KeyError):  # Error class changed in mpl36 
                 raise ValueError(f"{palette} is not a valid palette name")
 
     if desat is not None:

--- a/seaborn/rcmod.py
+++ b/seaborn/rcmod.py
@@ -1,5 +1,4 @@
 """Control plot style and scaling using the matplotlib rcParams interface."""
-import warnings
 import functools
 import matplotlib as mpl
 from cycler import cycler
@@ -141,9 +140,7 @@ def reset_defaults():
 def reset_orig():
     """Restore all RC params to original settings (respects custom rc)."""
     from . import _orig_rc_params
-    with warnings.catch_warnings():
-        warnings.simplefilter('ignore', mpl.cbook.MatplotlibDeprecationWarning)
-        mpl.rcParams.update(_orig_rc_params)
+    mpl.rcParams.update(_orig_rc_params)
 
 
 def axes_style(style=None, rc=None):

--- a/tests/_core/test_properties.py
+++ b/tests/_core/test_properties.py
@@ -21,7 +21,7 @@ from seaborn._core.properties import (
     Marker,
     PointSize,
 )
-from seaborn._compat import MarkerStyle
+from seaborn._compat import MarkerStyle, get_colormap
 from seaborn.palettes import color_palette
 
 
@@ -168,7 +168,7 @@ class TestColor(DataFixtures):
 
     def test_continuous_callable_palette(self, num_vector):
 
-        cmap = mpl.cm.get_cmap("viridis")
+        cmap = get_colormap("viridis")
         m = Color().get_mapping(Continuous(cmap), num_vector)
         self.assert_same_rgb(m(num_vector), cmap(num_vector))
 
@@ -186,7 +186,7 @@ class TestColor(DataFixtures):
     def test_bad_scale_values_nominal(self, cat_vector):
 
         with pytest.raises(TypeError, match="Scale values for color with a Nominal"):
-            Color().get_mapping(Nominal(mpl.cm.get_cmap("viridis")), cat_vector)
+            Color().get_mapping(Nominal(get_colormap("viridis")), cat_vector)
 
     def test_bad_inference_arg(self, cat_vector):
 
@@ -225,7 +225,7 @@ class TestColor(DataFixtures):
             ({2: "r", 4: "g", 8: "b"}, "num", Nominal),  # Based on dict palette
             (("r", "b"), "num", Continuous),  # Based on tuple / variable type
             (("g", "m"), "cat", Nominal),  # Based on tuple / variable type
-            (mpl.cm.get_cmap("inferno"), "num", Continuous),  # Based on callable
+            (get_colormap("inferno"), "num", Continuous),  # Based on callable
         ]
     )
     def test_inference(self, values, data_type, scale_class, vectors):

--- a/tests/test_categorical.py
+++ b/tests/test_categorical.py
@@ -29,6 +29,7 @@ from seaborn.categorical import (
 )
 from seaborn.palettes import color_palette
 from seaborn.utils import _normal_quantile_func, _draw_figure
+from seaborn._compat import get_colormap
 from seaborn._testing import assert_plots_equal
 
 
@@ -1662,7 +1663,7 @@ class SharedScatterTests(SharedAxesLevelTests):
 
     def test_supplied_color_array(self, long_df):
 
-        cmap = mpl.cm.get_cmap("Blues")
+        cmap = get_colormap("Blues")
         norm = mpl.colors.Normalize()
         colors = cmap(norm(long_df["y"].to_numpy()))
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -239,7 +239,7 @@ class TestHueMapping:
 
     def test_hue_map_numeric(self, long_df):
 
-        vals = np.concatenate(np.linspace(0, 1, 256), [-.1, 1.1, np.nan])
+        vals = np.concatenate([np.linspace(0, 1, 256), [-.1, 1.1, np.nan]])
 
         # Test default colormap
         p = VectorPlotter(

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -239,6 +239,8 @@ class TestHueMapping:
 
     def test_hue_map_numeric(self, long_df):
 
+        vals = np.concatenate(np.linspace(0, 1, 256), [-.1, 1.1, np.nan])
+
         # Test default colormap
         p = VectorPlotter(
             data=long_df,
@@ -253,12 +255,12 @@ class TestHueMapping:
         # Test named colormap
         palette = "Purples"
         m = HueMapping(p, palette=palette)
-        assert m.cmap is get_colormap(palette)
+        assert_array_equal(m.cmap(vals), get_colormap(palette)(vals))
 
         # Test colormap object
         palette = get_colormap("Greens")
         m = HueMapping(p, palette=palette)
-        assert m.cmap is get_colormap(palette)
+        assert_array_equal(m.cmap(vals), get_colormap(palette)(vals))
 
         # Test cubehelix shorthand
         palette = "ch:2,0,light=.2"

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -260,7 +260,7 @@ class TestHueMapping:
         # Test colormap object
         palette = get_colormap("Greens")
         m = HueMapping(p, palette=palette)
-        assert_array_equal(m.cmap(vals), get_colormap(palette)(vals))
+        assert_array_equal(m.cmap(vals), palette(vals))
 
         # Test cubehelix shorthand
         palette = "ch:2,0,light=.2"

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -9,6 +9,7 @@ from numpy.testing import assert_array_equal
 from pandas.testing import assert_frame_equal
 
 from seaborn.axisgrid import FacetGrid
+from seaborn._compat import get_colormap
 from seaborn._oldcore import (
     SemanticMapping,
     HueMapping,
@@ -252,12 +253,12 @@ class TestHueMapping:
         # Test named colormap
         palette = "Purples"
         m = HueMapping(p, palette=palette)
-        assert m.cmap is mpl.cm.get_cmap(palette)
+        assert m.cmap is get_colormap(palette)
 
         # Test colormap object
-        palette = mpl.cm.get_cmap("Greens")
+        palette = get_colormap("Greens")
         m = HueMapping(p, palette=palette)
-        assert m.cmap is mpl.cm.get_cmap(palette)
+        assert m.cmap is get_colormap(palette)
 
         # Test cubehelix shorthand
         palette = "ch:2,0,light=.2"

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -29,6 +29,7 @@ import pytest
 
 from seaborn import matrix as mat
 from seaborn import color_palette
+from seaborn._compat import get_colormap
 from seaborn._testing import assert_colors_equal
 
 
@@ -228,7 +229,7 @@ class TestHeatmap:
     def test_cmap_with_properties(self):
 
         kws = self.default_kws.copy()
-        cmap = copy.copy(mpl.cm.get_cmap("BrBG"))
+        cmap = copy.copy(get_colormap("BrBG"))
         cmap.set_bad("red")
         kws["cmap"] = cmap
         hm = mat._HeatMapper(self.df_unif, **kws)
@@ -243,7 +244,7 @@ class TestHeatmap:
             hm.cmap(np.ma.masked_invalid([np.nan])))
 
         kws = self.default_kws.copy()
-        cmap = copy.copy(mpl.cm.get_cmap("BrBG"))
+        cmap = copy.copy(get_colormap("BrBG"))
         cmap.set_under("red")
         kws["cmap"] = cmap
         hm = mat._HeatMapper(self.df_unif, **kws)
@@ -254,7 +255,7 @@ class TestHeatmap:
         npt.assert_array_equal(cmap(-np.inf), hm.cmap(-np.inf))
 
         kws = self.default_kws.copy()
-        cmap = copy.copy(mpl.cm.get_cmap("BrBG"))
+        cmap = copy.copy(get_colormap("BrBG"))
         cmap.set_over("red")
         kws["cmap"] = cmap
         hm = mat._HeatMapper(self.df_unif, **kws)

--- a/tests/test_palettes.py
+++ b/tests/test_palettes.py
@@ -7,6 +7,7 @@ import numpy.testing as npt
 
 from seaborn import palettes, utils, rcmod
 from seaborn.external import husl
+from seaborn._compat import get_colormap
 from seaborn.colors import xkcd_rgb, crayons
 
 
@@ -95,7 +96,7 @@ class TestColorPalettes:
         pal2 = palettes.color_palette("Reds")
         npt.assert_array_equal(pal1, pal2)
 
-        cmap1 = mpl.cm.get_cmap("Reds")
+        cmap1 = get_colormap("Reds")
         cmap2 = palettes.mpl_palette("Reds", as_cmap=True)
         cmap3 = palettes.color_palette("Reds", as_cmap=True)
         npt.assert_array_equal(cmap1, cmap2)

--- a/tests/test_relational.py
+++ b/tests/test_relational.py
@@ -21,6 +21,7 @@ from seaborn.relational import (
 )
 
 from seaborn.utils import _draw_figure
+from seaborn._compat import get_colormap
 from seaborn._testing import assert_plots_equal
 
 
@@ -1627,7 +1628,7 @@ class TestScatterPlotter(SharedAxesLevelTests, Helpers):
 
     def test_supplied_color_array(self, long_df):
 
-        cmap = mpl.cm.get_cmap("Blues")
+        cmap = get_colormap("Blues")
         norm = mpl.colors.Normalize()
         colors = cmap(norm(long_df["y"].to_numpy()))
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,5 @@
 """Tests for seaborn utility functions."""
+import re
 import tempfile
 from urllib.request import urlopen
 from http.client import HTTPException
@@ -328,15 +329,10 @@ def test_locator_to_legend_entries():
         assert str_levels == ['10', '100', '1000']
 
     limits = (0.00003, 0.02)
-    levels, str_levels = utils.locator_to_legend_entries(
-        locator, limits, float
-    )
-    if Version(mpl.__version__) >= Version("3.1"):
-        assert str_levels == ['1e-04', '1e-03', '1e-02']
-    elif Version(mpl.__version__) >= Version("3.6"):
-        # Change to use minus sign rather than hyphen
-        # (yes it's a VERY subtle difference!)
-        assert str_levels == ['1e−04', '1e−03', '1e−02']
+    _, str_levels = utils.locator_to_legend_entries(locator, limits, float)
+    for i, exp in enumerate([4, 3, 2]):
+        # Use regex as mpl switched to minus sign, not hyphen, in 3.6
+        assert re.match(f"1e.0{exp}", str_levels[i])
 
 
 def test_move_legend_matplotlib_objects():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -333,6 +333,10 @@ def test_locator_to_legend_entries():
     )
     if Version(mpl.__version__) >= Version("3.1"):
         assert str_levels == ['1e-04', '1e-03', '1e-02']
+    elif Version(mpl.__version__) >= Version("3.6"):
+        # Change to use minus sign rather than hyphen
+        # (yes it's a VERY subtle difference!)
+        assert str_levels == ['1e−04', '1e−03', '1e−02']
 
 
 def test_move_legend_matplotlib_objects():


### PR DESCRIPTION
- No longer reference the deprecated path for `MatplotlibDeprecationWarning` (we actually don't need to silence this warning at all anymore; we only did so before because this would get called as part of `import seaborn.apionly`).
- Relax test against matplotlib labels with scientific notation as they switched from a dash to a unicode minus
- Add compat layer for registering / accessing matplotlib colormaps with new API
- Switch post-hoc axis sharing to new API
- Add compatibility with new layout engine API