### PR TITLE
Add caps to the Range object

### DIFF
--- a/doc/_docstrings/objects.Range.ipynb
+++ b/doc/_docstrings/objects.Range.ipynb
@@ -3,7 +3,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2923956c-f141-4ecb-ab08-e819099f0fa9",
    "metadata": {
     "tags": [
      "hide"
@@ -18,29 +17,26 @@
   },
   {
    "cell_type": "raw",
-   "id": "576cbc86-f869-47b5-a98f-6ee727287a8b",
    "metadata": {},
    "source": [
-    "This mark will often be used in the context of a stat transform that adds an errorbar interval:"
+    "This mark will often be used in the context of a stat transform that adds an errorbar interval, with an optional parameter `capsize` controlling the size of the caps:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f6217b85-7479-49fd-aeda-9f435aa0473a",
    "metadata": {},
    "outputs": [],
    "source": [
     "(\n",
     "    so.Plot(penguins, x=\"body_mass_g\", y=\"species\", color=\"sex\")\n",
     "    .add(so.Dot(), so.Agg(), so.Dodge())\n",
-    "    .add(so.Range(), so.Est(errorbar=\"sd\"), so.Dodge())\n",
+    "    .add(so.Range(capsize=0.1), so.Est(errorbar=\"sd\"), so.Dodge())\n",
     ")"
    ]
   },
   {
    "cell_type": "raw",
-   "id": "e156ea24-d8b4-4d67-acb5-750034be4dde",
    "metadata": {},
    "source": [
     "One feature (or potential gotcha) is that the mark will pick up properties like `linestyle` and `linewidth`; exclude those properties from the relevant layer if this behavior is undesired:"
@@ -49,7 +45,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4bb63ebb-7733-4313-844c-cb7613298da3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -63,7 +58,6 @@
   },
   {
    "cell_type": "raw",
-   "id": "5387e049-b343-49ea-a943-7dd9c090f184",
    "metadata": {},
    "source": [
     "It's also possible to directly assign the minimum and maximum values for the range:"
@@ -72,7 +66,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4e795770-4481-4e23-a49b-e828a1f5cbbd",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -86,7 +79,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2191bec6-a02e-48e0-b92c-69c38826049d",
    "metadata": {},
    "source": [
     "When `min`/`max` variables are neither computed as part of a transform or explicitly assigned, the range will cover the full extent of the data at each unique observation on the orient axis:"
@@ -95,7 +87,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "63c6352e-4ef5-4cff-940e-35fa5804b2c7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -110,7 +101,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c215deb1-e510-4631-b999-737f5f41cae2",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/seaborn/_marks/line.py
+++ b/seaborn/_marks/line.py
@@ -270,15 +270,17 @@ class Range(Paths):
         cols = [orient, f"{val}min", f"{val}max"]
         data = data[cols].melt(orient, value_name=val)[["x", "y"]]
         segments = [d.to_numpy() for _, d in data.groupby(orient)]
-        segments_with_caps = [s for s in segments]
-        ori = ["x", "y"].index(orient)
-        for s in segments:
-            for i in range(2):
-                caps = np.stack([s[i], s[i]], axis=0)
-                caps[0, ori] -= self.capsize / 2
-                caps[1, ori] += self.capsize / 2
-                segments_with_caps.append(caps)
-        return segments_with_caps
+        if self.capsize:
+            caps_list = []
+            ori = ["x", "y"].index(orient)
+            for s in segments:
+                for i in range(2):
+                    caps = np.stack([s[i], s[i]], axis=0)
+                    caps[0, ori] -= self.capsize / 2
+                    caps[1, ori] += self.capsize / 2
+                    caps_list.append(caps)
+            segments.extend(caps_list)
+        return segments
 
 
 @document_properties

--- a/seaborn/_marks/line.py
+++ b/seaborn/_marks/line.py
@@ -256,6 +256,8 @@ class Range(Paths):
     .. include:: ../docstrings/objects.Range.rst
 
     """
+    capsize: float = 0.0
+
     def _setup_segments(self, data, orient):
 
         # TODO better checks on what variables we have
@@ -268,7 +270,15 @@ class Range(Paths):
         cols = [orient, f"{val}min", f"{val}max"]
         data = data[cols].melt(orient, value_name=val)[["x", "y"]]
         segments = [d.to_numpy() for _, d in data.groupby(orient)]
-        return segments
+        segments_with_caps = [s for s in segments]
+        ori = ["x", "y"].index(orient)
+        for s in segments:
+            for i in range(2):
+                caps = np.stack([s[i], s[i]], axis=0)
+                caps[0, ori] -= self.capsize / 2
+                caps[1, ori] += self.capsize / 2
+                segments_with_caps.append(caps)
+        return segments_with_caps
 
 
 @document_properties


### PR DESCRIPTION
As suggested in issue #2985, this PR adds an optional capsize parameter to the Range object for drawing caps at the end, e.g. for error bars.
Here is an example of how it looks : 
```
import seaborn as sns
import seaborn.objects as so

penguins = sns.load_dataset("penguins")
p = (
    so.Plot(penguins, x="body_mass_g", y="species", color="sex")
    .add(so.Range(capsize=0.1), so.Est(errorbar="sd"), so.Dodge())
    .add(so.Dot(), so.Agg(), so.Dodge())
)
```
![seaborn_range_caps](https://user-images.githubusercontent.com/1338337/201231096-8e877080-2b18-4b7d-8a87-c6a3c97c6fe2.png)
