### PR TITLE
Add Boolean scale

### DIFF
--- a/doc/_docstrings/FacetGrid.ipynb
+++ b/doc/_docstrings/FacetGrid.ipynb
@@ -294,7 +294,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/JointGrid.ipynb
+++ b/doc/_docstrings/JointGrid.ipynb
@@ -236,7 +236,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/PairGrid.ipynb
+++ b/doc/_docstrings/PairGrid.ipynb
@@ -263,7 +263,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/axes_style.ipynb
+++ b/doc/_docstrings/axes_style.ipynb
@@ -94,7 +94,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/barplot.ipynb
+++ b/doc/_docstrings/barplot.ipynb
@@ -117,7 +117,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/blend_palette.ipynb
+++ b/doc/_docstrings/blend_palette.ipynb
@@ -95,7 +95,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/boxenplot.ipynb
+++ b/doc/_docstrings/boxenplot.ipynb
@@ -122,7 +122,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/boxplot.ipynb
+++ b/doc/_docstrings/boxplot.ipynb
@@ -165,7 +165,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/catplot.ipynb
+++ b/doc/_docstrings/catplot.ipynb
@@ -182,7 +182,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/clustermap.ipynb
+++ b/doc/_docstrings/clustermap.ipynb
@@ -176,7 +176,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/color_palette.ipynb
+++ b/doc/_docstrings/color_palette.ipynb
@@ -269,7 +269,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/countplot.ipynb
+++ b/doc/_docstrings/countplot.ipynb
@@ -91,7 +91,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/cubehelix_palette.ipynb
+++ b/doc/_docstrings/cubehelix_palette.ipynb
@@ -221,7 +221,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/dark_palette.ipynb
+++ b/doc/_docstrings/dark_palette.ipynb
@@ -131,7 +131,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/displot.ipynb
+++ b/doc/_docstrings/displot.ipynb
@@ -231,7 +231,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/diverging_palette.ipynb
+++ b/doc/_docstrings/diverging_palette.ipynb
@@ -175,7 +175,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/ecdfplot.ipynb
+++ b/doc/_docstrings/ecdfplot.ipynb
@@ -134,7 +134,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/heatmap.ipynb
+++ b/doc/_docstrings/heatmap.ipynb
@@ -205,7 +205,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/histplot.ipynb
+++ b/doc/_docstrings/histplot.ipynb
@@ -475,7 +475,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/hls_palette.ipynb
+++ b/doc/_docstrings/hls_palette.ipynb
@@ -149,7 +149,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/husl_palette.ipynb
+++ b/doc/_docstrings/husl_palette.ipynb
@@ -149,7 +149,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/jointplot.ipynb
+++ b/doc/_docstrings/jointplot.ipynb
@@ -186,7 +186,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/kdeplot.ipynb
+++ b/doc/_docstrings/kdeplot.ipynb
@@ -341,7 +341,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/light_palette.ipynb
+++ b/doc/_docstrings/light_palette.ipynb
@@ -131,7 +131,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/lineplot.ipynb
+++ b/doc/_docstrings/lineplot.ipynb
@@ -445,7 +445,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/lmplot.ipynb
+++ b/doc/_docstrings/lmplot.ipynb
@@ -149,7 +149,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/move_legend.ipynb
+++ b/doc/_docstrings/move_legend.ipynb
@@ -148,7 +148,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/mpl_palette.ipynb
+++ b/doc/_docstrings/mpl_palette.ipynb
@@ -131,7 +131,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/objects.Agg.ipynb
+++ b/doc/_docstrings/objects.Agg.ipynb
@@ -132,7 +132,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/objects.Area.ipynb
+++ b/doc/_docstrings/objects.Area.ipynb
@@ -153,7 +153,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/objects.Band.ipynb
+++ b/doc/_docstrings/objects.Band.ipynb
@@ -135,7 +135,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/objects.Bar.ipynb
+++ b/doc/_docstrings/objects.Bar.ipynb
@@ -178,7 +178,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/objects.Bars.ipynb
+++ b/doc/_docstrings/objects.Bars.ipynb
@@ -157,7 +157,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/objects.Count.ipynb
+++ b/doc/_docstrings/objects.Count.ipynb
@@ -113,7 +113,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/objects.Dash.ipynb
+++ b/doc/_docstrings/objects.Dash.ipynb
@@ -160,7 +160,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/objects.Dodge.ipynb
+++ b/doc/_docstrings/objects.Dodge.ipynb
@@ -190,7 +190,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/objects.Dot.ipynb
+++ b/doc/_docstrings/objects.Dot.ipynb
@@ -182,7 +182,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/objects.Dots.ipynb
+++ b/doc/_docstrings/objects.Dots.ipynb
@@ -138,7 +138,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/objects.Est.ipynb
+++ b/doc/_docstrings/objects.Est.ipynb
@@ -134,7 +134,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/objects.Hist.ipynb
+++ b/doc/_docstrings/objects.Hist.ipynb
@@ -223,7 +223,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/objects.Jitter.ipynb
+++ b/doc/_docstrings/objects.Jitter.ipynb
@@ -170,7 +170,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/objects.KDE.ipynb
+++ b/doc/_docstrings/objects.KDE.ipynb
@@ -262,7 +262,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/objects.Line.ipynb
+++ b/doc/_docstrings/objects.Line.ipynb
@@ -160,7 +160,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/objects.Lines.ipynb
+++ b/doc/_docstrings/objects.Lines.ipynb
@@ -89,7 +89,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/objects.Norm.ipynb
+++ b/doc/_docstrings/objects.Norm.ipynb
@@ -85,7 +85,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/objects.Path.ipynb
+++ b/doc/_docstrings/objects.Path.ipynb
@@ -78,7 +78,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/objects.Paths.ipynb
+++ b/doc/_docstrings/objects.Paths.ipynb
@@ -95,7 +95,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/objects.Perc.ipynb
+++ b/doc/_docstrings/objects.Perc.ipynb
@@ -122,7 +122,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/objects.Plot.add.ipynb
+++ b/doc/_docstrings/objects.Plot.add.ipynb
@@ -210,7 +210,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/objects.Plot.facet.ipynb
+++ b/doc/_docstrings/objects.Plot.facet.ipynb
@@ -214,7 +214,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/objects.Plot.label.ipynb
+++ b/doc/_docstrings/objects.Plot.label.ipynb
@@ -153,7 +153,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/objects.Plot.layout.ipynb
+++ b/doc/_docstrings/objects.Plot.layout.ipynb
@@ -94,7 +94,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/objects.Plot.limit.ipynb
+++ b/doc/_docstrings/objects.Plot.limit.ipynb
@@ -112,7 +112,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/objects.Plot.on.ipynb
+++ b/doc/_docstrings/objects.Plot.on.ipynb
@@ -174,7 +174,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/objects.Plot.pair.ipynb
+++ b/doc/_docstrings/objects.Plot.pair.ipynb
@@ -209,7 +209,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/objects.Plot.scale.ipynb
+++ b/doc/_docstrings/objects.Plot.scale.ipynb
@@ -308,7 +308,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/objects.Plot.share.ipynb
+++ b/doc/_docstrings/objects.Plot.share.ipynb
@@ -123,7 +123,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/objects.Plot.theme.ipynb
+++ b/doc/_docstrings/objects.Plot.theme.ipynb
@@ -139,7 +139,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/objects.Range.ipynb
+++ b/doc/_docstrings/objects.Range.ipynb
@@ -132,7 +132,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/objects.Shift.ipynb
+++ b/doc/_docstrings/objects.Shift.ipynb
@@ -86,7 +86,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/objects.Stack.ipynb
+++ b/doc/_docstrings/objects.Stack.ipynb
@@ -81,7 +81,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/objects.Text.ipynb
+++ b/doc/_docstrings/objects.Text.ipynb
@@ -180,7 +180,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/pairplot.ipynb
+++ b/doc/_docstrings/pairplot.ipynb
@@ -217,7 +217,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/plotting_context.ipynb
+++ b/doc/_docstrings/plotting_context.ipynb
@@ -102,7 +102,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/pointplot.ipynb
+++ b/doc/_docstrings/pointplot.ipynb
@@ -134,7 +134,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/regplot.ipynb
+++ b/doc/_docstrings/regplot.ipynb
@@ -243,7 +243,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/relplot.ipynb
+++ b/doc/_docstrings/relplot.ipynb
@@ -254,7 +254,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/residplot.ipynb
+++ b/doc/_docstrings/residplot.ipynb
@@ -105,7 +105,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/rugplot.ipynb
+++ b/doc/_docstrings/rugplot.ipynb
@@ -129,7 +129,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/scatterplot.ipynb
+++ b/doc/_docstrings/scatterplot.ipynb
@@ -299,7 +299,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/set_context.ipynb
+++ b/doc/_docstrings/set_context.ipynb
@@ -96,7 +96,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/set_style.ipynb
+++ b/doc/_docstrings/set_style.ipynb
@@ -77,7 +77,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/set_theme.ipynb
+++ b/doc/_docstrings/set_theme.ipynb
@@ -153,7 +153,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/stripplot.ipynb
+++ b/doc/_docstrings/stripplot.ipynb
@@ -305,7 +305,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/swarmplot.ipynb
+++ b/doc/_docstrings/swarmplot.ipynb
@@ -277,7 +277,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_docstrings/violinplot.ipynb
+++ b/doc/_docstrings/violinplot.ipynb
@@ -185,7 +185,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_tutorial/aesthetics.ipynb
+++ b/doc/_tutorial/aesthetics.ipynb
@@ -418,7 +418,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_tutorial/axis_grids.ipynb
+++ b/doc/_tutorial/axis_grids.ipynb
@@ -545,7 +545,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_tutorial/categorical.ipynb
+++ b/doc/_tutorial/categorical.ipynb
@@ -534,7 +534,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_tutorial/color_palettes.ipynb
+++ b/doc/_tutorial/color_palettes.ipynb
@@ -996,7 +996,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_tutorial/data_structure.ipynb
+++ b/doc/_tutorial/data_structure.ipynb
@@ -489,7 +489,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_tutorial/distributions.ipynb
+++ b/doc/_tutorial/distributions.ipynb
@@ -850,7 +850,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_tutorial/error_bars.ipynb
+++ b/doc/_tutorial/error_bars.ipynb
@@ -361,7 +361,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_tutorial/function_overview.ipynb
+++ b/doc/_tutorial/function_overview.ipynb
@@ -488,7 +488,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_tutorial/introduction.ipynb
+++ b/doc/_tutorial/introduction.ipynb
@@ -461,7 +461,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_tutorial/objects_interface.ipynb
+++ b/doc/_tutorial/objects_interface.ipynb
@@ -1071,7 +1071,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_tutorial/properties.ipynb
+++ b/doc/_tutorial/properties.ipynb
@@ -1119,7 +1119,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_tutorial/regression.ipynb
+++ b/doc/_tutorial/regression.ipynb
@@ -446,7 +446,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/_tutorial/relational.ipynb
+++ b/doc/_tutorial/relational.ipynb
@@ -677,7 +677,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -114,6 +114,7 @@ Scale objects
     :template: scale
     :nosignatures:
 
