### PR TITLE
Use a stable algorithm in sorting marks

### DIFF
--- a/doc/whatsnew/v0.12.1.rst
+++ b/doc/whatsnew/v0.12.1.rst
@@ -6,6 +6,8 @@ v0.12.1 (Unreleased)
 
 - |Feature| The :class:`Band` and :class:`Range` marks will now cover the full extent of the data if `min` / `max` variables are not explicitly assigned or added in a transform (:pr:`3056`).
 
+- |Enhancement| Marks that sort along the orient axis (e.g. :class:`Line`) now use a stable algorithm (:pr:`3064`).
+
 - |Fix| Make :class:`objects.PolyFit` robust to missing data (:pr:`3010`).
 
 - |Fix| Fixed a bug that caused an exception when more than two layers with the same mappings were added (:pr:`3055`).

--- a/seaborn/_marks/area.py
+++ b/seaborn/_marks/area.py
@@ -59,7 +59,7 @@ class AreaBase:
     def _get_verts(self, data, orient):
 
         dv = {"x": "y", "y": "x"}[orient]
-        data = data.sort_values(orient)
+        data = data.sort_values(orient, kind="mergesort")
         verts = np.concatenate([
             data[[orient, f"{dv}min"]].to_numpy(),
             data[[orient, f"{dv}max"]].to_numpy()[::-1],

--- a/seaborn/_marks/line.py
+++ b/seaborn/_marks/line.py
@@ -60,7 +60,7 @@ class Path(Mark):
                 vals["marker"] = vals["marker"]._marker
 
             if self._sort:
-                data = data.sort_values(orient)
+                data = data.sort_values(orient, kind="mergesort")
 
             artist_kws = self.artist_kws.copy()
             self._handle_capstyle(artist_kws, vals)
@@ -184,7 +184,7 @@ class Paths(Mark):
             vals["color"] = resolve_color(self, keys, scales=scales)
 
             if self._sort:
-                data = data.sort_values(orient)
+                data = data.sort_values(orient, kind="mergesort")
 
             # Column stack to avoid block consolidation
             xy = np.column_stack([data["x"], data["y"]])


### PR DESCRIPTION
Closes #3059. With the example from that issue:

```python
(
    so.Plot(x=falseposrate_logistic, y=trueposrate_logistic)
    .add(so.Line(marker="o", pointsize=2))
)
```
<img width=500 src="https://user-images.githubusercontent.com/315810/194728742-237bc556-b46e-4843-aa93-fa16037c79c2.png" />

I wasn't able to cook up a toy example to demonstrate the problem so I haven't added a separate test for it. Would be a great addition if anyone can come up with one (i.e. not involving scikit learn, etc.).
