### PR TITLE
Add notebook display configuration for Plot, including SVG output

### DIFF
--- a/doc/_docstrings/objects.Plot.config.ipynb
+++ b/doc/_docstrings/objects.Plot.config.ipynb
@@ -22,6 +22,8 @@
     "Theme configuration\n",
     "^^^^^^^^^^^^^^^^^^^\n",
     "\n",
+    "Theme changes made through the the :attr:`Plot.config` interface will apply to all subsequent :class:`Plot` instances. Use the :meth:`Plot.theme` method to modify the theme on a plot-by-plot basis.\n",
+    "\n",
     "The theme is a dictionary of matplotlib `rc parameters <https://matplotlib.org/stable/tutorials/introductory/customizing.html>`_. You can set individual parameters directly:"
    ]
   },
@@ -93,14 +95,6 @@
   },
   {
    "cell_type": "raw",
-   "id": "eae5da42-cf7f-41c9-b13d-8fa25e5cf0be",
-   "metadata": {},
-   "source": [
-    "Changes made through this interface will apply to all subsequent :class:`Plot` instances. Use the :meth:`Plot.theme` method to modify the theme on a plot-by-plot basis."
-   ]
-  },
-  {
-   "cell_type": "raw",
    "id": "b6370088-02f6-4933-91c0-5763b86b7299",
    "metadata": {},
    "source": [
@@ -125,9 +119,9 @@
    "id": "845239ed-3a0f-4a94-97d0-364c2db3b9c8",
    "metadata": {},
    "source": [
-    "SVG images use vector graphics with \"infinite\" resolution, so they will appear crisper. The downside is that each plot element is drawn separately, so image data can get very large at times (e.g., for a dense scatterplot).\n",
+    "SVG images use vector graphics with \"infinite\" resolution, so they will appear crisp at any amount of zoom. The downside is that each plot element is drawn separately, so the image data can get very heavy for certain kinds of plots (e.g., for dense scatterplots).\n",
     "\n",
-    "The HiDPI scaling of the default PNG images will also inflate the size of your notebooks (unlike with SVG, PNG size will scale with the size of the plot but not it's complexity). When not useful, it can be disabled:"
+    "The HiDPI scaling of the default PNG images will also inflate the size of the notebook they are stored in. (Unlike with SVG, PNG size will scale with the dimensions of the plot but not its complexity). When not useful, it can be disabled:"
    ]
   },
   {
@@ -141,8 +135,8 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "5f34fbac-782d-4d64-83ba-9f19c4f4208b",
+   "cell_type": "raw",
+   "id": "ddebe3eb-1d64-41e9-9cfd-f8359d6f8a38",
    "metadata": {},
    "source": [
     "The embedded images are scaled down slightly — independently from the figure size or DPI — so that more information can be presented on the screen. The precise scaling factor is also configurable:"

--- a/doc/_docstrings/objects.Plot.config.ipynb
+++ b/doc/_docstrings/objects.Plot.config.ipynb
@@ -98,6 +98,65 @@
    "source": [
     "Changes made through this interface will apply to all subsequent :class:`Plot` instances. Use the :meth:`Plot.theme` method to modify the theme on a plot-by-plot basis."
    ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "b6370088-02f6-4933-91c0-5763b86b7299",
+   "metadata": {},
+   "source": [
+    "Display configuration\n",
+    "^^^^^^^^^^^^^^^^^^^^^\n",
+    "\n",
+    "When returned from the last statement in a notebook cell, a :class:`Plot` will be compiled and embedded in the notebook as an image. By default, the image is rendered as HiDPI PNG. Alternatively, it is possible to display the plots in SVG format:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1bd9966e-d08f-46b4-ad44-07276d5efba8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "so.Plot.config.display[\"format\"] = \"svg\""
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "845239ed-3a0f-4a94-97d0-364c2db3b9c8",
+   "metadata": {},
+   "source": [
+    "SVG images use vector graphics with \"infinite\" resolution, so they will appear crisper. The downside is that each plot element is drawn separately, so image data can get very large at times (e.g., for a dense scatterplot).\n",
+    "\n",
+    "The HiDPI scaling of the default PNG images will also inflate the size of your notebooks (unlike with SVG, PNG size will scale with the size of the plot but not it's complexity). When not useful, it can be disabled:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "13ac09f7-d4ad-4b4e-8963-edc0c6c71a94",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "so.Plot.config.display[\"hidpi\"] = False"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5f34fbac-782d-4d64-83ba-9f19c4f4208b",
+   "metadata": {},
+   "source": [
+    "The embedded images are scaled down slightly — independently from the figure size or DPI — so that more information can be presented on the screen. The precise scaling factor is also configurable:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f10c5596-598d-4258-bf8f-67c07eaba266",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "so.Plot.config.display[\"scaling\"] = 0.7"
+   ]
   }
  ],
  "metadata": {

--- a/seaborn/_core/plot.py
+++ b/seaborn/_core/plot.py
@@ -227,12 +227,27 @@ class PlotConfig:
 
     @property
     def theme(self) -> dict[str, Any]:
-        """Dictionary of base theme parameters for :class:`Plot`."""
+        """
+        Dictionary of base theme parameters for :class:`Plot`.
+
+        Keys and values correspond to matplotlib rc params, as documented here:
+        https://matplotlib.org/stable/tutorials/introductory/customizing.html
+
+        """
         return self._theme
 
     @property
-    def display(self) -> DisplayConfig:  # TODO rename to display?
-        """Dictionary of parameters for rich display in Jupyter notebook."""
+    def display(self) -> DisplayConfig:
+        """
+        Dictionary of parameters for rich display in Jupyter notebook.
+
+        Valid parameters:
+
+        - format ("png" or "svg"): Image format to produce
+        - scaling (float): Relative scaling of embedded image
+        - hidpi (bool): When True, double the DPI while preserving the size
+
+        """
         return self._display
 
 

--- a/seaborn/_core/plot.py
+++ b/seaborn/_core/plot.py
@@ -222,8 +222,10 @@ class DisplayConfig(TypedDict):
 
 class PlotConfig:
     """Configuration for default behavior / appearance of class:`Plot` instances."""
-    _theme = ThemeConfig()
-    _display: DisplayConfig = {"format": "png", "scaling": .85, "hidpi": True}
+    def __init__(self):
+
+        self._theme = ThemeConfig()
+        self._display = {"format": "png", "scaling": .85, "hidpi": True}
 
     @property
     def theme(self) -> dict[str, Any]:

--- a/tests/_core/test_plot.py
+++ b/tests/_core/test_plot.py
@@ -2190,21 +2190,6 @@ class TestDisplayConfig:
         yield
         Plot.config.display.update(PlotConfig().display)
 
-    def test_svg_format(self):
-
-        Plot.config.display["format"] = "svg"
-
-        assert Plot()._repr_png_() is None
-        assert Plot().plot()._repr_png_() is None
-
-        def assert_valid_svg(p):
-            res = p._repr_svg_()
-            root = xml.etree.ElementTree.fromstring(res)
-            assert root.tag == "{http://www.w3.org/2000/svg}svg"
-
-        assert_valid_svg(Plot())
-        assert_valid_svg(Plot().plot())
-
     def test_png_format(self):
 
         Plot.config.display["format"] = "png"
@@ -2220,3 +2205,67 @@ class TestDisplayConfig:
 
         assert_valid_png(Plot())
         assert_valid_png(Plot().plot())
+
+    def test_svg_format(self):
+
+        Plot.config.display["format"] = "svg"
+
+        assert Plot()._repr_png_() is None
+        assert Plot().plot()._repr_png_() is None
+
+        def assert_valid_svg(p):
+            res = p._repr_svg_()
+            root = xml.etree.ElementTree.fromstring(res)
+            assert root.tag == "{http://www.w3.org/2000/svg}svg"
+
+        assert_valid_svg(Plot())
+        assert_valid_svg(Plot().plot())
+
+    def test_png_scaling(self):
+
+        Plot.config.display["scaling"] = 1.
+        res1, meta1 = Plot()._repr_png_()
+
+        Plot.config.display["scaling"] = .5
+        res2, meta2 = Plot()._repr_png_()
+
+        assert meta1["width"] / 2 == meta2["width"]
+        assert meta1["height"] / 2 == meta2["height"]
+
+        img1 = Image.open(io.BytesIO(res1))
+        img2 = Image.open(io.BytesIO(res2))
+        assert img1.size == img2.size
+
+    def test_svg_scaling(self):
+
+        Plot.config.display["format"] = "svg"
+
+        Plot.config.display["scaling"] = 1.
+        res1 = Plot()._repr_svg_()
+
+        Plot.config.display["scaling"] = .5
+        res2 = Plot()._repr_svg_()
+
+        root1 = xml.etree.ElementTree.fromstring(res1)
+        root2 = xml.etree.ElementTree.fromstring(res2)
+
+        def getdim(root, dim):
+            return float(root.attrib[dim][:-2])
+
+        assert getdim(root1, "width") / 2 == getdim(root2, "width")
+        assert getdim(root1, "height") / 2 == getdim(root2, "height")
+
+    def test_png_hidpi(self):
+
+        res1, meta1 = Plot()._repr_png_()
+
+        Plot.config.display["hidpi"] = False
+        res2, meta2 = Plot()._repr_png_()
+
+        assert meta1["width"] == meta2["width"]
+        assert meta1["height"] == meta2["height"]
+
+        img1 = Image.open(io.BytesIO(res1))
+        img2 = Image.open(io.BytesIO(res2))
+        assert img1.size[0] // 2 == img2.size[0]
+        assert img1.size[1] // 2 == img2.size[1]


### PR DESCRIPTION
`Plot` renders images in a Jupyter notebook not through the matplotlib "inline" backend but by returning data through the rich display hooks (e.g. `_repr_png_`). This PR makes that system configurable, with the following new behaviors.

It is now possible to emit svg images, rather than pngs:

```python
so.Plot.config.display["format"] = "svg"
(
    so.Plot(penguins, "bill_length_mm", "bill_depth_mm", color="species")
    .add(so.Dot(fill=False))
)
```
<img width="476" alt="image" src="https://user-images.githubusercontent.com/315810/212793116-c4a67df1-f626-4580-a4d6-9add6c9da255.png">

Well, that's a screenshot .... but trust me it's an svg:

<img width="403" alt="image" src="https://user-images.githubusercontent.com/315810/212793265-a56dcd21-50cf-44b1-bfaa-18f31af66e2e.png">

Both png and svg elements (but not the underlying images) are scaled to be equivalent size, and this scaling is configurable:

```python
so.Plot.config.display["scaling"] = 1  # Default is 0.85
```

Additionally, pngs are rendered for HiDPI screens with 2x the "apparent" DPI and then scaled down, but that can be turned off if it's not useful (it does inflate notebook size substantially):

```python
so.Plot.config.display["hidpi"] = False
```