### PR TITLE
Fix unfilled kdeplot cmap regression

### DIFF
--- a/doc/whatsnew/v0.12.1.rst
+++ b/doc/whatsnew/v0.12.1.rst
@@ -10,4 +10,6 @@ v0.12.1 (Unreleased)
 
 - |Fix| Fixed a bug that caused an exception when more than two layers with the same mappings were added (:pr:`3055`).
 
+- |Fix| Fixed a regression in :func:`kdeplot` where passing `cmap` for an unfilled bivariate plot would raise an exception (:pr:`3065`).
+
 - |Build| Seaborn no longer contains doctest-style examples, simplifying the testing infrastructure (:pr:`3034`).

--- a/seaborn/distributions.py
+++ b/seaborn/distributions.py
@@ -1130,14 +1130,6 @@ class _DistributionPlotter(VectorPlotter):
                 for k, d in densities.items()
             }
 
-        # Get a default single color from the attribute cycle
-        if self.ax is None:
-            default_color = "C0" if color is None else color
-        else:
-            scout, = self.ax.plot([], color=color)
-            default_color = scout.get_color()
-            scout.remove()
-
         # Define the coloring of the contours
         if "hue" in self.variables:
             for param in ["cmap", "colors"]:
@@ -1150,10 +1142,10 @@ class _DistributionPlotter(VectorPlotter):
             # Work out a default coloring of the contours
             coloring_given = set(contour_kws) & {"cmap", "colors"}
             if fill and not coloring_given:
-                cmap = self._cmap_from_color(default_color)
+                cmap = self._cmap_from_color(color)
                 contour_kws["cmap"] = cmap
             if not fill and not coloring_given:
-                contour_kws["colors"] = [default_color]
+                contour_kws["colors"] = [color]
 
             # Use our internal colormap lookup
             cmap = contour_kws.pop("cmap", None)

--- a/seaborn/utils.py
+++ b/seaborn/utils.py
@@ -100,7 +100,8 @@ def _default_color(method, hue, color, kws):
 
     elif method.__name__ == "plot":
 
-        scout, = method([], [], scalex=False, scaley=False, **kws)
+        color = _normalize_kwargs(kws, mpl.lines.Line2D).get("color")
+        scout, = method([], [], scalex=False, scaley=False, color=color)
         color = scout.get_color()
         scout.remove()
 

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -1060,6 +1060,15 @@ class TestKDEPlotBivariate:
         for c in ax.collections:
             assert_colors_equal(get_contour_color(c), color)
 
+    def test_contour_line_cmap(self, long_df):
+
+        color_list = color_palette("Blues", 12)
+        cmap = mpl.colors.ListedColormap(color_list)
+        ax = kdeplot(data=long_df, x="x", y="y", cmap=cmap)
+        for c in ax.collections:
+            color = to_rgb(get_contour_color(c).squeeze())
+            assert color in color_list
+
     def test_contour_fill_colors(self, long_df):
 
         n = 6


### PR DESCRIPTION
Fixes #3058

```python
geyser = sns.load_dataset("geyser")
sns.kdeplot(geyser, x="waiting", y="duration", cmap="viridis")
```

![image](https://user-images.githubusercontent.com/315810/194729481-110b8da9-7a97-4109-9063-a9d47c74dd5d.png)
