### PR TITLE
Updates pydata_sphinx_theme to work with Sphinx >= 6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,12 +47,12 @@ docs = [
     "numpydoc",
     "nbconvert",
     "ipykernel",
-    "sphinx<6.0.0",
+    "sphinx",
     "sphinx-copybutton",
     "sphinx-issues",
     "sphinx-design",
     "pyyaml",
-    "pydata_sphinx_theme==0.10.0rc2",
+    "pydata_sphinx_theme==0.13.3",
 ]
 
 [project.urls]


### PR DESCRIPTION
Fixes https://github.com/mwaskom/seaborn/issues/3322

`pydata_sphinx_theme==0.13.X` includes https://github.com/pydata/pydata-sphinx-theme/pull/1097 which fixes the `logo` issue in Sphinx 6.0