### PR TITLE
CI: Make tests more robust to concurrency

### DIFF
--- a/tests/_core/test_plot.py
+++ b/tests/_core/test_plot.py
@@ -880,7 +880,7 @@ class TestPlotting:
 
     def test_theme_params(self):
 
-        color = "r"
+        color = ".888"
         p = Plot().theme({"axes.facecolor": color}).plot()
         assert mpl.colors.same_color(p._figure.axes[0].get_facecolor(), color)
 

--- a/tests/_marks/test_area.py
+++ b/tests/_marks/test_area.py
@@ -17,6 +17,7 @@ class TestAreaMarks:
         ax = p._figure.axes[0]
         poly = ax.patches[0]
         verts = poly.get_path().vertices.T
+        colors = p._theme["axes.prop_cycle"].by_key()["color"]
 
         expected_x = [1, 2, 3, 3, 2, 1, 1]
         assert_array_equal(verts[0], expected_x)
@@ -25,21 +26,21 @@ class TestAreaMarks:
         assert_array_equal(verts[1], expected_y)
 
         fc = poly.get_facecolor()
-        assert_array_equal(fc, to_rgba("C0", .2))
+        assert_array_equal(fc, to_rgba(colors[0], .2))
 
         ec = poly.get_edgecolor()
-        assert_array_equal(ec, to_rgba("C0", 1))
+        assert_array_equal(ec, to_rgba(colors[0], 1))
 
         lw = poly.get_linewidth()
         assert_array_equal(lw, mpl.rcParams["patch.linewidth"] * 2)
 
