### PR TITLE
POC: Compound marks

### DIFF
--- a/seaborn/_marks/area.py
+++ b/seaborn/_marks/area.py
@@ -87,7 +87,7 @@ class AreaBase:
 
 
 @document_properties
-@dataclass
+@dataclass(repr=False)
 class Area(AreaBase, Mark):
     """
     A fill mark drawn from a baseline to data values.
@@ -137,7 +137,7 @@ class Area(AreaBase, Mark):
 
 
 @document_properties
-@dataclass
+@dataclass(repr=False)
 class Band(AreaBase, Mark):
     """
     A fill mark representing an interval between values.

--- a/seaborn/_marks/bar.py
+++ b/seaborn/_marks/bar.py
@@ -104,7 +104,7 @@ class BarBase(Mark):
 
 
 @document_properties
-@dataclass
+@dataclass(repr=False)
 class Bar(BarBase):
     """
     A bar mark drawn between baseline and data values.
@@ -174,7 +174,7 @@ class Bar(BarBase):
 
 
 @document_properties
-@dataclass
+@dataclass(repr=False)
 class Bars(BarBase):
     """
     A faster bar mark with defaults more suitable histograms.

--- a/seaborn/_marks/base.py
+++ b/seaborn/_marks/base.py
@@ -130,10 +130,8 @@ class Mark:
 
     def __add__(self, other: Mark) -> CompoundMark:
 
