### PR TITLE
Avoid exception from Continuous scale for normed property with non-float data

### DIFF
--- a/doc/whatsnew/v0.12.2.rst
+++ b/doc/whatsnew/v0.12.2.rst
@@ -14,6 +14,8 @@ v0.12.2 (Unreleased)
 
 - |Fix| Fixed a regression in v0.12.0 where manually-added labels could have duplicate legend entries (:pr:`3116`).
 
+- |Fix| Normed properties using a :class:`objects.Continuous` scale  no longer raise on boolean data (:pr:`3189`).
+
 - |Fix| Fixed a bug in :func:`histplot` with `kde=True` and `log_scale=True` where the curve was not scaled properly (:pr:`3173`).
 
 - |Fix| Fixed a bug in :func:`relplot` where inner axis labels would be shown when axis sharing was disabled (:pr:`3180`).

--- a/seaborn/_core/scales.py
+++ b/seaborn/_core/scales.py
@@ -346,7 +346,7 @@ class ContinuousBase(Scale):
                 vmin, vmax = data.min(), data.max()
             else:
                 vmin, vmax = new.norm
-            vmin, vmax = axis.convert_units((vmin, vmax))
+            vmin, vmax = map(float, axis.convert_units((vmin, vmax)))
             a = forward(vmin)
             b = forward(vmax) - forward(vmin)
 

--- a/tests/_core/test_scales.py
+++ b/tests/_core/test_scales.py
@@ -90,6 +90,12 @@ class TestContinuous:
         s = Continuous((2, 3), (10, 100), "log")._setup(x, IntervalProperty())
         assert_array_equal(s(x), [1, 2, 3])
 
+    def test_interval_with_bools(self):
+
+        x = pd.Series([True, False, False])
+        s = Continuous()._setup(x, IntervalProperty())
+        assert_array_equal(s(x), [1, 0, 0])
+
     def test_color_defaults(self, x):
 
         cmap = color_palette("ch:", as_cmap=True)


### PR DESCRIPTION
Fixes #3106 in a narrow way by avoiding a TypeError when sorting out the normalization:

<img width=500 src=https://user-images.githubusercontent.com/315810/208310583-89cc1099-81ae-4dc9-9320-6b4b3640c419.png />

This result isn't ideal, we'd like to propagate the boolean-ness of the data through to the visualization, but this is consistent with other numpy / matplotlib behavior where boolean data are upcast to 0/1 floats in numeric contexts. So boolean data should still get a non-continuous scale by default but contra #3135 I think there should be a separate `Boolean` scale concept rather than default to `Nominal`.