### PR TITLE
Fixed the issue with wrong width in log scale for Bar(s)

### DIFF
--- a/seaborn/_core/plot.py
+++ b/seaborn/_core/plot.py
@@ -1356,6 +1356,7 @@ class Plotter:
 
             grouping_vars = mark._grouping_props + default_grouping_vars
             split_generator = self._setup_split_generator(grouping_vars, df, subplots)
+
             mark._plot(split_generator, scales, orient)
 
         # TODO is this the right place for this?
@@ -1397,6 +1398,7 @@ class Plotter:
                     out_df.loc[values.index, f"{orient}base"] = (
                         transform(values - width / 2)
                     )
+
         return out_df
 
     def _generate_pairings(

--- a/seaborn/_core/plot.py
+++ b/seaborn/_core/plot.py
@@ -1356,7 +1356,6 @@ class Plotter:
 
             grouping_vars = mark._grouping_props + default_grouping_vars
             split_generator = self._setup_split_generator(grouping_vars, df, subplots)
-
             mark._plot(split_generator, scales, orient)
 
         # TODO is this the right place for this?
@@ -1395,7 +1394,9 @@ class Plotter:
                     out_df.loc[values.index, "width"] = (
                         transform(values + width / 2) - transform(values - width / 2)
                     )
-
+                    out_df.loc[values.index, f"{orient}base"] = (
+                        transform(values - width / 2)
+                    )
         return out_df
 
     def _generate_pairings(

--- a/seaborn/_marks/bar.py
+++ b/seaborn/_marks/bar.py
@@ -31,16 +31,15 @@ class BarBase(Mark):
 
         kws = self._resolve_properties(data, scales)
         if orient == "x":
-            kws["x"] = (data["x"] - data["width"] / 2).to_numpy()
+            kws["x"] = (data["xbase"]).to_numpy()
             kws["y"] = data["baseline"].to_numpy()
             kws["w"] = data["width"].to_numpy()
             kws["h"] = (data["y"] - data["baseline"]).to_numpy()
         else:
             kws["x"] = data["baseline"].to_numpy()
-            kws["y"] = (data["y"] - data["width"] / 2).to_numpy()
+            kws["y"] = (data["ybase"]).to_numpy()
             kws["w"] = (data["x"] - data["baseline"]).to_numpy()
             kws["h"] = data["width"].to_numpy()
-
         kws.pop("width", None)
         kws.pop("baseline", None)
 

--- a/seaborn/_marks/bar.py
+++ b/seaborn/_marks/bar.py
@@ -40,6 +40,7 @@ class BarBase(Mark):
             kws["y"] = (data["ybase"]).to_numpy()
             kws["w"] = (data["x"] - data["baseline"]).to_numpy()
             kws["h"] = data["width"].to_numpy()
+
         kws.pop("width", None)
         kws.pop("baseline", None)
 


### PR DESCRIPTION
Fixes the issue #2907, but in a hacky way. The core issue is that currently, the bars' positions relative to each other are defined by a coordinate (say x) and their width. When applying a transform, what happens is that x is transformed (into `transformed_x`), and the new width is obtained with `transformed_width = transform(x+width/2)-transform(x-width/2)`. While this is actually correct, it falls apart when passing the coordinates to the matplotlib API, which asks for the bottom left of the rectangle. It is currently obtained by doing `transformed_x-transformed_width/2`, whereas it should really be `transform(x-width/2)`, which is obviously not the same in the case of the log.
In this PR, I solve the problem by storing the `transform(x-width/2)` value and retrieving it when needed, but this feels a bit weird to have it as an additional variable ; however we cannot ditch the normal `transformed_x` as it is needed for other things than the bars. There is probably some underlying flow change that would make this more straightforward but I expect this to be a big change.