### PR TITLE
enhance legend positioning with usage of matplotlib rc params …

### DIFF
--- a/doc/_docstrings/objects.Plot.theme.ipynb
+++ b/doc/_docstrings/objects.Plot.theme.ipynb
@@ -77,6 +77,48 @@
    ]
   },
   {
+   "cell_type": "raw",
+   "id": "d73ed0dc",
+   "metadata": {},
+   "source": [
+    "Use the legend and its parameters."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ba165c95",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "p = (\n",
+    "    so.Plot(anscombe, x=\"x\", y=\"y\", color=\"dataset\")\n",
+    "    .add(so.Line(), legend=True)\n",
+    ")\n",
+    "p"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c7c72007",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "p.theme({\"legend_loc__bbox_to_anchor\": (0.8, 0.3)})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "771117cf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "p.theme({\"legend.loc\": \"upper left\"}).theme({\"legend_loc__bbox_to_anchor\": (0.1, 0.95)})"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "2c8fa27e-d1ea-4376-a717-c3059ba1d272",
    "metadata": {},


### PR DESCRIPTION
…'legend.loc' and additional 'legend_loc__bbox_to_anchor' inside there as replacement for the 'bbox_to_anchor' of the matplotlib figure legend function.