+    Boolean
     Continuous
     Nominal
     Temporal

--- a/doc/whatsnew/index.rst
+++ b/doc/whatsnew/index.rst
@@ -8,6 +8,7 @@ v0.12
 .. toctree::
    :maxdepth: 2
 
+   v0.12.2
    v0.12.1
    v0.12.0
 

--- a/doc/whatsnew/v0.12.2.rst
+++ b/doc/whatsnew/v0.12.2.rst
@@ -4,6 +4,8 @@ v0.12.2 (Unreleased)
 
 - |Feature| Added the :class:`objects.KDE` stat (:pr:`3111`).
 
+- |Feature| Added the :class:`objects.Boolean` scale (:pr:`3205`).
+
 - |Enhancement| Automatic mark widths are now calculated separately for unshared facet axes (:pr:`3119`).
 
 - |Enhancement| Improved user feedback for failures during plot compilation by catching exceptions an reraising with a `PlotSpecError` that provides additional context (:pr:`3203`).

--- a/seaborn/_core/plot.py
+++ b/seaborn/_core/plot.py
@@ -1659,16 +1659,8 @@ class Plotter:
                         hi = cast(float, hi) + 0.5
                     ax.set(**{f"{axis}lim": (lo, hi)})
 
-                # Nominal scale special-casing
-                if isinstance(self._scales.get(axis_key), Nominal):
-                    axis_obj.grid(False, which="both")
-                    if axis_key not in p._limits:
-                        nticks = len(axis_obj.get_major_ticks())
-                        lo, hi = -.5, nticks - .5
-                        if axis == "y":
-                            lo, hi = hi, lo
-                        set_lim = getattr(ax, f"set_{axis}lim")
-                        set_lim(lo, hi, auto=None)
+                if axis_key in self._scales:  # TODO when would it not be?
+                    self._scales[axis_key]._finalize(p, axis_obj)
 
         engine_default = None if p._target is not None else "tight"
         layout_engine = p._layout_spec.get("engine", engine_default)

