### PR TITLE
Fix log scaled histplot kde

### DIFF
--- a/doc/whatsnew/v0.12.2.rst
+++ b/doc/whatsnew/v0.12.2.rst
@@ -7,3 +7,5 @@ v0.12.2 (Unreleased)
 - |Enhancement| Automatic mark widths are now calculated separately for unshared facet axes (:pr:`3119`).
 
 - |Fix| Fixed a regression in v0.12.0 where manually-added labels could have duplicate legend entries (:pr:`3116`).
+
+- |Fix| Fixed a bug in :func:`histplot` with `kde=True` and `log_scale=True` where the curve was not scaled properly (:pr:`3173`).

--- a/seaborn/distributions.py
+++ b/seaborn/distributions.py
@@ -478,11 +478,6 @@ class _DistributionPlotter(VectorPlotter):
             widths = res["space"].to_numpy()
             edges = res[orient].to_numpy() - widths / 2
 
-            # Convert edges back to original units for plotting
-            if self._log_scaled(self.data_variable):
-                widths = np.power(10, edges + widths) - np.power(10, edges)
-                edges = np.power(10, edges)
-
             # Rescale the smoothed curve to match the histogram
             if kde and key in densities:
                 density = densities[key]
@@ -491,6 +486,11 @@ class _DistributionPlotter(VectorPlotter):
                 else:
                     hist_norm = (heights * widths).sum()
                 densities[key] *= hist_norm
+
+            # Convert edges back to original units for plotting
+            if self._log_scaled(self.data_variable):
+                widths = np.power(10, edges + widths) - np.power(10, edges)
+                edges = np.power(10, edges)
 
             # Pack the histogram data and metadata together
             edges = edges + (1 - shrink) / 2 * widths

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -1757,6 +1757,14 @@ class TestHistPlotUnivariate(SharedAxesLevelTests):
         x_max = np.log([b.get_x() + b.get_width() for b in ax.patches])
         assert np.unique(np.round(x_max - x_min, 10)).size == 1
 
+    def test_log_scale_kde(self, rng):
+
+        x = rng.lognormal(0, 1, 1000)
+        ax = histplot(x=x, log_scale=True, kde=True, bins=20)
+        bar_height = max(p.get_height() for p in ax.patches)
+        kde_height = max(ax.lines[0].get_ydata())
+        assert bar_height == pytest.approx(kde_height, rel=.1)
+
     @pytest.mark.parametrize(
         "fill", [True, False],
     )


### PR DESCRIPTION
Fixes #3171

```python
x = np.random.lognormal(0, 1, 1000)
ax = sns.histplot(x=x, log_scale=True, kde=True)
```
![image](https://user-images.githubusercontent.com/315810/205504032-e6e618e5-c302-4813-b4b9-7c1219114c94.png)
