### PR TITLE
Fix inner axis visibility in relplot with unshared axes

### DIFF
--- a/doc/whatsnew/v0.12.2.rst
+++ b/doc/whatsnew/v0.12.2.rst
@@ -9,3 +9,5 @@ v0.12.2 (Unreleased)
 - |Fix| Fixed a regression in v0.12.0 where manually-added labels could have duplicate legend entries (:pr:`3116`).
 
 - |Fix| Fixed a bug in :func:`histplot` with `kde=True` and `log_scale=True` where the curve was not scaled properly (:pr:`3173`).
+
+- |Fix| Fixed a bug in :func:`relplot` where inner axis labels would be shown when axis sharing was disabled (:pr:`3180`).

--- a/seaborn/relational.py
+++ b/seaborn/relational.py
@@ -955,7 +955,8 @@ def relplot(
     g.map_dataframe(func, **plot_kws)
 
     # Label the axes, using the original variables
-    g.set_axis_labels(variables.get("x"), variables.get("y"))
+    # Pass "" when the variable name is None to overwrite internal variables
+    g.set_axis_labels(variables.get("x") or "", variables.get("y") or "")
 
     # Show the legend
     if legend:

--- a/seaborn/relational.py
+++ b/seaborn/relational.py
@@ -955,7 +955,7 @@ def relplot(
     g.map_dataframe(func, **plot_kws)
 
     # Label the axes, using the original variables
-    g.set(xlabel=variables.get("x"), ylabel=variables.get("y"))
+    g.set_axis_labels(variables.get("x"), variables.get("y"))
 
     # Show the legend
     if legend:

--- a/tests/test_relational.py
+++ b/tests/test_relational.py
@@ -624,6 +624,23 @@ class TestRelationalPlotter(Helpers):
         for line, color in zip(lines, palette):
             assert line.get_color() == color
 
+    def test_relplot_axis_labels(self, long_df):
+
+        col, row = "a", "b"
+        g = relplot(
+            data=long_df, x="x", y="y", col=col, row=row,
+            facet_kws=dict(sharex=False, sharey=False),
+        )
+
+        for ax in g.axes[-1, :].flat:
+            assert ax.get_xlabel() == "x"
+        for ax in g.axes[:-1, :].flat:
+            assert ax.get_xlabel() == ""
+        for ax in g.axes[:, 0].flat:
+            assert ax.get_ylabel() == "y"
+        for ax in g.axes[:, 1:].flat:
+            assert ax.get_ylabel() == ""
+
     def test_relplot_data(self, long_df):
 
         g = relplot(

--- a/tests/test_relational.py
+++ b/tests/test_relational.py
@@ -624,7 +624,7 @@ class TestRelationalPlotter(Helpers):
         for line, color in zip(lines, palette):
             assert line.get_color() == color
 
-    def test_relplot_axis_labels(self, long_df):
+    def test_relplot_unshared_axis_labels(self, long_df):
 
         col, row = "a", "b"
         g = relplot(


### PR DESCRIPTION
Fixes #3179 

With (modified) example from that issue:

```
g = sns.relplot(data=iris, x='sepal_length', y='sepal_width', col='species', 
                col_wrap=2, height=2.5, facet_kws=dict(sharex=False, sharey=False))
```
![image](https://user-images.githubusercontent.com/315810/206603260-9077e24c-9565-46e7-81f5-3ca1fca134f3.png)
