### PR TITLE
Increase minimally-supported versions of Python and dependencies

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,10 +20,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Setup Python 3.10
+      - name: Setup Python 3.11
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install seaborn
         run: |
@@ -53,15 +53,15 @@ jobs:
 
     strategy:
       matrix:
-        python: ["3.7", "3.8", "3.9", "3.10"]
+        python: ["3.8", "3.9", "3.10", "3.11"]
         install: [full]
         deps: [latest]
 
         include:
-          - python: "3.7"
+          - python: "3.8"
             install: full
             deps: pinned
-          - python: "3.10"
+          - python: "3.11"
             install: light
             deps: latest
 

--- a/ci/deps_pinned.txt
+++ b/ci/deps_pinned.txt
@@ -1,8 +1,5 @@
-numpy~=1.17.0
-pandas~=0.25.0
-matplotlib~=3.1.0
-scipy~=1.3.0
-statsmodels~=0.10.0
-# Pillow added in install_requires for later matplotlibs
-pillow>=6.2.0
-typing_extensions
+numpy~=1.20.0
+pandas~=1.2.0
+matplotlib~=3.3.0
+scipy~=1.7.0
+statsmodels~=0.12.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,28 +11,27 @@ license = {file = "LICENSE.md"}
 dynamic = ["version"]
 classifiers = [
     "Intended Audience :: Science/Research",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "License :: OSI Approved :: BSD License",
     "Topic :: Scientific/Engineering :: Visualization",
     "Topic :: Multimedia :: Graphics",
     "Operating System :: OS Independent",
     "Framework :: Matplotlib",
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 dependencies = [
-    "numpy>=1.17,!=1.24.0",
-    "pandas>=0.25",
-    "matplotlib>=3.1,!=3.6.1",
-    "typing_extensions; python_version < '3.8'",
+    "numpy>=1.20,!=1.24.0",
+    "pandas>=1.2",
+    "matplotlib>=3.3,!=3.6.1",
 ]
 
 [project.optional-dependencies]
 stats = [
-    "scipy>=1.3",
-    "statsmodels>=0.10",
+    "scipy>=1.7",
+    "statsmodels>=0.12",
 ]
 dev = [
     "pytest",

--- a/seaborn/_core/rules.py
+++ b/seaborn/_core/rules.py
@@ -8,8 +8,6 @@ from datetime import datetime
 import numpy as np
 import pandas as pd
 
-from seaborn.external.version import Version
-
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from typing import Literal
@@ -90,10 +88,10 @@ def variable_type(
             category=(FutureWarning, DeprecationWarning)  # type: ignore  # mypy bug?
         )
         if strict_boolean:
-            if Version(pd.__version__) < Version("1.0.0"):
-                boolean_dtypes = ["bool"]
-            else:
+            if isinstance(vector.dtype, pd.core.dtypes.base.ExtensionDtype):
                 boolean_dtypes = ["bool", "boolean"]
+            else:
+                boolean_dtypes = ["bool"]
             boolean_vector = vector.dtype in boolean_dtypes
         else:
             boolean_vector = bool(np.isin(vector, [0, 1, np.nan]).all())

--- a/tests/_core/test_plot.py
+++ b/tests/_core/test_plot.py
@@ -1404,7 +1404,7 @@ class TestFacetInterface:
 
         sep1 = bb12.corners()[0, 0] - bb11.corners()[2, 0]
         sep2 = bb22.corners()[0, 0] - bb21.corners()[2, 0]
-        assert sep1 < sep2
+        assert sep1 <= sep2
 
     def test_axis_sharing(self, long_df):
 
@@ -2056,7 +2056,7 @@ class TestLegend:
         labels = [t.get_text() for t in legend.get_texts()]
         assert labels == names
 
-        if Version(mpl.__version__) >= Version("3.2"):
+        if Version(mpl.__version__) >= Version("3.4"):
             contents = legend.get_children()[0]
             assert len(contents.findobj(mpl.lines.Line2D)) == len(names)
             assert len(contents.findobj(mpl.patches.Patch)) == len(names)


### PR DESCRIPTION
These more-or-less follow the guidelines in [NEP29](https://numpy.org/neps/nep-0029-deprecation_policy.html) (we're a little ahead of schedule on numpy 1.20 but I don't expect 0.13.0 to go out before it's inside the window).

Additionally, drops support for Python 3.7 and adds Python 3.11 for the main CI build environment.