### PR TITLE
Use pip extras for installation of dev tools

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,11 +26,10 @@ jobs:
       - name: Install seaborn
         run: |
           pip install --upgrade pip
-          pip install .[stats] -r ci/utils.txt
+          pip install .[stats,docs]
 
-      - name: Install doc tools
+      - name: Install pandoc
         run: |
-          pip install -r doc/requirements.txt
           sudo apt-get install pandoc
 
       - name: Build docs
@@ -71,9 +70,9 @@ jobs:
       - name: Install seaborn
         run: |
           pip install --upgrade pip wheel
-          if [[ ${{matrix.install}} == 'full' ]]; then EXTRAS='[stats]'; fi
+          if [[ ${{matrix.install}} == 'full' ]]; then EXTRAS=',stats'; fi
           if [[ ${{matrix.deps }} == 'pinned' ]]; then DEPS='-r ci/deps_pinned.txt'; fi
-          pip install .$EXTRAS $DEPS -r ci/utils.txt
+          pip install .[dev$EXTRAS] $DEPS
 
       - name: Cache datastes
         run: python ci/cache_test_datasets.py

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,6 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: "3.10"
-          cache: "pip"
 
       - name: Install seaborn
         run: |
@@ -65,7 +64,6 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python }}
-          cache: "pip"
 
       - name: Install seaborn
         run: |

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ A paper describing seaborn has been published in the [Journal of Open Source Sof
 Testing
 -------
 
-Testing seaborn requires installing additional dependencies; they can be installed with `pip install seaborn[dev]`.
+Testing seaborn requires installing additional dependencies; they can be installed with the `dev` extra (e.g., `pip install .[dev]`).
 
 To test the code, run `make test` in the source directory. This will exercise both the unit tests and docstring examples (using [pytest](https://docs.pytest.org/)) and generate a coverage report.
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ A paper describing seaborn has been published in the [Journal of Open Source Sof
 Testing
 -------
 
-Testing seaborn requires installing additional packages listed in `ci/utils.txt`.
+Testing seaborn requires installing additional dependencies; they can be installed with `pip install seaborn[dev]`.
 
 To test the code, run `make test` in the source directory. This will exercise both the unit tests and docstring examples (using [pytest](https://docs.pytest.org/)) and generate a coverage report.
 

--- a/ci/utils.txt
+++ b/ci/utils.txt
@@ -1,5 +1,0 @@
-pytest!=5.3.4
-pytest-cov
-pytest-xdist
-flake8
-mypy

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,7 +1,7 @@
 Building the seaborn docs
 =========================
 
-Building the docs requires additional dependencies listed in [`./requirements.txt`](./requirements.txt).
+Building the docs requires additional dependencies; they can be installed with `pip install seaborn[docs]`.
 
 The build process involves conversion of Jupyter notebooks to `rst` files. To facilitate this, you may need to set `NB_KERNEL` environment variable to the name of a kernel on your machine (e.g. `export NB_KERNEL="python3"`). To get a list of available Python kernels, run `jupyter kernelspec list`.
 

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,8 +1,0 @@
-pydata-sphinx-theme==0.10.0rc1
-numpydoc
-nbconvert
-ipykernel
-sphinx-copybutton
-sphinx-issues
-sphinx-design
-pyyaml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ docs = [
     "sphinx-issues",
     "sphinx-design",
     "pyyaml",
+    "pydata_sphinx_theme==0.10.0rc2",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,22 @@ stats = [
     "scipy>=1.3",
     "statsmodels>=0.10",
 ]
+dev = [
+    "pytest",
+    "pytest-cov",
+    "pytest-xdist",
+    "flake8",
+    "mypy",
+]
+docs = [
+    "numpydoc",
+    "nbconvert",
+    "ipykernel",
+    "sphinx-copybutton",
+    "sphinx-issues",
+    "sphinx-design",
+    "pyyaml",
+]
 
 [project.urls]
 Source = "https://github.com/mwaskom/seaborn"


### PR DESCRIPTION
So e.g doing a source checkout and then installing with

```
pip install -e .[dev,docs,stats]
```

will get one set up to run the tests and build the docs in one step.