### PR TITLE
Use stable version of PyData Sphinx Theme for doc building

### DIFF
--- a/ci/cache_test_datasets.py
+++ b/ci/cache_test_datasets.py
@@ -12,6 +12,7 @@ datasets = (
     "flights",
     "fmri",
     "iris",
+    "penguins",
     "planets",
     "tips",
     "titanic"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ docs = [
     "sphinx-issues",
     "sphinx-design",
     "pyyaml",
-    "pydata_sphinx_theme==0.10.0rc2",
+    "pydata_sphinx_theme>=0.10",
 ]
 
 [project.urls]


### PR DESCRIPTION
0.10.0rc2 was a pre-release version of the PyData Sphinx Theme, this PR bumps the required version to 0.10 and thereby use a stable version.