### PR TITLE
Docs fix - heatmap.ipynb.

### DIFF
--- a/doc/_docstrings/heatmap.ipynb
+++ b/doc/_docstrings/heatmap.ipynb
@@ -179,7 +179,7 @@
     "ax.set(xlabel=\"\", ylabel=\"\")\n",
     "ax.xaxis.tick_top()"
    ]
-  },
+  }
  ],
  "metadata": {
   "kernelspec": {

--- a/doc/_docstrings/heatmap.ipynb
+++ b/doc/_docstrings/heatmap.ipynb
@@ -30,7 +30,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "glue = sns.load_dataset(\"glue\").pivot(\"Model\", \"Task\", \"Score\")\n",
+    "glue = sns.load_dataset(\"glue\").pivot(index=\"Model\", columns=\"Task\", values=\"Score\")\n",
     "sns.heatmap(glue)"
    ]
   },
@@ -180,14 +180,6 @@
     "ax.xaxis.tick_top()"
    ]
   },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "1d8e738c-388a-453a-b9c7-4c71a674b69c",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  }
  ],
  "metadata": {
   "kernelspec": {


### PR DESCRIPTION
1. Using keyword-arguments on `.pivot` call, to avoid FutureWarning when pivoting only using positional arguments (see current version of [sns.heatmap docs](https://seaborn.pydata.org/generated/seaborn.heatmap.html#seaborn.heatmap#examples) - first example). To verify the validity of the change, this code can be used:
```
import seaborn as sns
import pandas as pd
positional = sns.load_dataset("glue").pivot("Model", "Task", "Score")
kw = sns.load_dataset("glue").pivot(index="Model", columns="Task", values="Score") 
pd.testing.assert_frame_equal(positional, kw)
```

2. Removed empty code cell in the end of the document.