### PR TITLE
Add docstrings and API examples for remaining transform objects

### DIFF
--- a/doc/_docstrings/objects.Agg.ipynb
+++ b/doc/_docstrings/objects.Agg.ipynb
@@ -1,0 +1,140 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0d053943-66c9-410d-ad65-ce91f1c1ff48",
+   "metadata": {
+    "tags": [
+     "hide"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "import seaborn.objects as so\n",
+    "from seaborn import load_dataset\n",
+    "diamonds = load_dataset(\"diamonds\")"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "51b029af-b83b-4ae0-a6ff-f48bf9692518",
+   "metadata": {},
+   "source": [
+    "The default behavior is to aggregate by taking a mean over each group:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28451b4e-9f4e-4604-b2b9-6138c4f51436",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "p = so.Plot(diamonds, \"clarity\", \"carat\")\n",
+    "p.add(so.Bar(), so.Agg())"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "53859a3b-051c-423d-97ef-b03f647268b7",
+   "metadata": {},
+   "source": [
+    "Other aggregation functions can be selected by name if they are pandas methods:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5beaac3a-b9f7-4acc-81c7-480599e3675e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "p.add(so.Bar(), so.Agg(\"median\"))"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "2d318ee3-56c1-4fd4-99a5-fa87db770f67",
+   "metadata": {},
+   "source": [
+    "It's also possible to pass an arbitrary aggregation function:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bd11e289-7274-464a-b781-06fb756cf8de",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "p.add(so.Bar(), so.Agg(lambda x: x.quantile(.75) - x.quantile(.25)))"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "555394c1-25f8-4932-94d1-f67a8a9fa1c6",
+   "metadata": {},
+   "source": [
+    "When other mapping variables are assigned, they'll be used to define aggregation groups. With some marks, it may be helpful to use additional transforms, such as :class:`objects.Dodge`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5755cdeb-1d1a-4434-9cc5-91024735eb4e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "p.add(so.Bar(), so.Agg(), so.Dodge(), color=\"cut\")"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "07eb1150-db57-4a58-b830-8a7aba9f46ec",
+   "metadata": {},
+   "source": [
+    "The variable that gets aggregated depends on the orientation of the layer, which is usually inferred from the coordinate variable types (but may also be specified with the `orient` parameter in :meth:`objects.Plot.add`):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1bdcc970-1b6c-4a3d-b0bc-6c7a625163ff",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "so.Plot(diamonds, \"carat\", \"clarity\").add(so.Bar(), so.Agg())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ad8006ff-5472-4345-9537-a5680c519f4f",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "py310",
+   "language": "python",
+   "name": "py310"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/doc/_docstrings/objects.Dodge.ipynb
+++ b/doc/_docstrings/objects.Dodge.ipynb
@@ -1,0 +1,198 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4d44a940-db84-4e16-bc83-e67d08d6d56a",
+   "metadata": {
+    "tags": [
+     "hide"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "import seaborn.objects as so\n",
+    "from seaborn import load_dataset\n",
+    "tips = load_dataset(\"tips\").astype({\"time\": str})"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "ce99e1a1-c213-478f-a5bc-d19e2c4d70db",
+   "metadata": {},
+   "source": [
+    "This transform modifies both the width and position (along the orientation axis) of marks that would otherwise overlap:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f6a84062-2c2b-4a45-91cb-77f29462104d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(\n",
+    "    so.Plot(tips, \"day\", color=\"time\")\n",
+    "    .add(so.Bar(), so.Count(), so.Dodge())\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "55d3a9a8-c973-4e91-9f3a-bc137df15f48",
+   "metadata": {},
+   "source": [
+    "By default, empty space may appear when variables are not fully crossed:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "08ae1c65-5ad9-47a3-a8f3-d901bd4821f2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "p = so.Plot(tips, \"day\", color=\"time\")\n",
+    "p.add(so.Bar(), so.Count(), so.Dodge())"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "2125f07d-4210-4d49-8761-bcfa3f9c67f5",
+   "metadata": {},
+   "source": [
+    "The `empty` parameter handles this case; use it to fill out the space:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c2314343-de73-45d7-9595-acf5f7d62e93",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "p.add(so.Bar(), so.Count(), so.Dodge(empty=\"fill\"))"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "08f4382c-842e-4777-a452-1d88251da6e7",
+   "metadata": {},
+   "source": [
+    "Or center the marks while using a consistent width:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1e0745e4-be11-4703-bf9c-4b13cbb76e91",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "p.add(so.Bar(), so.Count(), so.Dodge(empty=\"drop\"))"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "7d29ec53-caef-4cff-9828-dc242adb5c49",
+   "metadata": {},
+   "source": [
+    "Use `gap` to add a bit of spacing between dodged marks:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "342aca16-c67b-4bc4-9101-fec6c398aa0f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "p = so.Plot(tips, \"day\", \"total_bill\", color=\"sex\")\n",
+    "p.add(so.Bar(), so.Agg(\"sum\"), so.Dodge(gap=.1))"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "68b52dcb-c5e7-4186-b61f-e96fac5f4d40",
+   "metadata": {},
+   "source": [
+    "When multiple semantic variables are used, each distinct group will be dodged:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "497f3e3b-39bc-4381-85bb-be5bb5c60b1f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "p.add(so.Dot(), so.Dodge(), fill=\"smoker\")"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "795835d2-904f-4343-89c2-b91be9c1c504",
+   "metadata": {},
+   "source": [
+    "Use `by` to dodge only a subset of variables:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "da01f6c0-c425-409c-a010-5cb52a794dc9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "p.add(so.Dot(), so.Dodge(by=[\"color\"]), fill=\"smoker\")"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "77de77da-2fad-4374-9d14-90520e448c90",
+   "metadata": {},
+   "source": [
+    "When combining with other transforms (such as :class:`Jitter` or :class:`Stack`), be mindful of the order that they are applied in:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "29ccabd6-6bd5-4563-a337-f8f8d25f7dad",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "p.add(so.Dot(), so.Dodge(), so.Jitter())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a73fe9a5-c717-41fd-874e-be72334ea6d4",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "py310",
+   "language": "python",
+   "name": "py310"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/doc/_docstrings/objects.Est.ipynb
+++ b/doc/_docstrings/objects.Est.ipynb
@@ -1,0 +1,144 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "57ececfa-0ae0-4acb-b85d-7c6a6ca8d3db",
+   "metadata": {
+    "tags": [
+     "hide"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "import seaborn.objects as so\n",
+    "from seaborn import load_dataset\n",
+    "diamonds = load_dataset(\"diamonds\")"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "03c64256-8daf-4b32-87bd-b425e27a7823",
+   "metadata": {},
+   "source": [
+    "The default behavior is to compute the mean and 95% confidence interval (using bootstrapping):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "46017dc7-7c3c-4dcf-9232-2e3ac490d980",
+   "metadata": {
+    "tags": [
+     "hide"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "p = so.Plot(diamonds, \"clarity\", \"carat\")\n",
+    "p.add(so.Range(), so.Est())"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "1bf04e8d-998e-4a47-9375-ddcde76e3914",
+   "metadata": {},
+   "source": [
+    "Other estimators may be selected by name if they are pandas methods:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ea394c55-8fa6-4fb0-8665-42c03ef3576e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "p.add(so.Range(), so.Est(\"median\"))"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "9c5f3c91-fecb-4e75-b045-b30870154083",
+   "metadata": {},
+   "source": [
+    "There are several options for computing the error bar interval, such as (scaled) standard errors:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9c350af5-d549-4cce-b3f2-e9bef33aef36",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "p.add(so.Range(), so.Est(errorbar=\"se\"))"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "8c8d321b-5e73-418c-8c71-4b91cf187e57",
+   "metadata": {},
+   "source": [
+    "The error bars can also represent the spread of the distribution around the estimate using (scaled) standard deviations:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fd2cd9dc-e4c9-4ba1-ac79-38806cf1e009",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "p.add(so.Range(), so.Est(errorbar=\"sd\"))"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "6dba074b-881c-40df-b42e-458e4a26e23d",
+   "metadata": {},
+   "source": [
+    "Because confidence intervals are computed using bootstrapping, there will be small amounts of randomness. Reduce the random variability by increasing the nubmer of bootstrap iterations (although this will be slower), or eliminate it by seeding the random number generator:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d6b450e1-8b1f-411f-aa01-bbb46ab3b6ec",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "p.add(so.Range(), so.Est(seed=0))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5e4a0594-e1ee-4f72-971e-3763dd626e8b",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "py310",
+   "language": "python",
+   "name": "py310"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/doc/_docstrings/objects.Norm.ipynb
+++ b/doc/_docstrings/objects.Norm.ipynb
@@ -1,0 +1,89 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0bfee8b6-1e3e-499d-96ae-735a5c230b32",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import seaborn.objects as so\n",
+    "from seaborn import load_dataset\n",
+    "healthexp = load_dataset(\"healthexp\")"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "43adf565-2843-48fe-a12a-1a65bc9fce9f",
+   "metadata": {},
+   "source": [
+    "By default, this transform scales each group relative to its maximum value:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6262c89d-56cd-41b4-8276-0bf737b02f29",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(\n",
+    "    so.Plot(healthexp, x=\"Year\", y=\"Spending_USD\", color=\"Country\")\n",
+    "    .add(so.Lines(), so.Norm())\n",
+    "    .label(y=\"Spending relative to maximum amount\")\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "5941b47a-7f2f-4540-9944-c6a16e7eec75",
+   "metadata": {},
+   "source": [
+    "Use `where` to constrain the values used to define a baseline, and `percent` to scale the output:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8142d0b4-1b91-4ba9-bc60-3df148130ff9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(\n",
+    "    so.Plot(healthexp, x=\"Year\", y=\"Spending_USD\", color=\"Country\")\n",
+    "    .add(so.Lines(), so.Norm(where=\"x == x.min()\", percent=True))\n",
+    "    .label(y=\"Percent change in spending from 1970 baseline\")\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2f2d2d33-8a92-44fb-b37a-24dee23a7d75",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "py310",
+   "language": "python",
+   "name": "py310"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/doc/_docstrings/objects.Shift.ipynb
+++ b/doc/_docstrings/objects.Shift.ipynb
@@ -1,0 +1,94 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2605c8d0-5872-4dff-9172-db81fac1cee1",
+   "metadata": {
+    "tags": [
+     "hide"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "import seaborn.objects as so\n",
+    "from seaborn import load_dataset\n",
+    "penguins = load_dataset(\"penguins\")\n",
+    "diamonds = load_dataset(\"diamonds\")"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "e70d701a-cd7c-4b38-aaa0-4729e2be56d9",
+   "metadata": {},
+   "source": [
+    "Use this transform to layer multiple marks that would otherwise overlap and be hard to interpret:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5ea7a2c4-cb69-4ad0-8ea8-73067b756371",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(\n",
+    "    so.Plot(penguins, \"species\", \"body_mass_g\")\n",
+    "    .add(so.Dots(), so.Jitter())\n",
+    "    .add(so.Range(), so.Perc([25, 75]), so.Shift(x=.2))\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "940b87b2-04fb-40ba-a62f-52f461039ab9",
+   "metadata": {},
+   "source": [
+    "For y variables with a nominal scale, bear in mind that the axis will be inverted and a positive shift will move downwards:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "54b5f728-4fbc-474a-8865-0f58d0ad9b0b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(\n",
+    "    so.Plot(diamonds, \"carat\", \"clarity\")\n",
+    "    .add(so.Dots(), so.Jitter())\n",
+    "    .add(so.Range(), so.Perc([25, 75]), so.Shift(y=.25))\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "78d9bb6a-ea3d-491e-b43e-25efd386bd59",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "py310",
+   "language": "python",
+   "name": "py310"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/doc/_docstrings/objects.Stack.ipynb
+++ b/doc/_docstrings/objects.Stack.ipynb
@@ -1,0 +1,89 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "87244f49-8cf2-4668-a556-a8c7828b31bf",
+   "metadata": {
+    "tags": [
+     "hide"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "import seaborn.objects as so\n",
+    "from seaborn import load_dataset\n",
+    "titanic = load_dataset(\"titanic\").sort_values(\"alive\", ascending=False)"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "c9a1a7db-f365-4c5f-85ae-1f00e15b0af9",
+   "metadata": {},
+   "source": [
+    "This transform applies a vertical shift to eliminate overlap between marks with a baseline, such as :class:`Bar` or :class:`Area`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "07579f71-842d-4dc1-98ab-38652409238d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "so.Plot(titanic, x=\"class\", color=\"sex\").add(so.Bar(), so.Count(), so.Stack())"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "2488a821-3bf1-4bb9-9963-bf726d11925c",
+   "metadata": {},
+   "source": [
+    "Stacking can make it much harder to compare values between groups that get shifted, but it can work well when depicting a part-whole relationship:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dcb8ea58-3cf2-455b-b6b7-98b434f2f152",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(\n",
+    "    so.Plot(titanic, x=\"age\", alpha=\"alive\")\n",
+    "    .facet(\"sex\")\n",
+    "    .add(so.Bars(), so.Hist(binwidth=10), so.Stack())\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b649198f-898e-4103-84bc-d74de71de5a7",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "py310",
+   "language": "python",
+   "name": "py310"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/seaborn/_core/moves.py
+++ b/seaborn/_core/moves.py
@@ -154,6 +154,11 @@ class Dodge(Move):
 class Stack(Move):
     """
     Displacement of overlapping bar or area marks along the value axis.
+
+    Examples
+    --------
+    .. include:: ../docstrings/objects.Stack.rst
+
     """
     # TODO center? (or should this be a different move, eg. Stream())
 
@@ -189,6 +194,16 @@ class Stack(Move):
 class Shift(Move):
     """
     Displacement of all marks with the same magnitude / direction.
+
+    Parameters
+    ----------
+    x, y : float
+        Magnitude of shift, in data units, along each axis.
+
+    Examples
+    --------
+    .. include:: ../docstrings/objects.Shift.rst
+
     """
     x: float = 0
     y: float = 0

--- a/seaborn/_core/moves.py
+++ b/seaborn/_core/moves.py
@@ -81,6 +81,19 @@ class Jitter(Move):
 class Dodge(Move):
     """
     Displacement and narrowing of overlapping marks along orientation axis.
+
+    Parameters
+    ----------
+    empty : {'keep', 'drop', 'fill'}
+    gap : float
+        Size of gap between dodged marks.
+    by : list of variable names
+        Variables to apply the movement to, otherwise use all.
+
+    Examples
+    --------
+    .. include:: ../docstrings/objects.Dodge.rst
+
     """
     empty: str = "keep"  # Options: keep, drop, fill
     gap: float = 0

--- a/seaborn/_core/moves.py
+++ b/seaborn/_core/moves.py
@@ -222,6 +222,22 @@ class Shift(Move):
 class Norm(Move):
     """
     Divisive scaling on the value axis after aggregating within groups.
+
+    Parameters
+    ----------
+    func : str or callable
+        Function called on each group to define the comparison value.
+    where : str
+        Query string defining the subset used to define the comparison values.
+    by : list of variables
+        Variables used to define aggregation groups.
+    percent : bool
+        If True, multiply the result by 100.
+
+    Examples
+    --------
+    .. include:: ../docstrings/objects.Norm.rst
+
     """
 
     func: Union[Callable, str] = "max"

--- a/seaborn/_stats/aggregation.py
+++ b/seaborn/_stats/aggregation.py
@@ -22,6 +22,14 @@ class Agg(Stat):
     func : str or callable
         Name of a :class:`pandas.Series` method or a vector -> scalar function.
 
+    See Also
+    --------
+    objects.Est : Aggregation with error bars.
+
+    Examples
+    --------
+    .. include:: ../docstrings/objects.Agg.rst
+
     """
     func: str | Callable[[Vector], float] = "mean"
 
@@ -46,6 +54,9 @@ class Est(Stat):
     """
     Calculate a point estimate and error bar interval.
 
+    For additional information about the various `errorbar` choices, see
+    the :doc:`errorbar tutorial </tutorial/error_bars>`.
+
     Parameters
     ----------
     func : str or callable
@@ -58,6 +69,10 @@ class Est(Stat):
        Number of bootstrap samples to draw for "ci" errorbars.
     seed : int
         Seed for the PRNG used to draw bootstrap samples.
+
+    Examples
+    --------
+    .. include:: ../docstrings/objects.Est.rst
 
     """
     func: str | Callable[[Vector], float] = "mean"


### PR DESCRIPTION
Ran out of time for these before the v0.12.0 release so this is just filling in some documentation gaps.