-        # TODO commenting out as this makes iterating difficult with
-        # IPython's buggy dataclass autoreload
-        # if not isinstance(other, Mark):
-        #     raise TypeError()  # TODO
+        if not isinstance(other, Mark):
+            raise TypeError()  # TODO
 
         for prop, val in self._mappable_props.items():
             if (
@@ -267,6 +265,16 @@ class CompoundMark(Mark):
             res.extend(x for x in mark._grouping_props if x not in res)
         return res
 
+    def __repr__(self):
+
+        res = f"{self.__class__.__name__}([\n"
+        for mark in self._marks:
+            for line in repr(mark).split("\n"):
+                if line.endswith(")"):
+                    line += ","
+                res += f"  {line}\n"
+        return res + "])"
+
     def _plot(
         self,
         split_generator: Callable[[], Generator],
@@ -277,15 +285,13 @@ class CompoundMark(Mark):
         for mark in self._marks:
             mark._plot(split_generator, scales, orient)
 
-    def __repr__(self):
+    def _legend_artist(
+        self, variables: list[str], value: Any, scales: dict[str, Scale],
+    ) -> Artist:
 
-        res = "CompoundMark([\n"
-        for mark in self._marks:
-            for line in repr(mark).split("\n"):
-                if line.endswith(")"):
-                    line += ","
-                res += f"  {line}\n"
-        return res + "])"
+        return tuple(
+            mark._legend_artist(variables, value, scales) for mark in self._marks
+        )
 
 
 def resolve_properties(

--- a/seaborn/_marks/dot.py
+++ b/seaborn/_marks/dot.py
@@ -104,7 +104,7 @@ class DotBase(Mark):
 
 
 @document_properties
-@dataclass
+@dataclass(repr=False)
 class Dot(DotBase):
     """
     A mark suitable for dot plots or less-dense scatterplots.
@@ -158,7 +158,7 @@ class Dot(DotBase):
 
 
 @document_properties
-@dataclass
+@dataclass(repr=False)
 class Dots(DotBase):
     """
     A dot mark defined by strokes to better handle overplotting.

--- a/seaborn/_marks/line.py
+++ b/seaborn/_marks/line.py
@@ -19,7 +19,7 @@ from seaborn.external.version import Version
 
 
 @document_properties
-@dataclass
+@dataclass(repr=False)
 class Path(Mark):
     """
     A mark connecting data points in the order they appear.
@@ -118,7 +118,7 @@ class Path(Mark):
 
 
 @document_properties
-@dataclass
+@dataclass(repr=False)
 class Line(Path):
     """
     A mark connecting data points with sorting along the orientation axis.
@@ -137,7 +137,7 @@ class Line(Path):
 
 
 @document_properties
-@dataclass
+@dataclass(repr=False)
 class Paths(Mark):
     """
     A faster but less-flexible mark for drawing many paths.
@@ -228,7 +228,7 @@ class Paths(Mark):
 
 
 @document_properties
-@dataclass
+@dataclass(repr=False)
 class Lines(Paths):
     """
     A faster but less-flexible mark for drawing many lines.
@@ -246,7 +246,7 @@ class Lines(Paths):
 
 
 @document_properties
-@dataclass
+@dataclass(repr=False)
 class Range(Paths):
     """
     An oriented line mark drawn between min/max values.
@@ -272,7 +272,7 @@ class Range(Paths):
 
 
 @document_properties
-@dataclass
+@dataclass(repr=False)
 class Dash(Paths):
     """
     A line mark drawn as an oriented segment for each datapoint.

--- a/seaborn/_marks/text.py
+++ b/seaborn/_marks/text.py
@@ -19,7 +19,7 @@ from seaborn._marks.base import (
 
 
 @document_properties
-@dataclass
+@dataclass(repr=False)
 class Text(Mark):
     """
     A textual mark to annotate or represent data values.


### PR DESCRIPTION
This PR has a proof of concept for a "compound mark" concept (cf #2991). In this implementation, marks are combined through the addition operator (e.g. `Dot() + Range()`):

```python
(
    so.Plot(glue, "Score", "Model")
    .add(so.Dot() + so.Range(), so.Est())
)
```
<img width=700 src=https://user-images.githubusercontent.com/315810/198901013-e0c46b1e-0a1f-4b80-b1ac-4bf8ce3ed7c6.png />

A potentially useful (but also potentially surprising) behavior is that the second mark will inherit any properties set directly on the first mark:

```python
(
    so.Plot(glue, "Score", "Model")
    .add(so.Dot(color=".15") + so.Range(), so.Est())
)
```
<img width=700 src=https://user-images.githubusercontent.com/315810/198901086-6c5998ce-4499-42fc-8bc6-0f6a452b1adf.png />

(We could decide that this is too magical to be helpful).

Mark properties are mapped together:

```python
(
    so.Plot(glue, "Score", "Model", color="Encoder")
    .add(so.Dot() + so.Range(), so.Est())
)
```
<img width=800 src=https://user-images.githubusercontent.com/315810/198901253-1a5d5afa-4c2c-44d7-8fda-d6a5d2c7280a.png />

Compound marks also move together and simplify some existing edge cases (cf. #2987)

```python
(
    so.Plot(glue, "Score", "Encoder", color="Model")
    .add(so.Bar(width=.5) + so.Range(), so.Est(), so.Dodge(empty="fill"))
)
```
<img width=700 src=https://user-images.githubusercontent.com/315810/198901463-5b12f2eb-ee50-4ce2-97b8-24b52d0dbb5b.png />

### Open questions

Is overloading `Mark.__add__` the right approach here? It would be the only place where a mathematical operator is overloaded to build a plot. And we need to be mindful of the adjacency to ggplot syntax, which uses `+` overloading for _everything_. There's also potentially the odd tension of having this operation happening _within_ a method called `.add`.

Alternatives considered:
- Make `CompoundMark` a public object and use it, possibly setting common properties with kwargs, e.g. `CompoundMark(Dot(), Range(), color="r")`
- Accept a list in `Plot.add` with the same general logic, e.g. `Plot().add([Dot(), Range()], Est())`
- Change the `Plot.add` signature to be `*args` and then work out what's what based on types e.g. `Plot().add(Dot(), Range(), Est(), Dodge())`

My current thinking is that these are, in turn, too verbose / too fussy with brackets / too opaque when read. But I'm not completely sold on addition overloading...

### Needs

- [ ] Decision on spelling
- [ ] Decision on "property inheritance"
- [ ] Unit tests
- [ ] Documentation
- [ ] Release note