### PR TITLE
Silence various warnings in test suite

### DIFF
--- a/tests/test_categorical.py
+++ b/tests/test_categorical.py
@@ -1,5 +1,6 @@
 import itertools
 from functools import partial
+import warnings
 
 import numpy as np
 import pandas as pd
@@ -2943,19 +2944,19 @@ class TestCatPlot(CategoricalFixture):
                 assert len(ax.patches) == 1
 
         # Make sure no warning is raised if color is provided on unshared plot
-        with pytest.warns(None) as record:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
             g = cat.catplot(
                 x="g", y="y", col="g", data=self.df, sharex=False, color="b"
             )
-            assert not len(record)
         for ax in g.axes.flat:
             assert ax.get_xlim() == (-.5, .5)
 
-        with pytest.warns(None) as record:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
             g = cat.catplot(
                 x="y", y="g", col="g", data=self.df, sharey=False, color="r"
             )
-            assert not len(record)
         for ax in g.axes.flat:
             assert ax.get_ylim() == (.5, -.5)
 

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -1559,14 +1559,15 @@ class TestHistPlotUnivariate(SharedAxesLevelTests):
 
     def test_kde_singular_data(self):
 
-        with pytest.warns(None) as record:
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
             ax = histplot(x=np.ones(10), kde=True)
-        assert not record
         assert not ax.lines
 
-        with pytest.warns(None) as record:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
             ax = histplot(x=[5], kde=True)
-        assert not record
         assert not ax.lines
 
     def test_element_default(self, long_df):

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -1,3 +1,5 @@
+import warnings
+
 import numpy as np
 import matplotlib as mpl
 import matplotlib.pyplot as plt
@@ -400,7 +402,8 @@ class TestRegressionPlotter:
         y = self.df.x > self.df.x.mean()
         p = lm._RegressionPlotter("x", y, data=self.df,
                                   logistic=True, n_boot=10)
-        with np.errstate(all="ignore"):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", RuntimeWarning)
             _, yhat, _ = p.fit_regression(x_range=(-3, 3))
         assert np.isnan(yhat).all()
 

--- a/tests/test_relational.py
+++ b/tests/test_relational.py
@@ -1,4 +1,6 @@
 from itertools import product
+import warnings
+
 import numpy as np
 import matplotlib as mpl
 import matplotlib.pyplot as plt
@@ -1735,9 +1737,9 @@ class TestScatterPlotter(SharedAxesLevelTests, Helpers):
 
     def test_unfilled_marker_edgecolor_warning(self, long_df):  # GH2636
 
-        with pytest.warns(None) as record:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
             scatterplot(data=long_df, x="x", y="y", marker="+")
-        assert not record
 
     def test_scatterplot_vs_relplot(self, long_df, long_semantics):
 


### PR DESCRIPTION
- Update approach to asserting absence of warnings
- Ignore expected RuntimeWarning from numpy