### PR TITLE
Retrieve list of available datasets from a github url with correct CORS headers set.

### DIFF
--- a/seaborn/utils.py
+++ b/seaborn/utils.py
@@ -19,7 +19,7 @@ from seaborn.external.version import Version
 from seaborn.external.appdirs import user_cache_dir
 
 __all__ = ["desaturate", "saturate", "set_hls_values", "move_legend",
-           "despine", "get_dataset_names", "get_data_home", "load_dataset", "DATASET_NAMES_URL"]
+           "despine", "get_dataset_names", "get_data_home", "load_dataset"]
 
 DATASET_NAMES_URL = "https://raw.githubusercontent.com/mwaskom/seaborn-data/master/dataset_names.txt"
 

--- a/seaborn/utils.py
+++ b/seaborn/utils.py
@@ -19,7 +19,9 @@ from seaborn.external.version import Version
 from seaborn.external.appdirs import user_cache_dir
 
 __all__ = ["desaturate", "saturate", "set_hls_values", "move_legend",
-           "despine", "get_dataset_names", "get_data_home", "load_dataset"]
+           "despine", "get_dataset_names", "get_data_home", "load_dataset", "DATASET_NAMES_URL"]
+
+DATASET_NAMES_URL = "https://raw.githubusercontent.com/mwaskom/seaborn-data/master/dataset_names.txt"
 
 
 def ci_to_errsize(cis, heights):
@@ -496,13 +498,11 @@ def get_dataset_names():
     Requires an internet connection.
 
     """
-    url = "https://github.com/mwaskom/seaborn-data"
+    url = "https://raw.githubusercontent.com/mwaskom/seaborn-data/master/datasets.txt"
     with urlopen(url) as resp:
-        html = resp.read()
+        txt = resp.read()
 
-    pat = r"/mwaskom/seaborn-data/blob/master/(\w*).csv"
-    datasets = re.findall(pat, html.decode())
-    return datasets
+    return txt.split("\n")
 
 
 def get_data_home(data_home=None):

--- a/seaborn/utils.py
+++ b/seaborn/utils.py
@@ -1,6 +1,5 @@
 """Utility functions, mostly for internal use."""
 import os
-import re
 import inspect
 import warnings
 import colorsys

--- a/seaborn/utils.py
+++ b/seaborn/utils.py
@@ -21,7 +21,8 @@ from seaborn.external.appdirs import user_cache_dir
 __all__ = ["desaturate", "saturate", "set_hls_values", "move_legend",
            "despine", "get_dataset_names", "get_data_home", "load_dataset"]
 
-DATASET_NAMES_URL = "https://raw.githubusercontent.com/mwaskom/seaborn-data/master/dataset_names.txt"
+DATASET_SOURCE = "https://raw.githubusercontent.com/mwaskom/seaborn-data/master"
+DATASET_NAMES_URL = f"{DATASET_SOURCE}/dataset_names.txt"
 
 
 def ci_to_errsize(cis, heights):
@@ -566,7 +567,7 @@ def load_dataset(name, cache=True, data_home=None, **kws):
         )
         raise TypeError(err)
 
-    url = f"https://raw.githubusercontent.com/mwaskom/seaborn-data/master/{name}.csv"
+    url = f"{DATASET_SOURCE}/{name}.csv"
 
     if cache:
         cache_path = os.path.join(get_data_home(data_home), os.path.basename(url))

--- a/seaborn/utils.py
+++ b/seaborn/utils.py
@@ -501,7 +501,8 @@ def get_dataset_names():
     with urlopen(DATASET_NAMES_URL) as resp:
         txt = resp.read()
 
-    return txt.split("\n")
+    dataset_names = [name.strip() for name in txt.decode().split("\n")]
+    return list(filter(None, dataset_names))
 
 
 def get_data_home(data_home=None):

--- a/seaborn/utils.py
+++ b/seaborn/utils.py
@@ -498,8 +498,7 @@ def get_dataset_names():
     Requires an internet connection.
 
     """
-    url = "https://raw.githubusercontent.com/mwaskom/seaborn-data/master/datasets.txt"
-    with urlopen(url) as resp:
+    with urlopen(DATASET_NAMES_URL) as resp:
         txt = resp.read()
 
     return txt.split("\n")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -29,7 +29,7 @@ from seaborn.utils import (
     _assign_default_kwargs,
     _draw_figure,
     _deprecate_ci,
-    _version_predates,
+    _version_predates, DATASET_NAMES_URL,
 )
 
 
@@ -441,14 +441,14 @@ def check_load_cached_dataset(name):
         assert_frame_equal(ds, ds2)
 
 
-@_network(url="https://github.com/mwaskom/seaborn-data")
+@_network(url=DATASET_NAMES_URL)
 def test_get_dataset_names():
     names = get_dataset_names()
     assert names
     assert "tips" in names
 
 
-@_network(url="https://github.com/mwaskom/seaborn-data")
+@_network(url=DATASET_NAMES_URL)
 def test_load_datasets():
 
     # Heavy test to verify that we can load all available datasets
@@ -459,7 +459,7 @@ def test_load_datasets():
         check_load_dataset(name)
 
 
-@_network(url="https://github.com/mwaskom/seaborn-data")
+@_network(url=DATASET_NAMES_URL)
 def test_load_dataset_string_error():
 
     name = "bad_name"


### PR DESCRIPTION
This PR is a fix for https://github.com/mwaskom/seaborn-data/issues/24. It assumes there is a file called `dataset_names.txt` in the `seaborn-data` repository containing all the available dataset names. Each line should contain the name of the file without extension.