### PR TITLE
Don't use offset / scientific notation in numeric legends

### DIFF
--- a/doc/whatsnew/v0.12.2.rst
+++ b/doc/whatsnew/v0.12.2.rst
@@ -6,6 +6,8 @@ v0.12.2 (Unreleased)
 
 - |Enhancement| Automatic mark widths are now calculated separately for unshared facet axes (:pr:`3119`).
 
+- |Fix| Fixed a bug where legends for numeric variables with large values with be incorrectly shown (i.e. with a missing offset or exponent; :pr:`3187`).
+
 - |Fix| Fixed a regression in v0.12.0 where manually-added labels could have duplicate legend entries (:pr:`3116`).
 
 - |Fix| Fixed a bug in :func:`histplot` with `kde=True` and `log_scale=True` where the curve was not scaled properly (:pr:`3173`).

--- a/seaborn/_core/scales.py
+++ b/seaborn/_core/scales.py
@@ -378,6 +378,14 @@ class ContinuousBase(Scale):
             axis.set_view_interval(vmin, vmax)
             locs = axis.major.locator()
             locs = locs[(vmin <= locs) & (locs <= vmax)]
+            # Avoid having an offset / scientific notation in a legend
+            # as we don't represent that anywhere so it ends up incorrect.
+            # This could become an option (e.g. Continuous.label(offset=True))
+            # in which case we would need to figure out how to show it.
+            if hasattr(axis.major.formatter, "set_useOffset"):
+                axis.major.formatter.set_useOffset(False)
+            if hasattr(axis.major.formatter, "set_scientific"):
+                axis.major.formatter.set_scientific(False)
             labels = axis.major.formatter.format_ticks(locs)
             new._legend = list(locs), list(labels)
 

--- a/seaborn/utils.py
+++ b/seaborn/utils.py
@@ -699,6 +699,10 @@ def locator_to_legend_entries(locator, limits, dtype):
         formatter = mpl.ticker.LogFormatter()
     else:
         formatter = mpl.ticker.ScalarFormatter()
+        # Avoid having an offset/scientific notation which we don't currently
+        # have any way of representing in the legend
+        formatter.set_useOffset(False)
+        formatter.set_scientific(False)
     formatter.axis = dummy_axis()
 
     # TODO: The following two lines should be replaced

--- a/tests/_core/test_plot.py
+++ b/tests/_core/test_plot.py
@@ -2051,6 +2051,15 @@ class TestLegend:
         p = Plot(**xy, color=["a", "b", "c", "d"]).add(NoLegendMark()).plot()
         assert not p._figure.legends
 
+    def test_legend_has_no_offset(self, xy):
+
+        color = np.add(xy["x"], 1e8)
+        p = Plot(**xy, color=color).add(MockMark()).plot()
+        legend = p._figure.legends[0]
+        assert legend.texts
+        for text in legend.texts:
+            assert float(text.get_text()) > 1e7
+
 
 class TestDefaultObject:
 

--- a/tests/test_relational.py
+++ b/tests/test_relational.py
@@ -675,6 +675,12 @@ class TestRelationalPlotter(Helpers):
         assert len(ax.collections) == 0
         assert len(g.ax.collections) > 0
 
+    def test_legend_has_no_offset(self, long_df):
+
+        g = relplot(data=long_df, x="x", y="y", hue=long_df["z"] + 1e8)
+        for text in g.legend.texts:
+            assert float(text.get_text()) > 1e7
+
 
 class TestLinePlotter(SharedAxesLevelTests, Helpers):
 


### PR DESCRIPTION
Fixes #3174:

<img width=500 src=https://user-images.githubusercontent.com/315810/208270683-5fe7b44c-b620-47c3-8783-bab89f548b40.png />

This takes the shortest path solution of simply disabling the offset / scientific notation on a scalar formatter used in the legend. I think it's possible that we'll want to add those as options in `Continuous.label` in which case we may want to figure out how to show the extra information in a legend context (e.g. as a subtitle or extra row at the bottom of the legend). Punting on that as it seems complicated.

Note that if you do want to format legend entries with scientific notation, you can do `Continuous().label(like="{x:.2g}")` (not exactly the same thing, but will help when variables have very large values).