### PR TITLE
Avoid matplotlib 3.7.0 warnings

### DIFF
--- a/examples/heat_scatter.py
+++ b/examples/heat_scatter.py
@@ -6,6 +6,7 @@ _thumb: .5, .5
 
 """
 import seaborn as sns
+from seaborn._compat import get_legend_handles
 sns.set_theme(style="whitegrid")
 
 # Load the brain networks dataset, select subset, and collapse the multi-index
@@ -37,5 +38,5 @@ g.despine(left=True, bottom=True)
 g.ax.margins(.02)
 for label in g.ax.get_xticklabels():
     label.set_rotation(90)
-for artist in g.legend.legendHandles:
+for artist in get_legend_handles(g.legend):
     artist.set_edgecolor(".7")

--- a/seaborn/_compat.py
+++ b/seaborn/_compat.py
@@ -166,3 +166,11 @@ def share_axis(ax0, ax1, which):
         group.join(ax1, ax0)
     else:
         getattr(ax1, f"share{which}")(ax0)
+
+
+def get_legend_handles(legend):
+    """Handle legendHandles attribute rename."""
+    if _version_predates(mpl, "3.7"):
+        return legend.legendHandles
+    else:
+        return legend.legend_handles

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -10,7 +10,7 @@ import matplotlib as mpl
 import matplotlib.pyplot as plt
 
 from ._oldcore import VectorPlotter, variable_type, categorical_order
-from ._compat import share_axis
+from ._compat import share_axis, get_legend_handles
 from . import utils
 from .utils import (
     adjust_legend_subtitles, _check_argument, _draw_figure, _disable_autolayout
@@ -229,7 +229,7 @@ class Grid(_BaseGrid):
         # Get data directly from the legend, which is necessary
         # for newer functions that don't add labeled proxy artists
         if ax.legend_ is not None and self._extract_legend_handles:
-            handles = ax.legend_.legendHandles
+            handles = get_legend_handles(ax.legend_)
             labels = [t.get_text() for t in ax.legend_.texts]
             data.update({l: h for h, l in zip(handles, labels)})
 

--- a/seaborn/utils.py
+++ b/seaborn/utils.py
@@ -445,7 +445,9 @@ def move_legend(obj, loc, **kwargs):
         raise ValueError(err)
 
     # Extract the components of the legend we need to reuse
-    handles = old_legend.legendHandles
+    # Import here to avoid a circular import
+    from seaborn._compat import get_legend_handles
+    handles = get_legend_handles(old_legend)
     labels = [t.get_text() for t in old_legend.get_texts()]
 
     # Extract legend properties that can be passed to the recreation method

--- a/tests/test_axisgrid.py
+++ b/tests/test_axisgrid.py
@@ -22,6 +22,7 @@ from seaborn._testing import (
     assert_plots_equal,
     assert_colors_equal,
 )
+from seaborn._compat import get_legend_handles
 
 rs = np.random.RandomState(0)
 
@@ -1280,7 +1281,7 @@ class TestPairGrid:
         g.map_offdiag(histplot)
         g.add_legend()
 
-        assert len(g._legend.legendHandles) == len(self.df["a"].unique())
+        assert len(get_legend_handles(g._legend)) == len(self.df["a"].unique())
 
     def test_pairplot(self):
 
@@ -1417,8 +1418,8 @@ class TestPairGrid:
         vars = ["x", "y", "z"]
         markers = ["o", "X", "s"]
         g = ag.pairplot(self.df, hue="a", vars=vars, markers=markers)
-        m1 = g._legend.legendHandles[0].get_paths()[0]
-        m2 = g._legend.legendHandles[1].get_paths()[0]
+        m1 = get_legend_handles(g._legend)[0].get_paths()[0]
+        m2 = get_legend_handles(g._legend)[1].get_paths()[0]
         assert m1 != m2
 
         with pytest.warns(UserWarning):

--- a/tests/test_categorical.py
+++ b/tests/test_categorical.py
@@ -34,7 +34,7 @@ from seaborn.categorical import (
 )
 from seaborn.palettes import color_palette
 from seaborn.utils import _draw_figure
-from seaborn._compat import get_colormap
+from seaborn._compat import get_colormap, get_legend_handles
 from seaborn._testing import assert_plots_equal
 
 
@@ -2658,7 +2658,7 @@ class TestPointPlot(SharedAggTests):
         _draw_figure(ax.figure)
         legend = ax.get_legend()
         assert [t.get_text() for t in legend.texts] == ["x", "y"]
-        for i, handle in enumerate(legend.legendHandles):
+        for i, handle in enumerate(get_legend_handles(legend)):
             assert handle.get_marker() == "o"
             assert handle.get_linestyle() == "-"
             assert same_color(handle.get_color(), f"C{i}")
@@ -2674,7 +2674,7 @@ class TestPointPlot(SharedAggTests):
         kws = dict(marker="s", linewidth=1)
         ax = pointplot(x=x, y=y, hue=hue, **kws)
         legend = ax.get_legend()
-        for i, handle in enumerate(legend.legendHandles):
+        for i, handle in enumerate(get_legend_handles(legend)):
             assert handle.get_marker() == kws["marker"]
             assert handle.get_linewidth() == kws["linewidth"]
 
@@ -2689,7 +2689,7 @@ class TestPointPlot(SharedAggTests):
         kws = dict(markers=["s", "d"], linestyles=["--", ":"])
         ax = pointplot(x=x, y=y, hue=hue, **kws)
         legend = ax.get_legend()
-        for i, handle in enumerate(legend.legendHandles):
+        for i, handle in enumerate(get_legend_handles(legend)):
             assert handle.get_marker() == kws["markers"][i]
             assert handle.get_linestyle() == kws["linestyles"][i]
 

--- a/tests/test_relational.py
+++ b/tests/test_relational.py
@@ -22,7 +22,7 @@ from seaborn.relational import (
 )
 
 from seaborn.utils import _draw_figure
-from seaborn._compat import get_colormap
+from seaborn._compat import get_colormap, get_legend_handles
 from seaborn._testing import assert_plots_equal
 
 
@@ -1739,7 +1739,7 @@ class TestScatterPlotter(SharedAxesLevelTests, Helpers):
         legend_data = [
             {
                 label.get_text(): handle.get_sizes().item()
-                for label, handle in zip(legend.get_texts(), legend.legendHandles)
+                for label, handle in zip(legend.get_texts(), get_legend_handles(legend))
             } for legend in legends
         ]
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -31,6 +31,7 @@ from seaborn.utils import (
     _deprecate_ci,
     _version_predates, DATASET_NAMES_URL,
 )
+from seaborn._compat import get_legend_handles
 
 
 a_norm = np.random.randn(100)
@@ -407,8 +408,8 @@ def test_move_legend_grid_object(long_df):
     assert g.legend.get_title().get_text() == hue_var
     assert g.legend.get_title().get_size() == fontsize
 
-    assert g.legend.legendHandles
-    for i, h in enumerate(g.legend.legendHandles):
+    assert get_legend_handles(g.legend)
+    for i, h in enumerate(get_legend_handles(g.legend)):
         assert mpl.colors.to_rgb(h.get_color()) == mpl.colors.to_rgb(f"C{i}")
 
 


### PR DESCRIPTION
`matplotlib==3.7.0` warns upon accessing the `legend.legendHandles` attribute, which is an undocumented legend attribute (see https://github.com/matplotlib/matplotlib/pull/24538). This PR changes the usage of this attribute to the new documented way of accessing the handles (`legend.legend_handles`).

The fix involves a dedicated function in `seaborn._compat` module. 