### PR TITLE
docs: fix typo in docstring

### DIFF
--- a/seaborn/rcmod.py
+++ b/seaborn/rcmod.py
@@ -504,7 +504,7 @@ def set_palette(palette, n_colors=None, desat=None, color_codes=False):
 
     Parameters
     ----------
-    palette : seaborn color paltte | matplotlib colormap | hls | husl
+    palette : seaborn color palette | matplotlib colormap | hls | husl
         Palette definition. Should be something :func:`color_palette` can process.
     n_colors : int
         Number of colors in the cycle. The default number of colors will depend


### PR DESCRIPTION
Change `paltte` to `palette`.