### PR TITLE
Refactor countplot to use common infra and add stat parameter for normalization

### DIFF
--- a/doc/_docstrings/countplot.ipynb
+++ b/doc/_docstrings/countplot.ipynb
@@ -4,19 +4,24 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "2fdf0f63-d515-4cb8-b3e0-62cac7852b12",
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "hide"
+    ]
+   },
    "outputs": [],
    "source": [
     "import seaborn as sns\n",
-    "sns.set_theme(style=\"whitegrid\")"
+    "sns.set_theme(style=\"whitegrid\")\n",
+    "titanic = sns.load_dataset(\"titanic\")"
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "5adcc785-6643-4c55-ba38-ac9b65857932",
+   "cell_type": "raw",
+   "id": "af16d745-734a-4f11-9f8f-fa54deadfb12",
    "metadata": {},
    "source": [
-    "Show the number of datapoints with each value of a categorical variable:"
+    "Show the count of value for a single categorical variable:"
    ]
   },
   {
@@ -26,13 +31,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df = sns.load_dataset(\"titanic\")\n",
-    "sns.countplot(x=df[\"class\"])"
+    "sns.countplot(titanic, x=\"class\")"
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "c2e36b42-5453-4478-918b-3699ac1fbc0e",
+   "cell_type": "raw",
+   "id": "173f47c4-d5fb-4fc0-bdbd-ec228419d451",
    "metadata": {},
    "source": [
     "Group by a second variable:"
@@ -45,34 +49,26 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.countplot(data=df, x=\"class\", hue=\"alive\")"
+    "sns.countplot(titanic, x=\"class\", hue=\"survived\")"
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "eac30be1-c9d8-472c-afa9-16119afab86e",
+   "cell_type": "raw",
+   "id": "377bfb01-64a2-4f07-b06b-fb1a4f7c3b12",
    "metadata": {},
    "source": [
-    "Plot horizontally to make more space for category labels:"
+    "Normalize the counts to show percentages:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "31758c56-106e-4a9c-bcee-ef1f93f472e8",
+   "id": "7267aefc-f2bc-4a64-956a-bb25013ca9ec",
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.countplot(data=df, y=\"deck\", hue=\"alive\")"
+    "sns.countplot(titanic, x=\"class\", hue=\"survived\", stat=\"percent\")"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "5c049d0c-d91b-4675-a9aa-7deea1421d68",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/seaborn/utils.py
+++ b/seaborn/utils.py
@@ -781,6 +781,7 @@ def _check_argument(param, options, value):
         raise ValueError(
             f"`{param}` must be one of {options}, but {repr(value)} was passed."
         )
+    return value
 
 
 def _assign_default_kwargs(kws, call_func, source_func):

--- a/tests/test_categorical.py
+++ b/tests/test_categorical.py
@@ -2740,7 +2740,22 @@ class TestBarPlot(SharedAggTests):
             assert same_color(bar.get_facecolor(), colors[i])
 
 
-class TestCountPlot(SharedAxesLevelTests):
+class TestCountPlot:
+
+    def test_labels_long(self, long_df):
+
+        fig = mpl.figure.Figure()
+        axs = fig.subplots(2)
+        countplot(long_df, x="a", ax=axs[0])
+        countplot(long_df, x="b", stat="percent", ax=axs[1])
+
+        # To populate texts; only needed on older matplotlibs
+        _draw_figure(fig)
+
+        assert axs[0].get_xlabel() == "a"
+        assert axs[1].get_xlabel() == "b"
+        assert axs[0].get_ylabel() == "count"
+        assert axs[1].get_ylabel() == "percent"
 
     def test_wide_data(self, wide_df):
 

--- a/tests/test_categorical.py
+++ b/tests/test_categorical.py
@@ -2742,6 +2742,14 @@ class TestBarPlot(SharedAggTests):
 
 class TestCountPlot:
 
+    def test_empty(self):
+
+        ax = countplot()
+        assert not ax.patches
+
+        ax = countplot(x=[])
+        assert not ax.patches
+
     def test_labels_long(self, long_df):
 
         fig = mpl.figure.Figure()
@@ -2819,9 +2827,9 @@ class TestCountPlot:
 
     def test_hue_dodged(self):
 
-        vals = ["a", "a", "a", "b", "b", "b", "b"]
-        hue = ["x", "y", "y", "x", "x", "x", "y"]
-        counts = [1, 3, 2, 1]
+        vals = ["a", "a", "a", "b", "b", "b"]
+        hue = ["x", "y", "y", "x", "x", "x"]
+        counts = [1, 3, 2, 0]
 
         ax = countplot(x=vals, hue=hue, saturation=1)
         for i, bar in enumerate(ax.patches):
@@ -2870,6 +2878,7 @@ class TestCountPlot:
             dict(data="flat"),
             dict(data="long", x="a"),
             dict(data=None, x="a"),
+            dict(data="long", y="b"),
             dict(data="long", x="a", hue="a"),
             dict(data=None, x="a", hue="a"),
             dict(data="long", x="a", hue="b"),


### PR DESCRIPTION
Part of #2429 and followup to #3255, routing `countplot` through the new `barplot` backend code.

See #3255 for a thorough description of the default changes / new features and a link to a demonstration. The same behaviors (aside from the statistical estimation) now apply to `countplot` and to `catplot` with `kind="count"`.

This PR also adds a new ([long-desired](https://github.com/mwaskom/seaborn/issues/1027)) feature: normalization of bar heights to represent percentages or proportions:

```python
sns.countplot(diamonds, x="cut", stat="percent")
```
<img width=400 src=https://user-images.githubusercontent.com/315810/219878755-b605447a-48fa-457a-bc1a-7859c6b9ac45.png />

It is not quite as flexible as the normalization in `histplot` (there is no `common_norm` parameter) but should suffice for most usecases.
