### PR TITLE
CI: Add biweekly scheduled run to detect changes in environment or dependencies

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,8 @@ on:
     branches: [master, v0.*]
   pull_request:
     branches: master
+  schedule:
+    - cron:  '0 6 * * 1,4' # Each Monday and Thursday at 06:00 UTC
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
This PR adds schedule that triggers the CI twice a week (on Monday and Thursday 06:00 UTC). This way changes in the GitHub Actions environment or upstream dependencies that results into failures, errors or warnings can be detected and traced back seperately from code changes.

So If the CI fails, with this schedule, there is always an up-to-date reference run from the master branch to compare it to.