### PR TITLE
Remove container added when inferring default color for bar artist

### DIFF
--- a/seaborn/distributions.py
+++ b/seaborn/distributions.py
@@ -253,6 +253,7 @@ class _DistributionPlotter(VectorPlotter):
                 column_groups[facet_key].append(i)
 
             baselines = curves.copy()
+
             for col_idxs in column_groups.values():
                 cols = curves.columns[col_idxs]
 

--- a/seaborn/utils.py
+++ b/seaborn/utils.py
@@ -145,6 +145,8 @@ def _default_color(method, hue, color, kws):
         scout, = method([np.nan], [np.nan], **kws)
         color = to_rgb(scout.get_facecolor())
         scout.remove()
+        # Axes.bar adds both a patch and a container
+        method.__self__.containers.pop(-1)
 
     elif method.__name__ == "fill_between":
 

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -1827,6 +1827,11 @@ class TestHistPlotUnivariate(SharedAxesLevelTests):
         assert len(handles) == 1
         assert labels == ["a label"]
 
+    def test_default_color_scout_cleanup(self, flat_series):
+
+        ax = histplot(flat_series)
+        assert len(ax.containers) == 1
+
 
 class TestHistPlotBivariate:
 


### PR DESCRIPTION
Fixes an issue introduced in (#2449) that primarily affects `histplot` (e.g. #3241) because `ax.bar` adds both patches and a container for the patches, but the current code neglects to clean up the container (and it is used in some cases, e.g. by matplotlib's automatic legend code).