### PR TITLE
Add read-only permissions to ci.yaml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,6 +9,9 @@ on:
     - cron:  '0 6 * * 1,4' # Each Monday and Thursday at 06:00 UTC
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   NB_KERNEL: python
   MPLBACKEND: Agg


### PR DESCRIPTION
Fixes #3318.

As mentioned in the issue, this PR adds top-level read-only permissions to ci.yaml. This helps protect the project from supply-chain attacks.