### PR TITLE
use .items() instead of .iteritems() (deprecated)

### DIFF
--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -742,7 +742,7 @@ class FacetGrid(Grid):
             plot_data = data_ijk[list(args)]
             if self._dropna:
                 plot_data = plot_data.dropna()
-            plot_args = [v for k, v in plot_data.iteritems()]
+            plot_args = [v for k, v in plot_data.items()]
 
             # Some matplotlib functions don't handle pandas objects correctly
             if func_module.startswith("matplotlib"):

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -466,7 +466,7 @@ class _CategoricalPlotter:
                 group_label = data.columns.name
 
                 # Convert to a list of arrays, the common representation
-                iter_data = plot_data.iteritems()
+                iter_data = plot_data.items()
                 plot_data = [np.asarray(s, float) for k, s in iter_data]
 
             # Option 1b:


### PR DESCRIPTION
fixes #3037 (maybe; it's a naive quick attempt at a fix --- I haven't yet examined your minimium supported versions or anything so this may well fail some of your tests)