### PR TITLE
Adds keyword only arguments to pivot in lineplot docs

### DIFF
--- a/doc/_docstrings/lineplot.ipynb
+++ b/doc/_docstrings/lineplot.ipynb
@@ -65,7 +65,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "flights_wide = flights.pivot(\"year\", \"month\", \"passengers\")\n",
+    "flights_wide = flights.pivot(index=\"year\", columns=\"month\", values=\"passengers\")\n",
     "flights_wide.head()"
    ]
   },


### PR DESCRIPTION
Currently the [generate docs](https://seaborn.pydata.org/generated/seaborn.lineplot.html) for lineplot raises a `FutureWarning`:

```python
FutureWarning: In a future version of pandas all arguments of DataFrame.pivot will be keyword-only.
  flights_wide = flights.pivot("year", "month", "passengers")
```

This PR removes the warning by passing in the keywords to pandas.