### PR TITLE
Fix visibility of internal axis labels with Plot.pair(wrap=...)

### DIFF
--- a/seaborn/_core/plot.py
+++ b/seaborn/_core/plot.py
@@ -1152,7 +1152,7 @@ class Plotter:
             # behavior, so we will raise rather than hack together a workaround.
             if axis is not None and Version(mpl.__version__) < Version("3.4.0"):
                 from seaborn._core.scales import Nominal
-                paired_axis = axis in p._pair_spec["structure"]
+                paired_axis = axis in p._pair_spec.get("structure", {})
                 cat_scale = isinstance(scale, Nominal)
                 ok_dim = {"x": "col", "y": "row"}[axis]
                 shared_axes = share_state not in [False, "none", ok_dim]

--- a/seaborn/_core/plot.py
+++ b/seaborn/_core/plot.py
@@ -943,8 +943,11 @@ class Plotter:
                 visible_side = {"x": "bottom", "y": "left"}.get(axis)
                 show_axis_label = (
                     sub[visible_side]
-                    or axis in p._pair_spec and bool(p._pair_spec.get("wrap"))
                     or not p._pair_spec.get("cross", True)
+                    or (
+                        axis in p._pair_spec.get("structure", {})
+                        and bool(p._pair_spec.get("wrap"))
+                    )
                 )
                 axis_obj.get_label().set_visible(show_axis_label)
                 show_tick_labels = (
@@ -1149,7 +1152,7 @@ class Plotter:
             # behavior, so we will raise rather than hack together a workaround.
             if axis is not None and Version(mpl.__version__) < Version("3.4.0"):
                 from seaborn._core.scales import Nominal
-                paired_axis = axis in p._pair_spec
+                paired_axis = axis in p._pair_spec["structure"]
                 cat_scale = isinstance(scale, Nominal)
                 ok_dim = {"x": "col", "y": "row"}[axis]
                 shared_axes = share_state not in [False, "none", ok_dim]

--- a/seaborn/_core/subplots.py
+++ b/seaborn/_core/subplots.py
@@ -30,9 +30,8 @@ class Subplots:
 
     """
     def __init__(
-        # TODO defined TypedDict types for these specs
         self,
-        subplot_spec: dict,
+        subplot_spec: dict,  # TODO define as TypedDict
         facet_spec: FacetSpec,
         pair_spec: PairSpec,
     ):
@@ -130,7 +129,7 @@ class Subplots:
             if key not in self.subplot_spec:
                 if axis in pair_spec.get("structure", {}):
                     # Paired axes are shared along one dimension by default
-                    if self.wrap in [None, 1] and pair_spec.get("cross", True):
+                    if self.wrap is None and pair_spec.get("cross", True):
                         val = axis_to_dim[axis]
                     else:
                         val = False

--- a/tests/_core/test_plot.py
+++ b/tests/_core/test_plot.py
@@ -1538,8 +1538,10 @@ class TestPairInterface:
 
         assert_gridspec_shape(p._figure.axes[0], len(x_vars) // wrap + 1, wrap)
         assert len(p._figure.axes) == len(x_vars)
-
-        # TODO test axis labels and visibility
+        for ax, var in zip(p._figure.axes, x_vars):
+            label = ax.xaxis.get_label()
+            assert label.get_visible()
+            assert label.get_text() == var
 
     def test_y_wrapping(self, long_df):
 
@@ -1549,8 +1551,10 @@ class TestPairInterface:
 
         assert_gridspec_shape(p._figure.axes[0], wrap, len(y_vars) // wrap + 1)
         assert len(p._figure.axes) == len(y_vars)
-
-        # TODO test axis labels and visibility
+        for ax, var in zip(p._figure.axes, y_vars):
+            label = ax.yaxis.get_label()
+            assert label.get_visible()
+            assert label.get_text() == var
 
     def test_non_cross_wrapping(self, long_df):
 

--- a/tests/_core/test_plot.py
+++ b/tests/_core/test_plot.py
@@ -1549,12 +1549,17 @@ class TestPairInterface:
         wrap = 3
         p = Plot(long_df, x="x").pair(y=y_vars, wrap=wrap).plot()
 
-        assert_gridspec_shape(p._figure.axes[0], wrap, len(y_vars) // wrap + 1)
+        n_row, n_col = wrap, len(y_vars) // wrap + 1
+        assert_gridspec_shape(p._figure.axes[0], n_row, n_col)
         assert len(p._figure.axes) == len(y_vars)
-        for ax, var in zip(p._figure.axes, y_vars):
+        label_array = np.empty(n_row * n_col, object)
+        label_array[:len(y_vars)] = y_vars
+        label_array = label_array.reshape((n_row, n_col), order="F")
+        label_array = [y for y in label_array.flat if y is not None]
+        for i, ax in enumerate(p._figure.axes):
             label = ax.yaxis.get_label()
             assert label.get_visible()
-            assert label.get_text() == var
+            assert label.get_text() == label_array[i]
 
     def test_non_cross_wrapping(self, long_df):
 

--- a/tests/_core/test_subplots.py
+++ b/tests/_core/test_subplots.py
@@ -191,6 +191,18 @@ class TestSubplotSpec:
         assert s.subplot_spec["sharex"] is True
         assert s.subplot_spec["sharey"] is False
 
+    def test_y_paired_and_wrapped_single_row(self):
+
+        y = ["x", "y", "z"]
+        wrap = 1
+        s = Subplots({}, {}, {"structure": {"y": y}, "wrap": wrap})
+
+        assert s.n_subplots == len(y)
+        assert s.subplot_spec["ncols"] == len(y)
+        assert s.subplot_spec["nrows"] == 1
+        assert s.subplot_spec["sharex"] is True
+        assert s.subplot_spec["sharey"] is False
+
     def test_col_faceted_y_paired(self):
 
         y = ["x", "y", "z"]


### PR DESCRIPTION

1. Fix visibility of internal axis labels with `Plot.pair(wrap=...)`  (Closes #2976)

```python
(
    so.Plot(mpg, y="mpg")
    .pair(["displacement", "weight", "horsepower", "acceleration"], wrap=2)
    .add(so.Dots())
)
```
![image](https://user-images.githubusercontent.com/315810/186991689-69c61e56-3054-49b3-ad87-7797198b1cd1.png)

2. Fix (non-)sharing of axes for distinct variables with `Plot.pair(wrap=1)`

```python
(
    so.Plot(mpg, x="mpg")
    .pair(y=["displacement", "weight"], wrap=1)
    .add(so.Dots())
)
```
![image](https://user-images.githubusercontent.com/315810/186991550-5be28208-c5aa-4d47-b2c6-a36e0f1fe59b.png)