--- a/seaborn/_core/rules.py
+++ b/seaborn/_core/rules.py
@@ -24,7 +24,7 @@ class VarType(UserString):
     """
     # TODO VarType is an awfully overloaded name, but so is DataType ...
     # TODO adding unknown because we are using this in for scales, is that right?
-    allowed = "numeric", "datetime", "categorical", "unknown"
+    allowed = "numeric", "datetime", "categorical", "boolean", "unknown"
 
     def __init__(self, data):
         assert data in self.allowed, data
@@ -37,24 +37,28 @@ class VarType(UserString):
 
 def variable_type(
     vector: Series,
-    boolean_type: Literal["numeric", "categorical"] = "numeric",
+    boolean_type: Literal["numeric", "categorical", "boolean"] = "numeric",
+    strict_boolean: bool = False,
 ) -> VarType:
     """
     Determine whether a vector contains numeric, categorical, or datetime data.
 
-    This function differs from the pandas typing API in two ways:
+    This function differs from the pandas typing API in a few ways:
 
     - Python sequences or object-typed PyData objects are considered numeric if
       all of their entries are numeric.
     - String or mixed-type data are considered categorical even if not
       explicitly represented as a :class:`pandas.api.types.CategoricalDtype`.
+    - There is some flexibility about how to treat binary / boolean data.
 
     Parameters
     ----------
     vector : :func:`pandas.Series`, :func:`numpy.ndarray`, or Python sequence
         Input data to test.
