### PR TITLE
Add default theme configuration to Plot

### DIFF
--- a/doc/_docstrings/objects.Plot.config.ipynb
+++ b/doc/_docstrings/objects.Plot.config.ipynb
@@ -1,0 +1,124 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a38a6fed-51de-4dbc-8d5b-4971d06acf2e",
+   "metadata": {
+    "tags": [
+     "hide"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "import seaborn.objects as so"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "38081259-9382-4623-8d67-09aa114e0949",
+   "metadata": {},
+   "source": [
+    "Theme configuration\n",
+    "^^^^^^^^^^^^^^^^^^^\n",
+    "\n",
+    "The theme is a dictionary of matplotlib `rc parameters <https://matplotlib.org/stable/tutorials/introductory/customizing.html>`_. You can set individual parameters directly:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "34ca0ce9-5284-47b6-8281-180709dbec89",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "so.Plot.config.theme[\"axes.facecolor\"] = \"white\""
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "b3f93646-8370-4c16-ace4-7bb811688758",
+   "metadata": {},
+   "source": [
+    "To change the overall style of the plot, update the theme with a dictionary of parameters, perhaps from one of seaborn's theming functions:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8e5eb7d3-cc7a-4231-b887-db37045f3db4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from seaborn import axes_style\n",
+    "so.Plot.config.theme.update(axes_style(\"whitegrid\"))"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "f7c7bd9c-722d-45db-902a-c2dcdef571ee",
+   "metadata": {},
+   "source": [
+    "To sync :class:`Plot` with matplotlib's global state, pass the `rcParams` dictionary:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fd1cd96e-1a2c-474a-809f-20b8c4794578",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib as mpl\n",
+    "so.Plot.config.theme.update(mpl.rcParams)"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "7e305ec1-4a83-411f-91df-aee2ec4d1806",
+   "metadata": {},
+   "source": [
+    "The theme can also be reset back to seaborn defaults:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e3146b1d-1b5e-464f-a631-e6d6caf161b3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "so.Plot.config.theme.reset()"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "eae5da42-cf7f-41c9-b13d-8fa25e5cf0be",
+   "metadata": {},
+   "source": [
+    "Changes made through this interface will apply to all subsequent :class:`Plot` instances. Use the :meth:`Plot.theme` method to modify the theme on a plot-by-plot basis."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "py310",
+   "language": "python",
+   "name": "py310"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/doc/_docstrings/objects.Plot.theme.ipynb
+++ b/doc/_docstrings/objects.Plot.theme.ipynb
@@ -32,7 +32,7 @@
    "outputs": [],
    "source": [
     "p = (\n",
-    "    so.Plot(anscombe, \"x\", \"y\")\n",
+    "    so.Plot(anscombe, \"x\", \"y\", color=\"dataset\")\n",
     "    .facet(\"dataset\", wrap=2)\n",
     "    .add(so.Line(), so.PolyFit(order=1))\n",
     "    .add(so.Dot())\n",
@@ -55,7 +55,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "p.theme({\"axes.facecolor\": \"w\", \"axes.edgecolor\": \"C0\"})"
+    "p.theme({\"axes.facecolor\": \"w\", \"axes.edgecolor\": \"slategray\"})"
    ]
   },
   {
@@ -92,7 +92,7 @@
    "outputs": [],
    "source": [
     "from seaborn import axes_style\n",
-    "p.theme({**axes_style(\"ticks\")})"
+    "p.theme(axes_style(\"ticks\"))"
    ]
   },
   {
@@ -111,13 +111,32 @@
    "outputs": [],
    "source": [
     "from matplotlib import style\n",
-    "p.theme({**style.library[\"fivethirtyeight\"]})"
+    "p.theme(style.library[\"fivethirtyeight\"])"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "e1870ad0-48a0-4fd1-a557-d337979bc845",
+   "metadata": {},
+   "source": [
+    "Multiple parameter dictionaries should be passed to the same function call. On Python 3.9+, you can use dictionary union syntax for this:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "dec4db5b-1b2b-4b9d-97e1-9cf0f20d6b83",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from seaborn import plotting_context\n",
+    "p.theme(axes_style(\"whitegrid\") | plotting_context(\"talk\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "579dc06f-9ea0-406b-8861-a25ad7a08113",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/doc/_docstrings/objects.Plot.theme.ipynb
+++ b/doc/_docstrings/objects.Plot.theme.ipynb
@@ -77,8 +77,8 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "2c8fa27e-d1ea-4376-a717-c3059ba1d272",
+   "cell_type": "raw",
+   "id": "0186e852-9c47-4da1-999a-f61f41687dfb",
    "metadata": {},
    "source": [
     "Apply seaborn styles by passing in the output of the style functions:"
@@ -134,12 +134,31 @@
    ]
   },
   {
+   "cell_type": "raw",
+   "id": "7cc09720-887d-463e-a162-1e3ef8a46ad9",
+   "metadata": {},
+   "source": [
+    "The default theme for all :class:`Plot` instances can be changed using the :attr:`Plot.config` attribute:"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "579dc06f-9ea0-406b-8861-a25ad7a08113",
+   "id": "4e535ddf-d394-4ce1-8d09-4dc95ca314b4",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "so.Plot.config.theme.update(axes_style(\"white\"))\n",
+    "p"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "2f19f645-3f8d-4044-82e9-4a87165a0078",
+   "metadata": {},
+   "source": [
+    "See :ref:`Plot Configuration <plot_config>` for more details."
+   ]
   }
  ],
  "metadata": {

--- a/doc/_templates/autosummary/plot.rst
+++ b/doc/_templates/autosummary/plot.rst
@@ -4,54 +4,66 @@
 
 .. autoclass:: {{ objname }}
 
-   {% block methods %}
+{% block methods %}
 
-   .. rubric:: Specification methods
+Methods
+~~~~~~~
 
-   .. autosummary::
-      :toctree: ./
-      :nosignatures:
+.. rubric:: Specification methods
 
-      ~Plot.add
-      ~Plot.scale
+.. autosummary::
+   :toctree: ./
+   :nosignatures:
 
-   .. rubric:: Subplot methods
+   ~Plot.add
+   ~Plot.scale
 
-   .. autosummary::
-      :toctree: ./
-      :nosignatures:
+.. rubric:: Subplot methods
 
-      ~Plot.facet
-      ~Plot.pair
+.. autosummary::
+   :toctree: ./
+   :nosignatures:
 
-   .. rubric:: Customization methods
+   ~Plot.facet
+   ~Plot.pair
 
-   .. autosummary::
-      :toctree: ./
-      :nosignatures:
+.. rubric:: Customization methods
 
-      ~Plot.layout
-      ~Plot.label
-      ~Plot.limit
-      ~Plot.share
-      ~Plot.theme
+.. autosummary::
+   :toctree: ./
+   :nosignatures:
 
-   .. rubric:: Integration methods
+   ~Plot.layout
+   ~Plot.label
+   ~Plot.limit
+   ~Plot.share
+   ~Plot.theme
 
-   .. autosummary::
-      :toctree: ./
-      :nosignatures:
+.. rubric:: Integration methods
 
-      ~Plot.on
+.. autosummary::
+   :toctree: ./
+   :nosignatures:
 
-   .. rubric:: Output methods
+   ~Plot.on
 
-   .. autosummary::
-      :toctree: ./
-      :nosignatures:
+.. rubric:: Output methods
 
-      ~Plot.plot
-      ~Plot.save
-      ~Plot.show
+.. autosummary::
+   :toctree: ./
+   :nosignatures:
 
-   {% endblock %}
+   ~Plot.plot
+   ~Plot.save
+   ~Plot.show
+
+{% endblock %}
+
+.. _plot_config:
+
+Configuration
+~~~~~~~~~~~~~
+
+The :class:`Plot` object's default behavior can be configured through its :attr:`Plot.config` attribute. Notice that this is a property of the class, not a method on an instance.
+
+.. include:: ../docstrings/objects.Plot.config.rst

--- a/doc/_tutorial/objects_interface.ipynb
+++ b/doc/_tutorial/objects_interface.ipynb
@@ -1037,22 +1037,45 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "2df40831-fd41-4b76-90ff-042aecd694d4",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'so' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn [1], line 3\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01mseaborn\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m axes_style\n\u001b[1;32m      2\u001b[0m theme \u001b[38;5;241m=\u001b[39m {\u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39maxes_style(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mwhitegrid\u001b[39m\u001b[38;5;124m\"\u001b[39m), \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mgrid.linestyle\u001b[39m\u001b[38;5;124m\"\u001b[39m: \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m:\u001b[39m\u001b[38;5;124m\"\u001b[39m}\n\u001b[0;32m----> 3\u001b[0m \u001b[43mso\u001b[49m\u001b[38;5;241m.\u001b[39mPlot()\u001b[38;5;241m.\u001b[39mtheme(theme)\n",
+      "\u001b[0;31mNameError\u001b[0m: name 'so' is not defined"
+     ]
+    }
+   ],
    "source": [
     "from seaborn import axes_style\n",
-    "so.Plot().theme({**axes_style(\"whitegrid\"), \"grid.linestyle\": \":\"})"
+    "theme_dict = {**axes_style(\"whitegrid\"), \"grid.linestyle\": \":\"}\n",
+    "so.Plot().theme(theme)"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "475d5157-5e88-473e-991f-528219ed3744",
+   "metadata": {},
+   "source": [
+    "To change the theme for all :class:`Plot` instances, update the settings in :attr:`Plot.config:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8ac5e809-e4a0-4c08-b9c0-fa78bd93eb82",
+   "id": "41ac347c-766f-495c-8a7f-43fee8cad29a",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "so.Plot.config.theme.update(theme_dict)"
+   ]
   }
  ],
  "metadata": {

--- a/doc/_tutorial/objects_interface.ipynb
+++ b/doc/_tutorial/objects_interface.ipynb
@@ -1044,7 +1044,7 @@
    "source": [
     "from seaborn import axes_style\n",
     "theme_dict = {**axes_style(\"whitegrid\"), \"grid.linestyle\": \":\"}\n",
-    "so.Plot().theme(theme)"
+    "so.Plot().theme(theme_dict)"
    ]
   },
   {

--- a/doc/_tutorial/objects_interface.ipynb
+++ b/doc/_tutorial/objects_interface.ipynb
@@ -1037,22 +1037,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "2df40831-fd41-4b76-90ff-042aecd694d4",
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "NameError",
-     "evalue": "name 'so' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn [1], line 3\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01mseaborn\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m axes_style\n\u001b[1;32m      2\u001b[0m theme \u001b[38;5;241m=\u001b[39m {\u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39maxes_style(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mwhitegrid\u001b[39m\u001b[38;5;124m\"\u001b[39m), \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mgrid.linestyle\u001b[39m\u001b[38;5;124m\"\u001b[39m: \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m:\u001b[39m\u001b[38;5;124m\"\u001b[39m}\n\u001b[0;32m----> 3\u001b[0m \u001b[43mso\u001b[49m\u001b[38;5;241m.\u001b[39mPlot()\u001b[38;5;241m.\u001b[39mtheme(theme)\n",
-      "\u001b[0;31mNameError\u001b[0m: name 'so' is not defined"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from seaborn import axes_style\n",
     "theme_dict = {**axes_style(\"whitegrid\"), \"grid.linestyle\": \":\"}\n",

--- a/seaborn/_core/plot.py
+++ b/seaborn/_core/plot.py
@@ -57,7 +57,7 @@ else:
 default = Default()
 
 
-# ---- Definitions for internal specs --------------------------------- #
+# ---- Definitions for internal specs ---------------------------------------------- #
 
 
 class Layer(TypedDict, total=False):
@@ -87,7 +87,7 @@ class PairSpec(TypedDict, total=False):
     wrap: int | None
 
 
-# --- Local helpers ----------------------------------------------------------------
+# --- Local helpers ---------------------------------------------------------------- #
 
 
 @contextmanager
@@ -143,7 +143,7 @@ def build_plot_signature(cls):
     return cls
 
 
-# ---- TODO -------------------- #
+# ---- Plot configuration ---------------------------------------------------------- #
 
 
 class ThemeConfig(mpl.RcParams):
@@ -177,7 +177,7 @@ class ThemeConfig(mpl.RcParams):
         }
 
     def reset(self):
-
+        """Update the theme dictionary with seaborn's default values."""
         self.update(self._default)
 
     def update(self, other=(), /, **kwds):
@@ -211,24 +211,20 @@ class ThemeConfig(mpl.RcParams):
             "</div>",
             "</div>",
         ]
-        return "".join(repr)
+        return "\n".join(repr)
 
 
 class PlotConfig:
-    """
-    Configuration for :class:`Plot`.
-    """
+    """Configuration for default behavior / appearance of class:`Plot` instances."""
     _theme = ThemeConfig()
 
     @property
     def theme(self):
-        """
-        Dictionary of base theme parameters for :class:`Plot`.
-        """
+        """Dictionary of base theme parameters for :class:`Plot`."""
         return self._theme
 
 
-# ---- The main interface for declarative plotting -------------------- #
+# ---- The main interface for declarative plotting --------------------------------- #
 
 
 @build_plot_signature
@@ -817,7 +813,7 @@ class Plot:
 
     def theme(self, *args: dict[str, Any]) -> Plot:
         """
-        Control the default appearance of elements in the plot.
+        Control the appearance of elements in the plot.
 
         .. note::
 

--- a/seaborn/_core/plot.py
+++ b/seaborn/_core/plot.py
@@ -180,6 +180,19 @@ class ThemeConfig(mpl.RcParams):
 
         self.update(self._default)
 
+    def update(self, other=(), /, **kwds):
+        """Update the theme with a dictionary or keyword arguments of rc parameters."""
+        if other:
+            theme = {
+                # Restrict to rcParams we consider part of the "theme"
+                k: v for k, v in other.items()
+                if any(k.startswith(p) for p in self.style_groups)
+            }
+        else:
+            theme = {}
+        theme.update(kwds)
+        super().update(theme)
+
     def _html_table(self, params):
 
         lines = ["<table>"]

--- a/seaborn/_core/plot.py
+++ b/seaborn/_core/plot.py
@@ -830,7 +830,7 @@ class Plot:
             err = f"theme() takes 1 positional argument, but {nargs} were given"
             raise TypeError(err)
 
-        rc = args[0]
+        rc = mpl.RcParams(args[0])
         new._theme.update(rc)
 
         return new

--- a/seaborn/_core/plot.py
+++ b/seaborn/_core/plot.py
@@ -150,50 +150,47 @@ class ThemeConfig(mpl.RcParams):
     """
     Configuration object for the Plot.theme, using matplotlib rc parameters.
     """
-    style_groups = [
+    THEME_GROUPS = [
         "axes", "figure", "font", "grid", "hatch", "legend", "lines",
         "mathtext", "markers", "patch", "savefig", "scatter",
         "xaxis", "xtick", "yaxis", "ytick",
     ]
 
     def __init__(self):
-
         super().__init__()
         self.reset()
 
     @property
-    def _default(self):
-
-        base = {
-            k: v for k, v in mpl.rcParamsDefault.items()
-            if any(k.startswith(p) for p in self.style_groups)
-        }
+    def _default(self) -> dict[str, Any]:
 
         return {
-            **base,
+            **self._filter_params(mpl.rcParamsDefault),
             **axes_style("darkgrid"),
             **plotting_context("notebook"),
             "axes.prop_cycle": cycler("color", color_palette("deep")),
         }
 
-    def reset(self):
+    def reset(self) -> None:
         """Update the theme dictionary with seaborn's default values."""
         self.update(self._default)
 
-    def update(self, other=(), /, **kwds):
+    def update(self, other: dict[str, Any] | None = None, /, **kwds):
         """Update the theme with a dictionary or keyword arguments of rc parameters."""
-        if other:
-            theme = {
-                # Restrict to rcParams we consider part of the "theme"
-                k: v for k, v in other.items()
-                if any(k.startswith(p) for p in self.style_groups)
-            }
+        if other is not None:
+            theme = self._filter_params(other)
         else:
             theme = {}
         theme.update(kwds)
         super().update(theme)
 
-    def _html_table(self, params):
+    def _filter_params(self, params: dict[str, Any]) -> dict[str, Any]:
+        """Restruct to thematic rc params."""
+        return {
+            k: v for k, v in params.items()
+            if any(k.startswith(p) for p in self.THEME_GROUPS)
+        }
+
+    def _html_table(self, params: dict[str, Any]) -> list[str]:
 
         lines = ["<table>"]
         for k, v in params.items():
@@ -202,7 +199,7 @@ class ThemeConfig(mpl.RcParams):
         lines.append("</table>")
         return lines
 
-    def _repr_html_(self):
+    def _repr_html_(self) -> str:
 
         repr = [
             "<div style='height: 300px'>",
@@ -219,7 +216,7 @@ class PlotConfig:
     _theme = ThemeConfig()
 
     @property
-    def theme(self):
+    def theme(self) -> dict[str, Any]:
         """Dictionary of base theme parameters for :class:`Plot`."""
         return self._theme
 

--- a/tests/_core/test_plot.py
+++ b/tests/_core/test_plot.py
@@ -2126,3 +2126,60 @@ class TestDefaultObject:
     def test_default_repr(self):
 
         assert repr(Default()) == "<default>"
+
+
+class TestThemeConfig:
+
+    @pytest.fixture(autouse=True)
+    def reset_config(self):
+        yield
+        Plot.config.theme.reset()
+
+    def test_default(self):
+
+        p = Plot().plot()
+        ax = p._figure.axes[0]
+        expected = Plot.config.theme["axes.facecolor"]
+        assert mpl.colors.same_color(ax.get_facecolor(), expected)
+
+    def test_setitem(self):
+
+        color = "#CCC"
+        Plot.config.theme["axes.facecolor"] = color
+        p = Plot().plot()
+        ax = p._figure.axes[0]
+        assert mpl.colors.same_color(ax.get_facecolor(), color)
+
+    def test_update(self):
+
+        color = "#DDD"
+        Plot.config.theme.update({"axes.facecolor": color})
+        p = Plot().plot()
+        ax = p._figure.axes[0]
+        assert mpl.colors.same_color(ax.get_facecolor(), color)
+
+    def test_reset(self):
+
+        orig = Plot.config.theme["axes.facecolor"]
+        Plot.config.theme.update({"axes.facecolor": "#EEE"})
+        Plot.config.theme.reset()
+        p = Plot().plot()
+        ax = p._figure.axes[0]
+        assert mpl.colors.same_color(ax.get_facecolor(), orig)
+
+    def test_copy(self):
+
+        key, val = "axes.facecolor", ".95"
+        orig = Plot.config.theme[key]
+        theme = Plot.config.theme.copy()
+        theme.update({key: val})
+        assert Plot.config.theme[key] == orig
+
+    def test_html_repr(self):
+
+        res = Plot.config.theme._repr_html_()
+        for tag in ["div", "table", "tr", "td"]:
+            assert res.count(f"<{tag}") == res.count(f"</{tag}")
+
+        for key in Plot.config.theme:
+            assert f"<td>{key}:</td>" in res

--- a/tests/_core/test_plot.py
+++ b/tests/_core/test_plot.py
@@ -922,6 +922,16 @@ class TestPlotting:
         with pytest.raises(TypeError, match=r"theme\(\) takes 1 positional"):
             p.theme("arg1", "arg2")
 
+    def test_theme_validation(self):
+
+        p = Plot()
+        # You'd think matplotlib would raise a TypeError here, but it doesn't
+        with pytest.raises(ValueError, match="Key axes.linewidth:"):
+            p.theme({"axes.linewidth": "thick"})
+
+        with pytest.raises(KeyError, match="not.a.key is not a valid rc"):
+            p.theme({"not.a.key": True})
+
     def test_stat(self, long_df):
 
         orig_df = long_df.copy(deep=True)


### PR DESCRIPTION
This PR introduces a mechanism for changing the appearance of _all_ plots made with `so.Plot`. It adds a configuration interface, accessible through `so.Plot.config` (this is an attribute of the class, not an instance). I expect to add a number of configuration objects; this PR adds `so.Plot.config.theme`, which exposes a dictionary of rcParams that will be used by default in all `Plot` plots, unless overridden by `so.Plot().theme()`. So to change the appearance of all plots, you could put at the top of your notebook:

```python
theme = sns.axes_style("whitegrid") | sns.plotting_context("talk")
so.Plot.config.theme.update(theme)
```
then do
```python
so.Plot()
```
<img width=400 src=https://user-images.githubusercontent.com/315810/212571473-4f1c108d-3338-4b79-be6c-43a3ae3ab8a5.png />

To use the matplotlib globals (whether determined by a `matplotlibrc` file or functions that modify the global state, you'd only need do)

```python
so.Plot.config.theme.update(mpl.rcParams)  # or plt.rcParams
```

I've added a nice `_repr_html_` for the theme config object, so you can see the available parameters and what they're set to more easily:

<img width="455" alt="image" src="https://user-images.githubusercontent.com/315810/212571559-833fa7b3-b884-4c4b-856b-2c3c831ecf92.png">

(One could even imaging making this an editable table for interactive updating. We'll see...)

Also, we actually store the theme defaults in a matplotlib `RcParams` object, so we get to take advantage of their validation:

```python
so.Plot.config.theme["axes.linewidth"] = "thick"
```
```python-traceback
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
Cell In [9], line 1
----> 1 so.Plot.config.theme["axes.linewidth"] = "thick"

File ~/miniconda/envs/py310/lib/python3.10/site-packages/matplotlib/__init__.py:651, in RcParams.__setitem__(self, key, val)
    649         cval = self.validate[key](val)
    650     except ValueError as ve:
--> 651         raise ValueError(f"Key {key}: {ve}") from None
    652     dict.__setitem__(self, key, cval)
    653 except KeyError as err:

ValueError: Key axes.linewidth: Could not convert 'thick' to float
```

One possibility that I'm undecided on is whether there should be more direct access to seaborn's named themes, i.e. something like

```python
so.Plot.config.theme.set(style="ticks", context="paper")
```

I'm a little unsure of how/where best to document this, but for now I'm adding a configuration section right on the `Plot` API docs page.

cf. https://github.com/mwaskom/seaborn/discussions/3005