### PR TITLE
Convert color palette docstrings to notebooks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,17 +53,14 @@ jobs:
     strategy:
       matrix:
         python: ["3.7", "3.8", "3.9", "3.10"]
-        target: [test]
         install: [full]
         deps: [latest]
 
         include:
           - python: "3.7"
-            target: unittests
             install: full
             deps: pinned
           - python: "3.10"
-            target: unittests
             install: light
             deps: latest
 
@@ -83,7 +80,7 @@ jobs:
           pip install .[dev$EXTRAS] $DEPS
 
       - name: Run tests
-        run: make ${{ matrix.target }}
+        run: make test
 
       - name: Upload coverage
         uses: codecov/codecov-action@v2

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,6 @@
 export SHELL := /bin/bash
 
 test:
-	pytest -n auto --doctest-modules --cov=seaborn --cov=tests --cov-config=.coveragerc seaborn tests
-
-unittests:
 	pytest -n auto --cov=seaborn --cov=tests --cov-config=.coveragerc tests
 
 lint:

--- a/README.md
+++ b/README.md
@@ -60,11 +60,9 @@ Testing
 
 Testing seaborn requires installing additional dependencies; they can be installed with the `dev` extra (e.g., `pip install .[dev]`).
 
-To test the code, run `make test` in the source directory. This will exercise both the unit tests and docstring examples (using [pytest](https://docs.pytest.org/)) and generate a coverage report.
+To test the code, run `make test` in the source directory. This will exercise the unit tests (using [pytest](https://docs.pytest.org/)) and generate a coverage report.
 
-The doctests require a network connection (unless all example datasets are cached), but the unit tests can be run offline with `make unittests`.
-
-Code style is enforced with `flake8` using the settings in the [`setup.cfg`](./setup.cfg) file. Run `make lint` to check. Alternately, you can use `pre-commit` to automatically run lint checks on any files you are committing &ndash; just run `pre-commit install` to set it up, and then commit as usual going forward.
+Code style is enforced with `flake8` using the settings in the [`setup.cfg`](./setup.cfg) file. Run `make lint` to check. Alternately, you can use `pre-commit` to automatically run lint checks on any files you are committing: just run `pre-commit install` to set it up, and then commit as usual going forward.
 
 Development
 -----------

--- a/doc/_docstrings/FacetGrid.ipynb
+++ b/doc/_docstrings/FacetGrid.ipynb
@@ -280,9 +280,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "seaborn-py39-latest",
+   "display_name": "py310",
    "language": "python",
-   "name": "seaborn-py39-latest"
+   "name": "py310"
   },
   "language_info": {
    "codemirror_mode": {
@@ -294,7 +294,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/JointGrid.ipynb
+++ b/doc/_docstrings/JointGrid.ipynb
@@ -222,9 +222,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "seaborn-py39-latest",
+   "display_name": "py310",
    "language": "python",
-   "name": "seaborn-py39-latest"
+   "name": "py310"
   },
   "language_info": {
    "codemirror_mode": {
@@ -236,7 +236,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/PairGrid.ipynb
+++ b/doc/_docstrings/PairGrid.ipynb
@@ -249,9 +249,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "seaborn-py39-latest",
+   "display_name": "py310",
    "language": "python",
-   "name": "seaborn-py39-latest"
+   "name": "py310"
   },
   "language_info": {
    "codemirror_mode": {
@@ -263,7 +263,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/axes_style.ipynb
+++ b/doc/_docstrings/axes_style.ipynb
@@ -80,9 +80,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "seaborn-py39-latest",
+   "display_name": "py310",
    "language": "python",
-   "name": "seaborn-py39-latest"
+   "name": "py310"
   },
   "language_info": {
    "codemirror_mode": {
@@ -94,7 +94,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/barplot.ipynb
+++ b/doc/_docstrings/barplot.ipynb
@@ -103,9 +103,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "seaborn-py39-latest",
+   "display_name": "py310",
    "language": "python",
-   "name": "seaborn-py39-latest"
+   "name": "py310"
   },
   "language_info": {
    "codemirror_mode": {
@@ -117,7 +117,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/blend_palette.ipynb
+++ b/doc/_docstrings/blend_palette.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "thorough-equipment",
+   "id": "8f97280e-cec8-42b2-a968-4fd4364594f8",
    "metadata": {
     "tags": [
      "hide"
@@ -11,70 +11,69 @@
    },
    "outputs": [],
    "source": [
-    "import seaborn as sns"
+    "import seaborn as sns\n",
+    "sns.set_theme()\n",
+    "sns.palettes._patch_colormap_display()"
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "canadian-protection",
+   "cell_type": "raw",
+   "id": "972edede-df1a-4010-9674-00b864d020e2",
    "metadata": {},
    "source": [
-    "Call the function with the name of a context to set the default for all plots:"
+    "Pass a list of two colors to interpolate between them:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "freelance-leonard",
+   "id": "e6ae2547-1042-4ac0-84ea-6f37a0229871",
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.set_context(\"notebook\")\n",
-    "sns.lineplot(x=[0, 1, 2], y=[1, 3, 2])"
+    "sns.blend_palette([\"b\", \"r\"])"
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "studied-adventure",
+   "cell_type": "raw",
+   "id": "1d983eac-2dd5-4746-b27f-4dfa19b5e091",
    "metadata": {},
    "source": [
-    "You can independently scale the font elements relative to the current context:"
+    "The color list can be arbitrarily long, and any color format can be used:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "irish-digest",
+   "id": "846b78fd-30ce-4507-93f4-4274122c1987",
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.set_context(\"notebook\", font_scale=1.25)\n",
-    "sns.lineplot(x=[0, 1, 2], y=[1, 3, 2])"
+    "sns.blend_palette([\"#45a872\", \".8\", \"xkcd:golden\"])"
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "fourth-technical",
+   "cell_type": "raw",
+   "id": "318fef32-1f83-44d9-9ff9-21fa0231b7c6",
    "metadata": {},
    "source": [
-    "It is also possible to override some of the parameters with specific values:"
+    "Return a continuous colormap instead of a discrete palette:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "advance-request",
+   "id": "f0a05bc3-c60b-47a1-b276-d2e28a4a8226",
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.set_context(\"notebook\", rc={\"lines.linewidth\": 3})\n",
-    "sns.lineplot(x=[0, 1, 2], y=[1, 3, 2])"
+    "sns.blend_palette([\"#bdc\", \"#7b9\", \"#47a\"], as_cmap=True)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "compatible-string",
+   "id": "0473a402-0ec2-4877-81d2-ed6c57aefc77",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/doc/_docstrings/boxplot.ipynb
+++ b/doc/_docstrings/boxplot.ipynb
@@ -151,9 +151,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "seaborn-py39-latest",
+   "display_name": "py310",
    "language": "python",
-   "name": "seaborn-py39-latest"
+   "name": "py310"
   },
   "language_info": {
    "codemirror_mode": {
@@ -165,7 +165,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/catplot.ipynb
+++ b/doc/_docstrings/catplot.ipynb
@@ -168,9 +168,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "seaborn-py39-latest",
+   "display_name": "py310",
    "language": "python",
-   "name": "seaborn-py39-latest"
+   "name": "py310"
   },
   "language_info": {
    "codemirror_mode": {
@@ -182,7 +182,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/color_palette.ipynb
+++ b/doc/_docstrings/color_palette.ipynb
@@ -10,47 +10,9 @@
    },
    "outputs": [],
    "source": [
-    "import seaborn as sns; sns.set_theme()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": [
-     "hide"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "# Add colormap display methods to matplotlib colormaps.\n",
-    "# These are forthcoming in matplotlib 3.4, but, the matplotlib display\n",
-    "# method includes the colormap name, which is redundant.\n",
-    "def _repr_png_(self):\n",
-    "    \"\"\"Generate a PNG representation of the Colormap.\"\"\"\n",
-    "    import io\n",
-    "    from PIL import Image\n",
-    "    import numpy as np\n",
-    "    IMAGE_SIZE = (400, 50)\n",
-    "    X = np.tile(np.linspace(0, 1, IMAGE_SIZE[0]), (IMAGE_SIZE[1], 1))\n",
-    "    pixels = self(X, bytes=True)\n",
-    "    png_bytes = io.BytesIO()\n",
-    "    Image.fromarray(pixels).save(png_bytes, format='png')\n",
-    "    return png_bytes.getvalue()\n",
-    "    \n",
-    "def _repr_html_(self):\n",
-    "    \"\"\"Generate an HTML representation of the Colormap.\"\"\"\n",
-    "    import base64\n",
-    "    png_bytes = self._repr_png_()\n",
-    "    png_base64 = base64.b64encode(png_bytes).decode('ascii')\n",
-    "    return ('<img ' +\n",
-    "            'alt=\"' + self.name + ' color map\" ' +\n",
-    "            'title=\"' + self.name + '\"' +\n",
-    "            'src=\"data:image/png;base64,' + png_base64 + '\">')\n",
-    "    \n",
-    "import matplotlib as mpl\n",
-    "mpl.colors.Colormap._repr_png_ = _repr_png_\n",
-    "mpl.colors.Colormap._repr_html_ = _repr_html_"
+    "import seaborn as sns\n",
+    "sns.set_theme()\n",
+    "sns.palettes._patch_colormap_display()"
    ]
   },
   {
@@ -122,7 +84,39 @@
    "cell_type": "raw",
    "metadata": {},
    "source": [
-    "Return one of the perceptually-uniform colormaps included in seaborn:"
+    "Return a diverging Color Brewer palette as a continuous colormap:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sns.color_palette(\"Spectral\", as_cmap=True)"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Return one of the perceptually-uniform palettes included in seaborn as a discrete palette:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sns.color_palette(\"flare\")"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Return one of the perceptually-uniform palettes included in seaborn as a continuous colormap:"
    ]
   },
   {
@@ -154,7 +148,7 @@
    "cell_type": "raw",
    "metadata": {},
    "source": [
-    "Return a light-themed sequential colormap to a seed color:"
+    "Return a light sequential gradient:"
    ]
   },
   {
@@ -167,6 +161,91 @@
    ]
   },
   {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Return a reversed dark sequential gradient:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sns.color_palette(\"dark:#5A9_r\", as_cmap=True)"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Return a blend gradient between two endpoints:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sns.color_palette(\"blend:#7AB,#EDA\", as_cmap=True)"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Use as a context manager to change the default qualitative color palette:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "hide"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "x, y = list(range(10)), [0] * 10\n",
+    "hue = list(map(str, x))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with sns.color_palette(\"Set3\"):\n",
+    "    sns.relplot(x=x, y=y, hue=hue, s=500, legend=False, height=1.3, aspect=4)\n",
+    "\n",
+    "sns.relplot(x=x, y=y, hue=hue, s=500, legend=False, height=1.3, aspect=4)"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "See the underlying color values as hex codes:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "show-output"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "print(sns.color_palette(\"pastel6\").as_hex())"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -176,9 +255,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "seaborn-py39-latest",
+   "display_name": "py310",
    "language": "python",
-   "name": "seaborn-py39-latest"
+   "name": "py310"
   },
   "language_info": {
    "codemirror_mode": {
@@ -190,7 +269,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/countplot.ipynb
+++ b/doc/_docstrings/countplot.ipynb
@@ -77,9 +77,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "seaborn-py39-latest",
+   "display_name": "py310",
    "language": "python",
-   "name": "seaborn-py39-latest"
+   "name": "py310"
   },
   "language_info": {
    "codemirror_mode": {
@@ -91,7 +91,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/cubehelix_palette.ipynb
+++ b/doc/_docstrings/cubehelix_palette.ipynb
@@ -3,6 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "60aebc68-2c7c-4af5-a159-8421e1f94ba6",
    "metadata": {
     "tags": [
      "hide"
@@ -11,194 +12,197 @@
    "outputs": [],
    "source": [
     "import seaborn as sns\n",
-    "sns.set_theme(style=\"ticks\")"
+    "sns.set_theme()\n",
+    "sns.palettes._patch_colormap_display()"
    ]
   },
   {
    "cell_type": "raw",
+   "id": "242b3d42-1f10-4da2-9ef9-af06f7fbd724",
    "metadata": {},
    "source": [
-    "The simplest invocation uses :func:`scatterplot` for each pairing of the variables and :func:`histplot` for the marginal plots along the diagonal:"
+    "Return a discrete palette with default parameters:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "6526accb-9930-4e39-9f58-1ca2941c1c9d",
    "metadata": {},
    "outputs": [],
    "source": [
-    "penguins = sns.load_dataset(\"penguins\")\n",
-    "sns.pairplot(penguins)"
+    "sns.cubehelix_palette()"
    ]
   },
   {
    "cell_type": "raw",
+   "id": "887a40f0-d949-41fa-9a43-0ee246c9a077",
    "metadata": {},
    "source": [
-    "Assigning a ``hue`` variable adds a semantic mapping and changes the default marginal plot to a layered kernel density estimate (KDE):"
+    "Increase the number of colors:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "02833290-b1ee-46df-a2a0-8268fba94628",
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.pairplot(penguins, hue=\"species\")"
+    "sns.cubehelix_palette(8)"
    ]
   },
   {
    "cell_type": "raw",
+   "id": "a9eb86c7-f92e-4422-ae62-a2ef136e7e35",
    "metadata": {},
    "source": [
-    "It's possible to force marginal histograms:"
+    "Return a continuous colormap rather than a discrete palette:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "a460efc2-cf0a-46bf-a12f-12870afce8a5",
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.pairplot(penguins, hue=\"species\", diag_kind=\"hist\")"
+    "sns.cubehelix_palette(as_cmap=True)"
    ]
   },
   {
    "cell_type": "raw",
+   "id": "5b84aa6c-ad79-45b1-a7d2-44b7ecba5f7d",
    "metadata": {},
    "source": [
-    "The ``kind`` parameter determines both the diagonal and off-diagonal plotting style. Several options are available, including using :func:`kdeplot` to draw KDEs:"
+    "Change the starting point of the helix:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "70ee079a-e760-4d43-8447-648fd236ab15",
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.pairplot(penguins, kind=\"kde\")"
+    "sns.cubehelix_palette(start=2)"
    ]
   },
   {
    "cell_type": "raw",
+   "id": "5e21fa22-9ac3-4354-8694-967f2447b286",
    "metadata": {},
    "source": [
-    "Or :func:`histplot` to draw both bivariate and univariate histograms:"
+    "Change the amount of rotation in the helix:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "ddb1b8c7-8933-4317-827f-4f10d2b4cecc",
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.pairplot(penguins, kind=\"hist\")"
+    "sns.cubehelix_palette(rot=.2)"
    ]
   },
   {
    "cell_type": "raw",
+   "id": "fa91aff7-54e7-4754-a13c-b629dfc33e8f",
    "metadata": {},
    "source": [
-    "The ``markers`` parameter applies a style mapping on the off-diagonal axes. Currently, it will be redundant with the ``hue`` variable:"
+    "Rotate in the reverse direction:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "548a3942-48ae-40d2-abb7-acc2ffd71601",
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.pairplot(penguins, hue=\"species\", markers=[\"o\", \"s\", \"D\"])"
+    "sns.cubehelix_palette(rot=-.2)"
    ]
   },
   {
    "cell_type": "raw",
+   "id": "e7188a1b-183f-4b04-93a0-975c27fe408e",
    "metadata": {},
    "source": [
-    "As with other figure-level functions, the size of the figure is controlled by setting the ``height`` of each individual subplot:"
+    "Apply a nonlinearity to the luminance ramp:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "9ced54ff-a396-451e-b17f-2366b56f920b",
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.pairplot(penguins, height=1.5)"
+    "sns.cubehelix_palette(gamma=.5)"
    ]
   },
   {
    "cell_type": "raw",
+   "id": "bc82ce48-2df3-464e-b70e-a1d73d0432c6",
    "metadata": {},
    "source": [
-    "Use ``vars`` or ``x_vars`` and ``y_vars`` to select the variables to plot:"
+    "Increase the saturation of the colors:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "a38b91a8-3fdc-4293-a3ea-71b4006cd2a1",
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.pairplot(\n",
-    "    penguins,\n",
-    "    x_vars=[\"bill_length_mm\", \"bill_depth_mm\", \"flipper_length_mm\"],\n",
-    "    y_vars=[\"bill_length_mm\", \"bill_depth_mm\"],\n",
-    ")"
+    "sns.cubehelix_palette(hue=1)"
    ]
   },
   {
    "cell_type": "raw",
+   "id": "f8d23ba1-013a-489f-94c4-f2080bfdae87",
    "metadata": {},
    "source": [
-    "Set ``corner=True`` to plot only the lower triangle:"
+    "Change the luminance at the start and end points:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "a4f05a16-18f0-4c14-99a4-57a0734aad02",
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.pairplot(penguins, corner=True)"
+    "sns.cubehelix_palette(dark=.25, light=.75)"
    ]
   },
   {
    "cell_type": "raw",
+   "id": "0bfcc5d9-05ba-4715-94ac-8d430d9416c2",
    "metadata": {},
    "source": [
-    "The ``plot_kws`` and ``diag_kws`` parameters accept dicts of keyword arguments to customize the off-diagonal and diagonal plots, respectively:"
+    "Reverse the direction of the luminance ramp:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "74563491-5448-42c3-86c5-f5d55ce6924c",
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.pairplot(\n",
-    "    penguins,\n",
-    "    plot_kws=dict(marker=\"+\", linewidth=1),\n",
-    "    diag_kws=dict(fill=False),\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "raw",
-   "metadata": {},
-   "source": [
-    "The return object is the underlying :class:`PairGrid`, which can be used to further customize the plot:"
+    "sns.cubehelix_palette(reverse=True)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "94a83211-8b8e-4e60-8365-9600e71ddc5d",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "g = sns.pairplot(penguins, diag_kind=\"kde\")\n",
-    "g.map_lower(sns.kdeplot, levels=4, color=\".2\")"
-   ]
+   "source": []
   }
  ],
  "metadata": {
@@ -221,5 +225,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 5
 }

--- a/doc/_docstrings/dark_palette.ipynb
+++ b/doc/_docstrings/dark_palette.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "882d215b-88d8-4b5e-ae7a-0e3f6bb53bad",
+   "id": "5cd1cbb8-ba1a-460b-8e3a-bc285867f1d1",
    "metadata": {
     "tags": [
      "hide"
@@ -12,95 +12,104 @@
    "outputs": [],
    "source": [
     "import seaborn as sns\n",
-    "sns.set_theme(style=\"whitegrid\")"
+    "sns.set_theme()\n",
+    "sns.palettes._patch_colormap_display()"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "b157eb25-015f-4dd6-9785-83ba19cf4f94",
+   "metadata": {},
+   "source": [
+    "Define a sequential ramp from a dark gray to a specified color:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6809326c-14a9-4314-994d-b4e8e7414172",
+   "id": "5b655d28-9855-4528-8b8e-a6c50288fd1b",
    "metadata": {},
    "outputs": [],
    "source": [
-    "df = sns.load_dataset(\"diamonds\")"
+    "sns.dark_palette(\"seagreen\")"
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "9ccbc2d5-5a44-4e80-8b07-e12629729f4a",
+   "cell_type": "raw",
+   "id": "50053b26-112a-4378-8ef0-9be0fb565ec7",
    "metadata": {},
    "source": [
-    "Draw a single horizontal plot, assigning the data directly to the coordinate variable:"
+    "Specify the color with a hex code:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "391e1162-b438-4486-9a08-60686ee8e96a",
+   "id": "74ae0d17-f65b-4bcf-ae66-d97d46964d5c",
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.boxenplot(x=df[\"price\"])"
+    "sns.dark_palette(\"#79C\")"
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "a3b0e9b8-1673-494c-a27a-aa9c60457ba1",
+   "cell_type": "raw",
+   "id": "eea376a2-fdf5-40e4-a187-3a28af529072",
    "metadata": {},
    "source": [
-    "Group by a categorical variable, referencing columns in a datafame"
+    "Specify the color from the husl system:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e30fec18-f127-40a3-bfaf-f71324dd60ec",
+   "id": "66e451ee-869a-41ea-8dc5-4240b11e7be5",
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.boxenplot(data=df, x=\"price\", y=\"clarity\")"
+    "sns.dark_palette((20, 60, 50), input=\"husl\")"
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "4f01a821-74d1-452d-a1f7-cf5b806169e8",
+   "cell_type": "raw",
+   "id": "e4f44dcd-cf49-4920-ac05-b4db67870363",
    "metadata": {},
    "source": [
-    "Use a different scaling rule to control the width of each box:"
+    "Increase the number of colors:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d0c1aa43-5e8a-486c-bd6d-3c29d6d23138",
+   "id": "75985f07-de92-4d8b-89d5-caf445b9375e",
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.boxenplot(data=df, x=\"carat\", y=\"cut\", scale=\"linear\")"
+    "sns.dark_palette(\"xkcd:golden\", 8)"
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "fd5d197c-8cbb-4be3-a14d-76447f06d3f1",
+   "cell_type": "raw",
+   "id": "34687ae8-fd6d-427a-a639-208f19e61122",
    "metadata": {},
    "source": [
-    "Use a different method to determine the number of boxes:"
+    "Return a continuous colormap rather than a discrete palette:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1aead6a3-6f12-47d3-b472-a39c61867963",
+   "id": "2c342db4-7f97-40f5-934e-9a82201890d1",
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.boxenplot(data=df, x=\"carat\", y=\"cut\", k_depth=\"trustworthy\")"
+    "sns.dark_palette(\"#b285bc\", as_cmap=True)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "719fd61f-9795-47d6-96bd-4929d8647038",
+   "id": "e7ebe64b-25fa-4c52-9ebe-fdcbba0ee51e",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/doc/_docstrings/displot.ipynb
+++ b/doc/_docstrings/displot.ipynb
@@ -217,9 +217,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "seaborn-py39-latest",
+   "display_name": "py310",
    "language": "python",
-   "name": "seaborn-py39-latest"
+   "name": "py310"
   },
   "language_info": {
    "codemirror_mode": {
@@ -231,7 +231,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/diverging_palette.ipynb
+++ b/doc/_docstrings/diverging_palette.ipynb
@@ -1,0 +1,183 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "01295cb6-cc7a-4c6d-94cf-9b0e6cde9fa7",
+   "metadata": {
+    "tags": [
+     "hide"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "import seaborn as sns\n",
+    "sns.set_theme()\n",
+    "sns.palettes._patch_colormap_display()"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "84880848-0805-4c41-999a-50808b397275",
+   "metadata": {},
+   "source": [
+    "Generate diverging ramps from blue to red through white:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "643b3e07-8365-46e3-b033-af7a2fdcd158",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sns.diverging_palette(240, 20)"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "5ae53941-d9d9-4b5a-8abc-173911ebee74",
+   "metadata": {},
+   "source": [
+    "Change the center color to be dark:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "41f03771-8fb2-46f6-93c5-5a0e28be625c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sns.diverging_palette(240, 20, center=\"dark\")"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "0aeb2402-2cbe-4546-a354-f1f501f762ae",
+   "metadata": {},
+   "source": [
+    "Return a continuous colormap rather than a discrete palette:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "64d335a5-f8b2-433f-a83f-5aeff7db583a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sns.diverging_palette(240, 20, as_cmap=True)"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "77223a07-8492-4056-a0f7-14e133e3ce2c",
+   "metadata": {},
+   "source": [
+    "Increase the amount of separation around the center value:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "82472c1e-4b16-40eb-be1d-480bbd2aa702",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sns.diverging_palette(240, 20, sep=30, as_cmap=True)"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "966e8594-b458-414c-a7b0-3e804ce407bf",
+   "metadata": {},
+   "source": [
+    "Use a magenta-to-green palette instead:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a03f8ede-b424-4e06-beb6-cf63c94bcd9e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sns.diverging_palette(280, 150)"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "b3b17689-58e2-4065-9d52-1cf5ebcd4e89",
+   "metadata": {},
+   "source": [
+    "Decrease the saturation of the endpoints:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "02aaa009-f257-4fc7-a2de-40fbb1464490",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sns.diverging_palette(280, 150, s=50)"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "db75ca48-ba72-4ca2-8480-bc72c20a70cc",
+   "metadata": {},
+   "source": [
+    "Decrease the lightness of the endpoints:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "89e3bcb1-a17c-4465-830f-46043cb6c322",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sns.diverging_palette(280, 150, l=35)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4e42452a-a485-43e7-bbc3-338db58e4637",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e19f523f-c2f7-489a-ba00-326810e31a67",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "py310",
+   "language": "python",
+   "name": "py310"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/doc/_docstrings/ecdfplot.ipynb
+++ b/doc/_docstrings/ecdfplot.ipynb
@@ -120,9 +120,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "seaborn-py39-latest",
+   "display_name": "py310",
    "language": "python",
-   "name": "seaborn-py39-latest"
+   "name": "py310"
   },
   "language_info": {
    "codemirror_mode": {
@@ -134,7 +134,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/histplot.ipynb
+++ b/doc/_docstrings/histplot.ipynb
@@ -461,9 +461,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "seaborn-py39-latest",
+   "display_name": "py310",
    "language": "python",
-   "name": "seaborn-py39-latest"
+   "name": "py310"
   },
   "language_info": {
    "codemirror_mode": {
@@ -475,7 +475,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/hls_palette.ipynb
+++ b/doc/_docstrings/hls_palette.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9252d5a5-8af1-4f99-b799-ee044329fb23",
+   "id": "158cd1cf-6b30-4054-b32f-a166fcb883be",
    "metadata": {
     "tags": [
      "hide"
@@ -11,113 +11,123 @@
    },
    "outputs": [],
    "source": [
-    "import seaborn.objects as so\n",
-    "from seaborn import load_dataset\n",
-    "anscombe = load_dataset(\"anscombe\")"
+    "import seaborn as sns\n",
+    "sns.set_theme()\n",
+    "sns.palettes._patch_colormap_display()"
    ]
   },
   {
    "cell_type": "raw",
-   "id": "406f6608-daf2-4d3e-9f2c-1a9e93ecb840",
+   "id": "c81b86cb-fb4e-418b-8d2f-6cd10601ac5a",
    "metadata": {},
    "source": [
-    "The default theme uses the same parameters as :func:`seaborn.set_theme` with no additional arguments:"
+    "By default, return 6 colors with identical lightness and saturation and evenly-sampled hues:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5e3d639c-1167-48d2-b9b5-c26b7fa12c66",
+   "id": "6c3eaeaf-88eb-4012-96ea-41b328fa98b9",
    "metadata": {},
    "outputs": [],
    "source": [
-    "p = (\n",
-    "    so.Plot(anscombe, \"x\", \"y\")\n",
-    "    .facet(\"dataset\", wrap=2)\n",
-    "    .add(so.Line(), so.PolyFit(order=1))\n",
-    "    .add(so.Dot())\n",
-    ")\n",
-    "p"
+    "sns.hls_palette()"
    ]
   },
   {
    "cell_type": "raw",
-   "id": "e2823a91-47f1-40a8-a150-32f00bcb59ea",
+   "id": "f7624b0b-2311-45de-b6a5-fc07132ce455",
    "metadata": {},
    "source": [
-    "Pass a dictionary of rc parameters to change the appearance of the plot:"
+    "Increase the number of colors:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "368c8cdb-2e6f-4520-8412-cd1864a6c09b",
+   "id": "555c29d1-6972-4a19-ad32-957fb7545634",
    "metadata": {},
    "outputs": [],
    "source": [
-    "p.theme({\"axes.facecolor\": \"w\", \"axes.edgecolor\": \"C0\"})"
+    "sns.hls_palette(8)"
    ]
   },
   {
    "cell_type": "raw",
-   "id": "637cf0ba-e9b7-4f0f-a628-854e300c4122",
+   "id": "24713fa6-e485-4358-9ffc-d40bd9543caa",
    "metadata": {},
    "source": [
-    "Many (though not all) mark properties will reflect theme parameters by default:"
+    "Decrease the lightness:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9eb330b3-f424-405b-9653-5df9948792d9",
+   "id": "b6f80b4c-f7b4-4deb-a119-cdf6cfe1f7b5",
    "metadata": {},
    "outputs": [],
    "source": [
-    "p.theme({\"lines.linewidth\": 4})"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "2c8fa27e-d1ea-4376-a717-c3059ba1d272",
-   "metadata": {},
-   "source": [
-    "Apply seaborn styles by passing in the output of the style functions:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "48cafbb1-37da-42c7-a20e-b63c0fef4d41",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from seaborn import axes_style\n",
-    "p.theme({**axes_style(\"ticks\")})"
+    "sns.hls_palette(l=.3)"
    ]
   },
   {
    "cell_type": "raw",
-   "id": "bbdecb4b-382a-49f3-8928-16f5f72c39b5",
+   "id": "e521b514-5572-43e8-95ae-a20cc30169b8",
    "metadata": {},
    "source": [
-    "Or apply styles that ship with matplotlib:"
+    "Decrease the saturation:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "84a7ac28-798d-4560-bbc8-d214fd6fcada",
+   "id": "f88bd038-0c9c-48b1-92b0-d272a9c199f4",
    "metadata": {},
    "outputs": [],
    "source": [
-    "from matplotlib import style\n",
-    "p.theme({**style.library[\"fivethirtyeight\"]})"
+    "sns.hls_palette(s=.3)"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "92a2212c-2177-4c82-8a5e-9dd788e9f87c",
+   "metadata": {},
+   "source": [
+    "Change the start-point for hue sampling:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dec4db5b-1b2b-4b9d-97e1-9cf0f20d6b83",
+   "id": "f8da8fbc-551c-4896-b1b8-04203e740d78",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sns.hls_palette(h=.5)"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "87780608-1f5a-409f-b31f-6a31a599f122",
+   "metadata": {},
+   "source": [
+    "Return a continuous colormap. Notice the perceptual discontinuities, especially around yellow, cyan, and magenta: "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4c622b3b-70d7-4139-8389-f3d0d4addd66",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sns.hls_palette(as_cmap=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3a83c1de-88c5-4327-abd2-19e8f3642052",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/doc/_docstrings/husl_palette.ipynb
+++ b/doc/_docstrings/husl_palette.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9252d5a5-8af1-4f99-b799-ee044329fb23",
+   "id": "a6794650-f28f-40eb-95a7-3f0e5c4b332d",
    "metadata": {
     "tags": [
      "hide"
@@ -11,113 +11,123 @@
    },
    "outputs": [],
    "source": [
-    "import seaborn.objects as so\n",
-    "from seaborn import load_dataset\n",
-    "anscombe = load_dataset(\"anscombe\")"
+    "import seaborn as sns\n",
+    "sns.set_theme()\n",
+    "sns.palettes._patch_colormap_display()"
    ]
   },
   {
    "cell_type": "raw",
-   "id": "406f6608-daf2-4d3e-9f2c-1a9e93ecb840",
+   "id": "fab2f86e-45d4-4982-ade7-0a5ea6d762d1",
    "metadata": {},
    "source": [
-    "The default theme uses the same parameters as :func:`seaborn.set_theme` with no additional arguments:"
+    "By default, return 6 colors with identical lightness and saturation and evenly-sampled hues:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5e3d639c-1167-48d2-b9b5-c26b7fa12c66",
+   "id": "b220950e-0ca2-4101-b56a-14eebe8ee8d0",
    "metadata": {},
    "outputs": [],
    "source": [
-    "p = (\n",
-    "    so.Plot(anscombe, \"x\", \"y\")\n",
-    "    .facet(\"dataset\", wrap=2)\n",
-    "    .add(so.Line(), so.PolyFit(order=1))\n",
-    "    .add(so.Dot())\n",
-    ")\n",
-    "p"
+    "sns.husl_palette()"
    ]
   },
   {
    "cell_type": "raw",
-   "id": "e2823a91-47f1-40a8-a150-32f00bcb59ea",
+   "id": "c5e4a2e3-e6b8-42bf-be19-348ff7ae2798",
    "metadata": {},
    "source": [
-    "Pass a dictionary of rc parameters to change the appearance of the plot:"
+    "Increase the number of colors:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "368c8cdb-2e6f-4520-8412-cd1864a6c09b",
+   "id": "7d0af740-cfca-49fb-a472-1daa4ccb3f3a",
    "metadata": {},
    "outputs": [],
    "source": [
-    "p.theme({\"axes.facecolor\": \"w\", \"axes.edgecolor\": \"C0\"})"
+    "sns.husl_palette(8)"
    ]
   },
   {
    "cell_type": "raw",
-   "id": "637cf0ba-e9b7-4f0f-a628-854e300c4122",
+   "id": "1a7189f2-2a26-446a-90e7-cf41dcac4f25",
    "metadata": {},
    "source": [
-    "Many (though not all) mark properties will reflect theme parameters by default:"
+    "Decrease the lightness:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9eb330b3-f424-405b-9653-5df9948792d9",
+   "id": "43af79c7-f497-41e5-874a-83eed99500f3",
    "metadata": {},
    "outputs": [],
    "source": [
-    "p.theme({\"lines.linewidth\": 4})"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "2c8fa27e-d1ea-4376-a717-c3059ba1d272",
-   "metadata": {},
-   "source": [
-    "Apply seaborn styles by passing in the output of the style functions:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "48cafbb1-37da-42c7-a20e-b63c0fef4d41",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from seaborn import axes_style\n",
-    "p.theme({**axes_style(\"ticks\")})"
+    "sns.husl_palette(l=.4)"
    ]
   },
   {
    "cell_type": "raw",
-   "id": "bbdecb4b-382a-49f3-8928-16f5f72c39b5",
+   "id": "6d4099b7-5115-4365-b120-33a345581f5d",
    "metadata": {},
    "source": [
-    "Or apply styles that ship with matplotlib:"
+    "Decrease the saturation:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "84a7ac28-798d-4560-bbc8-d214fd6fcada",
+   "id": "52c1afc7-d982-4199-b218-222aa94563c5",
    "metadata": {},
    "outputs": [],
    "source": [
-    "from matplotlib import style\n",
-    "p.theme({**style.library[\"fivethirtyeight\"]})"
+    "sns.husl_palette(s=.4)"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "d26131ac-0d11-48c5-88b1-4e5cf9383000",
+   "metadata": {},
+   "source": [
+    "Change the start-point for hue sampling:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dec4db5b-1b2b-4b9d-97e1-9cf0f20d6b83",
+   "id": "d72f06a0-13e0-47f7-bc70-4c5935eaa130",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sns.husl_palette(h=.5)"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "7e6c3c19-41d3-4315-b03e-909d201d0e76",
+   "metadata": {},
+   "source": [
+    "Return a continuous colormap:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "49c18838-0589-496f-9a61-635195c07f61",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sns.husl_palette(as_cmap=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c710a557-8e84-44cb-ab4c-baabcc4fd328",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/doc/_docstrings/jointplot.ipynb
+++ b/doc/_docstrings/jointplot.ipynb
@@ -172,9 +172,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "seaborn-py39-latest",
+   "display_name": "py310",
    "language": "python",
-   "name": "seaborn-py39-latest"
+   "name": "py310"
   },
   "language_info": {
    "codemirror_mode": {
@@ -186,7 +186,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/kdeplot.ipynb
+++ b/doc/_docstrings/kdeplot.ipynb
@@ -327,9 +327,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "seaborn-py39-latest",
+   "display_name": "py310",
    "language": "python",
-   "name": "seaborn-py39-latest"
+   "name": "py310"
   },
   "language_info": {
    "codemirror_mode": {
@@ -341,7 +341,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/light_palette.ipynb
+++ b/doc/_docstrings/light_palette.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "882d215b-88d8-4b5e-ae7a-0e3f6bb53bad",
+   "id": "5cd1cbb8-ba1a-460b-8e3a-bc285867f1d1",
    "metadata": {
     "tags": [
      "hide"
@@ -12,95 +12,104 @@
    "outputs": [],
    "source": [
     "import seaborn as sns\n",
-    "sns.set_theme(style=\"whitegrid\")"
+    "sns.set_theme()\n",
+    "sns.palettes._patch_colormap_display()"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "b157eb25-015f-4dd6-9785-83ba19cf4f94",
+   "metadata": {},
+   "source": [
+    "Define a sequential ramp from a light gray to a specified color:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6809326c-14a9-4314-994d-b4e8e7414172",
+   "id": "851a4742-6276-4383-b17e-480beb896877",
    "metadata": {},
    "outputs": [],
    "source": [
-    "df = sns.load_dataset(\"diamonds\")"
+    "sns.light_palette(\"seagreen\")"
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "9ccbc2d5-5a44-4e80-8b07-e12629729f4a",
+   "cell_type": "raw",
+   "id": "50053b26-112a-4378-8ef0-9be0fb565ec7",
    "metadata": {},
    "source": [
-    "Draw a single horizontal plot, assigning the data directly to the coordinate variable:"
+    "Specify the color with a hex code:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "391e1162-b438-4486-9a08-60686ee8e96a",
+   "id": "74ae0d17-f65b-4bcf-ae66-d97d46964d5c",
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.boxenplot(x=df[\"price\"])"
+    "sns.light_palette(\"#79C\")"
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "a3b0e9b8-1673-494c-a27a-aa9c60457ba1",
+   "cell_type": "raw",
+   "id": "eea376a2-fdf5-40e4-a187-3a28af529072",
    "metadata": {},
    "source": [
-    "Group by a categorical variable, referencing columns in a datafame"
+    "Specify the color from the husl system:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e30fec18-f127-40a3-bfaf-f71324dd60ec",
+   "id": "66e451ee-869a-41ea-8dc5-4240b11e7be5",
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.boxenplot(data=df, x=\"price\", y=\"clarity\")"
+    "sns.light_palette((20, 60, 50), input=\"husl\")"
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "4f01a821-74d1-452d-a1f7-cf5b806169e8",
+   "cell_type": "raw",
+   "id": "e4f44dcd-cf49-4920-ac05-b4db67870363",
    "metadata": {},
    "source": [
-    "Use a different scaling rule to control the width of each box:"
+    "Increase the number of colors:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d0c1aa43-5e8a-486c-bd6d-3c29d6d23138",
+   "id": "75985f07-de92-4d8b-89d5-caf445b9375e",
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.boxenplot(data=df, x=\"carat\", y=\"cut\", scale=\"linear\")"
+    "sns.light_palette(\"xkcd:copper\", 8)"
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "fd5d197c-8cbb-4be3-a14d-76447f06d3f1",
+   "cell_type": "raw",
+   "id": "34687ae8-fd6d-427a-a639-208f19e61122",
    "metadata": {},
    "source": [
-    "Use a different method to determine the number of boxes:"
+    "Return a continuous colormap rather than a discrete palette:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1aead6a3-6f12-47d3-b472-a39c61867963",
+   "id": "2c342db4-7f97-40f5-934e-9a82201890d1",
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.boxenplot(data=df, x=\"carat\", y=\"cut\", k_depth=\"trustworthy\")"
+    "sns.light_palette(\"#a275ac\", as_cmap=True)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "719fd61f-9795-47d6-96bd-4929d8647038",
+   "id": "e7ebe64b-25fa-4c52-9ebe-fdcbba0ee51e",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/doc/_docstrings/lineplot.ipynb
+++ b/doc/_docstrings/lineplot.ipynb
@@ -431,9 +431,9 @@
    "hash": "8bdfc9d9da1e36addfcfc8a3409187c45d33387af0f87d0d91e99e8d6403f1c3"
   },
   "kernelspec": {
-   "display_name": "seaborn-py39-latest",
+   "display_name": "py310",
    "language": "python",
-   "name": "seaborn-py39-latest"
+   "name": "py310"
   },
   "language_info": {
    "codemirror_mode": {
@@ -445,7 +445,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/move_legend.ipynb
+++ b/doc/_docstrings/move_legend.ipynb
@@ -134,9 +134,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "seaborn-py39-latest",
+   "display_name": "py310",
    "language": "python",
-   "name": "seaborn-py39-latest"
+   "name": "py310"
   },
   "language_info": {
    "codemirror_mode": {
@@ -148,7 +148,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/mpl_palette.ipynb
+++ b/doc/_docstrings/mpl_palette.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "882d215b-88d8-4b5e-ae7a-0e3f6bb53bad",
+   "id": "1d0d41d3-463c-4c6f-aa65-38131bdf3ddb",
    "metadata": {
     "tags": [
      "hide"
@@ -12,95 +12,104 @@
    "outputs": [],
    "source": [
     "import seaborn as sns\n",
-    "sns.set_theme(style=\"whitegrid\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "6809326c-14a9-4314-994d-b4e8e7414172",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "df = sns.load_dataset(\"diamonds\")"
+    "sns.set_theme()\n",
+    "sns.palettes._patch_colormap_display()"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "9ccbc2d5-5a44-4e80-8b07-e12629729f4a",
+   "id": "d2a0ae1e-a01e-49b3-a677-2b05a195990a",
    "metadata": {},
    "source": [
-    "Draw a single horizontal plot, assigning the data directly to the coordinate variable:"
+    "Return discrete samples from a continuous matplotlib colormap:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "391e1162-b438-4486-9a08-60686ee8e96a",
+   "id": "2b6a4ce9-6e4e-4b59-ada8-14ef8aef21d7",
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.boxenplot(x=df[\"price\"])"
+    "sns.mpl_palette(\"viridis\")"
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "a3b0e9b8-1673-494c-a27a-aa9c60457ba1",
+   "cell_type": "raw",
+   "id": "0ccc47b1-c969-46e2-93bb-b9eb5a2e2141",
    "metadata": {},
    "source": [
-    "Group by a categorical variable, referencing columns in a datafame"
+    "Return the continuous colormap instead; note how the extreme values are more intense:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e30fec18-f127-40a3-bfaf-f71324dd60ec",
+   "id": "a8a1bc5d-1d62-45c6-a53b-9fadb58f11c0",
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.boxenplot(data=df, x=\"price\", y=\"clarity\")"
+    "sns.mpl_palette(\"viridis\", as_cmap=True)"
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "4f01a821-74d1-452d-a1f7-cf5b806169e8",
+   "cell_type": "raw",
+   "id": "ff0d1a3b-8641-40c0-bb4b-c22b83ec9432",
    "metadata": {},
    "source": [
-    "Use a different scaling rule to control the width of each box:"
+    "Return more colors:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d0c1aa43-5e8a-486c-bd6d-3c29d6d23138",
+   "id": "8faef1d8-a1eb-4060-be10-377342c9bd1d",
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.boxenplot(data=df, x=\"carat\", y=\"cut\", scale=\"linear\")"
+    "sns.mpl_palette(\"viridis\", 8)"
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "fd5d197c-8cbb-4be3-a14d-76447f06d3f1",
+   "cell_type": "raw",
+   "id": "612bf052-e888-411d-a2ea-6a742a78bc63",
    "metadata": {},
    "source": [
-    "Use a different method to determine the number of boxes:"
+    "Return values from a qualitative colormap:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1aead6a3-6f12-47d3-b472-a39c61867963",
+   "id": "74db95a8-4898-4f6c-a57d-c751af1dc7bf",
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.boxenplot(data=df, x=\"carat\", y=\"cut\", k_depth=\"trustworthy\")"
+    "sns.mpl_palette(\"Set2\")"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "918494bf-1b8e-4b00-8950-1bd73032dee1",
+   "metadata": {},
+   "source": [
+    "Notice how the palette will only contain distinct colors and can be shorter than requested:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "719fd61f-9795-47d6-96bd-4929d8647038",
+   "id": "d97efa25-9050-4e28-b758-da6f43c9f963",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sns.mpl_palette(\"Set2\", 10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f64ad118-e213-43cc-a714-98ed13cc3824",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/doc/_docstrings/objects.Area.ipynb
+++ b/doc/_docstrings/objects.Area.ipynb
@@ -139,9 +139,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "seaborn-py39-latest",
+   "display_name": "py310",
    "language": "python",
-   "name": "seaborn-py39-latest"
+   "name": "py310"
   },
   "language_info": {
    "codemirror_mode": {
@@ -153,7 +153,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/objects.Band.ipynb
+++ b/doc/_docstrings/objects.Band.ipynb
@@ -97,9 +97,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "seaborn-py39-latest",
+   "display_name": "py310",
    "language": "python",
-   "name": "seaborn-py39-latest"
+   "name": "py310"
   },
   "language_info": {
    "codemirror_mode": {
@@ -111,7 +111,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/objects.Bar.ipynb
+++ b/doc/_docstrings/objects.Bar.ipynb
@@ -164,9 +164,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "seaborn-py39-latest",
+   "display_name": "py310",
    "language": "python",
-   "name": "seaborn-py39-latest"
+   "name": "py310"
   },
   "language_info": {
    "codemirror_mode": {
@@ -178,7 +178,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/objects.Bars.ipynb
+++ b/doc/_docstrings/objects.Bars.ipynb
@@ -143,9 +143,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "seaborn-py39-latest",
+   "display_name": "py310",
    "language": "python",
-   "name": "seaborn-py39-latest"
+   "name": "py310"
   },
   "language_info": {
    "codemirror_mode": {
@@ -157,7 +157,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/objects.Dot.ipynb
+++ b/doc/_docstrings/objects.Dot.ipynb
@@ -168,9 +168,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "seaborn-py39-latest",
+   "display_name": "py310",
    "language": "python",
-   "name": "seaborn-py39-latest"
+   "name": "py310"
   },
   "language_info": {
    "codemirror_mode": {
@@ -182,7 +182,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/objects.Dots.ipynb
+++ b/doc/_docstrings/objects.Dots.ipynb
@@ -124,9 +124,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "seaborn-py39-latest",
+   "display_name": "py310",
    "language": "python",
-   "name": "seaborn-py39-latest"
+   "name": "py310"
   },
   "language_info": {
    "codemirror_mode": {
@@ -138,7 +138,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/objects.Line.ipynb
+++ b/doc/_docstrings/objects.Line.ipynb
@@ -146,9 +146,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "seaborn-py39-latest",
+   "display_name": "py310",
    "language": "python",
-   "name": "seaborn-py39-latest"
+   "name": "py310"
   },
   "language_info": {
    "codemirror_mode": {
@@ -160,7 +160,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/objects.Lines.ipynb
+++ b/doc/_docstrings/objects.Lines.ipynb
@@ -75,9 +75,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "seaborn-py39-latest",
+   "display_name": "py310",
    "language": "python",
-   "name": "seaborn-py39-latest"
+   "name": "py310"
   },
   "language_info": {
    "codemirror_mode": {
@@ -89,7 +89,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/objects.Path.ipynb
+++ b/doc/_docstrings/objects.Path.ipynb
@@ -64,9 +64,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "seaborn-py39-latest",
+   "display_name": "py310",
    "language": "python",
-   "name": "seaborn-py39-latest"
+   "name": "py310"
   },
   "language_info": {
    "codemirror_mode": {
@@ -78,7 +78,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/objects.Paths.ipynb
+++ b/doc/_docstrings/objects.Paths.ipynb
@@ -81,9 +81,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "seaborn-py39-latest",
+   "display_name": "py310",
    "language": "python",
-   "name": "seaborn-py39-latest"
+   "name": "py310"
   },
   "language_info": {
    "codemirror_mode": {
@@ -95,7 +95,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/objects.Plot.add.ipynb
+++ b/doc/_docstrings/objects.Plot.add.ipynb
@@ -196,9 +196,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "seaborn-py39-latest",
+   "display_name": "py310",
    "language": "python",
-   "name": "seaborn-py39-latest"
+   "name": "py310"
   },
   "language_info": {
    "codemirror_mode": {
@@ -210,7 +210,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/objects.Plot.facet.ipynb
+++ b/doc/_docstrings/objects.Plot.facet.ipynb
@@ -200,9 +200,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "seaborn-py39-latest",
+   "display_name": "py310",
    "language": "python",
-   "name": "seaborn-py39-latest"
+   "name": "py310"
   },
   "language_info": {
    "codemirror_mode": {
@@ -214,7 +214,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/objects.Plot.label.ipynb
+++ b/doc/_docstrings/objects.Plot.label.ipynb
@@ -139,9 +139,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "seaborn-py39-latest",
+   "display_name": "py310",
    "language": "python",
-   "name": "seaborn-py39-latest"
+   "name": "py310"
   },
   "language_info": {
    "codemirror_mode": {
@@ -153,7 +153,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/objects.Plot.layout.ipynb
+++ b/doc/_docstrings/objects.Plot.layout.ipynb
@@ -80,9 +80,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "seaborn-py39-latest",
+   "display_name": "py310",
    "language": "python",
-   "name": "seaborn-py39-latest"
+   "name": "py310"
   },
   "language_info": {
    "codemirror_mode": {
@@ -94,7 +94,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/objects.Plot.limit.ipynb
+++ b/doc/_docstrings/objects.Plot.limit.ipynb
@@ -98,9 +98,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "seaborn-py39-latest",
+   "display_name": "py310",
    "language": "python",
-   "name": "seaborn-py39-latest"
+   "name": "py310"
   },
   "language_info": {
    "codemirror_mode": {
@@ -112,7 +112,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/objects.Plot.on.ipynb
+++ b/doc/_docstrings/objects.Plot.on.ipynb
@@ -160,9 +160,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "seaborn-py39-latest",
+   "display_name": "py310",
    "language": "python",
-   "name": "seaborn-py39-latest"
+   "name": "py310"
   },
   "language_info": {
    "codemirror_mode": {
@@ -174,7 +174,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/objects.Plot.pair.ipynb
+++ b/doc/_docstrings/objects.Plot.pair.ipynb
@@ -195,9 +195,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "seaborn-py39-latest",
+   "display_name": "py310",
    "language": "python",
-   "name": "seaborn-py39-latest"
+   "name": "py310"
   },
   "language_info": {
    "codemirror_mode": {
@@ -209,7 +209,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/objects.Plot.scale.ipynb
+++ b/doc/_docstrings/objects.Plot.scale.ipynb
@@ -294,9 +294,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "seaborn-py39-latest",
+   "display_name": "py310",
    "language": "python",
-   "name": "seaborn-py39-latest"
+   "name": "py310"
   },
   "language_info": {
    "codemirror_mode": {
@@ -308,7 +308,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/objects.Plot.share.ipynb
+++ b/doc/_docstrings/objects.Plot.share.ipynb
@@ -109,9 +109,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "seaborn-py39-latest",
+   "display_name": "py310",
    "language": "python",
-   "name": "seaborn-py39-latest"
+   "name": "py310"
   },
   "language_info": {
    "codemirror_mode": {
@@ -123,7 +123,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/objects.Range.ipynb
+++ b/doc/_docstrings/objects.Range.ipynb
@@ -100,9 +100,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "seaborn-py39-latest",
+   "display_name": "py310",
    "language": "python",
-   "name": "seaborn-py39-latest"
+   "name": "py310"
   },
   "language_info": {
    "codemirror_mode": {
@@ -114,7 +114,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/plotting_context.ipynb
+++ b/doc/_docstrings/plotting_context.ipynb
@@ -88,9 +88,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "seaborn-py39-latest",
+   "display_name": "py310",
    "language": "python",
-   "name": "seaborn-py39-latest"
+   "name": "py310"
   },
   "language_info": {
    "codemirror_mode": {
@@ -102,7 +102,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/pointplot.ipynb
+++ b/doc/_docstrings/pointplot.ipynb
@@ -120,9 +120,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "seaborn-py39-latest",
+   "display_name": "py310",
    "language": "python",
-   "name": "seaborn-py39-latest"
+   "name": "py310"
   },
   "language_info": {
    "codemirror_mode": {
@@ -134,7 +134,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/relplot.ipynb
+++ b/doc/_docstrings/relplot.ipynb
@@ -240,9 +240,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "seaborn-py39-latest",
+   "display_name": "py310",
    "language": "python",
-   "name": "seaborn-py39-latest"
+   "name": "py310"
   },
   "language_info": {
    "codemirror_mode": {
@@ -254,7 +254,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/rugplot.ipynb
+++ b/doc/_docstrings/rugplot.ipynb
@@ -115,9 +115,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "seaborn-py39-latest",
+   "display_name": "py310",
    "language": "python",
-   "name": "seaborn-py39-latest"
+   "name": "py310"
   },
   "language_info": {
    "codemirror_mode": {
@@ -129,7 +129,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/scatterplot.ipynb
+++ b/doc/_docstrings/scatterplot.ipynb
@@ -285,9 +285,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "seaborn-py39-latest",
+   "display_name": "py310",
    "language": "python",
-   "name": "seaborn-py39-latest"
+   "name": "py310"
   },
   "language_info": {
    "codemirror_mode": {
@@ -299,7 +299,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/set_style.ipynb
+++ b/doc/_docstrings/set_style.ipynb
@@ -63,9 +63,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "seaborn-py39-latest",
+   "display_name": "py310",
    "language": "python",
-   "name": "seaborn-py39-latest"
+   "name": "py310"
   },
   "language_info": {
    "codemirror_mode": {
@@ -77,7 +77,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/set_theme.ipynb
+++ b/doc/_docstrings/set_theme.ipynb
@@ -139,9 +139,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "seaborn-py39-latest",
+   "display_name": "py310",
    "language": "python",
-   "name": "seaborn-py39-latest"
+   "name": "py310"
   },
   "language_info": {
    "codemirror_mode": {
@@ -153,7 +153,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/stripplot.ipynb
+++ b/doc/_docstrings/stripplot.ipynb
@@ -291,9 +291,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "seaborn-py39-latest",
+   "display_name": "py310",
    "language": "python",
-   "name": "seaborn-py39-latest"
+   "name": "py310"
   },
   "language_info": {
    "codemirror_mode": {
@@ -305,7 +305,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/swarmplot.ipynb
+++ b/doc/_docstrings/swarmplot.ipynb
@@ -263,9 +263,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "seaborn-py39-latest",
+   "display_name": "py310",
    "language": "python",
-   "name": "seaborn-py39-latest"
+   "name": "py310"
   },
   "language_info": {
    "codemirror_mode": {
@@ -277,7 +277,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/violinplot.ipynb
+++ b/doc/_docstrings/violinplot.ipynb
@@ -171,9 +171,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "seaborn-py39-latest",
+   "display_name": "py310",
    "language": "python",
-   "name": "seaborn-py39-latest"
+   "name": "py310"
   },
   "language_info": {
    "codemirror_mode": {
@@ -185,7 +185,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,

--- a/doc/_tutorial/aesthetics.ipynb
+++ b/doc/_tutorial/aesthetics.ipynb
@@ -404,9 +404,9 @@
  "metadata": {
   "celltoolbar": "Tags",
   "kernelspec": {
-   "display_name": "seaborn-py39-latest",
+   "display_name": "py310",
    "language": "python",
-   "name": "seaborn-py39-latest"
+   "name": "py310"
   },
   "language_info": {
    "codemirror_mode": {
@@ -418,7 +418,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,

--- a/doc/_tutorial/axis_grids.ipynb
+++ b/doc/_tutorial/axis_grids.ipynb
@@ -531,9 +531,9 @@
  "metadata": {
   "celltoolbar": "Tags",
   "kernelspec": {
-   "display_name": "seaborn-py39-latest",
+   "display_name": "py310",
    "language": "python",
-   "name": "seaborn-py39-latest"
+   "name": "py310"
   },
   "language_info": {
    "codemirror_mode": {
@@ -545,7 +545,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,

--- a/doc/_tutorial/categorical.ipynb
+++ b/doc/_tutorial/categorical.ipynb
@@ -520,9 +520,9 @@
  "metadata": {
   "celltoolbar": "Tags",
   "kernelspec": {
-   "display_name": "seaborn-py39-latest",
+   "display_name": "py310",
    "language": "python",
-   "name": "seaborn-py39-latest"
+   "name": "py310"
   },
   "language_info": {
    "codemirror_mode": {
@@ -534,7 +534,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,

--- a/doc/_tutorial/color_palettes.ipynb
+++ b/doc/_tutorial/color_palettes.ipynb
@@ -982,9 +982,9 @@
  "metadata": {
   "celltoolbar": "Tags",
   "kernelspec": {
-   "display_name": "seaborn-py39-latest",
+   "display_name": "py310",
    "language": "python",
-   "name": "seaborn-py39-latest"
+   "name": "py310"
   },
   "language_info": {
    "codemirror_mode": {
@@ -996,7 +996,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,

--- a/doc/_tutorial/data_structure.ipynb
+++ b/doc/_tutorial/data_structure.ipynb
@@ -475,9 +475,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "seaborn-py39-latest",
+   "display_name": "py310",
    "language": "python",
-   "name": "seaborn-py39-latest"
+   "name": "py310"
   },
   "language_info": {
    "codemirror_mode": {
@@ -489,7 +489,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,

--- a/doc/_tutorial/distributions.ipynb
+++ b/doc/_tutorial/distributions.ipynb
@@ -836,9 +836,9 @@
  "metadata": {
   "celltoolbar": "Tags",
   "kernelspec": {
-   "display_name": "seaborn-py39-latest",
+   "display_name": "py310",
    "language": "python",
-   "name": "seaborn-py39-latest"
+   "name": "py310"
   },
   "language_info": {
    "codemirror_mode": {
@@ -850,7 +850,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,

--- a/doc/_tutorial/error_bars.ipynb
+++ b/doc/_tutorial/error_bars.ipynb
@@ -347,9 +347,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "seaborn-py39-latest",
+   "display_name": "py310",
    "language": "python",
-   "name": "seaborn-py39-latest"
+   "name": "py310"
   },
   "language_info": {
    "codemirror_mode": {
@@ -361,7 +361,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,

--- a/doc/_tutorial/function_overview.ipynb
+++ b/doc/_tutorial/function_overview.ipynb
@@ -474,9 +474,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "seaborn-py39-latest",
+   "display_name": "py310",
    "language": "python",
-   "name": "seaborn-py39-latest"
+   "name": "py310"
   },
   "language_info": {
    "codemirror_mode": {
@@ -488,7 +488,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,

--- a/doc/_tutorial/introduction.ipynb
+++ b/doc/_tutorial/introduction.ipynb
@@ -447,9 +447,9 @@
  "metadata": {
   "celltoolbar": "Tags",
   "kernelspec": {
-   "display_name": "seaborn-py39-latest",
+   "display_name": "py310",
    "language": "python",
-   "name": "seaborn-py39-latest"
+   "name": "py310"
   },
   "language_info": {
    "codemirror_mode": {
@@ -461,7 +461,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,

--- a/doc/_tutorial/objects_interface.ipynb
+++ b/doc/_tutorial/objects_interface.ipynb
@@ -1057,9 +1057,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "seaborn-py39-latest",
+   "display_name": "py310",
    "language": "python",
-   "name": "seaborn-py39-latest"
+   "name": "py310"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1071,7 +1071,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,

--- a/doc/_tutorial/properties.ipynb
+++ b/doc/_tutorial/properties.ipynb
@@ -949,9 +949,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "seaborn-py39-latest",
+   "display_name": "py310",
    "language": "python",
-   "name": "seaborn-py39-latest"
+   "name": "py310"
   },
   "language_info": {
    "codemirror_mode": {
@@ -963,7 +963,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,

--- a/doc/_tutorial/regression.ipynb
+++ b/doc/_tutorial/regression.ipynb
@@ -432,9 +432,9 @@
  "metadata": {
   "celltoolbar": "Tags",
   "kernelspec": {
-   "display_name": "seaborn-py39-latest",
+   "display_name": "py310",
    "language": "python",
-   "name": "seaborn-py39-latest"
+   "name": "py310"
   },
   "language_info": {
    "codemirror_mode": {
@@ -446,7 +446,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,

--- a/doc/_tutorial/relational.ipynb
+++ b/doc/_tutorial/relational.ipynb
@@ -663,9 +663,9 @@
  "metadata": {
   "celltoolbar": "Tags",
   "kernelspec": {
-   "display_name": "seaborn-py39-latest",
+   "display_name": "py310",
    "language": "python",
-   "name": "seaborn-py39-latest"
+   "name": "py310"
   },
   "language_info": {
    "codemirror_mode": {
@@ -677,7 +677,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,

--- a/doc/whatsnew/index.rst
+++ b/doc/whatsnew/index.rst
@@ -8,6 +8,7 @@ v0.12
 .. toctree::
    :maxdepth: 2
 
+   v0.12.1
    v0.12.0
 
 v0.11

--- a/doc/whatsnew/v0.12.1.rst
+++ b/doc/whatsnew/v0.12.1.rst
@@ -3,3 +3,5 @@ v0.12.1 (Unreleased)
 --------------------
 
 - |Fix| Make :class:`objects.PolyFit` robust to missing data (:pr:`3010`).
+
+- |Build| Seaborn no longer contains doctest-style examples, simplifying the testing infrastructure (:pr:`3034`).

--- a/seaborn/palettes.py
+++ b/seaborn/palettes.py
@@ -814,32 +814,17 @@ def set_color_codes(palette="deep"):
     set_palette : Color codes can also be set through the function that
                   sets the matplotlib color cycle.
 
-    Examples
-    --------
-
-    Map matplotlib color codes to the default seaborn palette.
-
-    .. plot::
-        :context: close-figs
-
-        >>> import matplotlib.pyplot as plt
-        >>> import seaborn as sns; sns.set_theme()
-        >>> sns.set_color_codes()
-        >>> _ = plt.plot([0, 1], color="r")
-
-    Use a different seaborn palette.
-
-    .. plot::
-        :context: close-figs
-
-        >>> sns.set_color_codes("dark")
-        >>> _ = plt.plot([0, 1], color="g")
-        >>> _ = plt.plot([0, 2], color="m")
-
     """
     if palette == "reset":
-        colors = [(0., 0., 1.), (0., .5, 0.), (1., 0., 0.), (.75, 0., .75),
-                  (.75, .75, 0.), (0., .75, .75), (0., 0., 0.)]
+        colors = [
+            (0., 0., 1.),
+            (0., .5, 0.),
+            (1., 0., 0.),
+            (.75, 0., .75),
+            (.75, .75, 0.),
+            (0., .75, .75),
+            (0., 0., 0.)
+        ]
     elif not isinstance(palette, str):
         err = "set_color_codes requires a named seaborn palette"
         raise TypeError(err)

--- a/seaborn/rcmod.py
+++ b/seaborn/rcmod.py
@@ -516,12 +516,6 @@ def set_palette(palette, n_colors=None, desat=None, color_codes=False):
         If ``True`` and ``palette`` is a seaborn palette, remap the shorthand
         color codes (e.g. "b", "g", "r", etc.) to the colors from this palette.
 
-    Examples
-    --------
-    >>> set_palette("Reds")
-
-    >>> set_palette("Set1", 8, .75)
-
     See Also
     --------
     color_palette : build a color palette or set the color cycle temporarily

--- a/seaborn/widgets.py
+++ b/seaborn/widgets.py
@@ -2,26 +2,12 @@ import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib.colors import LinearSegmentedColormap
 
-# Lots of different places that widgets could come from...
 try:
     from ipywidgets import interact, FloatSlider, IntSlider
 except ImportError:
-    import warnings
-    # ignore ShimWarning raised by IPython, see GH #892
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
-        try:
-            from IPython.html.widgets import interact, FloatSlider, IntSlider
-        except ImportError:
-            try:
-                from IPython.html.widgets import (interact,
-                                                  FloatSliderWidget,
-                                                  IntSliderWidget)
-                FloatSlider = FloatSliderWidget
-                IntSlider = IntSliderWidget
-            except ImportError:
-                pass
-
+    def interact(f):
+        msg = "Interactive palettes require `ipywidgets`, which is not installed."
+        raise ImportError(msg)
 
 from .miscplot import palplot
 from .palettes import (color_palette, dark_palette, light_palette,

--- a/tests/test_palettes.py
+++ b/tests/test_palettes.py
@@ -416,9 +416,22 @@ class TestColorPalettes:
         pal_out = palettes.color_palette(pal_in)
         assert pal_in == pal_out
 
-    def test_html_rep(self):
+    def test_html_repr(self):
 
         pal = palettes.color_palette()
         html = pal._repr_html_()
         for color in pal.as_hex():
             assert color in html
+
+    def test_colormap_display_patch(self):
+
+        orig_repr_png = mpl.colors.Colormap._repr_png_
+        orig_repr_html = mpl.colors.Colormap._repr_html_
+
+        try:
+            palettes._patch_colormap_display()
+            cmap = mpl.cm.Reds
+            assert cmap._repr_html_().startswith('<img alt="Reds')
+        finally:
+            mpl.colors.Colormap._repr_png_ = orig_repr_png
+            mpl.colors.Colormap._repr_html_ = orig_repr_html

--- a/tests/test_palettes.py
+++ b/tests/test_palettes.py
@@ -9,7 +9,6 @@ from seaborn import palettes, utils, rcmod
 from seaborn.external import husl
 from seaborn._compat import get_colormap
 from seaborn.colors import xkcd_rgb, crayons
-from seaborn.external.version import Version
 
 
 class TestColorPalettes:
@@ -424,16 +423,17 @@ class TestColorPalettes:
         for color in pal.as_hex():
             assert color in html
 
-    @pytest.mark.skipif(Version(mpl.__version__) < Version("3.4.0"))
     def test_colormap_display_patch(self):
 
-        orig_repr_png = mpl.colors.Colormap._repr_png_
-        orig_repr_html = mpl.colors.Colormap._repr_html_
+        orig_repr_png = getattr(mpl.colors.Colormap, "_repr_png_", None)
+        orig_repr_html = getattr(mpl.colors.Colormap, "_repr_html_", None)
 
         try:
             palettes._patch_colormap_display()
             cmap = mpl.cm.Reds
             assert cmap._repr_html_().startswith('<img alt="Reds')
         finally:
-            mpl.colors.Colormap._repr_png_ = orig_repr_png
-            mpl.colors.Colormap._repr_html_ = orig_repr_html
+            if orig_repr_png is not None:
+                mpl.colors.Colormap._repr_png_ = orig_repr_png
+            if orig_repr_html is not None:
+                mpl.colors.Colormap._repr_html_ = orig_repr_html

--- a/tests/test_palettes.py
+++ b/tests/test_palettes.py
@@ -9,6 +9,7 @@ from seaborn import palettes, utils, rcmod
 from seaborn.external import husl
 from seaborn._compat import get_colormap
 from seaborn.colors import xkcd_rgb, crayons
+from seaborn.external.version import Version
 
 
 class TestColorPalettes:
@@ -423,6 +424,7 @@ class TestColorPalettes:
         for color in pal.as_hex():
             assert color in html
 
+    @pytest.mark.skipif(Version(mpl.__version__) < Version("3.4.0"))
     def test_colormap_display_patch(self):
 
         orig_repr_png = mpl.colors.Colormap._repr_png_


### PR DESCRIPTION
This completes the removal of doctest-style examples from the seaborn codebase, so testing infrastructure complexity distinguishing between unit/doc tests is also removed. Closes #2110 

Additionally:

- make various docstring improvements
- provide better feedback for the colormap widgets when `ipywidgets` is not installed.