### PR TITLE
Fixed mwaskom/seaborn#3272

### DIFF
--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -683,11 +683,12 @@ class _CategoricalPlotterNew(_RelationalPlotter):
         markers = self._map_prop_with_hue("marker", markers, "o", plot_kws)
         linestyles = self._map_prop_with_hue("linestyle", linestyles, "-", plot_kws)
 
+        ax = self.ax
+
         positions = self.var_levels[self.orient]
         if self.var_types[self.orient] == "categorical":
-            min_cat_val = int(self.comp_data[self.orient].min())
-            max_cat_val = int(self.comp_data[self.orient].max())
-            positions = [i for i in range(min_cat_val, max_cat_val + 1)]
+            existing_labels = ax._axis_map[self.orient].units._mapping
+            positions = [existing_labels[p] for p in positions]
         else:
             if self._log_scaled(self.orient):
                 positions = np.log10(positions)
@@ -698,8 +699,6 @@ class _CategoricalPlotterNew(_RelationalPlotter):
         n_hue_levels = 0 if self._hue_map.levels is None else len(self._hue_map.levels)
         if dodge is True:
             dodge = .025 * n_hue_levels
-
-        ax = self.ax
 
         for sub_vars, sub_data in self.iter_data(iter_vars,
                                                  from_comp_data=True,

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -685,7 +685,9 @@ class _CategoricalPlotterNew(_RelationalPlotter):
 
         positions = self.var_levels[self.orient]
         if self.var_types[self.orient] == "categorical":
-            positions = [i for i, _ in enumerate(positions)]
+            min_cat_val = int(self.comp_data[self.orient].min())
+            max_cat_val = int(self.comp_data[self.orient].max())
+            positions = [i for i in range(min_cat_val, max_cat_val + 1)]
         else:
             if self._log_scaled(self.orient):
                 positions = np.log10(positions)

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -683,8 +683,6 @@ class _CategoricalPlotterNew(_RelationalPlotter):
         markers = self._map_prop_with_hue("marker", markers, "o", plot_kws)
         linestyles = self._map_prop_with_hue("linestyle", linestyles, "-", plot_kws)
 
-        ax = self.ax
-
         positions = self.var_levels[self.orient]
         if self.var_types[self.orient] == "categorical":
             min_cat_val = int(self.comp_data[self.orient].min())
@@ -700,6 +698,8 @@ class _CategoricalPlotterNew(_RelationalPlotter):
         n_hue_levels = 0 if self._hue_map.levels is None else len(self._hue_map.levels)
         if dodge is True:
             dodge = .025 * n_hue_levels
+
+        ax = self.ax
 
         for sub_vars, sub_data in self.iter_data(iter_vars,
                                                  from_comp_data=True,

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -687,8 +687,9 @@ class _CategoricalPlotterNew(_RelationalPlotter):
 
         positions = self.var_levels[self.orient]
         if self.var_types[self.orient] == "categorical":
-            existing_labels = ax._axis_map[self.orient].units._mapping
-            positions = [existing_labels[p] for p in positions]
+            min_cat_val = int(self.comp_data[self.orient].min())
+            max_cat_val = int(self.comp_data[self.orient].max())
+            positions = [i for i in range(min_cat_val, max_cat_val + 1)]
         else:
             if self._log_scaled(self.orient):
                 positions = np.log10(positions)

--- a/tests/test_categorical.py
+++ b/tests/test_categorical.py
@@ -2917,6 +2917,15 @@ class TestPointPlot(SharedAggTests):
         assert l2.get_linewidth() == 2 * l1.get_linewidth()
         assert l2.get_markersize() > l1.get_markersize()
 
+    def test_clipping(self):
+
+            x, y = ['a'], [4]
+            pointplot(x=x, y=y)
+            x, y = ['b'], [5]
+            ax = pointplot(x=x, y=y)
+            y_range = ax.viewLim.intervaly
+            assert y_range[0] < 4 and y_range[1] > 5
+
 
 class TestCountPlot:
 


### PR DESCRIPTION
This pull request fixes bug #3272. Now, sequential calls to seaborn.pointplot, where the oriented axis is categorical, will display all data properly. As a quick demo, here is the output of my code on the original example:
```
sns.pointplot(
    x=pd.Series(["a", "b", "c"], index=[1, 2, 3]),
    y=pd.Series([1, 2, 3], index=[1, 2, 3])
)

sns.pointplot(
    x=pd.Series(["b", "c", "d"], index=[1, 2, 3]),
    y=pd.Series([3, 4, 5], index=[1, 2, 3])
)
```
<img src="https://user-images.githubusercontent.com/37743499/230735881-0ac89452-48c7-4643-b706-7039a52466de.png" width="350" />

Inside `categorical.py::plot_points`, the variables `positions` is used to reindex the data about to be plotted, which is needed to include null-values for certain categories. However, `positions` took the explicit list of categorical variables passed in, and assigned them values starting from 0, instead of their correct positions with respect to the existing image.

In the above example, during the second call, the Series `["b", "c", "d"]` would set `positions=[0, 1, 2]`, when it should have been `positions = [1,2,3]`. This caused the point for `d` to not be graphed.

If the second series was `["b", "c"]`, only the data for `"b"` would show up, and if the second series was `["c", "d"]`, a spot for `d` would appear, but no data for `c` or `d` would be plotted. 
