### PR TITLE
Add notebook cleanup to pre-commit hooks.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,3 +18,8 @@ repos:
      -  id: mypy
         args: [--follow-imports=skip]
         files: seaborn/_(core|marks|stats)/
+-   repo: https://github.com/kynan/nbstripout
+    rev: 0.6.1
+    hooks:
+    -   id: nbstripout
+        args: [--extra-keys=metadata.language_info.version metadata.kernelspec.name metadata.kernelspec.display_name]


### PR DESCRIPTION
Addresses https://github.com/mwaskom/seaborn/issues/3041

Adds nbstripout pre-commit hook to clear out the following from Jupyter Notebooks being committed:
- output
- kernelspec name and display name
- Python version

As stated in the issue, the part that clears out the metadata may be a bit of an annoyance to the contribution flow if you don't make a habit of clearing out the metadata.