### PR TITLE
MAINT: address numpy125 deprecations

### DIFF
--- a/seaborn/_core/plot.py
+++ b/seaborn/_core/plot.py
@@ -45,15 +45,9 @@ from seaborn.rcmod import axes_style, plotting_context
 from seaborn.palettes import color_palette
 from seaborn.utils import _version_predates
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypedDict
 if TYPE_CHECKING:
     from matplotlib.figure import SubFigure
-
-
-if sys.version_info >= (3, 8):
-    from typing import TypedDict
-else:
-    from typing_extensions import TypedDict
 
 
 default = Default()

--- a/seaborn/_core/plot.py
+++ b/seaborn/_core/plot.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import io
 import os
 import re
-import sys
 import inspect
 import itertools
 import textwrap

--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -554,7 +554,7 @@ class _DendrogramPlotter:
         try:
             return self._calculate_linkage_fastcluster()
         except ImportError:
-            if np.product(self.shape) >= 10000:
+            if np.prod(self.shape) >= 10000:
                 msg = ("Clustering large matrix with scipy. Installing "
                        "`fastcluster` may give better performance.")
                 warnings.warn(msg)

--- a/tests/test_axisgrid.py
+++ b/tests/test_axisgrid.py
@@ -6,10 +6,7 @@ import matplotlib.pyplot as plt
 import pytest
 import numpy.testing as npt
 from numpy.testing import assert_array_equal, assert_array_almost_equal
-try:
-    import pandas.testing as tm
-except ImportError:
-    import pandas.util.testing as tm
+import pandas.testing as tm
 
 from seaborn._oldcore import categorical_order
 from seaborn import rcmod

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -21,10 +21,7 @@ except ImportError:
     _no_fastcluster = True
 
 import numpy.testing as npt
-try:
-    import pandas.testing as pdt
-except ImportError:
-    import pandas.util.testing as pdt
+import pandas.testing as pdt
 import pytest
 
 from seaborn import matrix as mat

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -7,10 +7,7 @@ import pandas as pd
 
 import pytest
 import numpy.testing as npt
-try:
-    import pandas.testing as pdt
-except ImportError:
-    import pandas.util.testing as pdt
+import pandas.testing as pdt
 
 try:
     import statsmodels.regression.linear_model as smlm

--- a/tests/test_relational.py
+++ b/tests/test_relational.py
@@ -95,7 +95,7 @@ class TestRelationalPlotter(Helpers):
         p.assign_variables(data=wide_df)
         assert p.input_format == "wide"
         assert list(p.variables) == ["x", "y", "hue", "style"]
-        assert len(p.plot_data) == np.product(wide_df.shape)
+        assert len(p.plot_data) == np.prod(wide_df.shape)
 
         x = p.plot_data["x"]
         expected_x = np.tile(wide_df.index, wide_df.shape[1])
@@ -127,7 +127,7 @@ class TestRelationalPlotter(Helpers):
 
         numeric_df = long_df.select_dtypes("number")
 
-        assert len(p.plot_data) == np.product(numeric_df.shape)
+        assert len(p.plot_data) == np.prod(numeric_df.shape)
 
         x = p.plot_data["x"]
         expected_x = np.tile(numeric_df.index, numeric_df.shape[1])
@@ -158,7 +158,7 @@ class TestRelationalPlotter(Helpers):
         p.assign_variables(data=wide_array)
         assert p.input_format == "wide"
         assert list(p.variables) == ["x", "y", "hue", "style"]
-        assert len(p.plot_data) == np.product(wide_array.shape)
+        assert len(p.plot_data) == np.prod(wide_array.shape)
 
         nrow, ncol = wide_array.shape
 
@@ -189,7 +189,7 @@ class TestRelationalPlotter(Helpers):
         p.assign_variables(data=flat_array)
         assert p.input_format == "wide"
         assert list(p.variables) == ["x", "y"]
-        assert len(p.plot_data) == np.product(flat_array.shape)
+        assert len(p.plot_data) == np.prod(flat_array.shape)
 
         x = p.plot_data["x"]
         expected_x = np.arange(flat_array.shape[0])


### PR DESCRIPTION
This PR addresses deprecations in the forthcoming numpy 1.25 and also removes some unreachable code paths.