-    boolean_type : 'numeric' or 'categorical'
+    boolean_type : 'numeric', 'categorical', or 'boolean'
         Type to use for vectors containing only 0s and 1s (and NAs).
+    strict_boolean : bool
+        If True, only consider data to be boolean when the dtype is bool or Boolean.
 
     Returns
     -------
@@ -83,7 +87,11 @@ def variable_type(
             action='ignore',
             category=(FutureWarning, DeprecationWarning)  # type: ignore  # mypy bug?
         )
-        if np.isin(vector, [0, 1, np.nan]).all():
+        if strict_boolean:
+            boolean_vector = vector.dtype in ["bool", "boolean"]
+        else:
+            boolean_vector = bool(np.isin(vector, [0, 1, np.nan]).all())
+        if boolean_vector:
             return VarType(boolean_type)
 
     # Defer to positive pandas tests

--- a/seaborn/_core/rules.py
+++ b/seaborn/_core/rules.py
@@ -8,6 +8,8 @@ from datetime import datetime
 import numpy as np
 import pandas as pd
 
+from seaborn.external.version import Version
+
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from typing import Literal
@@ -88,7 +90,11 @@ def variable_type(
             category=(FutureWarning, DeprecationWarning)  # type: ignore  # mypy bug?
         )
         if strict_boolean:
-            boolean_vector = vector.dtype in ["bool", "boolean"]
+            if Version(pd.__version__) < Version("1.0.0"):
+                boolean_dtypes = ["bool"]
+            else:
+                boolean_dtypes = ["bool", "boolean"]
+            boolean_vector = vector.dtype in boolean_dtypes
         else:
             boolean_vector = bool(np.isin(vector, [0, 1, np.nan]).all())
         if boolean_vector:

--- a/seaborn/_core/scales.py
+++ b/seaborn/_core/scales.py
@@ -39,6 +39,7 @@ from seaborn._core.typing import Default, default
 
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
+    from seaborn._core.plot import Plot
     from seaborn._core.properties import Property
     from numpy.typing import ArrayLike, NDArray
 
@@ -60,7 +61,7 @@ class Scale:
     _pipeline: Pipeline
     _matplotlib_scale: ScaleBase
     _spacer: staticmethod
-    _legend: tuple[list[str], list[Any]] | None
+    _legend: tuple[list[Any], list[str]] | None
 
     def __post_init__(self):
 
@@ -107,6 +108,10 @@ class Scale:
     ) -> Scale:
         raise NotImplementedError()
 
+    def _finalize(self, p: Plot, axis: Axis) -> None:
+        """Perform scale-specific axis tweaks after adding artists."""
+        pass
+
     def __call__(self, data: Series) -> ArrayLike:
 
         trans_data: Series | NDArray | list
@@ -141,6 +146,91 @@ class Scale:
 
 
 @dataclass
