### PR TITLE
Fix typo in documentation of "seaborn.jointplot"

### DIFF
--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -2352,7 +2352,6 @@ Parameters
 {params.core.data}
 {params.core.xy}
 {params.core.hue}
-    Semantic variable that is mapped to determine the color of plot elements.
 kind : {{ "scatter" | "kde" | "hist" | "hex" | "reg" | "resid" }}
     Kind of plot to draw. See the examples for references to the underlying functions.
 height : numeric


### PR DESCRIPTION
In the documentation of [`seaborn.jointplot`](https://seaborn.pydata.org/generated/seaborn.jointplot.html) the docstring for the `hue`  parameter is stated twice. This PR removes the manual added text to show only the (identical) text set via [`_docstring.py`](https://github.com/mwaskom/seaborn/blob/master/seaborn/_docstrings.py). 