### PR TITLE
COMPAT: Change pandas use_inf_as_null to reflect 2.0 deprecation

### DIFF
--- a/seaborn/_core/plot.py
+++ b/seaborn/_core/plot.py
@@ -1484,7 +1484,7 @@ class Plotter:
 
                 axes_df = self._filter_subplot_data(df, view)
 
-                with pd.option_context("mode.use_inf_as_null", True):
+                with pd.option_context("mode.use_inf_as_na", True):
                     if keep_na:
                         # The simpler thing to do would be x.dropna().reindex(x.index).
                         # But that doesn't work with the way that the subset iteration

--- a/seaborn/_oldcore.py
+++ b/seaborn/_oldcore.py
@@ -1116,7 +1116,7 @@ class VectorPlotter:
                 parts = []
                 grouped = self.plot_data[var].groupby(self.converters[var], sort=False)
                 for converter, orig in grouped:
-                    with pd.option_context('mode.use_inf_as_null', True):
+                    with pd.option_context('mode.use_inf_as_na', True):
                         orig = orig.dropna()
                         if var in self.var_levels:
                             # TODO this should happen in some centralized location

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -1791,7 +1791,7 @@ class _LVPlotter(_CategoricalPlotter):
         vals = np.asarray(vals)
         # Remove infinite values while handling a 'object' dtype
         # that can come from pd.Float64Dtype() input
-        with pd.option_context('mode.use_inf_as_null', True):
+        with pd.option_context('mode.use_inf_as_na', True):
             vals = vals[~pd.isnull(vals)]
         n = len(vals)
         p = self.outlier_prop


### PR DESCRIPTION
pandas 2.0 will enforce the deprecation of the option `use_inf_as_null` in favor of `use_if_as na`, so changing the usages I found in seaborn