+class Boolean(Scale):
+    """
+    A scale with a discrete domain of True and False values.
+
+    The behavior is similar to the :class:`Nominal` scale, but property
+    mappings and legends will use a [True, False] ordering rather than
+    a sort using numeric rules. Coordinate variables accomplish this by
+    inverting axis limits so as to maintain underlying numeric positioning.
+    Input data are cast to boolean values, respecting missing data.
+
+    """
+    values: tuple | list | dict | None = None
+
+    _priority: ClassVar[int] = 3
+
+    def _setup(
+        self, data: Series, prop: Property, axis: Axis | None = None,
+    ) -> Scale:
+
+        new = copy(self)
+        if new._tick_params is None:
+            new = new.tick()
+        if new._label_params is None:
+            new = new.label()
+
+        def cast(x):
+            if np.isscalar(x):
+                return bool(x)
+            else:
+                return np.asarray(x, dtype=bool)
+
+        new._pipeline = [cast, prop.get_mapping(new, data)]
+        new._spacer = _default_spacer
+        if prop.legend:
+            new._legend = [True, False], ["True", "False"]
+
+        forward, inverse = _make_identity_transforms()
+        mpl_scale = new._get_scale(str(data.name), forward, inverse)
+
+        axis = PseudoAxis(mpl_scale) if axis is None else axis
+        mpl_scale.set_default_locators_and_formatters(axis)
+        new._matplotlib_scale = mpl_scale
+
+        return new
+
+    def _finalize(self, p: Plot, axis: Axis) -> None:
+
+        # We want values to appear in a True, False order but also want
+        # True/False to be drawn at 1/0 positions respectively to avoid nasty
+        # surprises if additional artists are added through the matplotlib API.
+        # We accomplish this using axis inversion akin to what we do in Nominal.
+
+        ax = axis.axes
+        name = axis.axis_name
+        axis.grid(False, which="both")
+        if name not in p._limits:
+            nticks = len(axis.get_major_ticks())
+            lo, hi = -.5, nticks - .5
+            if name == "x":
+                lo, hi = hi, lo
+            set_lim = getattr(ax, f"set_{name}lim")
+            set_lim(lo, hi, auto=None)
+
+    def tick(self, locator: Locator | None = None):
+        new = copy(self)
+        new._tick_params = {"locator": locator}
+        return new
+
+    def label(self, formatter: Formatter | None = None):
+        new = copy(self)
+        new._label_params = {"formatter": formatter}
+        return new
+
+    def _get_locators(self, locator):
+        if locator is not None:
+            return locator
+        return FixedLocator([0, 1]), None
+
+    def _get_formatter(self, locator, formatter):
+        if formatter is not None:
+            return formatter
+        return FuncFormatter(lambda x, _: str(bool(x)))
+
+
+@dataclass
 class Nominal(Scale):
     """
     A categorical scale without relative importance / magnitude.
@@ -150,7 +240,7 @@ class Nominal(Scale):
     values: tuple | str | list | dict | None = None
     order: list | None = None
 
-    _priority: ClassVar[int] = 3
+    _priority: ClassVar[int] = 4
 
     def _setup(
         self, data: Series, prop: Property, axis: Axis | None = None,
@@ -217,23 +307,28 @@ class Nominal(Scale):
             out[keep] = axis.convert_units(stringify(x[keep]))
             return out
 
-        new._pipeline = [
-            convert_units,
-            prop.get_mapping(new, data),
-            # TODO how to handle color representation consistency?
-        ]
-
-        def spacer(x):
-            return 1
-
-        new._spacer = spacer
+        new._pipeline = [convert_units, prop.get_mapping(new, data)]
+        new._spacer = _default_spacer
 
         if prop.legend:
             new._legend = units_seed, list(stringify(units_seed))
 
         return new
 
-    def tick(self, locator: Locator | None = None):
+    def _finalize(self, p: Plot, axis: Axis) -> None:
+
+        ax = axis.axes
+        name = axis.axis_name
+        axis.grid(False, which="both")
+        if name not in p._limits:
+            nticks = len(axis.get_major_ticks())
+            lo, hi = -.5, nticks - .5
+            if name == "y":
+                lo, hi = hi, lo
+            set_lim = getattr(ax, f"set_{name}lim")
+            set_lim(lo, hi, auto=None)
+
+    def tick(self, locator: Locator | None = None) -> Nominal:
         """
         Configure the selection of ticks for the scale's axis or legend.
 
@@ -252,12 +347,10 @@ class Nominal(Scale):
 
         """
         new = copy(self)
-        new._tick_params = {
-            "locator": locator,
-        }
+        new._tick_params = {"locator": locator}
         return new
 
-    def label(self, formatter: Formatter | None = None):
+    def label(self, formatter: Formatter | None = None) -> Nominal:
         """
         Configure the selection of labels for the scale's axis or legend.
 
