### PR TITLE
Temporarily restrict sphinx version to unbreak docs build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ docs = [
     "numpydoc",
     "nbconvert",
     "ipykernel",
+    "sphinx<6.0.0",
     "sphinx-copybutton",
     "sphinx-issues",
     "sphinx-design",


### PR DESCRIPTION
Workaround for the issue in #3322
