### PR TITLE
Allow base=None to disable log formatter in Continuous.label

### DIFF
--- a/doc/whatsnew/v0.12.1.rst
+++ b/doc/whatsnew/v0.12.1.rst
@@ -14,7 +14,9 @@ v0.12.1 (Unreleased)
 
 - |Enhancement| |Defaults| Axes with a :class:`objects.Nominal` scale now appear like categorical axes in class seaborn, with fixed margins, no grid, and an inverted y axis (:pr:`3069`).
 
-- |Enhancement| Marks that sort along the orient axis (e.g. :class:`objects.Line`) now use a stable algorithm (:pr:`3064`).
+- |Enhancement| |API| The :meth:`objects.Continuous.label` method now accepts `base=None` to override the default formatter with a log transform (:pr:`3087`).
+
+- |Enhancement| |Fix| Marks that sort along the orient axis (e.g. :class:`objects.Line`) now use a stable algorithm (:pr:`3064`).
 
 - |Enhancement| |Fix| Added a `label` parameter to :func:`pointplot`, which addresses a regression in 0.12.0 when :func:`pointplot` is passed to :class:`FacetGrid` (:pr:`3016`).
 

--- a/seaborn/_core/scales.py
+++ b/seaborn/_core/scales.py
@@ -35,6 +35,7 @@ from matplotlib.scale import ScaleBase
 from pandas import Series
 
 from seaborn._core.rules import categorical_order
+from seaborn._core.typing import Default, default
 
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
@@ -494,7 +495,7 @@ class Continuous(ContinuousBase):
         self,
         formatter: Formatter | None = None, *,
         like: str | Callable | None = None,
-        base: int | None = None,
+        base: int | None | Default = default,
         unit: str | None = None,
     ) -> Continuous:
         """
@@ -510,6 +511,7 @@ class Continuous(ContinuousBase):
             and returns a string.
         base : number
             Use log formatter (with scientific notation) having this value as the base.
+            Set to `None` to override the default formatter with a log transform.
         unit : str or (str, str) tuple
             Use  SI prefixes with these units (e.g., with `unit="g"`, a tick value
             of 5000 will appear as `5 kg`). When a tuple, the first element gives the
@@ -613,7 +615,7 @@ class Continuous(ContinuousBase):
     def _get_formatter(self, locator, formatter, like, base, unit):
 
         log_base, symlog_thresh = self._parse_for_log_params(self.trans)
-        if base is None:
+        if base is default:
             if symlog_thresh:
                 log_base = 10
             base = log_base

--- a/tests/_core/test_scales.py
+++ b/tests/_core/test_scales.py
@@ -213,6 +213,15 @@ class TestContinuous:
         a.set_view_interval(.5, 1050)
         assert_array_equal(a.major.locator(), [1, 10, 100, 1000])
 
+    def test_log_tick_format_disabled(self, x):
+
+        s = Continuous(trans="log").label(base=None)._setup(x, Coordinate())
+        a = PseudoAxis(s._matplotlib_scale)
+        a.set_view_interval(20, 20000)
+        labels = a.major.formatter.format_ticks(a.major.locator())
+        for text in labels:
+            assert re.match(r"^\d+$", text)
+
     def test_log_tick_every(self, x):
 
         with pytest.raises(RuntimeError, match="`every` not supported"):


### PR DESCRIPTION
Simple change to make it possible *not* to use log formatted (scientific notation) ticks with a log transform:

```python
(
    so.Plot(diamonds, "carat", "price")
    .add(so.Dots())
    .scale(y=so.Continuous(trans="log").tick(at=[300, 1000, 3000, 10000]).label(base=None))
)
```
<img width=500 src="https://user-images.githubusercontent.com/315810/196044501-31017e5b-a67e-4adf-91af-ab252152b7af.png" />
