### PR TITLE
Don't pass label when creating color cycle scout

### DIFF
--- a/doc/whatsnew/v0.12.2.rst
+++ b/doc/whatsnew/v0.12.2.rst
@@ -2,4 +2,6 @@
 v0.12.2 (Unreleased)
 --------------------
 
-- Added the :class:`objects.KDE` stat (:pr:`3111`).
+- |Feature| Added the :class:`objects.KDE` stat (:pr:`3111`).
+
+- |Fix| Fixed a regression in v0.12.0 where manually-added labels could have duplicate legend entries (:pr:`3116`).

--- a/seaborn/utils.py
+++ b/seaborn/utils.py
@@ -95,6 +95,9 @@ def _default_color(method, hue, color, kws):
         #      warnings.warn(msg)
         return None
 
+    kws = kws.copy()
+    kws.pop("label", None)
+
     if color is not None:
         return color
 

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -1816,6 +1816,13 @@ class TestHistPlotUnivariate(SharedAxesLevelTests):
         assert line.get_linewidth() == lw
         assert line.get_linestyle() == ls
 
+    def test_label(self, flat_series):
+
+        ax = histplot(flat_series, label="a label")
+        handles, labels = ax.get_legend_handles_labels()
+        assert len(handles) == 1
+        assert labels == ["a label"]
+
 
 class TestHistPlotBivariate:
 


### PR DESCRIPTION
Fixes #3115 

```python
import numpy as np
import seaborn as sns

rng = np.random.default_rng(43)
data = rng.random(1000)
ax = sns.histplot(data, label="Random Data", stat="density")
ax.legend()
```
![image](https://user-images.githubusercontent.com/315810/198747480-ba5dffe0-e1ce-4dab-8823-870027e72676.png)
