### PR TITLE
Typing: use pandas-type-stubs and address arising issues

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dev = [
     "pytest-xdist",
     "flake8",
     "mypy",
+    "pandas-stubs",
     "pre-commit",
 ]
 docs = [

--- a/seaborn/_core/data.py
+++ b/seaborn/_core/data.py
@@ -3,16 +3,14 @@ Components for parsing variable assignments and internally representing plot dat
 """
 from __future__ import annotations
 
-from collections import abc
+from collections.abc import Mapping, Sized
+from typing import cast
+
 import pandas as pd
+from pandas import DataFrame
 
-from typing import TYPE_CHECKING
-if TYPE_CHECKING:
-    from pandas import DataFrame
-    from seaborn._core.typing import DataSource, VariableSpec
+from seaborn._core.typing import DataSource, VariableSpec, ColumnName
 
-
-# TODO Repetition in the docstrings should be reduced with interpolation tools
 
 class PlotData:
     """
@@ -154,7 +152,7 @@ class PlotData:
             non-indexed vector datatypes that have a different length from `data`.
 
         """
-        source_data: dict | DataFrame
+        source_data: Mapping | DataFrame
         frame: DataFrame
         names: dict[str, str | None]
         ids: dict[str, str | int]
@@ -164,7 +162,7 @@ class PlotData:
         ids = {}
 
         given_data = data is not None
-        if given_data:
+        if data is not None:
             source_data = data
         else:
             # Data is optional; all variables can be defined as vectors
@@ -208,7 +206,7 @@ class PlotData:
             )
 
             if val_as_data_key:
-
+                val = cast(ColumnName, val)
                 if val in source_data:
                     plot_data[key] = source_data[val]
                 elif val in index:
@@ -231,12 +229,12 @@ class PlotData:
                 # Otherwise, assume the value somehow represents data
 
                 # Ignore empty data structures
-                if isinstance(val, abc.Sized) and len(val) == 0:
+                if isinstance(val, Sized) and len(val) == 0:
                     continue
 
                 # If vector has no index, it must match length of data table
                 if isinstance(data, pd.DataFrame) and not isinstance(val, pd.Series):
-                    if isinstance(val, abc.Sized) and len(data) != len(val):
+                    if isinstance(val, Sized) and len(data) != len(val):
                         val_cls = val.__class__.__name__
                         err = (
                             f"Length of {val_cls} vectors must match length of `data`"

--- a/seaborn/_core/plot.py
+++ b/seaborn/_core/plot.py
@@ -1311,7 +1311,7 @@ class Plotter:
             if "width" in mark._mappable_props:
                 width = mark._resolve(df, "width", None)
             else:
-                width = df.get("width", 0.8)  # TODO what default
+                width = 0.8 if "width" not in df else df["width"]  # TODO what default?
             if orient in df:
                 df["width"] = width * scales[orient]._spacing(df[orient])
 
@@ -1325,7 +1325,7 @@ class Plotter:
                 # TODO unlike width, we might not want to add baseline to data
                 # if the mark doesn't use it. Practically, there is a concern about
                 # Mark abstraction like Area / Ribbon
-                baseline = df.get("baseline", 0)
+                baseline = 0 if "baseline" not in df else df["baseline"]
             df["baseline"] = baseline
 
             if move is not None:

--- a/seaborn/_core/plot.py
+++ b/seaborn/_core/plot.py
@@ -1373,7 +1373,7 @@ class Plotter:
                 axes_df = axes_df.dropna()
             for var, values in axes_df.items():
                 scale = view[f"{str(var)[0]}scale"]
-                out_df.loc[values.index, var] = scale(values)
+                out_df.loc[values.index, str(var)] = scale(values)
 
         return out_df
 
@@ -1399,7 +1399,7 @@ class Plotter:
                 # TODO see https://github.com/matplotlib/matplotlib/issues/22713
                 transform = axis.get_transform().inverted().transform
                 inverted = transform(values)
-                out_df.loc[values.index, var] = inverted
+                out_df.loc[values.index, str(var)] = inverted
 
                 if var == orient and "width" in view_df:
                     width = view_df["width"]

--- a/seaborn/_core/plot.py
+++ b/seaborn/_core/plot.py
@@ -258,7 +258,8 @@ class Plot:
                 if name in variables:
                     raise TypeError(f"`{name}` given by both name and position.")
                 # Keep coordinates at the front of the variables dict
-                variables = {name: var, **variables}
+                # Cast type because we know this isn't a DataSource at this point
+                variables = {name: cast(VariableSpec, var), **variables}
 
         return data, variables
 

--- a/seaborn/_core/plot.py
+++ b/seaborn/_core/plot.py
@@ -562,7 +562,7 @@ class Plot:
         .. include:: ../docstrings/objects.Plot.facet.rst
 
         """
-        variables = {}
+        variables: dict[str, VariableSpec] = {}
         if col is not None:
             variables["col"] = col
         if row is not None:

--- a/seaborn/_core/plot.py
+++ b/seaborn/_core/plot.py
@@ -1180,7 +1180,7 @@ class Plotter:
             for layer in layers:
                 variables.extend(layer["data"].frame.columns)
                 for df in layer["data"].frames.values():
-                    variables.extend(v for v in df if v not in variables)
+                    variables.extend(str(v) for v in df if v not in variables)
             variables = [v for v in variables if v not in self._scales]
 
         for var in variables:
@@ -1358,7 +1358,7 @@ class Plotter:
     def _scale_coords(self, subplots: list[dict], df: DataFrame) -> DataFrame:
         # TODO stricter type on subplots
 
-        coord_cols = [c for c in df if re.match(r"^[xy]\D*$", c)]
+        coord_cols = [c for c in df if re.match(r"^[xy]\D*$", str(c))]
         out_df = (
             df
             .copy(deep=False)
@@ -1372,7 +1372,7 @@ class Plotter:
             with pd.option_context("mode.use_inf_as_null", True):
                 axes_df = axes_df.dropna()
             for var, values in axes_df.items():
-                scale = view[f"{var[0]}scale"]
+                scale = view[f"{str(var)[0]}scale"]
                 out_df.loc[values.index, var] = scale(values)
 
         return out_df
@@ -1381,7 +1381,7 @@ class Plotter:
         self, subplots: list[dict], df: DataFrame, orient: str,
     ) -> DataFrame:
         # TODO do we still have numbers in the variable name at this point?
-        coord_cols = [c for c in df if re.match(r"^[xy]\D*$", c)]
+        coord_cols = [c for c in df if re.match(r"^[xy]\D*$", str(c))]
         drop_cols = [*coord_cols, "width"] if "width" in df else coord_cols
         out_df = (
             df
@@ -1395,7 +1395,7 @@ class Plotter:
             axes_df = view_df[coord_cols]
             for var, values in axes_df.items():
 
-                axis = getattr(view["ax"], f"{var[0]}axis")
+                axis = getattr(view["ax"], f"{str(var)[0]}axis")
                 # TODO see https://github.com/matplotlib/matplotlib/issues/22713
                 transform = axis.get_transform().inverted().transform
                 inverted = transform(values)

--- a/seaborn/_core/plot.py
+++ b/seaborn/_core/plot.py
@@ -15,7 +15,7 @@ from typing import Any, List, Optional, cast
 
 from cycler import cycler
 import pandas as pd
-from pandas import DataFrame, Series
+from pandas import DataFrame, Series, Index
 import matplotlib as mpl
 from matplotlib.axes import Axes
 from matplotlib.artist import Artist
@@ -1451,7 +1451,7 @@ class Plotter:
 
             yield subplots, out_df, scales
 
-    def _get_subplot_index(self, df: DataFrame, subplot: dict) -> DataFrame:
+    def _get_subplot_index(self, df: DataFrame, subplot: dict) -> Index:
 
         dims = df.columns.intersection(["col", "row"])
         if dims.empty:

--- a/seaborn/_core/plot.py
+++ b/seaborn/_core/plot.py
@@ -1557,11 +1557,12 @@ class Plotter:
     ) -> None:
         """Add legend artists / labels for one layer in the plot."""
         if data.frame.empty and data.frames:
-            legend_vars = set()
+            legend_vars: list[str] = []
             for frame in data.frames.values():
-                legend_vars.update(frame.columns.intersection(scales))
+                frame_vars = frame.columns.intersection(list(scales))
+                legend_vars.extend(v for v in frame_vars if v not in legend_vars)
         else:
-            legend_vars = data.frame.columns.intersection(scales)
+            legend_vars = list(data.frame.columns.intersection(list(scales)))
 
         # First pass: Identify the values that will be shown for each variable
         schema: list[tuple[

--- a/seaborn/_core/plot.py
+++ b/seaborn/_core/plot.py
@@ -1355,28 +1355,6 @@ class Plotter:
         if layer["legend"]:
             self._update_legend_contents(p, mark, data, scales)
 
-    def _scale_coords(self, subplots: list[dict], df: DataFrame) -> DataFrame:
-        # TODO stricter type on subplots
-
-        coord_cols = [c for c in df if re.match(r"^[xy]\D*$", str(c))]
-        out_df = (
-            df
-            .copy(deep=False)
-            .drop(coord_cols, axis=1)
-            .reindex(df.columns, axis=1)  # So unscaled columns retain their place
-        )
-
-        for view in subplots:
-            view_df = self._filter_subplot_data(df, view)
-            axes_df = view_df[coord_cols]
-            with pd.option_context("mode.use_inf_as_null", True):
-                axes_df = axes_df.dropna()
-            for var, values in axes_df.items():
-                scale = view[f"{str(var)[0]}scale"]
-                out_df.loc[values.index, str(var)] = scale(values)
-
-        return out_df
-
     def _unscale_coords(
         self, subplots: list[dict], df: DataFrame, orient: str,
     ) -> DataFrame:

--- a/seaborn/_core/plot.py
+++ b/seaborn/_core/plot.py
@@ -332,8 +332,11 @@ class Plot:
             + list(self._facet_spec.get("variables", []))
         )
         for layer in self._layers:
-            variables.extend(c for c in layer["vars"] if c not in variables)
-        return variables
+            variables.extend(v for v in layer["vars"] if v not in variables)
+
+        # Coerce to str in return to appease mypy; we know these will only
+        # ever be strings but I don't think we can type a DataFrame that way yet
+        return [str(v) for v in variables]
 
     def on(self, target: Axes | SubFigure | Figure) -> Plot:
         """

--- a/seaborn/_core/plot.py
+++ b/seaborn/_core/plot.py
@@ -1110,7 +1110,7 @@ class Plotter:
                 for axis, var in zip(*pairings):
                     if axis != var:
                         df = df.rename(columns={var: axis})
-                        drop_cols = [x for x in df if re.match(rf"{axis}\d+", x)]
+                        drop_cols = [x for x in df if re.match(rf"{axis}\d+", str(x))]
                         df = df.drop(drop_cols, axis=1)
                         scales[axis] = scales[var]
 
@@ -1446,7 +1446,7 @@ class Plotter:
             for axis, var in zip("xy", (x, y)):
                 if axis != var:
                     out_df = out_df.rename(columns={var: axis})
-                    cols = [col for col in out_df if re.match(rf"{axis}\d+", col)]
+                    cols = [col for col in out_df if re.match(rf"{axis}\d+", str(col))]
                     out_df = out_df.drop(cols, axis=1)
 
             yield subplots, out_df, scales

--- a/seaborn/_core/rules.py
+++ b/seaborn/_core/rules.py
@@ -147,7 +147,7 @@ def categorical_order(vector: Series, order: list | None = None) -> list:
         order = list(vector.cat.categories)
     else:
         order = list(filter(pd.notnull, vector.unique()))
-        if variable_type(order) == "numeric":
+        if variable_type(pd.Series(order)) == "numeric":
             order.sort()
 
     return order

--- a/seaborn/_core/typing.py
+++ b/seaborn/_core/typing.py
@@ -1,16 +1,22 @@
 from __future__ import annotations
 
+from datetime import date, datetime, timedelta
 from typing import Any, Optional, Union, Mapping, Tuple, List, Dict
 from collections.abc import Hashable, Iterable
+
 from numpy import ndarray  # TODO use ArrayLike?
-from pandas import DataFrame, Series, Index
+from pandas import DataFrame, Series, Index, Timestamp, Timedelta
 from matplotlib.colors import Colormap, Normalize
 
+
+ColumnName = Union[
+    str, bytes, date, datetime, timedelta, bool, complex, Timestamp, Timedelta
+]
 Vector = Union[Series, Index, ndarray]
-PaletteSpec = Union[str, list, dict, Colormap, None]
-VariableSpec = Union[Hashable, Vector, None]
+
+VariableSpec = Union[ColumnName, Vector, None]
 VariableSpecList = Union[List[VariableSpec], Index, None]
-# TODO can we better unify the VarType object and the VariableType alias?
+
 DataSource = Union[DataFrame, Mapping[Hashable, Vector], None]
 
 OrderSpec = Union[Iterable, None]  # TODO technically str is iterable
@@ -18,6 +24,7 @@ NormSpec = Union[Tuple[Optional[float], Optional[float]], Normalize, None]
 
 # TODO for discrete mappings, it would be ideal to use a parameterized type
 # as the dict values / list entries should be of specific type(s) for each method
+PaletteSpec = Union[str, list, dict, Colormap, None]
 DiscreteValueSpec = Union[dict, list, None]
 ContinuousValueSpec = Union[
     Tuple[float, float], List[float], Dict[Any, float], None,

--- a/seaborn/_stats/aggregation.py
+++ b/seaborn/_stats/aggregation.py
@@ -83,7 +83,7 @@ class Est(Stat):
         boot_kws = {"n_boot": self.n_boot, "seed": self.seed}
         engine = EstimateAggregator(self.func, self.errorbar, **boot_kws)
 
-        var = {"x": "y", "y": "x"}.get(orient)
+        var = {"x": "y", "y": "x"}[orient]
         res = (
             groupby
             .apply(data, self._process, var, engine)


### PR DESCRIPTION
Most of these are related to not being able to statically type that the internal dataframe will only have strings for column names. I'm not sure if there's a better way to communicate that to mypy.

I'm also surprised to learn that the index values are not typed as "Hashable"; I guess it makes sense that the value of any index *level* are scalars, but our typing was perhaps a bit off with what we accept for variable specifiers. This may need some additional work as I think we want to be narrower than what pandas technically accepts for index values.