### PR TITLE
Tweak nominal scale axes akin to categorical axes in classic seaborn

### DIFF
--- a/doc/whatsnew/v0.12.1.rst
+++ b/doc/whatsnew/v0.12.1.rst
@@ -6,11 +6,13 @@ v0.12.1 (Unreleased)
 
 - |Feature| Added the :class:`objects.Perc` stat (:pr:`3063`).
 
-- |Feature| The :class:`Band` and :class:`Range` marks will now cover the full extent of the data if `min` / `max` variables are not explicitly assigned or added in a transform (:pr:`3056`).
+- |Feature| The :class:`objects.Band` and :class:`objects.Range` marks will now cover the full extent of the data if `min` / `max` variables are not explicitly assigned or added in a transform (:pr:`3056`).
 
-- |Enhancement| The :class:`Jitter` move now applies a small amount of jitter by default (:pr:`3066`).
+- |Enhancement| |Defaults| The :class:`objects.Jitter` move now applies a small amount of jitter by default (:pr:`3066`).
 
-- |Enhancement| Marks that sort along the orient axis (e.g. :class:`Line`) now use a stable algorithm (:pr:`3064`).
+- |Enhancement| |Defaults| Axes with a :class:`objects.Nominal` scale now appear like categorical axes in class seaborn, with fixed margins, no grid, and an inverted y axis (:pr:`3069`).
+
+- |Enhancement| Marks that sort along the orient axis (e.g. :class:`objects.Line`) now use a stable algorithm (:pr:`3064`).
 
 - |Fix| Make :class:`objects.PolyFit` robust to missing data (:pr:`3010`).
 

--- a/seaborn/_core/plot.py
+++ b/seaborn/_core/plot.py
@@ -25,7 +25,7 @@ from seaborn._marks.base import Mark
 from seaborn._stats.base import Stat
 from seaborn._core.data import PlotData
 from seaborn._core.moves import Move
-from seaborn._core.scales import Scale
+from seaborn._core.scales import Scale, Nominal
 from seaborn._core.subplots import Subplots
 from seaborn._core.groupby import GroupBy
 from seaborn._core.properties import PROPERTIES, Property
@@ -1238,7 +1238,6 @@ class Plotter:
             # This only affects us when sharing *paired* axes. This is a novel/niche
             # behavior, so we will raise rather than hack together a workaround.
             if axis is not None and Version(mpl.__version__) < Version("3.4.0"):
-                from seaborn._core.scales import Nominal
                 paired_axis = axis in p._pair_spec.get("structure", {})
                 cat_scale = isinstance(scale, Nominal)
                 ok_dim = {"x": "col", "y": "row"}[axis]
@@ -1631,6 +1630,7 @@ class Plotter:
             ax = sub["ax"]
             for axis in "xy":
                 axis_key = sub[axis]
+                axis_obj = getattr(ax, f"{axis}axis")
 
                 # Axis limits
                 if axis_key in p._limits:
@@ -1643,6 +1643,17 @@ class Plotter:
                     if isinstance(b, str):
                         hi = cast(float, hi) + 0.5
                     ax.set(**{f"{axis}lim": (lo, hi)})
+
+                # Nominal scale special-casing
+                if isinstance(self._scales.get(axis_key), Nominal):
+                    axis_obj.grid(False, which="both")
+                    if axis_key not in p._limits:
+                        nticks = len(axis_obj.get_major_ticks())
+                        lo, hi = -.5, nticks - .5
+                        if axis == "y":
+                            lo, hi = hi, lo
+                        set_lim = getattr(ax, f"set_{axis}lim")
+                        set_lim(lo, hi, auto=None)
 
         engine_default = None if p._target is not None else "tight"
         layout_engine = p._layout_spec.get("engine", engine_default)

--- a/tests/_core/test_plot.py
+++ b/tests/_core/test_plot.py
@@ -645,6 +645,28 @@ class TestScaling:
         with pytest.raises(RuntimeError, match=err):
             p.plot()
 
+    def test_nominal_x_axis_tweaks(self):
+
+        p = Plot(x=["a", "b", "c"], y=[1, 2, 3])
+        ax1 = p.plot()._figure.axes[0]
+        assert ax1.get_xlim() == (-.5, 2.5)
+        assert not any(x.get_visible() for x in ax1.xaxis.get_gridlines())
+
+        lim = (-1, 2.1)
+        ax2 = p.limit(x=lim).plot()._figure.axes[0]
+        assert ax2.get_xlim() == lim
+
+    def test_nominal_y_axis_tweaks(self):
+
+        p = Plot(x=[1, 2, 3], y=["a", "b", "c"])
+        ax1 = p.plot()._figure.axes[0]
+        assert ax1.get_ylim() == (2.5, -.5)
+        assert not any(y.get_visible() for y in ax1.yaxis.get_gridlines())
+
+        lim = (-1, 2.1)
+        ax2 = p.limit(y=lim).plot()._figure.axes[0]
+        assert ax2.get_ylim() == lim
+
 
 class TestPlotting:
 


### PR DESCRIPTION
Closes #2967

Three changes:

- Margins are now an additive 0.5 rather than a multiplicative 0.05
- Grids are disabled
- Y axis is inverted

```python
(
    so.Plot(tips, x="total_bill", y="time")
    .add(so.Dots(), so.Jitter())
    .layout(size=(6, 3))
)
```

Current:
<img width=500 src="https://user-images.githubusercontent.com/315810/194784784-d8070906-f617-42f4-9489-78731546d87b.png" />

With this change:

<img width=500 src="https://user-images.githubusercontent.com/315810/194784764-fe3203cf-3f67-47ae-97be-063cf5f82009.png" />

We'll want to allow users to override the grid parameterization. I think we'll need an API for that that is separate from `Plot.theme` and I'm not exactly sure where it should be off the top of my head. `Plot.layout` or on the `Nominal` object itself are two ideas.

I'd also still like this to be supported as a first-class operation in matplotlib, but I'm not sure how likely that is.

It feels like a bit of a hack to have this logic live in `Plot._finalize_figure` with an instance check on the Scale. Alternatively, we could put the logic in the Scale object and have `_finalize_figure` call into it. Maybe something to revisit once we either want other scale-specific tweaks or when the extension API is formally opened up.