### PR TITLE
Improve user feedback for errors during plot compilation

### DIFF
--- a/doc/whatsnew/v0.12.2.rst
+++ b/doc/whatsnew/v0.12.2.rst
@@ -6,9 +6,11 @@ v0.12.2 (Unreleased)
 
 - |Enhancement| Automatic mark widths are now calculated separately for unshared facet axes (:pr:`3119`).
 
+- |Enhancement| Improved user feedback for failures during plot compilation by catching exceptions an reraising with a `PlotSpecError` that provides additional context (:pr:`3203`).
+
 - |Fix| Fixed a bug where legends for numeric variables with large values with be incorrectly shown (i.e. with a missing offset or exponent; :pr:`3187`).
 
-- |Fix| Improve robustness to empty data in several components of the objects interface (:pr:`3202`).
+- |Fix| Improved robustness to empty data in several components of the objects interface (:pr:`3202`).
 
 - |Fix| Fixed a regression in v0.12.0 where manually-added labels could have duplicate legend entries (:pr:`3116`).
 

--- a/seaborn/_core/exceptions.py
+++ b/seaborn/_core/exceptions.py
@@ -1,0 +1,32 @@
+"""
+Custom exceptions for the seaborn.objects interface.
+
+This is very lightweight, but it's a separate module to avoid circular imports.
+
+"""
+from __future__ import annotations
+
+
+class PlotSpecError(RuntimeError):
+    """
+    Error class raised from seaborn.objects.Plot for compile-time failures.
+
+    In the declarative Plot interface, exceptions may not be triggered immediately
+    by bad user input (and validation at input time may not be possible). This class
+    is used to signal that indirect dependency. It should be raised in an exception
+    chain when compile-time operations fail with an error message providing useful
+    context (e.g., scaling errors could specify the variable that failed.)
+
+    """
+    @classmethod
+    def _during(cls, step: str, var: str = "") -> PlotSpecError:
+        """
+        Initialize the class to report the failure of a specific operation.
+        """
+        message = []
+        if var:
+            message.append(f"{step} failed for the `{var}` variable.")
+        else:
+            message.append(f"{step} failed.")
+        message.append("See the traceback above for more information.")
+        return cls(" ".join(message))

--- a/seaborn/_core/plot.py
+++ b/seaborn/_core/plot.py
@@ -1255,12 +1255,8 @@ class Plotter:
                 except Exception as err:
                     raise PlotSpecError._during("Scale setup", var) from err
 
-            # Everything below here applies only to coordinate variables
-            # We additionally skip it when we're working with a value
-            # that is derived from a coordinate we've already processed.
-            # e.g., the Stat consumed y and added ymin/ymax. In that case,
-            # we've already setup the y scale and ymin/max are in scale space.
             if axis is None or (var != coord and coord in p._variables):
+                # Everything below here applies only to coordinate variables
                 continue
 
             # Set up an empty series to receive the transformed values.
@@ -1280,13 +1276,15 @@ class Plotter:
 
                 for layer, new_series in zip(layers, transformed_data):
                     layer_df = layer["data"].frame
-                    if var in layer_df:
-                        idx = self._get_subplot_index(layer_df, view)
-                        try:
-                            new_series.loc[idx] = view_scale(layer_df.loc[idx, var])
-                        except Exception as err:
-                            spec_error = PlotSpecError._during("Scaling operation", var)
-                            raise spec_error from err
+                    if var not in layer_df:
+                        continue
+
+                    idx = self._get_subplot_index(layer_df, view)
+                    try:
+                        new_series.loc[idx] = view_scale(layer_df.loc[idx, var])
+                    except Exception as err:
+                        spec_error = PlotSpecError._during("Scaling operation", var)
+                        raise spec_error from err
 
             # Now the transformed data series are complete, set update the layer data
             for layer, new_series in zip(layers, transformed_data):

--- a/seaborn/_marks/base.py
+++ b/seaborn/_marks/base.py
@@ -178,7 +178,7 @@ class Mark:
                 try:
                     feature = scale(value)
                 except Exception as err:
-                    raise PlotSpecError._during("Scale operation", name) from err
+                    raise PlotSpecError._during("Scaling operation", name) from err
 
             if return_array:
                 feature = np.asarray(feature)

--- a/seaborn/_marks/base.py
+++ b/seaborn/_marks/base.py
@@ -20,6 +20,7 @@ from seaborn._core.properties import (
     DashPattern,
     DashPatternWithOffset,
 )
+from seaborn._core.exceptions import PlotSpecError
 
 
 class Mappable:
@@ -172,7 +173,13 @@ class Mark:
                 # TODO Might this obviate the identity scale? Just don't add a scale?
                 feature = data[name]
             else:
