### PR TITLE
Remove default pairing from Plot.pair and clean up interface

### DIFF
--- a/seaborn/_core/plot.py
+++ b/seaborn/_core/plot.py
@@ -495,8 +495,8 @@ class Plot:
             if keys:
                 pair_spec["structure"][axis] = keys
 
-        if cross and len(axes["x"]) != len(axes["y"]):
-            err = "The lengths of the `x` and `y` lists must match with cross=True"
+        if not cross and len(axes["x"]) != len(axes["y"]):
+            err = "Lengths of the `x` and `y` lists must match with cross=False"
             raise ValueError(err)
 
         pair_spec["cross"] = cross

--- a/seaborn/_core/typing.py
+++ b/seaborn/_core/typing.py
@@ -9,6 +9,7 @@ from matplotlib.colors import Colormap, Normalize
 Vector = Union[Series, Index, ndarray]
 PaletteSpec = Union[str, list, dict, Colormap, None]
 VariableSpec = Union[Hashable, Vector, None]
+VariableSpecList = Union[List[VariableSpec], Index, None]
 # TODO can we better unify the VarType object and the VariableType alias?
 DataSource = Union[DataFrame, Mapping[Hashable, Vector], None]
 

--- a/tests/_core/test_plot.py
+++ b/tests/_core/test_plot.py
@@ -1570,8 +1570,8 @@ class TestPairInterface:
     def test_cross_mismatched_lengths(self, long_df):
 
         p = Plot(long_df)
-        with pytest.raises(ValueError, match="The lengths of the `x` and `y`"):
-            p.pair(x=["a", "b"], y=["x", "y", "z"], cross=True)
+        with pytest.raises(ValueError, match="Lengths of the `x` and `y`"):
+            p.pair(x=["a", "b"], y=["x", "y", "z"], cross=False)
 
     def test_orient_inference(self, long_df):
 

--- a/tests/_core/test_plot.py
+++ b/tests/_core/test_plot.py
@@ -1390,9 +1390,7 @@ class TestPairInterface:
             assert ax.get_ylabel() == "" if y_i is None else y_i
             assert_gridspec_shape(subplot["ax"], len(y), len(x))
 
-    @pytest.mark.parametrize(
-        "vector_type", [list, np.array, pd.Series, pd.Index]
-    )
+    @pytest.mark.parametrize("vector_type", [list, pd.Index])
     def test_all_numeric(self, long_df, vector_type):
 
         x, y = ["x", "y", "z"], ["s", "f"]
@@ -1433,33 +1431,18 @@ class TestPairInterface:
             shareset = getattr(root, f"get_shared_{axis}_axes")()
             assert not any(shareset.joined(root, ax) for ax in other)
 
+    def test_list_of_vectors(self, long_df):
+
+        x_vars = ["x", "z"]
+        p = Plot(long_df, y="y").pair(x=[long_df[x] for x in x_vars]).plot()
+        assert len(p._figure.axes) == len(x_vars)
+        for ax, x_i in zip(p._figure.axes, x_vars):
+            assert ax.get_xlabel() == x_i
+
     def test_with_no_variables(self, long_df):
 
-        all_cols = long_df.columns
-
-        p1 = Plot(long_df).pair()
-        for axis in "xy":
-            actual = [
-                v for k, v in p1._pair_spec["variables"].items() if k.startswith(axis)
-            ]
-            assert actual == all_cols.to_list()
-
-        p2 = Plot(long_df, y="y").pair()
-        x_vars = [
-            v for k, v in p2._pair_spec["variables"].items() if k.startswith("x")
-        ]
-        assert all_cols.difference(x_vars).item() == "y"
-        assert "y" not in p2._pair_spec
-
-        p3 = Plot(long_df, color="a").pair()
-        for axis in "xy":
-            x_vars = [
-                v for k, v in p3._pair_spec["variables"].items() if k.startswith("x")
-            ]
-            assert all_cols.difference(x_vars).item() == "a"
-
-        with pytest.raises(RuntimeError, match="You must pass `data`"):
-            Plot().pair()
+        p = Plot(long_df).pair().plot()
+        assert len(p._figure.axes) == 1
 
     def test_with_facets(self, long_df):
 
@@ -1583,6 +1566,12 @@ class TestPairInterface:
 
         assert_gridspec_shape(p._figure.axes[0], len(x_vars) // wrap + 1, wrap)
         assert len(p._figure.axes) == len(x_vars)
+
+    def test_cross_mismatched_lengths(self, long_df):
+
+        p = Plot(long_df)
+        with pytest.raises(ValueError, match="The lengths of the `x` and `y`"):
+            p.pair(x=["a", "b"], y=["x", "y", "z"], cross=True)
 
     def test_orient_inference(self, long_df):
 


### PR DESCRIPTION
Originally, this method would produce a square matrix with all variables, like `PairGrid` (but not even filtering to numeric).

As the interface has developed, this no longer seems like a good behavior to me. Now there's no default pairing.

I would like to add some sort of regex/wildcard matching, and _maybe_ some way to say `x=<all_numeric_cols>` but that will be for post 0.12.0.

Cleanup includes typing and error handling.