### PR TITLE
Bugfix issue 3230

### DIFF
--- a/doc/whatsnew/v0.13.0.rst
+++ b/doc/whatsnew/v0.13.0.rst
@@ -12,3 +12,5 @@ v0.13.0 (Unreleased)
 - |Fix| Fixed a bug introduced in v0.12.0 where :func:`histplot` added a stray empty `BarContainer` (:pr:`3246`).
 
 - |Fix| Fixed a bug where :meth:`objects.Plot.on` would override a figure's layout engine (:pr:`3216`).
+
+- |Fix| Fixed a bug introduced in v0.12.0 where :func:`lineplot` with a list of tuples for the keyword argument dashes caused a TypeError (:pr:`3316`).

--- a/seaborn/relational.py
+++ b/seaborn/relational.py
@@ -417,22 +417,6 @@ class _LinePlotter(_RelationalPlotter):
                         sub_data[col] = np.power(10, sub_data[col])
 
             # --- Draw the main line(s)
-            if "hue" in sub_vars:
-                kws["color"] = self._hue_map(sub_vars["hue"])
-            if "size" in sub_vars:
-                kws["linewidth"] = self._size_map(sub_vars["size"])
-            if "style" in sub_vars:
-                attributes = self._style_map(sub_vars["style"])
-                if "dashes" in attributes:
-                    kws["dashes"] = attributes["dashes"]
-                if "marker" in attributes:
-                    kws["marker"] = attributes["marker"]
-
-            (line,) = ax.plot([], [], **kws)
-            line_color = line.get_color()
-            line_alpha = line.get_alpha()
-            line_capstyle = line.get_solid_capstyle()
-            line.remove()
 
             if "units" in self.variables:   # XXX why not add to grouping variables?
                 lines = []
@@ -440,6 +424,25 @@ class _LinePlotter(_RelationalPlotter):
                     lines.extend(ax.plot(unit_data["x"], unit_data["y"], **kws))
             else:
                 lines = ax.plot(sub_data["x"], sub_data["y"], **kws)
+
+            for line in lines:
+
+                if "hue" in sub_vars:
+                    line.set_color(self._hue_map(sub_vars["hue"]))
+
+                if "size" in sub_vars:
+                    line.set_linewidth(self._size_map(sub_vars["size"]))
+
+                if "style" in sub_vars:
+                    attributes = self._style_map(sub_vars["style"])
+                    if "dashes" in attributes:
+                        line.set_dashes(attributes["dashes"])
+                    if "marker" in attributes:
+                        line.set_marker(attributes["marker"])
+
+            line_color = line.get_color()
+            line_alpha = line.get_alpha()
+            line_capstyle = line.get_solid_capstyle()
 
             # --- Draw the confidence intervals
 
@@ -593,7 +596,7 @@ def lineplot(
     if ax is None:
         ax = plt.gca()
 
-    if style is None and not {"ls", "linestyle"} & set(kwargs):  # XXX
+    if "style" not in p.variables and not {"ls", "linestyle"} & set(kwargs):  # XXX
         kwargs["dashes"] = "" if dashes is None or isinstance(dashes, bool) else dashes
 
     if not p.has_xy_data:

--- a/seaborn/relational.py
+++ b/seaborn/relational.py
@@ -417,6 +417,22 @@ class _LinePlotter(_RelationalPlotter):
                         sub_data[col] = np.power(10, sub_data[col])
 
             # --- Draw the main line(s)
+            if "hue" in sub_vars:
+                kws["color"] = self._hue_map(sub_vars["hue"])
+            if "size" in sub_vars:
+                kws["linewidth"] = self._size_map(sub_vars["size"])
+            if "style" in sub_vars:
+                attributes = self._style_map(sub_vars["style"])
+                if "dashes" in attributes:
+                    kws["dashes"] = attributes["dashes"]
+                if "marker" in attributes:
+                    kws["marker"] = attributes["marker"]
+
+            (line,) = ax.plot([], [], **kws)
+            line_color = line.get_color()
+            line_alpha = line.get_alpha()
+            line_capstyle = line.get_solid_capstyle()
+            line.remove()
 
             if "units" in self.variables:   # XXX why not add to grouping variables?
                 lines = []
@@ -424,25 +440,6 @@ class _LinePlotter(_RelationalPlotter):
                     lines.extend(ax.plot(unit_data["x"], unit_data["y"], **kws))
             else:
                 lines = ax.plot(sub_data["x"], sub_data["y"], **kws)
-
-            for line in lines:
-
-                if "hue" in sub_vars:
-                    line.set_color(self._hue_map(sub_vars["hue"]))
-
-                if "size" in sub_vars:
-                    line.set_linewidth(self._size_map(sub_vars["size"]))
-
-                if "style" in sub_vars:
-                    attributes = self._style_map(sub_vars["style"])
-                    if "dashes" in attributes:
-                        line.set_dashes(attributes["dashes"])
-                    if "marker" in attributes:
-                        line.set_marker(attributes["marker"])
-
-            line_color = line.get_color()
-            line_alpha = line.get_alpha()
-            line_capstyle = line.get_solid_capstyle()
 
             # --- Draw the confidence intervals
 

--- a/tests/test_relational.py
+++ b/tests/test_relational.py
@@ -680,6 +680,12 @@ class TestRelationalPlotter(Helpers):
         for text in g.legend.texts:
             assert float(text.get_text()) > 1e7
 
+    def test_lineplot_2d_dashes(self, long_df):
+
+        ax = lineplot(data=long_df[["x", "y"]], dashes=[(5, 5), (10, 10)])
+        assert ax.get_lines()[0]._us_dashSeq
+        assert ax.get_lines()[3]._us_dashSeq
+
 
 class TestLinePlotter(SharedAxesLevelTests, Helpers):
 

--- a/tests/test_relational.py
+++ b/tests/test_relational.py
@@ -683,8 +683,8 @@ class TestRelationalPlotter(Helpers):
     def test_lineplot_2d_dashes(self, long_df):
 
         ax = lineplot(data=long_df[["x", "y"]], dashes=[(5, 5), (10, 10)])
-        assert ax.get_lines()[0]._us_dashSeq
-        assert ax.get_lines()[3]._us_dashSeq
+        assert ax.get_lines()[0]._us_dashSeq == (5, 5)
+        assert ax.get_lines()[3]._us_dashSeq == (10, 10)
 
 
 class TestLinePlotter(SharedAxesLevelTests, Helpers):

--- a/tests/test_relational.py
+++ b/tests/test_relational.py
@@ -681,10 +681,9 @@ class TestRelationalPlotter(Helpers):
             assert float(text.get_text()) > 1e7
 
     def test_lineplot_2d_dashes(self, long_df):
-
         ax = lineplot(data=long_df[["x", "y"]], dashes=[(5, 5), (10, 10)])
-        assert ax.get_lines()[0]._us_dashSeq == (5, 5)
-        assert ax.get_lines()[3]._us_dashSeq == (10, 10)
+        for line in ax.get_lines():
+            assert line.is_dashed()
 
 
 class TestLinePlotter(SharedAxesLevelTests, Helpers):


### PR DESCRIPTION
Dear @mwaskom,

I would love to contribute to the amazing project, so I have tried to resolve issue [3230](https://github.com/mwaskom/seaborn/issues/3230).

Issue: The `kws` dict contained a list of tuples of `dashes` instead of single tuple for plotting.
Solution: Revert code partially back to changes made [here](https://github.com/mwaskom/seaborn/pull/2449/files)
Prevention: add an additional test to check for the existing issue
