### PR TITLE
Text mark

### DIFF
--- a/doc/_docstrings/objects.Text.ipynb
+++ b/doc/_docstrings/objects.Text.ipynb
@@ -1,0 +1,188 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cd1cdefe-b8c1-40b9-be31-006d52ec9f18",
+   "metadata": {
+    "tags": [
+     "hide"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "import seaborn.objects as so\n",
+    "from seaborn import load_dataset\n",
+    "glue = (\n",
+    "    load_dataset(\"glue\")\n",
+    "    .pivot(index=[\"Model\", \"Encoder\"], columns=\"Task\", values=\"Score\")\n",
+    "    .assign(Average=lambda x: x.mean(axis=1).round(1))\n",
+    "    .sort_values(\"Average\")\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "3e49ffb1-8778-4cd5-80d6-9d7e1438bc9c",
+   "metadata": {},
+   "source": [
+    "Add text at x/y locations on the plot:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3bf21068-d39e-436c-8deb-aa1b15aeb2b3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(\n",
+    "    so.Plot(glue, x=\"SST-2\", y=\"MRPC\", text=\"Model\")\n",
+    "    .add(so.Text())\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "a4b9a8b2-6603-46db-9ede-3b3fb45e0e64",
+   "metadata": {},
+   "source": [
+    "Add bar annotations, horizontally-aligned with `halign`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f68501f0-c868-439e-9485-d71cca86ea47",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(\n",
+    "    so.Plot(glue, x=\"Average\", y=\"Model\", text=\"Average\")\n",
+    "    .add(so.Bar())\n",
+    "    .add(so.Text(color=\"w\", halign=\"right\"))\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "a9d39479-0afa-477b-8403-fe92a54643c9",
+   "metadata": {},
+   "source": [
+    "Fine-tune the alignment using `offset`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b5da4a9d-79f3-4c11-bab3-f89da8512ce4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(\n",
+    "    so.Plot(glue, x=\"Average\", y=\"Model\", text=\"Average\")\n",
+    "    .add(so.Bar())\n",
+    "    .add(so.Text(color=\"w\", halign=\"right\", offset=0.5))\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "e9c43798-70d5-42b5-bd91-b85684d1b671",
+   "metadata": {},
+   "source": [
+    "Add text above dots, mapping the text color with a third variable:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b2d26ebc-24ac-4531-9ba2-fa03720c58bc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(\n",
+    "    so.Plot(glue, x=\"SST-2\", y=\"MRPC\", color=\"Encoder\", text=\"Model\")\n",
+    "    .add(so.Dot())\n",
+    "    .add(so.Text(valign=\"bottom\"))\n",
+    "\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "f31aaa38-6728-4299-8422-8762c52c9857",
+   "metadata": {},
+   "source": [
+    "Map the text alignment for better use of space:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cf4bbf0c-0c5f-4c31-b971-720ea8910918",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(\n",
+    "    so.Plot(glue, x=\"RTE\", y=\"MRPC\", color=\"Encoder\", text=\"Model\")\n",
+    "    .add(so.Dot())\n",
+    "    .add(so.Text(offset=.5), halign=\"Encoder\")\n",
+    "    .scale(halign={\"LSTM\": \"left\", \"Transformer\": \"right\"})\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "a5de35a6-1ccf-4958-8013-edd9ed1cd4b0",
+   "metadata": {},
+   "source": [
+    "Use additional matplotlib parameters to control the appearance of the text:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9c4be188-1614-4c19-9bd7-b07e986f6a23",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(\n",
+    "    so.Plot(glue, x=\"RTE\", y=\"MRPC\", color=\"Encoder\", text=\"Model\")\n",
+    "    .add(so.Dot())\n",
+    "    .add(so.Text({\"fontweight\": \"bold\"}, offset=.5), halign=\"Encoder\")\n",
+    "    .scale(halign={\"LSTM\": \"left\", \"Transformer\": \"right\"})\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "95fb7aee-090a-4415-917c-b5258d2b298b",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "py310",
+   "language": "python",
+   "name": "py310"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/doc/_docstrings/objects.Text.ipynb
+++ b/doc/_docstrings/objects.Text.ipynb
@@ -82,7 +82,7 @@
     "(\n",
     "    so.Plot(glue, x=\"Average\", y=\"Model\", text=\"Average\")\n",
     "    .add(so.Bar())\n",
-    "    .add(so.Text(color=\"w\", halign=\"right\", offset=0.5))\n",
+    "    .add(so.Text(color=\"w\", halign=\"right\", offset=6))\n",
     ")"
    ]
   },
@@ -127,7 +127,7 @@
     "(\n",
     "    so.Plot(glue, x=\"RTE\", y=\"MRPC\", color=\"Encoder\", text=\"Model\")\n",
     "    .add(so.Dot())\n",
-    "    .add(so.Text(offset=.5), halign=\"Encoder\")\n",
+    "    .add(so.Text(), halign=\"Encoder\")\n",
     "    .scale(halign={\"LSTM\": \"left\", \"Transformer\": \"right\"})\n",
     ")"
    ]
@@ -150,7 +150,7 @@
     "(\n",
     "    so.Plot(glue, x=\"RTE\", y=\"MRPC\", color=\"Encoder\", text=\"Model\")\n",
     "    .add(so.Dot())\n",
-    "    .add(so.Text({\"fontweight\": \"bold\"}, offset=.5), halign=\"Encoder\")\n",
+    "    .add(so.Text({\"fontweight\": \"bold\"}), halign=\"Encoder\")\n",
     "    .scale(halign={\"LSTM\": \"left\", \"Transformer\": \"right\"})\n",
     ")"
    ]

--- a/doc/_tutorial/properties.ipynb
+++ b/doc/_tutorial/properties.ipynb
@@ -918,6 +918,157 @@
   },
   {
    "cell_type": "raw",
+   "id": "c2ca33db-df52-4958-889a-320b4833a0d7",
+   "metadata": {},
+   "source": [
+    "Text properties\n",
+    "---------------"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "b75af2fe-4d81-407c-9858-23362710f25f",
+   "metadata": {},
+   "source": [
+    ".. _horizontalalignment_property:\n",
+    "\n",
+    ".. _verticalalignment_property:\n",
+    "\n",
+    "halign, valign\n",
+    "~~~~~~~~~~~~~~\n",
+    "\n",
+    "The `halign` and `valign` properties control the *horizontal* and *vertical* alignment of text marks. The options for horizontal alignment are `'left'`, `'right'`, and `'center'`, while the options for vertical alignment are `'top'`, `'bottom'`, `'center'`, `'baseline'`, and `'center_baseline'`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e9588309-bee4-4b97-b428-eb91ea582105",
+   "metadata": {
+    "tags": [
+     "hide-input"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "x = [\"left\", \"right\", \"top\", \"bottom\", \"baseline\", \"center\"]\n",
+    "ha = x[:2] + [\"center\"] * 4\n",
+    "va = [\"center_baseline\"] * 2 + x[2:]\n",
+    "y = np.zeros(len(x))\n",
+    "(\n",
+    "    so.Plot(x=[f\"'{_x_}'\" for _x_ in x], y=y, halign=ha, valign=va)\n",
+    "    .add(so.Dot(marker=\"+\", color=\"r\", alpha=.5, stroke=1, pointsize=24))\n",
+    "    .add(so.Text(text=\"XyZ\", fontsize=14, offset=0))\n",
+    "    .scale(y=so.Continuous().tick(at=[]), halign=None, valign=None)\n",
+    "    .limit(x=(-.25, len(x) - .75))\n",
+    "    .layout(size=(9, .6), engine=None)\n",
+    "    .theme({\n",
+    "        **axes_style(\"ticks\"),\n",
+    "        **{f\"axes.spines.{side}\": False for side in [\"left\", \"right\", \"top\"]},\n",
+    "        \"xtick.labelsize\": 12,\n",
+    "        \"axes.xmargin\": .015,\n",
+    "        \"ytick.labelsize\": 12,\n",
+    "    })\n",
+    "    .plot()\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "ea74c7e5-798b-47bc-bc18-9086902fb5c6",
+   "metadata": {},
+   "source": [
+    ".. _fontsize_property:\n",
+    "\n",
+    "fontsize\n",
+    "~~~~~~~~\n",
+    "\n",
+    "The `fontsize` property controls the size of textual marks. The value has point units:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c515b790-385d-4521-b14a-0769c1902928",
+   "metadata": {
+    "tags": [
+     "hide-input"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "from string import ascii_uppercase\n",
+    "n = 26\n",
+    "s = np.arange(n) + 1\n",
+    "y = np.zeros(n)\n",
+    "t = list(ascii_uppercase[:n])\n",
+    "(\n",
+    "    so.Plot(x=s, y=y, text=t, fontsize=s)\n",
+    "    .add(so.Text())\n",
+    "    .scale(x=so.Nominal(), y=so.Continuous().tick(at=[]))\n",
+    "    .layout(size=(9, .5), engine=None)\n",
+    "    .theme({\n",
+    "        **axes_style(\"ticks\"),\n",
+    "        **{f\"axes.spines.{side}\": False for side in [\"left\", \"right\", \"top\"]},\n",
+    "        \"xtick.labelsize\": 12,\n",
+    "        \"axes.xmargin\": .015,\n",
+    "        \"ytick.labelsize\": 12,\n",
+    "    })\n",
+    "    .plot()\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "4b367f36-fb96-44fa-83a3-1cc66c7a3279",
+   "metadata": {},
+   "source": [
+    ".. _offset_property:\n",
+    "\n",
+    "offset\n",
+    "~~~~~~\n",
+    "\n",
+    "The `offset` property controls the spacing between a text mark and its anchor position. It applies when *not* using `center` alignment (i.e., when using left/right or top/bottom). The value has point units. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "25a49331-9580-4578-8bdb-d0d1829dde71",
+   "metadata": {
+    "tags": [
+     "hide-input"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "n = 17\n",
+    "x = np.linspace(0, 8, n)\n",
+    "y = np.full(n, .5)\n",
+    "(\n",
+    "    so.Plot(x=x, y=y, offset=x)\n",
+    "    .add(so.Bar(color=\".6\", edgecolor=\"k\"))\n",
+    "    .add(so.Text(text=\"abc\", valign=\"bottom\"))\n",
+    "    .scale(\n",
+    "        x=so.Continuous().tick(every=1, minor=1),\n",
+    "        y=so.Continuous().tick(at=[]),\n",
+    "        offset=None,\n",
+    "    )\n",
+    "    .limit(y=(0, 1.5))\n",
+    "    .layout(size=(9, .5), engine=None)\n",
+    "    .theme({\n",
+    "        **axes_style(\"ticks\"),\n",
+    "        **{f\"axes.spines.{side}\": False for side in [\"left\", \"right\", \"top\"]},\n",
+    "        \"axes.xmargin\": .015,\n",
+    "        \"xtick.labelsize\": 12,\n",
+    "        \"ytick.labelsize\": 12,\n",
+    "    })\n",
+    "    .plot()\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "raw",
    "id": "77723ffd-2da3-4ece-a97a-3c00e864c743",
    "metadata": {},
    "source": [
@@ -931,6 +1082,11 @@
    "metadata": {},
    "source": [
     ".. _property_property:\n",
+    "\n",
+    "text\n",
+    "~~~~\n",
+    "\n",
+    "The `text` property is used to set the content of a textual mark. It is always used literally (not mapped), and cast to string when necessary.\n",
     "\n",
     "group\n",
     "~~~~~\n",

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -66,6 +66,15 @@ Mark objects
     Area
     Band
 
+.. rubric:: Text marks
+
+.. autosummary::
+    :toctree: generated/
+    :template: object
+    :nosignatures:
+
+    Text
+
 Stat objects
 ~~~~~~~~~~~~
 

--- a/doc/whatsnew/v0.12.1.rst
+++ b/doc/whatsnew/v0.12.1.rst
@@ -2,6 +2,8 @@
 v0.12.1 (Unreleased)
 --------------------
 
+- |Feature| Added the :class:`objects.Text` mark (:pr:`3051`).
+
 - |Fix| Make :class:`objects.PolyFit` robust to missing data (:pr:`3010`).
 
 - |Build| Seaborn no longer contains doctest-style examples, simplifying the testing infrastructure (:pr:`3034`).

--- a/seaborn/_core/plot.py
+++ b/seaborn/_core/plot.py
@@ -1562,12 +1562,15 @@ class Plotter:
                     schema.append(entry)
 
         # Second pass, generate an artist corresponding to each value
-        contents = []
+        contents: list[tuple[tuple[str, str | int], Any, list[str]]] = []
         for key, variables, (values, labels) in schema:
             artists = []
             for val in values:
-                artists.append(mark._legend_artist(variables, val, scales))
-            contents.append((key, artists, labels))
+                artist = mark._legend_artist(variables, val, scales)
+                if artist is not None:
+                    artists.append(artist)
+            if contents:
+                contents.append((key, artists, labels))
 
         self._legend_contents.extend(contents)
 

--- a/seaborn/_core/plot.py
+++ b/seaborn/_core/plot.py
@@ -1569,7 +1569,7 @@ class Plotter:
                 artist = mark._legend_artist(variables, val, scales)
                 if artist is not None:
                     artists.append(artist)
-            if contents:
+            if artists:
                 contents.append((key, artists, labels))
 
         self._legend_contents.extend(contents)

--- a/seaborn/_core/properties.py
+++ b/seaborn/_core/properties.py
@@ -298,8 +298,16 @@ class Alpha(IntervalProperty):
     # TODO validate / enforce that output is in [0, 1]
 
 
+class Offset(IntervalProperty):
+    """Offset for edge-aligned text, in units of fontsize."""
+    _default_range = .1, .5
+    _legend = False
+
+
 class FontSize(IntervalProperty):
-    """Thickness of the edges on a patch mark, in points."""
+    """Font size for textual marks, in points."""
+    _legend = False
+
     @property
     def default_range(self) -> tuple[float, float]:
         """Min and max values used by default for semantic mapping."""
@@ -781,6 +789,7 @@ PROPERTY_CLASSES = {
     "text": Property,
     "halign": HorizontalAlignment,
     "valign": VerticalAlignment,
+    "offset": Offset,
     "fontsize": FontSize,
     "xmin": Coordinate,
     "xmax": Coordinate,

--- a/seaborn/_core/properties.py
+++ b/seaborn/_core/properties.py
@@ -299,8 +299,8 @@ class Alpha(IntervalProperty):
 
 
 class Offset(IntervalProperty):
-    """Offset for edge-aligned text, in units of fontsize."""
-    _default_range = .1, .5
+    """Offset for edge-aligned text, in point units."""
+    _default_range = 0, 5
     _legend = False
 
 

--- a/seaborn/_core/properties.py
+++ b/seaborn/_core/properties.py
@@ -510,7 +510,6 @@ class TextAlignment(ObjectProperty):
 
 
 class HorizontalAlignment(TextAlignment):
-    legend = False
 
     def _default_values(self, n: int) -> list:
         vals = itertools.cycle(["left", "right"])
@@ -518,7 +517,6 @@ class HorizontalAlignment(TextAlignment):
 
 
 class VerticalAlignment(TextAlignment):
-    legend = False
 
     def _default_values(self, n: int) -> list:
         vals = itertools.cycle(["top", "bottom"])

--- a/seaborn/_core/properties.py
+++ b/seaborn/_core/properties.py
@@ -298,6 +298,15 @@ class Alpha(IntervalProperty):
     # TODO validate / enforce that output is in [0, 1]
 
 
+class FontSize(IntervalProperty):
+    """Thickness of the edges on a patch mark, in points."""
+    @property
+    def default_range(self) -> tuple[float, float]:
+        """Min and max values used by default for semantic mapping."""
+        base = mpl.rcParams["font.size"]
+        return base * .5, base * 2
+
+
 # =================================================================================== #
 # Properties defined by arbitrary objects with inherently nominal scaling
 # =================================================================================== #
@@ -494,6 +503,26 @@ class LineStyle(ObjectProperty):
                 offset %= dsum
 
         return offset, dashes
+
+
+class TextAlignment(ObjectProperty):
+    legend = False
+
+
+class HorizontalAlignment(TextAlignment):
+    legend = False
+
+    def _default_values(self, n: int) -> list:
+        vals = itertools.cycle(["left", "right"])
+        return [next(vals) for _ in range(n)]
+
+
+class VerticalAlignment(TextAlignment):
+    legend = False
+
+    def _default_values(self, n: int) -> list:
+        vals = itertools.cycle(["top", "bottom"])
+        return [next(vals) for _ in range(n)]
 
 
 # =================================================================================== #
@@ -751,6 +780,10 @@ PROPERTY_CLASSES = {
     "edgestyle": LineStyle,
     "edgecolor": Color,
     "edgealpha": Alpha,
+    "text": Property,
+    "halign": HorizontalAlignment,
+    "valign": VerticalAlignment,
+    "fontsize": FontSize,
     "xmin": Coordinate,
     "xmax": Coordinate,
     "ymin": Coordinate,

--- a/seaborn/_marks/base.py
+++ b/seaborn/_marks/base.py
@@ -217,8 +217,8 @@ class Mark:
     def _legend_artist(
         self, variables: list[str], value: Any, scales: dict[str, Scale],
     ) -> Artist:
-        # TODO return some sensible default?
-        raise NotImplementedError
+
+        return None
 
 
 def resolve_properties(

--- a/seaborn/_marks/text.py
+++ b/seaborn/_marks/text.py
@@ -1,11 +1,9 @@
 from __future__ import annotations
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import Any
 
 import numpy as np
 import matplotlib as mpl
-from matplotlib.artist import Artist
 
 from seaborn._marks.base import (
     Mark,
@@ -17,7 +15,6 @@ from seaborn._marks.base import (
     resolve_color,
     document_properties,
 )
-from seaborn._core.scales import Scale
 
 
 @document_properties
@@ -31,7 +28,6 @@ class Text(Mark):
     .. include:: ../docstrings/objects.Text.rst
 
     """
-
     text: MappableString = Mappable("")
     color: MappableColor = Mappable("k")
     alpha: MappableFloat = Mappable(1)
@@ -62,10 +58,3 @@ class Text(Mark):
 
         for ax, ax_vals in ax_data.items():
             ax.update_datalim(np.array(ax_vals))
-
-    def _legend_artist(
-        self, variables: list[str], value: Any, scales=dict[str, Scale],
-    ) -> Artist:
-
-        # TODO
-        return mpl.lines.Line2D([], [])

--- a/seaborn/_marks/text.py
+++ b/seaborn/_marks/text.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+import matplotlib as mpl
+from matplotlib.artist import Artist
+
+from seaborn._marks.base import (
+    Mark,
+    Mappable,
+    MappableFloat,
+    MappableString,
+    MappableColor,
+    resolve_properties,
+    document_properties,
+)
+from seaborn._core.scales import Scale
+
+
+@document_properties
+@dataclass
+class Text(Mark):
+    """
+    TODO
+    """
+
+    text: MappableString = Mappable("")
+    color: MappableColor = Mappable("k")
+    fontsize: MappableFloat = Mappable(rc="font.size")
+    halign: MappableString = Mappable("center")
+    valign: MappableString = Mappable("center_baseline")
+
+    def _plot(self, split_gen, scales, orient):
+
+        ax_data = defaultdict(list)
+
+        for keys, data, ax in split_gen():
+            vals = resolve_properties(self, keys, scales)
+
+            for row in data.to_dict("records"):
+                artist = mpl.text.Text(
+                    x=row["x"],
+                    y=row["y"],
+                    text=str(row["text"]),  # TODO format
+                    color=vals["color"],
+                    fontsize=vals["fontsize"],
+                    horizontalalignment=vals["halign"],
+                    verticalalignment=vals["valign"],
+                    **self.artist_kws,
+                )
+                ax.add_artist(artist)
+                ax_data[ax].append([row["x"], row["y"]])
+
+        for ax, ax_vals in ax_data.items():
+            ax.update_datalim(np.array(ax_vals))
+
+    def _legend_artist(
+        self, variables: list[str], value: Any, scales=dict[str, Scale],
+    ) -> Artist:
+
+        # TODO
+        return mpl.line.Line2D()

--- a/seaborn/_marks/text.py
+++ b/seaborn/_marks/text.py
@@ -35,7 +35,7 @@ class Text(Mark):
     fontsize: MappableFloat = Mappable(rc="font.size")
     halign: MappableString = Mappable("center")
     valign: MappableString = Mappable("center_baseline")
-    offset: MappableFloat = Mappable(0.25)
+    offset: MappableFloat = Mappable(4)
 
     def _plot(self, split_gen, scales, orient):
 
@@ -49,7 +49,7 @@ class Text(Mark):
             halign = vals["halign"]
             valign = vals["valign"]
             fontsize = vals["fontsize"]
-            offset = vals["offset"] * fontsize / 72
+            offset = vals["offset"] / 72
 
             offset_trans = ScaledTranslation(
                 {"right": -offset, "left": +offset}.get(halign, 0),

--- a/seaborn/_marks/text.py
+++ b/seaborn/_marks/text.py
@@ -14,6 +14,7 @@ from seaborn._marks.base import (
     MappableString,
     MappableColor,
     resolve_properties,
+    resolve_color,
     document_properties,
 )
 from seaborn._core.scales import Scale
@@ -23,11 +24,17 @@ from seaborn._core.scales import Scale
 @dataclass
 class Text(Mark):
     """
-    TODO
+    A textual mark to represent or annotate data values.
+
+    Examples
+    --------
+    .. include:: ../docstrings/objects.Text.rst
+
     """
 
     text: MappableString = Mappable("")
     color: MappableColor = Mappable("k")
+    alpha: MappableFloat = Mappable(1)
     fontsize: MappableFloat = Mappable(rc="font.size")
     halign: MappableString = Mappable("center")
     valign: MappableString = Mappable("center_baseline")
@@ -38,13 +45,13 @@ class Text(Mark):
 
         for keys, data, ax in split_gen():
             vals = resolve_properties(self, keys, scales)
-
+            color = resolve_color(self, keys, "", scales)
             for row in data.to_dict("records"):
                 artist = mpl.text.Text(
                     x=row["x"],
                     y=row["y"],
-                    text=str(row["text"]),  # TODO format
-                    color=vals["color"],
+                    text=str(row.get("text", vals["text"])),
+                    color=color,
                     fontsize=vals["fontsize"],
                     horizontalalignment=vals["halign"],
                     verticalalignment=vals["valign"],
@@ -61,4 +68,4 @@ class Text(Mark):
     ) -> Artist:
 
         # TODO
-        return mpl.line.Line2D()
+        return mpl.lines.Line2D([], [])

--- a/seaborn/objects.py
+++ b/seaborn/objects.py
@@ -31,8 +31,9 @@ from seaborn._core.plot import Plot  # noqa: F401
 from seaborn._marks.base import Mark  # noqa: F401
 from seaborn._marks.area import Area, Band  # noqa: F401
 from seaborn._marks.bar import Bar, Bars  # noqa: F401
-from seaborn._marks.line import Line, Lines, Path, Paths, Range  # noqa: F401
 from seaborn._marks.dot import Dot, Dots  # noqa: F401
+from seaborn._marks.line import Line, Lines, Path, Paths, Range  # noqa: F401
+from seaborn._marks.text import Text  # noqa: F401
 
 from seaborn._stats.base import Stat  # noqa: F401
 from seaborn._stats.aggregation import Agg, Est  # noqa: F401

--- a/tests/_core/test_plot.py
+++ b/tests/_core/test_plot.py
@@ -1981,8 +1981,17 @@ class TestLegend:
         legend, = p._figure.legends
         assert legend.get_title().get_text() == ""
 
+    def test_legendless_mark(self, xy):
 
-class TestHelpers:
+        class NoLegendMark(MockMark):
+            def _legend_artist(self, variables, value, scales):
+                return None
+
+        p = Plot(**xy, color=["a", "b", "c", "d"]).add(NoLegendMark()).plot()
+        assert not p._figure.legends
+
+
+class TestDefaultObject:
 
     def test_default_repr(self):
 

--- a/tests/_marks/test_text.py
+++ b/tests/_marks/test_text.py
@@ -1,0 +1,69 @@
+
+from matplotlib.colors import to_rgba
+
+from seaborn._core.plot import Plot
+from seaborn._marks.text import Text
+
+
+class TestText:
+
+    def test_simple(self):
+
+        x = y = [1, 2, 3]
+        s = list("abc")
+
+        p = Plot(x, y, text=s).add(Text()).plot()
+        ax = p._figure.axes[0]
+        for i, text in enumerate(ax.texts):
+            x_, y_ = text.get_position()
+            assert x_ == x[i]
+            assert y_ == y[i]
+            assert text.get_text() == s[i]
+            assert text.get_horizontalalignment() == "center"
+            assert text.get_verticalalignment() == "center_baseline"
+
+    def test_set_properties(self):
+
+        x = y = [1, 2, 3]
+        s = list("abc")
+        color = "red"
+        alpha = .6
+        fontsize = 6
+        valign = "bottom"
+
+        m = Text(color=color, alpha=alpha, fontsize=fontsize, valign=valign)
+        p = Plot(x, y, text=s).add(m).plot()
+        ax = p._figure.axes[0]
+        for i, text in enumerate(ax.texts):
+            assert text.get_text() == s[i]
+            assert text.get_color() == to_rgba(m.color, m.alpha)
+            assert text.get_fontsize() == m.fontsize
+            assert text.get_verticalalignment() == m.valign
+
+    def test_mapped_properties(self):
+
+        x = y = [1, 2, 3]
+        s = list("abc")
+        color = list("aab")
+        fontsize = [1, 2, 4]
+
+        p = Plot(x, y, color=color, fontsize=fontsize, text=s).add(Text()).plot()
+        ax = p._figure.axes[0]
+        texts = ax.texts
+        assert texts[0].get_color() == texts[1].get_color()
+        assert texts[0].get_color() != texts[2].get_color()
+        assert (
+            texts[0].get_fontsize()
+            < texts[1].get_fontsize()
+            < texts[2].get_fontsize()
+        )
+
+    def test_identity_fontsize(self):
+
+        x = y = [1, 2, 3]
+        s = list("abc")
+        fs = [5, 8, 12]
+        p = Plot(x, y, text=s, fontsize=fs).add(Text()).scale(fontsize=None).plot()
+        ax = p._figure.axes[0]
+        for i, text in enumerate(ax.texts):
+            assert text.get_fontsize() == fs[i]

--- a/tests/_marks/test_text.py
+++ b/tests/_marks/test_text.py
@@ -1,6 +1,9 @@
 
+import numpy as np
 from matplotlib.colors import to_rgba
 from matplotlib.text import Text as MPLText
+
+from numpy.testing import assert_array_almost_equal
 
 from seaborn._core.plot import Plot
 from seaborn._marks.text import Text
@@ -86,3 +89,41 @@ class TestText:
         ax = p._figure.axes[0]
         for i, text in enumerate(self.get_texts(ax)):
             assert text.get_fontsize() == fs[i]
+
+    def test_offset_centered(self):
+
+        x = y = [1, 2, 3]
+        s = list("abc")
+        p = Plot(x, y, text=s).add(Text()).plot()
+        ax = p._figure.axes[0]
+        ax_trans = ax.transData.get_matrix()
+        for text in self.get_texts(ax):
+            assert_array_almost_equal(text.get_transform().get_matrix(), ax_trans)
+
+    def test_offset_valign(self):
+
+        x = y = [1, 2, 3]
+        s = list("abc")
+        m = Text(valign="bottom", fontsize=5, offset=.1)
+        p = Plot(x, y, text=s).add(m).plot()
+        ax = p._figure.axes[0]
+        expected_shift_matrix = np.zeros((3, 3))
+        expected_shift_matrix[1, -1] = m.offset * m.fontsize * ax.figure.dpi / 72
+        ax_trans = ax.transData.get_matrix()
+        for text in self.get_texts(ax):
+            shift_matrix = text.get_transform().get_matrix() - ax_trans
+            assert_array_almost_equal(shift_matrix, expected_shift_matrix)
+
+    def test_offset_halign(self):
+
+        x = y = [1, 2, 3]
+        s = list("abc")
+        m = Text(halign="right", fontsize=10, offset=.5)
+        p = Plot(x, y, text=s).add(m).plot()
+        ax = p._figure.axes[0]
+        expected_shift_matrix = np.zeros((3, 3))
+        expected_shift_matrix[0, -1] = -m.offset * m.fontsize * ax.figure.dpi / 72
+        ax_trans = ax.transData.get_matrix()
+        for text in self.get_texts(ax):
+            shift_matrix = text.get_transform().get_matrix() - ax_trans
+            assert_array_almost_equal(shift_matrix, expected_shift_matrix)

--- a/tests/_marks/test_text.py
+++ b/tests/_marks/test_text.py
@@ -1,11 +1,19 @@
 
 from matplotlib.colors import to_rgba
+from matplotlib.text import Text as MPLText
 
 from seaborn._core.plot import Plot
 from seaborn._marks.text import Text
 
 
 class TestText:
+
+    def get_texts(self, ax):
+        if ax.texts:
+            return list(ax.texts)
+        else:
+            # Compatibility with matplotlib < 3.5 (I think)
+            return [a for a in ax.artists if isinstance(a, MPLText)]
 
     def test_simple(self):
 
@@ -14,7 +22,7 @@ class TestText:
 
         p = Plot(x, y, text=s).add(Text()).plot()
         ax = p._figure.axes[0]
-        for i, text in enumerate(ax.texts):
+        for i, text in enumerate(self.get_texts(ax)):
             x_, y_ = text.get_position()
             assert x_ == x[i]
             assert y_ == y[i]
@@ -34,7 +42,7 @@ class TestText:
         m = Text(color=color, alpha=alpha, fontsize=fontsize, valign=valign)
         p = Plot(x, y, text=s).add(m).plot()
         ax = p._figure.axes[0]
-        for i, text in enumerate(ax.texts):
+        for i, text in enumerate(self.get_texts(ax)):
             assert text.get_text() == s[i]
             assert text.get_color() == to_rgba(m.color, m.alpha)
             assert text.get_fontsize() == m.fontsize
@@ -49,7 +57,7 @@ class TestText:
 
         p = Plot(x, y, color=color, fontsize=fontsize, text=s).add(Text()).plot()
         ax = p._figure.axes[0]
-        texts = ax.texts
+        texts = self.get_texts(ax)
         assert texts[0].get_color() == texts[1].get_color()
         assert texts[0].get_color() != texts[2].get_color()
         assert (
@@ -65,5 +73,5 @@ class TestText:
         fs = [5, 8, 12]
         p = Plot(x, y, text=s, fontsize=fs).add(Text()).scale(fontsize=None).plot()
         ax = p._figure.axes[0]
-        for i, text in enumerate(ax.texts):
+        for i, text in enumerate(self.get_texts(ax)):
             assert text.get_fontsize() == fs[i]

--- a/tests/_marks/test_text.py
+++ b/tests/_marks/test_text.py
@@ -108,7 +108,7 @@ class TestText:
         p = Plot(x, y, text=s).add(m).plot()
         ax = p._figure.axes[0]
         expected_shift_matrix = np.zeros((3, 3))
-        expected_shift_matrix[1, -1] = m.offset * m.fontsize * ax.figure.dpi / 72
+        expected_shift_matrix[1, -1] = m.offset * ax.figure.dpi / 72
         ax_trans = ax.transData.get_matrix()
         for text in self.get_texts(ax):
             shift_matrix = text.get_transform().get_matrix() - ax_trans
@@ -122,7 +122,7 @@ class TestText:
         p = Plot(x, y, text=s).add(m).plot()
         ax = p._figure.axes[0]
         expected_shift_matrix = np.zeros((3, 3))
-        expected_shift_matrix[0, -1] = -m.offset * m.fontsize * ax.figure.dpi / 72
+        expected_shift_matrix[0, -1] = -m.offset * ax.figure.dpi / 72
         ax_trans = ax.transData.get_matrix()
         for text in self.get_texts(ax):
             shift_matrix = text.get_transform().get_matrix() - ax_trans

--- a/tests/_marks/test_text.py
+++ b/tests/_marks/test_text.py
@@ -66,6 +66,17 @@ class TestText:
             < texts[2].get_fontsize()
         )
 
+    def test_mapped_alignment(self):
+
+        x = [1, 2]
+        p = Plot(x=x, y=x, halign=x, valign=x, text=x).add(Text()).plot()
+        ax = p._figure.axes[0]
+        t1, t2 = self.get_texts(ax)
+        assert t1.get_horizontalalignment() == "left"
+        assert t2.get_horizontalalignment() == "right"
+        assert t1.get_verticalalignment() == "top"
+        assert t2.get_verticalalignment() == "bottom"
+
     def test_identity_fontsize(self):
 
         x = y = [1, 2, 3]

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -1,0 +1,14 @@
+import seaborn.objects
+from seaborn._core.plot import Plot
+from seaborn._core.moves import Move
+from seaborn._core.scales import Scale
+from seaborn._marks.base import Mark
+from seaborn._stats.base import Stat
+
+
+def test_objects_namespace():
+
+    for name in dir(seaborn.objects):
+        if not name.startswith("__"):
+            obj = getattr(seaborn.objects, name)
+            assert issubclass(obj, (Plot, Mark, Stat, Move, Scale))


### PR DESCRIPTION
A new mark that shows text at x/y locations, with various other properties:

```python
(
    so.Plot(glue, "Average", "Model", text="Average")
    .add(so.Bar())
    .add(so.Text(halign="right", color="w"))
)
```
<img width=450 src="https://user-images.githubusercontent.com/315810/193574900-95783019-edde-4ede-b0d2-bb0ea08ac65f.png" />

Current properties:
```python
Init signature:
so.Text(
    artist_kws: 'dict' = <factory>,
    text: 'MappableString' = <''>,
    color: 'MappableColor' = <'k'>,
    alpha: 'MappableFloat' = <1>,
    fontsize: 'MappableFloat' = <rc:font.size>,
    halign: 'MappableString' = <'center'>,
    valign: 'MappableString' = <'center_baseline'>,
    offset: 'MappableFloat' = <4>,
) -> None

```

Note: this is somewhat limited in usefulness at the moment due to #3053; it's not possible to annotate using the result of a statistical transform. But that needs an upstream solution, I think.

To do:

- [x] Docstring w/ examples
- [x] Documentation of new properties
- [x] Unit tests
- [x] Decide on whether we'll have a formatting property (no, at least for now)
- [x] Allow marks to not have a legend artist