-    def test_set_parameters(self):
+    def test_set_properties(self):
 
         x, y = [1, 2, 3], [1, 2, 1]
         mark = Area(
-            color="C2",
+            color=".33",
             alpha=.3,
-            edgecolor=".3",
+            edgecolor=".88",
             edgealpha=.8,
             edgewidth=2,
             edgestyle=(0, (2, 1)),
@@ -62,11 +63,12 @@ class TestAreaMarks:
         expected = (0, (mark.edgewidth * dash_on / 4, mark.edgewidth * dash_off / 4))
         assert ls == expected
 
-    def test_mapped(self):
+    def test_mapped_properties(self):
 
         x, y = [1, 2, 3, 2, 3, 4], [1, 2, 1, 1, 3, 2]
         g = ["a", "a", "a", "b", "b", "b"]
-        p = Plot(x=x, y=y, color=g, edgewidth=g).add(Area()).plot()
+        cs = [".2", ".8"]
+        p = Plot(x=x, y=y, color=g, edgewidth=g).scale(color=cs).add(Area()).plot()
         ax = p._figure.axes[0]
 
         expected_x = [1, 2, 3, 3, 2, 1, 1], [2, 3, 4, 4, 3, 2, 2]
@@ -78,10 +80,10 @@ class TestAreaMarks:
             assert_array_equal(verts[1], expected_y[i])
 
         fcs = [p.get_facecolor() for p in ax.patches]
-        assert_array_equal(fcs, to_rgba_array(["C0", "C1"], .2))
+        assert_array_equal(fcs, to_rgba_array(cs, .2))
 
         ecs = [p.get_edgecolor() for p in ax.patches]
-        assert_array_equal(ecs, to_rgba_array(["C0", "C1"], 1))
+        assert_array_equal(ecs, to_rgba_array(cs, 1))
 
         lws = [p.get_linewidth() for p in ax.patches]
         assert lws[0] > lws[1]
@@ -89,10 +91,11 @@ class TestAreaMarks:
     def test_unfilled(self):
 
         x, y = [1, 2, 3], [1, 2, 1]
-        p = Plot(x=x, y=y).add(Area(fill=False)).plot()
+        c = ".5"
+        p = Plot(x=x, y=y).add(Area(fill=False, color=c)).plot()
         ax = p._figure.axes[0]
         poly = ax.patches[0]
-        assert poly.get_facecolor() == to_rgba("C0", 0)
+        assert poly.get_facecolor() == to_rgba(c, 0)
 
     def test_band(self):
 

--- a/tests/_marks/test_bar.py
+++ b/tests/_marks/test_bar.py
@@ -67,7 +67,7 @@ class TestBar:
         y = [1, 3, 2]
 
         mark = Bar(
-            color="C2",
+            color=".8",
             alpha=.5,
             edgecolor=".3",
             edgealpha=.9,
@@ -92,9 +92,10 @@ class TestBar:
         mark = Bar(alpha=.2)
         p = Plot(x, y, color=x, edgewidth=y).add(mark).plot()
         ax = p._figure.axes[0]
+        colors = p._theme["axes.prop_cycle"].by_key()["color"]
         for i, bar in enumerate(ax.patches):
-            assert bar.get_facecolor() == to_rgba(f"C{i}", mark.alpha)
-            assert bar.get_edgecolor() == to_rgba(f"C{i}", 1)
+            assert bar.get_facecolor() == to_rgba(colors[i], mark.alpha)
+            assert bar.get_edgecolor() == to_rgba(colors[i], 1)
         assert ax.patches[0].get_linewidth() < ax.patches[1].get_linewidth()
 
     def test_zero_height_skipped(self):
@@ -166,7 +167,8 @@ class TestBars:
         p = Plot(x, y, color=color).add(Bars(alpha=alpha)).plot()
         ax = p._figure.axes[0]
         fcs = ax.collections[0].get_facecolors()
-        expected = to_rgba_array(["C0", "C1", "C2", "C0", "C2"], alpha)
+        C0, C1, C2, *_ = p._theme["axes.prop_cycle"].by_key()["color"]
+        expected = to_rgba_array([C0, C1, C2, C0, C2], alpha)
         assert_array_equal(fcs, expected)
 
     def test_mapped_edgewidth(self, x, y):
@@ -195,5 +197,6 @@ class TestBars:
         ax = p._figure.axes[0]
         fcs = ax.collections[0].get_facecolors()
         ecs = ax.collections[0].get_edgecolors()
-        assert_array_equal(fcs, to_rgba_array(["C0"] * len(x), 0))
-        assert_array_equal(ecs, to_rgba_array(["C4"] * len(x), 1))
+        colors = p._theme["axes.prop_cycle"].by_key()["color"]
+        assert_array_equal(fcs, to_rgba_array([colors[0]] * len(x), 0))
+        assert_array_equal(ecs, to_rgba_array([colors[4]] * len(x), 1))

--- a/tests/_marks/test_dot.py
+++ b/tests/_marks/test_dot.py
@@ -39,9 +39,10 @@ class TestDot(DotBase):
         p = Plot(x=x, y=y).add(Dot()).plot()
         ax = p._figure.axes[0]
         points, = ax.collections
+        C0, *_ = p._theme["axes.prop_cycle"].by_key()["color"]
         self.check_offsets(points, x, y)
-        self.check_colors("face", points, ["C0"] * 3, 1)
-        self.check_colors("edge", points, ["C0"] * 3, 1)
+        self.check_colors("face", points, [C0] * 3, 1)
+        self.check_colors("edge", points, [C0] * 3, 1)
 
     def test_filled_unfilled_mix(self):
 
@@ -54,9 +55,10 @@ class TestDot(DotBase):
         p = Plot(x=x, y=y).add(mark, marker=marker).scale(marker=shapes).plot()
         ax = p._figure.axes[0]
         points, = ax.collections
+        C0, *_ = p._theme["axes.prop_cycle"].by_key()["color"]
         self.check_offsets(points, x, y)
-        self.check_colors("face", points, ["C0", to_rgba("C0", 0)], None)
-        self.check_colors("edge", points, ["w", "C0"], 1)
+        self.check_colors("face", points, [C0, to_rgba(C0, 0)], None)
+        self.check_colors("edge", points, ["w", C0], 1)
 
         expected = [mark.edgewidth, mark.stroke]
         assert_array_equal(points.get_linewidths(), expected)
@@ -93,22 +95,24 @@ class TestDots(DotBase):
         p = Plot(x=x, y=y).add(Dots()).plot()
         ax = p._figure.axes[0]
         points, = ax.collections
+        C0, *_ = p._theme["axes.prop_cycle"].by_key()["color"]
         self.check_offsets(points, x, y)
-        self.check_colors("face", points, ["C0"] * 3, .2)
-        self.check_colors("edge", points, ["C0"] * 3, 1)
+        self.check_colors("face", points, [C0] * 3, .2)
+        self.check_colors("edge", points, [C0] * 3, 1)
 
-    def test_color_direct(self):
+    def test_set_color(self):
 
         x = [1, 2, 3]
         y = [4, 5, 2]
-        p = Plot(x=x, y=y).add(Dots(color="g")).plot()
+        m = Dots(color=".25")
+        p = Plot(x=x, y=y).add(m).plot()
         ax = p._figure.axes[0]
         points, = ax.collections
         self.check_offsets(points, x, y)
-        self.check_colors("face", points, ["g"] * 3, .2)
-        self.check_colors("edge", points, ["g"] * 3, 1)
+        self.check_colors("face", points, [m.color] * 3, .2)
+        self.check_colors("edge", points, [m.color] * 3, 1)
 
-    def test_color_mapped(self):
+    def test_map_color(self):
 
         x = [1, 2, 3]
         y = [4, 5, 2]
@@ -116,9 +120,10 @@ class TestDots(DotBase):
         p = Plot(x=x, y=y, color=c).add(Dots()).plot()
         ax = p._figure.axes[0]
         points, = ax.collections
+        C0, C1, *_ = p._theme["axes.prop_cycle"].by_key()["color"]
         self.check_offsets(points, x, y)
-        self.check_colors("face", points, ["C0", "C1", "C0"], .2)
-        self.check_colors("edge", points, ["C0", "C1", "C0"], 1)
+        self.check_colors("face", points, [C0, C1, C0], .2)
+        self.check_colors("edge", points, [C0, C1, C0], 1)
 
     def test_fill(self):
 
@@ -128,9 +133,10 @@ class TestDots(DotBase):
         p = Plot(x=x, y=y, color=c).add(Dots(fill=False)).plot()
         ax = p._figure.axes[0]
         points, = ax.collections
+        C0, C1, *_ = p._theme["axes.prop_cycle"].by_key()["color"]
         self.check_offsets(points, x, y)
-        self.check_colors("face", points, ["C0", "C1", "C0"], 0)
-        self.check_colors("edge", points, ["C0", "C1", "C0"], 1)
+        self.check_colors("face", points, [C0, C1, C0], 0)
+        self.check_colors("edge", points, [C0, C1, C0], 1)
 
     def test_pointsize(self):
 
@@ -165,7 +171,8 @@ class TestDots(DotBase):
         p = Plot(x=x, y=y).add(mark, marker=marker).scale(marker=shapes).plot()
         ax = p._figure.axes[0]
         points, = ax.collections
+        C0, C1, *_ = p._theme["axes.prop_cycle"].by_key()["color"]
         self.check_offsets(points, x, y)
-        self.check_colors("face", points, [to_rgba("C0", .2), to_rgba("C0", 0)], None)
-        self.check_colors("edge", points, ["C0", "C0"], 1)
+        self.check_colors("face", points, [to_rgba(C0, .2), to_rgba(C0, 0)], None)
+        self.check_colors("edge", points, [C0, C0], 1)
         assert_array_equal(points.get_linewidths(), [mark.stroke] * 2)

--- a/tests/_marks/test_line.py
+++ b/tests/_marks/test_line.py
@@ -27,18 +27,19 @@ class TestPath:
     def test_shared_colors_direct(self):
 
         x = y = [1, 2, 3]
-        m = Path(color="r")
+        color = ".44"
+        m = Path(color=color)
         p = Plot(x=x, y=y).add(m).plot()
         line, = p._figure.axes[0].get_lines()
-        assert same_color(line.get_color(), "r")
-        assert same_color(line.get_markeredgecolor(), "r")
-        assert same_color(line.get_markerfacecolor(), "r")
+        assert same_color(line.get_color(), color)
+        assert same_color(line.get_markeredgecolor(), color)
+        assert same_color(line.get_markerfacecolor(), color)
 
     def test_separate_colors_direct(self):
 
         x = y = [1, 2, 3]
         y = [1, 2, 3]
-        m = Path(color="r", edgecolor="g", fillcolor="b")
+        m = Path(color=".22", edgecolor=".55", fillcolor=".77")
         p = Plot(x=x, y=y).add(m).plot()
         line, = p._figure.axes[0].get_lines()
         assert same_color(line.get_color(), m.color)
@@ -52,10 +53,11 @@ class TestPath:
         m = Path()
         p = Plot(x=x, y=y, color=c).add(m).plot()
         ax = p._figure.axes[0]
+        colors = p._theme["axes.prop_cycle"].by_key()["color"]
         for i, line in enumerate(ax.get_lines()):
-            assert same_color(line.get_color(), f"C{i}")
-            assert same_color(line.get_markeredgecolor(), f"C{i}")
-            assert same_color(line.get_markerfacecolor(), f"C{i}")
+            assert same_color(line.get_color(), colors[i])
+            assert same_color(line.get_markeredgecolor(), colors[i])
+            assert same_color(line.get_markerfacecolor(), colors[i])
 
     def test_separate_colors_mapped(self):
 
@@ -65,10 +67,11 @@ class TestPath:
         m = Path()
         p = Plot(x=x, y=y, color=c, fillcolor=d).add(m).plot()
         ax = p._figure.axes[0]
+        colors = p._theme["axes.prop_cycle"].by_key()["color"]
         for i, line in enumerate(ax.get_lines()):
-            assert same_color(line.get_color(), f"C{i // 2}")
-            assert same_color(line.get_markeredgecolor(), f"C{i // 2}")
-            assert same_color(line.get_markerfacecolor(), f"C{i % 2}")
+            assert same_color(line.get_color(), colors[i // 2])
+            assert same_color(line.get_markeredgecolor(), colors[i // 2])
+            assert same_color(line.get_markerfacecolor(), colors[i % 2])
 
     def test_color_with_alpha(self):
 
@@ -168,10 +171,10 @@ class TestPaths:
         assert_array_equal(verts[0], [5, 2])
         assert_array_equal(verts[1], [4, 3])
 
-    def test_props_direct(self):
+    def test_set_properties(self):
 
         x = y = [1, 2, 3]
-        m = Paths(color="r", linewidth=1, linestyle=(3, 1))
+        m = Paths(color=".737", linewidth=1, linestyle=(3, 1))
         p = Plot(x=x, y=y).add(m).plot()
         lines, = p._figure.axes[0].collections
 
@@ -179,7 +182,7 @@ class TestPaths:
         assert lines.get_linewidth().item() == m.linewidth
         assert lines.get_linestyle()[0] == (0, list(m.linestyle))
 
-    def test_props_mapped(self):
+    def test_mapped_properties(self):
 
         x = y = [1, 2, 3, 4]
         g = ["a", "a", "b", "b"]
@@ -269,12 +272,13 @@ class TestRange:
 
         p = Plot(x=x, ymin=ymin, ymax=ymax, color=group).add(Range()).plot()
         lines, = p._figure.axes[0].collections
+        colors = p._theme["axes.prop_cycle"].by_key()["color"]
 
         for i, path in enumerate(lines.get_paths()):
             verts = path.vertices.T
             assert_array_equal(verts[0], [x[i], x[i]])
             assert_array_equal(verts[1], [ymin[i], ymax[i]])
-            assert same_color(lines.get_colors()[i], f"C{i // 2}")
+            assert same_color(lines.get_colors()[i], colors[i // 2])
 
     def test_direct_properties(self):
 
@@ -282,7 +286,7 @@ class TestRange:
         ymin = [1, 4]
         ymax = [2, 3]
 
-        m = Range(color="r", linewidth=4)
+        m = Range(color=".654", linewidth=4)
         p = Plot(x=x, ymin=ymin, ymax=ymax).add(m).plot()
         lines, = p._figure.axes[0].collections
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,27 +1,13 @@
 import numpy as np
 import pandas as pd
-import datetime
-import matplotlib as mpl
-import matplotlib.pyplot as plt
 
 import pytest
-
-
-@pytest.fixture(scope="session", autouse=True)
-def remove_pandas_unit_conversion():
-    # Prior to pandas 1.0, it registered its own datetime converters,
-    # but they are less powerful than what matplotlib added in 2.2,
-    # and we rely on that functionality in seaborn.
-    # https://github.com/matplotlib/matplotlib/pull/9779
-    # https://github.com/pandas-dev/pandas/issues/27036
-    mpl.units.registry[np.datetime64] = mpl.dates.DateConverter()
-    mpl.units.registry[datetime.date] = mpl.dates.DateConverter()
-    mpl.units.registry[datetime.datetime] = mpl.dates.DateConverter()
 
 
 @pytest.fixture(autouse=True)
 def close_figs():
     yield
+    import matplotlib.pyplot as plt
     plt.close("all")
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1140,7 +1140,7 @@ class TestVectorPlotter:
         p = VectorPlotter(data=long_df, variables={"x": "x", "y": "t"})
         p._attach(ax)
         assert ax.xaxis.converter is None
-        assert "DateConverter" in ax.yaxis.converter.__class__.__name__
+        assert "Date" in ax.yaxis.converter.__class__.__name__
 
         _, ax = plt.subplots()
         p = VectorPlotter(data=long_df, variables={"x": "a", "y": "y"})

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1140,12 +1140,12 @@ class TestVectorPlotter:
         p = VectorPlotter(data=long_df, variables={"x": "x", "y": "t"})
         p._attach(ax)
         assert ax.xaxis.converter is None
-        assert isinstance(ax.yaxis.converter, mpl.dates.DateConverter)
+        assert "DateConverter" in ax.yaxis.converter.__class__.__name__
 
         _, ax = plt.subplots()
         p = VectorPlotter(data=long_df, variables={"x": "a", "y": "y"})
         p._attach(ax)
-        assert isinstance(ax.xaxis.converter, mpl.category.StrCategoryConverter)
+        assert "CategoryConverter" in ax.xaxis.converter.__class__.__name__
         assert ax.yaxis.converter is None
 
     def test_attach_facets(self, long_df):

--- a/tests/test_rcmod.py
+++ b/tests/test_rcmod.py
@@ -30,7 +30,12 @@ def has_verdana():
     return verdana_font != unlikely_font
 
 
-class RCParamTester:
+class RCParamFixtures:
+
+    @pytest.fixture(autouse=True)
+    def reset_params(self):
+        yield
+        rcmod.reset_orig()
 
     def flatten_list(self, orig_list):
 
@@ -65,7 +70,7 @@ class RCParamTester:
                 assert v1 == v2
 
 
-class TestAxesStyle(RCParamTester):
+class TestAxesStyle(RCParamFixtures):
 
     styles = ["white", "dark", "whitegrid", "darkgrid", "ticks"]
 
@@ -175,7 +180,7 @@ class TestAxesStyle(RCParamTester):
         rcmod.set_theme()
 
 
-class TestPlottingContext(RCParamTester):
+class TestPlottingContext(RCParamFixtures):
 
     contexts = ["paper", "notebook", "talk", "poster"]
 
@@ -244,7 +249,7 @@ class TestPlottingContext(RCParamTester):
         self.assert_rc_params(orig_params)
 
 
-class TestPalette:
+class TestPalette(RCParamFixtures):
 
     def test_set_palette(self):
 
@@ -265,7 +270,7 @@ class TestPalette:
         )
 
 
-class TestFonts:
+class TestFonts(RCParamFixtures):
 
     _no_verdana = not has_verdana()
 


### PR DESCRIPTION
Some tests were relying on global state that might not be set when tests are run concurrently. This gets everything green over several repeated runs with 8 processes on my laptop.