### PR TITLE
Compute spacing/width separately for unshared axes

### DIFF
--- a/doc/_docstrings/objects.Norm.ipynb
+++ b/doc/_docstrings/objects.Norm.ipynb
@@ -4,7 +4,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "0bfee8b6-1e3e-499d-96ae-735a5c230b32",
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "hide"
+    ]
+   },
    "outputs": [],
    "source": [
     "import seaborn.objects as so\n",

--- a/doc/whatsnew/v0.12.2.rst
+++ b/doc/whatsnew/v0.12.2.rst
@@ -4,4 +4,6 @@ v0.12.2 (Unreleased)
 
 - |Feature| Added the :class:`objects.KDE` stat (:pr:`3111`).
 
+- |Enhancement| Automatic mark widths are now calculated separately for unshared facet axes (:pr:`3119`).
+
 - |Fix| Fixed a regression in v0.12.0 where manually-added labels could have duplicate legend entries (:pr:`3116`).

--- a/seaborn/_core/plot.py
+++ b/seaborn/_core/plot.py
@@ -616,8 +616,8 @@ class Plot:
             - A list of values, implying a :class:`Nominal` scale (e.g. `["b", "r"]`)
 
         For more explicit control, pass a scale spec object such as :class:`Continuous`
-        or :class:`Nominal`. Or use `None` to use an "identity" scale, which treats data
-        values as literally encoding visual properties.
+        or :class:`Nominal`. Or pass `None` to use an "identity" scale, which treats
+        data values as literally encoding visual properties.
 
         Examples
         --------

--- a/seaborn/_core/plot.py
+++ b/seaborn/_core/plot.py
@@ -1309,12 +1309,22 @@ class Plotter:
                 if var not in "xy" and var in scales:
                     return getattr(scales[var], "order", None)
 
-            if "width" in mark._mappable_props:
-                width = mark._resolve(df, "width", None)
-            else:
-                width = 0.8 if "width" not in df else df["width"]  # TODO what default?
             if orient in df:
-                df["width"] = width * scales[orient]._spacing(df[orient])
+                width = pd.Series(index=df.index, dtype=float)
+                for view in subplots:
+                    view_idx = self._get_subplot_data(
+                        df, orient, view, p._shares.get(orient)
+                    ).index
+                    view_df = df.loc[view_idx]
+                    if "width" in mark._mappable_props:
+                        view_width = mark._resolve(view_df, "width", None)
+                    elif "width" in df:
+                        view_width = view_df["width"]
+                    else:
+                        view_width = 0.8  # TODO what default?
+                    spacing = scales[orient]._spacing(view_df.loc[view_idx, orient])
+                    width.loc[view_idx] = view_width * spacing
+                df["width"] = width
 
             if "baseline" in mark._mappable_props:
                 # TODO what marks should have this?

--- a/seaborn/utils.py
+++ b/seaborn/utils.py
@@ -87,6 +87,7 @@ def _draw_figure(fig):
 
 def _default_color(method, hue, color, kws):
     """If needed, get a default color by using the matplotlib property cycle."""
+
     if hue is not None:
         # This warning is probably user-friendly, but it's currently triggered
         # in a FacetGrid context and I don't want to mess with that logic right now

--- a/tests/_core/test_plot.py
+++ b/tests/_core/test_plot.py
@@ -12,7 +12,7 @@ from PIL import Image
 
 import pytest
 from pandas.testing import assert_frame_equal, assert_series_equal
-from numpy.testing import assert_array_equal
+from numpy.testing import assert_array_equal, assert_array_almost_equal
 
 from seaborn._core.plot import Plot, Default
 from seaborn._core.scales import Nominal, Continuous
@@ -1383,6 +1383,17 @@ class TestFacetInterface:
                 }
                 assert all(shareset[shared].joined(root, ax) for ax in other)
                 assert not any(shareset[unshared].joined(root, ax) for ax in other)
+
+    def test_unshared_spacing(self):
+
+        x = [1, 2, 10, 20]
+        y = [1, 2, 3, 4]
+        col = [1, 1, 2, 2]
+
+        m = MockMark()
+        Plot(x, y).facet(col).add(m).share(x=False).plot()
+        assert_array_almost_equal(m.passed_data[0]["width"], [0.8, 0.8])
+        assert_array_equal(m.passed_data[1]["width"], [8, 8])
 
     def test_col_wrapping(self):
 

--- a/tests/_core/test_plot.py
+++ b/tests/_core/test_plot.py
@@ -788,6 +788,12 @@ class TestPlotting:
             long_df, m, data_vars, split_vars, split_cols, split_keys
         )
 
+    def test_specified_width(self, long_df):
+
+        m = MockMark()
+        Plot(long_df, x="x", y="y").add(m, width="z").plot()
+        assert_array_almost_equal(m.passed_data[0]["width"], long_df["z"])
+
     def test_facets_no_subgroups(self, long_df):
 
         split_var = "col"


### PR DESCRIPTION
Motivating example (from #3112):

```python
(
    sns.load_dataset("penguins")
    .melt(["species"], ["bill_depth_mm", "bill_length_mm"])
    .pipe(so.Plot, x="value", color="species")
    .facet("variable")
    .add(so.Bars(), so.Hist(common_bins=["col"]))
    .share(x=False)
)
```

Before:
<img width=500 src=https://user-images.githubusercontent.com/315810/198892636-d4a22f77-6ffe-4d0d-b3d4-b25d1476e10f.png />

After:
<img width=500 src=https://user-images.githubusercontent.com/315810/198887899-1051d8ed-5cb1-4295-9a81-a566c30a27bc.png />

(This is a little artificial because you could just use `Plot.pair` here but there are other cases where you'd actually want faceting).