### PR TITLE
Fix Bar(s) width on nonlinear scale

### DIFF
--- a/seaborn/_core/plot.py
+++ b/seaborn/_core/plot.py
@@ -1377,10 +1377,9 @@ class Plotter:
     ) -> DataFrame:
         # TODO do we still have numbers in the variable name at this point?
         coord_cols = [c for c in df if re.match(r"^[xy]\D*$", str(c))]
-        drop_cols = [*coord_cols, "width"] if "width" in df else coord_cols
         out_df = (
             df
-            .drop(drop_cols, axis=1)
+            .drop(coord_cols, axis=1)
             .reindex(df.columns, axis=1)  # So unscaled columns retain their place
             .copy(deep=False)
         )
@@ -1395,12 +1394,6 @@ class Plotter:
                 transform = axis.get_transform().inverted().transform
                 inverted = transform(values)
                 out_df.loc[values.index, str(var)] = inverted
-
-                if var == orient and "width" in view_df:
-                    width = view_df["width"]
-                    out_df.loc[values.index, "width"] = (
-                        transform(values + width / 2) - transform(values - width / 2)
-                    )
 
         return out_df
 

--- a/seaborn/_marks/bar.py
+++ b/seaborn/_marks/bar.py
@@ -29,17 +29,23 @@ class BarBase(Mark):
 
     def _make_patches(self, data, scales, orient):
 
+        transform = scales[orient]._matplotlib_scale.get_transform()
+        forward = transform.transform
+        reverse = transform.inverted().transform
+
+        other = {"x": "y", "y": "x"}[orient]
+
+        pos = reverse(forward(data[orient]) - data["width"] / 2)
+        width = reverse(forward(data[orient]) + data["width"] / 2) - pos
+
+        val = (data[other] - data["baseline"]).to_numpy()
+        base = data["baseline"].to_numpy()
+
         kws = self._resolve_properties(data, scales)
         if orient == "x":
-            kws["x"] = (data["x"] - data["width"] / 2).to_numpy()
-            kws["y"] = data["baseline"].to_numpy()
-            kws["w"] = data["width"].to_numpy()
-            kws["h"] = (data["y"] - data["baseline"]).to_numpy()
+            kws.update(x=pos, y=base, w=width, h=val)
         else:
-            kws["x"] = data["baseline"].to_numpy()
-            kws["y"] = (data["y"] - data["width"] / 2).to_numpy()
-            kws["w"] = (data["x"] - data["baseline"]).to_numpy()
-            kws["h"] = data["width"].to_numpy()
+            kws.update(x=base, y=pos, w=val, h=width)
 
         kws.pop("width", None)
         kws.pop("baseline", None)

--- a/tests/_marks/test_bar.py
+++ b/tests/_marks/test_bar.py
@@ -200,3 +200,13 @@ class TestBars:
         colors = p._theme["axes.prop_cycle"].by_key()["color"]
         assert_array_equal(fcs, to_rgba_array([colors[0]] * len(x), 0))
         assert_array_equal(ecs, to_rgba_array([colors[4]] * len(x), 1))
+
+    def test_log_scale(self):
+
+        x = y = [1, 10, 100, 1000]
+        p = Plot(x, y).add(Bars()).scale(x="log").plot()
+        ax = p._figure.axes[0]
+
+        paths = ax.collections[0].get_paths()
+        for a, b in zip(paths, paths[1:]):
+            assert a.vertices[1, 0] == pytest.approx(b.vertices[0, 0])


### PR DESCRIPTION
Fixes #2907:

```python
x = np.random.lognormal(10, 1, 1000)
so.Plot(x).add(so.Bars(edgewidth=0, alpha=.5), so.Hist()).scale(x="log")
```
<img width=500 src=https://user-images.githubusercontent.com/315810/211552776-1d753532-cb40-453d-8f6d-4929c474b5a2.png />

Contra #3138, the approach here defers the "unscaling" of the width computation to the Mark's drawing logic, rather than adding a new variable to the post-transform data. The reason for this is that we will likely need other kinds of width/spacing-relative properties, such as errorbar or boxplot caps. This approach lets us compute what we need for each mark rather than adding a different "base" variable for each kind of width.

I don't really like needing to access `scales[orient]._matplotlib_scale` within the `Mark`. One alternative would be to pass the `Axes` into `BarBase._make_patches` and access the transform that way. But this may indicate a more general limitation of the `Scale` object that would be worth solving.