### PR TITLE
Update the single-letter color codes as part of the Plot theme context

### DIFF
--- a/seaborn/_core/plot.py
+++ b/seaborn/_core/plot.py
@@ -92,7 +92,7 @@ def theme_context(params: dict[str, Any]) -> Generator:
     """Temporarily modify specifc matplotlib rcParams."""
     orig_params = {k: mpl.rcParams[k] for k in params}
     color_codes = "bgrmyck"
-    nice_colors = [*color_palette("deep6"), (.2, .2, .2)]
+    nice_colors = [*color_palette("deep6"), (.15, .15, .15)]
     orig_colors = [mpl.colors.colorConverter.colors[x] for x in color_codes]
     # TODO how to allow this to reflect the color cycle when relevant?
     try:

--- a/seaborn/_core/plot.py
+++ b/seaborn/_core/plot.py
@@ -90,12 +90,22 @@ default = Default()
 @contextmanager
 def theme_context(params: dict[str, Any]) -> Generator:
     """Temporarily modify specifc matplotlib rcParams."""
-    orig = {k: mpl.rcParams[k] for k in params}
+    orig_params = {k: mpl.rcParams[k] for k in params}
+    color_codes = "bgrmyck"
+    nice_colors = [*color_palette("deep6"), (.2, .2, .2)]
+    orig_colors = [mpl.colors.colorConverter.colors[x] for x in color_codes]
+    # TODO how to allow this to reflect the color cycle when relevant?
     try:
         mpl.rcParams.update(params)
+        for (code, color) in zip(color_codes, nice_colors):
+            mpl.colors.colorConverter.colors[code] = color
+            mpl.colors.colorConverter.cache[code] = color
         yield
     finally:
-        mpl.rcParams.update(orig)
+        mpl.rcParams.update(orig_params)
+        for (code, color) in zip(color_codes, orig_colors):
+            mpl.colors.colorConverter.colors[code] = color
+            mpl.colors.colorConverter.cache[code] = color
 
 
 def build_plot_signature(cls):

--- a/tests/_marks/test_area.py
+++ b/tests/_marks/test_area.py
@@ -33,13 +33,13 @@ class TestAreaMarks:
         lw = poly.get_linewidth()
         assert_array_equal(lw, mpl.rcParams["patch.linewidth"] * 2)
 
-    def test_direct_parameters(self):
+    def test_set_parameters(self):
 
         x, y = [1, 2, 3], [1, 2, 1]
         mark = Area(
             color="C2",
             alpha=.3,
-            edgecolor="k",
+            edgecolor="#444",
             edgealpha=.8,
             edgewidth=2,
             edgestyle=(0, (2, 1)),

--- a/tests/_marks/test_area.py
+++ b/tests/_marks/test_area.py
@@ -39,7 +39,7 @@ class TestAreaMarks:
         mark = Area(
             color="C2",
             alpha=.3,
-            edgecolor="#444",
+            edgecolor=".3",
             edgealpha=.8,
             edgewidth=2,
             edgestyle=(0, (2, 1)),

--- a/tests/_marks/test_bar.py
+++ b/tests/_marks/test_bar.py
@@ -61,7 +61,7 @@ class TestBar:
         for i, bar in enumerate(bars):
             self.check_bar(bar, 0, y[i] - w / 2, x[i], w)
 
-    def test_direct_properties(self):
+    def test_set_properties(self):
 
         x = ["a", "b", "c"]
         y = [1, 3, 2]
@@ -69,7 +69,7 @@ class TestBar:
         mark = Bar(
             color="C2",
             alpha=.5,
-            edgecolor="k",
+            edgecolor="#444",
             edgealpha=.9,
             edgestyle=(2, 1),
             edgewidth=1.5,

--- a/tests/_marks/test_bar.py
+++ b/tests/_marks/test_bar.py
@@ -69,7 +69,7 @@ class TestBar:
         mark = Bar(
             color="C2",
             alpha=.5,
-            edgecolor="#444",
+            edgecolor=".3",
             edgealpha=.9,
             edgestyle=(2, 1),
             edgewidth=1.5,

--- a/tests/_marks/test_dot.py
+++ b/tests/_marks/test_dot.py
@@ -50,13 +50,13 @@ class TestDot(DotBase):
         marker = ["a", "b"]
         shapes = ["o", "x"]
 
-        mark = Dot(edgecolor="k", stroke=2, edgewidth=1)
+        mark = Dot(edgecolor="w", stroke=2, edgewidth=1)
         p = Plot(x=x, y=y).add(mark, marker=marker).scale(marker=shapes).plot()
         ax = p._figure.axes[0]
         points, = ax.collections
         self.check_offsets(points, x, y)
         self.check_colors("face", points, ["C0", to_rgba("C0", 0)], None)
-        self.check_colors("edge", points, ["k", "C0"], 1)
+        self.check_colors("edge", points, ["w", "C0"], 1)
 
         expected = [mark.edgewidth, mark.stroke]
         assert_array_equal(points.get_linewidths(), expected)


### PR DESCRIPTION
This means that `"b"`, `"r"`, etc. will produce theme-consistent colors with `Plot` rather than matplotlib's default (and ugly) pure RGB colors.

It's not 100% ideal because it would be nice to be able to set a different seaborn palette as the default cycle and have the single color codes reflect that (as happens with `set_palette`) but we don't have that functionality yet.