### PR TITLE
introduce set_legend_title() and make legend object available via get_legend_obj()

### DIFF
--- a/seaborn/utils.py
+++ b/seaborn/utils.py
@@ -19,7 +19,8 @@ from seaborn.external.version import Version
 from seaborn.external.appdirs import user_cache_dir
 
 __all__ = ["desaturate", "saturate", "set_hls_values", "move_legend",
-           "despine", "get_dataset_names", "get_data_home", "load_dataset"]
+           "despine", "get_dataset_names", "get_data_home", "load_dataset", 
+           "set_legend_title", "get_legend_obj"]
 
 
 def ci_to_errsize(cis, heights):
@@ -387,7 +388,8 @@ def despine(fig=None, ax=None, top=True, right=True, left=False,
 
 def get_legend_obj(obj):
     """
-    Get the legend object from a plot.
+    Get the legend object associated with the plot.
+    Requires a legend to be present, otherwise raises a ValueError.
 
     Parameters
     ----------

--- a/seaborn/utils.py
+++ b/seaborn/utils.py
@@ -19,7 +19,7 @@ from seaborn.external.version import Version
 from seaborn.external.appdirs import user_cache_dir
 
 __all__ = ["desaturate", "saturate", "set_hls_values", "move_legend",
-           "despine", "get_dataset_names", "get_data_home", "load_dataset", 
+           "despine", "get_dataset_names", "get_data_home", "load_dataset",
            "set_legend_title", "get_legend_obj"]
 
 
@@ -403,7 +403,8 @@ def get_legend_obj(obj):
     # upstream improvements to matplotlib legends that make them easier to
     # modify after creation.
 
-    from seaborn.axisgrid import Grid  # Avoid circular import, a second import is just looking it up in sys.modules["Grid"]
+    from seaborn.axisgrid import Grid  # Avoid circular import,
+    # a second import is just looking it up in sys.modules["Grid"]
 
     # Locate the legend object and a method to recreate the legend
     if isinstance(obj, Grid):
@@ -428,6 +429,7 @@ def get_legend_obj(obj):
 
     return legend_, legend_func
 
+
 def set_legend_title(obj, title, prop=None):
     """
     Get the legend of obj and set its title.
@@ -444,11 +446,13 @@ def set_legend_title(obj, title, prop=None):
         The title of the legend.
 
     prop : None or matplotlib.font_manager.FontProperties or dict
-        The font properties of the legend title. If None (default), the current matplotlib.rcParams will be used.
+        The font properties of the legend title. If None (default),
+        the current matplotlib.rcParams will be used.
     """
 
     legend_, _ = get_legend_obj(obj)
     legend_.set_title(title=title, prop=prop)
+
 
 def move_legend(obj, loc, **kwargs):
     """

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -412,17 +412,79 @@ def test_move_legend_grid_object(long_df):
         assert mpl.colors.to_rgb(h.get_color()) == mpl.colors.to_rgb(f"C{i}")
 
 
-def test_move_legend_input_checks():
+def test_get_legend_obj_input_checks():
+    """
+    implicitly tests also move_figure() and set_legend_title(), since they call get_legend_obj()
+    """
 
     ax = plt.figure().subplots()
     with pytest.raises(TypeError):
-        utils.move_legend(ax.xaxis, "best")
+        utils.get_legend_obj(ax.xaxis)
 
     with pytest.raises(ValueError):
-        utils.move_legend(ax, "best")
+        utils.get_legend_obj(ax)
 
     with pytest.raises(ValueError):
-        utils.move_legend(ax.figure, "best")
+        utils.get_legend_obj(ax.figure)
+
+
+def test_set_legend_title_matplotlib_objects():
+
+    fig, ax = plt.subplots()
+
+    colors = "C2", "C5"
+    labels = "first label", "second label"
+    title = "the legend"
+
+    for color, label in zip(colors, labels):
+        ax.plot([0, 1], color=color, label=label)
+    ax.legend(loc="upper right", title=title)
+    utils._draw_figure(fig)
+    
+    # --- Test title reset
+
+    new_fontsize = 20
+    new_title = "new legend title"
+    utils.set_legend_title(ax, title=new_title, prop={"size": new_fontsize})
+    utils._draw_figure(fig)
+
+    assert ax.legend_.get_title().get_text() == new_title
+    assert ax.legend_.get_title().get_size() == new_fontsize
+
+
+    # --- Test figure legend title reset
+    fig.legend(loc="upper right", title=title)
+    _draw_figure(fig)
+
+    utils.set_legend_title(fig, title=new_title, prop={"size": new_fontsize})
+    _draw_figure(fig)
+
+    assert fig.legends[0].get_title().get_text() == new_title
+    assert fig.legends[0].get_title().get_size() == new_fontsize
+
+
+def test_set_legend_title_grid_object(long_df):
+
+    from seaborn.axisgrid import FacetGrid
+
+    hue_var = "a"
+    g = FacetGrid(long_df, hue=hue_var)
+    g.map(plt.plot, "x", "y")
+
+    g.add_legend()
+    _draw_figure(g.figure)
+
+    new_fontsize = 20
+    new_title = "new legend title"
+    utils.set_legend_title(g, title=new_title, prop={"size": new_fontsize})
+    _draw_figure(g.figure)
+
+    assert g.legend.get_title().get_text() == new_title
+    assert g.legend.get_title().get_size() == new_fontsize
+
+    assert g.legend.legendHandles
+    for i, h in enumerate(g.legend.legendHandles):
+        assert mpl.colors.to_rgb(h.get_color()) == mpl.colors.to_rgb(f"C{i}")
 
 
 def check_load_dataset(name):


### PR DESCRIPTION
Introduced set_legend_title() which modifies the legend title without having to recreate the legend as in move_legend() - it is thereby a bit more lightweight. It also takes a prop-argument to modify e.g. title fonts.

For more elaborate modifications get_legend_obj() can be used to get a legend object. get_legend_obj() contains an extraction of code found within move_legend(), so that it can be called both from move_legend() and set_legend_title() or by itself.

This is related to: 
- https://github.com/mwaskom/seaborn/issues/2994 and 
- https://github.com/mwaskom/seaborn/discussions/2978#discussioncomment-3482430
and potentially addresses them, by making the legend object available.

Introduced tests for both functions, modeled after test_move_legend*()
"make tests" gave very similar results compared to results before the modification:
1943 passed, 14 skipped, 7 xfailed, 652 warnings