-                feature = scales[name](data[name])
+                scale = scales[name]
+                value = data[name]
+                try:
+                    feature = scale(value)
+                except Exception as err:
+                    raise PlotSpecError._during("Scale operation", name) from err
+
             if return_array:
                 feature = np.asarray(feature)
             return feature

--- a/seaborn/palettes.py
+++ b/seaborn/palettes.py
@@ -234,7 +234,7 @@ def color_palette(palette=None, n_colors=None, desat=None, as_cmap=False):
                 # Perhaps a named matplotlib colormap?
                 palette = mpl_palette(palette, n_colors, as_cmap=as_cmap)
             except (ValueError, KeyError):  # Error class changed in mpl36
-                raise ValueError(f"{palette} is not a valid palette name")
+                raise ValueError(f"{palette!r} is not a valid palette name")
 
     if desat is not None:
         palette = [desaturate(c, desat) for c in palette]

--- a/tests/_core/test_scales.py
+++ b/tests/_core/test_scales.py
@@ -448,7 +448,7 @@ class TestNominal:
     def test_color_unknown_palette(self, x):
 
         pal = "not_a_palette"
-        err = f"{pal} is not a valid palette name"
+        err = f"'{pal}' is not a valid palette name"
         with pytest.raises(ValueError, match=err):
             Nominal(pal)._setup(x, Color())
 

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -1934,8 +1934,8 @@ class TestHistPlotBivariate:
         edges = itertools.product(y_edges[:-1], x_edges[:-1])
         for i, (y_i, x_i) in enumerate(edges):
             path = mesh.get_paths()[i]
-            assert path.vertices[0, 0] == 10 ** x_i
-            assert path.vertices[0, 1] == 10 ** y_i
+            assert path.vertices[0, 0] == pytest.approx(10 ** x_i)
+            assert path.vertices[0, 1] == pytest.approx(10 ** y_i)
 
     def test_mesh_thresh(self, long_df):
 


### PR DESCRIPTION
Because most `so.Plot` methods simply define a spec and defer operations until the time when the plot is compiled, errors caused by bad user inputs (or seaborn edge cases) that cannot be trivially detected may not arise until later and will not be clearly connected to the problem.

In general I'd like to try and be as helpful as possible with what we actually raise to avoid this becoming a pain point for the new interface. This PR represents the first step, defining a `PlotSpecError` exception class that gets raised in an exception chain to provide some additional context that may help diagnose issues. Right now the use is limited to scale setup and scaling operations and the main benefit is that the exception message can call out the plot variable that was being processed when an exception was raised.

e.g., the traceback for the operation in #3106 (which is being obviated anyway by #3190, but is a useful demonstration):

```python-traceback
TypeError                                 Traceback (most recent call last)
File ~/code/seaborn/seaborn/_core/plot.py:1254, in Plotter._setup_scales(self, p, common, layers, variables)
   1253 try:
-> 1254     self._scales[var] = scale._setup(var_df[var], prop)
   1255 except Exception as err:

File ~/code/seaborn/seaborn/_core/scales.py:351, in ContinuousBase._setup(self, data, prop, axis)
    350 a = forward(vmin)
--> 351 b = forward(vmax) - forward(vmin)
    353 def normalize(x):

TypeError: numpy boolean subtract, the `-` operator, is not supported, use the bitwise_xor, the `^` operator, or the logical_xor function instead.

The above exception was the direct cause of the following exception:

PlotSpecError                             Traceback (most recent call last)
Cell In [2], line 1
----> 1 so.Plot(["a", "b"], [1, 2], color=[True, False]).add(so.Bar()).plot()

File ~/code/seaborn/seaborn/_core/plot.py:821, in Plot.plot(self, pyplot)
    817 """
    818 Compile the plot spec and return the Plotter object.
    819 """
    820 with theme_context(self._theme_with_defaults()):
--> 821     return self._plot(pyplot)

File ~/code/seaborn/seaborn/_core/plot.py:842, in Plot._plot(self, pyplot)
    839 plotter._compute_stats(self, layers)
    841 # Process scale spec for semantic variables and coordinates computed by stat
--> 842 plotter._setup_scales(self, common, layers)
    844 # TODO Remove these after updating other methods
    845 # ---- Maybe have debug= param that attaches these when True?
    846 plotter._data = common

File ~/code/seaborn/seaborn/_core/plot.py:1256, in Plotter._setup_scales(self, p, common, layers, variables)
   1254         self._scales[var] = scale._setup(var_df[var], prop)
   1255     except Exception as err:
-> 1256         raise PlotSpecError._during("Scale setup", var) from err
   1258 if axis is None or (var != coord and coord in p._variables):
   1259     # Everything below here applies only to coordinate variables
   1260     continue

PlotSpecError: Scale setup failed for the `color` variable. See the traceback above for more information.
```