@@ -277,9 +370,7 @@ class Nominal(Scale):
 
         """
         new = copy(self)
-        new._label_params = {
-            "formatter": formatter,
-        }
+        new._label_params = {"formatter": formatter}
         return new
 
     def _get_locators(self, locator):
@@ -986,3 +1077,7 @@ def _make_power_transforms(exp: float) -> TransFuncs:
         return np.sign(x) * np.power(np.abs(x), 1 / exp)
 
     return forward, inverse
+
+
+def _default_spacer(x: Series) -> float:
+    return 1

--- a/seaborn/objects.py
+++ b/seaborn/objects.py
@@ -44,4 +44,6 @@ from seaborn._stats.regression import PolyFit  # noqa: F401
 
 from seaborn._core.moves import Dodge, Jitter, Norm, Shift, Stack, Move  # noqa: F401
 
-from seaborn._core.scales import Nominal, Continuous, Temporal, Scale  # noqa: F401
+from seaborn._core.scales import (  # noqa: F401
+    Boolean, Continuous, Nominal, Temporal, Scale
+)

--- a/tests/_core/test_properties.py
+++ b/tests/_core/test_properties.py
@@ -9,7 +9,7 @@ from numpy.testing import assert_array_equal
 
 from seaborn.external.version import Version
 from seaborn._core.rules import categorical_order
-from seaborn._core.scales import Nominal, Continuous
+from seaborn._core.scales import Nominal, Continuous, Boolean
 from seaborn._core.properties import (
     Alpha,
     Color,
@@ -234,12 +234,6 @@ class TestColor(DataFixtures):
         assert isinstance(scale, scale_class)
         assert scale.values == values
 
-    def test_inference_binary_data(self):
-
-        x = pd.Series([0, 0, 1, 0, 1], dtype=int)
-        scale = Color().infer_scale("viridis", x)
-        assert isinstance(scale, Nominal)
-
     def test_standardization(self):
 
         f = Color().standardize
@@ -420,14 +414,14 @@ class TestFill(DataFixtures):
 
         x = vectors[data_type]
         scale = Fill().default_scale(x)
-        assert isinstance(scale, Nominal)
+        assert isinstance(scale, Boolean if data_type == "bool" else Nominal)
 
     @pytest.mark.parametrize("data_type", ["cat", "num", "bool"])
     def test_inference_list(self, data_type, vectors):
 
         x = vectors[data_type]
         scale = Fill().infer_scale([True, False], x)
-        assert isinstance(scale, Nominal)
+        assert isinstance(scale, Boolean if data_type == "bool" else Nominal)
         assert scale.values == [True, False]
 
     @pytest.mark.parametrize("data_type", ["cat", "num", "bool"])
@@ -436,7 +430,7 @@ class TestFill(DataFixtures):
         x = vectors[data_type]
         values = dict(zip(x.unique(), [True, False]))
         scale = Fill().infer_scale(values, x)
-        assert isinstance(scale, Nominal)
+        assert isinstance(scale, Boolean if data_type == "bool" else Nominal)
         assert scale.values == values
 
     def test_mapping_categorical_data(self, cat_vector):

--- a/tests/_core/test_rules.py
+++ b/tests/_core/test_rules.py
@@ -4,6 +4,7 @@ import pandas as pd
 
 import pytest
 
+from seaborn.external.version import Version
 from seaborn._core.rules import (
     VarType,
     variable_type,
@@ -35,8 +36,11 @@ def test_variable_type():
     assert variable_type(s) == "numeric"
 
     s = pd.Series([np.nan, np.nan])
-    # s = pd.Series([pd.NA, pd.NA])
     assert variable_type(s) == "numeric"
+
+    if Version(pd.__version__) >= Version("1.0.0"):
+        s = pd.Series([pd.NA, pd.NA])
+        assert variable_type(s) == "numeric"
 
     s = pd.Series(["1", "2", "3"])
     assert variable_type(s) == "categorical"
@@ -46,9 +50,16 @@ def test_variable_type():
     s = pd.Series([True, False, False])
     assert variable_type(s) == "numeric"
     assert variable_type(s, boolean_type="categorical") == "categorical"
+    assert variable_type(s, boolean_type="boolean") == "boolean"
+
     s_cat = s.astype("category")
     assert variable_type(s_cat, boolean_type="categorical") == "categorical"
     assert variable_type(s_cat, boolean_type="numeric") == "categorical"
+    assert variable_type(s_cat, boolean_type="boolean") == "categorical"
+
+    s = pd.Series([1, 0, 0])
+    assert variable_type(s, boolean_type="boolean") == "boolean"
+    assert variable_type(s, boolean_type="boolean", strict_boolean=True) == "numeric"
 
     s = pd.Series([pd.Timestamp(1), pd.Timestamp(2)])
     assert variable_type(s) == "datetime"

--- a/tests/_core/test_scales.py
+++ b/tests/_core/test_scales.py
@@ -8,6 +8,7 @@ import pytest
 from numpy.testing import assert_array_equal
 from pandas.testing import assert_series_equal
 
+from seaborn._core.plot import Plot
 from seaborn._core.scales import (
     Nominal,
     Continuous,
@@ -568,6 +569,18 @@ class TestNominal:
         s = Nominal()._setup(x, Coordinate())
         assert_array_equal(s(x), [])
 
+    def test_finalize(self, x):
+
+        ax = mpl.figure.Figure().subplots()
+        s = Nominal()._setup(x, Coordinate(), ax.yaxis)
+        s._finalize(Plot(), ax.yaxis)
+
+        levels = x.unique()
+        assert ax.get_ylim() == (len(levels) - .5, -.5)
+        assert_array_equal(ax.get_yticks(), list(range(len(levels))))
+        for i, expected in enumerate(levels):
+            assert ax.yaxis.major.formatter(i) == expected
+
 
 class TestTemporal:
 
@@ -796,3 +809,13 @@ class TestBoolean:
         s = Boolean(vs)._setup(x, IntervalProperty())
         expected = [vs[int(x_i)] for x_i in x]
         assert_array_equal(s(x), expected)
+
+    def test_finalize(self, x):
+
+        ax = mpl.figure.Figure().subplots()
+        s = Boolean()._setup(x, Coordinate(), ax.xaxis)
+        s._finalize(Plot(), ax.xaxis)
+        assert ax.get_xlim() == (1.5, -.5)
+        assert_array_equal(ax.get_xticks(), [0, 1])
+        assert ax.xaxis.major.formatter(0) == "False"
+        assert ax.xaxis.major.formatter(1) == "True"

--- a/tests/_core/test_scales.py
+++ b/tests/_core/test_scales.py
@@ -569,6 +569,10 @@ class TestNominal:
         s = Nominal()._setup(x, Coordinate())
         assert_array_equal(s(x), [])
 
+    @pytest.mark.skipif(
+        Version(mpl.__version__) < Version("3.4.0"),
+        reason="Test failing on older matplotlib for unclear reasons",
+    )
     def test_finalize(self, x):
 
         ax = mpl.figure.Figure().subplots()

--- a/tests/_core/test_scales.py
+++ b/tests/_core/test_scales.py
@@ -11,6 +11,7 @@ from pandas.testing import assert_series_equal
 from seaborn._core.scales import (
     Nominal,
     Continuous,
+    Boolean,
     Temporal,
     PseudoAxis,
 )
@@ -670,3 +671,128 @@ class TestTemporal:
         Temporal().label(concise=True)._setup(t, Coordinate(), ax.xaxis)
         formatter = ax.xaxis.get_major_formatter()
         assert isinstance(formatter, mpl.dates.ConciseDateFormatter)
+
+
+class TestBoolean:
+
+    @pytest.fixture
+    def x(self):
+        return pd.Series([True, False, False, True], name="x", dtype=bool)
+
+    def test_coordinate(self, x):
+
+        s = Boolean()._setup(x, Coordinate())
+        assert_array_equal(s(x), x.astype(float))
+
+    def test_coordinate_axis(self, x):
+
+        ax = mpl.figure.Figure().subplots()
+        s = Boolean()._setup(x, Coordinate(), ax.xaxis)
+        assert_array_equal(s(x), x.astype(float))
+        f = ax.xaxis.get_major_formatter()
+        assert f.format_ticks([0, 1]) == ["False", "True"]
+
+    @pytest.mark.parametrize(
+        "dtype,value",
+        [
+            (object, np.nan),
+            (object, None),
+            # TODO add boolean when we don't need the skipif below
+        ]
+    )
+    def test_coordinate_missing(self, x, dtype, value):
+
+        x = x.astype(dtype)
+        x[2] = value
+        s = Boolean()._setup(x, Coordinate())
+        assert_array_equal(s(x), x.astype(float))
+
+    @pytest.mark.skipif(
+        # TODO merge into test above when removing
+        Version(pd.__version__) < Version("1.0.0"),
+        reason="Test requires nullable booleans",
+    )
+    def test_coordinate_with_pd_na(self, x):
+
+        x = x.astype("boolean")
+        x[2] = pd.NA
+        s = Boolean()._setup(x, Coordinate())
+        assert_array_equal(s(x), x.astype(float))
+
+    def test_color_defaults(self, x):
+
+        s = Boolean()._setup(x, Color())
+        cs = color_palette()
+        expected = [cs[int(x_i)] for x_i in ~x]
+        assert_array_equal(s(x), expected)
+
+    def test_color_list_palette(self, x):
+
+        cs = color_palette("crest", 2)
+        s = Boolean(cs)._setup(x, Color())
+        expected = [cs[int(x_i)] for x_i in ~x]
+        assert_array_equal(s(x), expected)
+
+    def test_color_tuple_palette(self, x):
+
+        cs = tuple(color_palette("crest", 2))
+        s = Boolean(cs)._setup(x, Color())
+        expected = [cs[int(x_i)] for x_i in ~x]
+        assert_array_equal(s(x), expected)
+
+    def test_color_dict_palette(self, x):
+
+        cs = color_palette("crest", 2)
+        pal = {True: cs[0], False: cs[1]}
+        s = Boolean(pal)._setup(x, Color())
+        expected = [pal[x_i] for x_i in x]
+        assert_array_equal(s(x), expected)
+
+    def test_object_defaults(self, x):
+
+        vs = ["x", "y", "z"]
+
+        class MockProperty(ObjectProperty):
+            def _default_values(self, n):
+                return vs[:n]
+
+        s = Boolean()._setup(x, MockProperty())
+        expected = [vs[int(x_i)] for x_i in ~x]
+        assert s(x) == expected
+
+    def test_object_list(self, x):
+
+        vs = ["x", "y"]
+        s = Boolean(vs)._setup(x, ObjectProperty())
+        expected = [vs[int(x_i)] for x_i in ~x]
+        assert s(x) == expected
+
+    def test_object_dict(self, x):
+
+        vs = {True: "x", False: "y"}
+        s = Boolean(vs)._setup(x, ObjectProperty())
+        expected = [vs[x_i] for x_i in x]
+        assert s(x) == expected
+
+    def test_fill(self, x):
+
+        s = Boolean()._setup(x, Fill())
+        assert_array_equal(s(x), x)
+
+    def test_interval_defaults(self, x):
+
+        vs = (1, 2)
+
+        class MockProperty(IntervalProperty):
+            _default_range = vs
+
+        s = Boolean()._setup(x, MockProperty())
+        expected = [vs[int(x_i)] for x_i in x]
+        assert_array_equal(s(x), expected)
+
+    def test_interval_tuple(self, x):
+
+        vs = (3, 5)
+        s = Boolean(vs)._setup(x, IntervalProperty())
+        expected = [vs[int(x_i)] for x_i in x]
+        assert_array_equal(s(x), expected)


### PR DESCRIPTION
This PR adds a new `Scale` object, `Boolean`, that has a domain of `True` and `False`.

There's a bit of a tension with boolean data: True/False can be (and often are) cast to 0/1 and treated numerically, but   (even when using True and False as labels) it feels odd to sort them such that axes or legends read "False, True". Therefore, this scale aims to maintain a True, False ordering.

The scale is used by default for data with dtype `bool`, `"boolean"` (pandas' na-aware dtype), or object types (including bare Python lists) with only True/False values:

```python
(
    so.Plot(titanic, "adult_male", "age", color="survived")
    .add(so.Dots(), so.Jitter())
)
```
<img width=500 src=https://user-images.githubusercontent.com/315810/210026781-8dfb1df1-9a91-4282-ad52-581f17286495.png />

It can also be assigned manually, which will also cast the input values to booleans:

```python
(
    so.Plot(titanic, "adult_male", "age", color="survived")
    .add(so.Dots(), so.Jitter())
    .scale(color=so.Boolean())
)
```
<img width=500 src=https://user-images.githubusercontent.com/315810/210026809-8ee14026-cafa-433f-95a5-203cbeb17bb7.png />

There aren't currently many options; maybe it makes sense to add some, but for now it just accepts a single `values` parameter which is relevant for semantic properties (e.g., it can be a list of colors, or a palette name, or a range of point sizes, etc.).
