### PR TITLE
Mark numpy 1.24.0 as non-compatible

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 ]
 requires-python = ">=3.7"
 dependencies = [
-    "numpy>=1.17",
+    "numpy>=1.17,!=1.24.0",
     "pandas>=0.25",
     "matplotlib>=3.1,!=3.6.1",
     "typing_extensions; python_version < '3.8'",


### PR DESCRIPTION
A bug in numpy 1.24.0 hard-breaks a number of seaborn functions: https://github.com/numpy/numpy/issues/22826

Marking the whole release as non-compatible to avoid trouble.