### PR TITLE
Fix layout engine parameterization when using Plot.on

### DIFF
--- a/seaborn/_compat.py
+++ b/seaborn/_compat.py
@@ -149,6 +149,7 @@ def set_layout_engine(fig, engine):
     if hasattr(fig, "set_layout_engine"):
         fig.set_layout_engine(engine)
     else:
+        # _version_predates(mpl, 3.6)
         if engine == "tight":
             fig.set_tight_layout(True)
         elif engine == "constrained":

--- a/seaborn/_compat.py
+++ b/seaborn/_compat.py
@@ -146,7 +146,7 @@ def register_colormap(name, cmap):
 
 def set_layout_engine(fig, engine):
     """Handle changes to auto layout engine interface in 3.6"""
-    if hasattr(fig, "set_layout_engine") and engine is not None:
+    if hasattr(fig, "set_layout_engine"):
         fig.set_layout_engine(engine)
     else:
         if engine == "tight":

--- a/seaborn/_compat.py
+++ b/seaborn/_compat.py
@@ -146,7 +146,7 @@ def register_colormap(name, cmap):
 
 def set_layout_engine(fig, engine):
     """Handle changes to auto layout engine interface in 3.6"""
-    if hasattr(fig, "set_layout_engine"):
+    if hasattr(fig, "set_layout_engine") and engine is not None:
         fig.set_layout_engine(engine)
     else:
         if engine == "tight":

--- a/seaborn/_compat.py
+++ b/seaborn/_compat.py
@@ -153,6 +153,9 @@ def set_layout_engine(fig, engine):
             fig.set_tight_layout(True)
         elif engine == "constrained":
             fig.set_constrained_layout(True)
+        elif engine == "none":
+            fig.set_tight_layout(False)
+            fig.set_constrained_layout(False)
 
 
 def share_axis(ax0, ax1, which):

--- a/seaborn/_core/plot.py
+++ b/seaborn/_core/plot.py
@@ -1662,6 +1662,10 @@ class Plotter:
                 if axis_key in self._scales:  # TODO when would it not be?
                     self._scales[axis_key]._finalize(p, axis_obj)
 
-        engine_default = None if p._target is not None else "tight"
-        layout_engine = p._layout_spec.get("engine", engine_default)
-        set_layout_engine(self._figure, layout_engine)
+        if engine := p._layout_spec.get("engine"):
+            set_layout_engine(self._figure, engine)
+        elif p._target is None:
+            # Don't modify the layout engine if the user supplied their own
+            # matplotlib figure and didn't specify an engine through Plot
+            # TODO switch default to "constrained"?
+            set_layout_engine(self._figure, "tight")

--- a/seaborn/_core/plot.py
+++ b/seaborn/_core/plot.py
@@ -1662,7 +1662,8 @@ class Plotter:
                 if axis_key in self._scales:  # TODO when would it not be?
                     self._scales[axis_key]._finalize(p, axis_obj)
 
-        if engine := p._layout_spec.get("engine"):
+        if (engine := p._layout_spec.get("engine", default)) is not default:
+            # None is a valid arg for Figure.set_layout_engine, hence `default`
             set_layout_engine(self._figure, engine)
         elif p._target is None:
             # Don't modify the layout engine if the user supplied their own

--- a/tests/_core/test_plot.py
+++ b/tests/_core/test_plot.py
@@ -1133,11 +1133,30 @@ class TestPlotting:
         with pytest.raises(RuntimeError, match="Cannot create multiple subplots"):
             p2.plot()
 
-    def test_on_disables_layout_algo(self):
+    @pytest.mark.skipif(
+        _version_predates(mpl, "3.6"),
+        reason="Requires newer matplotlib layout engine API"
+    )
+    def test_on_layout_algo_default(self):
 
-        f = mpl.figure.Figure()
+        class MockEngine(mpl.layout_engine.ConstrainedLayoutEngine):
+            ...
+
+        f = mpl.figure.Figure(layout=MockEngine())
         p = Plot().on(f).plot()
-        assert not p._figure.get_tight_layout()
+        layout_engine = p._figure.get_layout_engine()
+        assert layout_engine.__class__.__name__ == "MockEngine"
+
+    @pytest.mark.skipif(
+        _version_predates(mpl, "3.6"),
+        reason="Requires newer matplotlib layout engine API"
+    )
+    def test_on_layout_algo_spec(self):
+
+        f = mpl.figure.Figure(layout="constrained")
+        p = Plot().on(f).layout(engine="tight").plot()
+        layout_engine = p._figure.get_layout_engine()
+        assert layout_engine.__class__.__name__ == "TightLayoutEngine"
 
     def test_axis_labels_from_constructor(self, long_df):
 

--- a/tests/_core/test_plot.py
+++ b/tests/_core/test_plot.py
@@ -1402,7 +1402,7 @@ class TestFacetInterface:
         p = Plot().facet(["a", "b"]).limit(x=(.1, .9))
 
         p1 = p.layout(engine=algo).plot()
-        p2 = p.layout(engine=None).plot()
+        p2 = p.layout(engine="none").plot()
 
         # Force a draw (we probably need a method for this)
         p1.save(io.BytesIO())


### PR DESCRIPTION
Fixes #3211 

The intended behavior here was to avoid overriding the user's choice of layout engine when they provide a matplotlib object with `Plot.on`, but `None` was getting passed through to `Figure.set_layout_engine` which unsets the user's choice (and defers to the rc defaults).