### PR TITLE
Remove matplotlib cache manipulation

### DIFF
--- a/seaborn/_core/plot.py
+++ b/seaborn/_core/plot.py
@@ -97,13 +97,11 @@ def theme_context(params: dict[str, Any]) -> Generator:
         mpl.rcParams.update(params)
         for (code, color) in zip(color_codes, nice_colors):
             mpl.colors.colorConverter.colors[code] = color
-            mpl.colors.colorConverter.cache[code] = color
         yield
     finally:
         mpl.rcParams.update(orig_params)
         for (code, color) in zip(color_codes, orig_colors):
             mpl.colors.colorConverter.colors[code] = color
-            mpl.colors.colorConverter.cache[code] = color
 
 
 def build_plot_signature(cls):

--- a/seaborn/palettes.py
+++ b/seaborn/palettes.py
@@ -839,4 +839,3 @@ def set_color_codes(palette="deep"):
     for code, color in zip("bgrmyck", colors):
         rgb = mpl.colors.colorConverter.to_rgb(color)
         mpl.colors.colorConverter.colors[code] = rgb
-        mpl.colors.colorConverter.cache[code] = rgb


### PR DESCRIPTION
The `colorConverter.cache` manipulation is not actually doing what appears to be expected.

Since mpl 2.0 (matplotlib/matplotlib#6382), whenever `colorConverter.colors` is updated, `colorConverter.cache` is emptied.
Thus in each location where it is accessed within seaborn, only the last element (`"k"`) actually survives in the cache at all.

Additionally, internal matplotlib usage uses the `("color", alpha)` tuple as the cache keys rather than just the `"color"`, so I don't think that `"k"` will ever be looked up by mpl code even though it is in the cache.

As such, I thought the simplest solution was to simply remove the cache manipulation entirely, since it has no ill effect, and the cache of old values is correctly invalidated regardless.

This was found as I have been running type checkers over some of our (matplotlib's) dependencies after matplotlib/matplotlib#24976.

I had typed the cache as having the tuple form as keys after inspecting internal usage, and that was flagged when I type checked over here.

There are still type checking errors that likely need to be addressed (some on our end which I either have submitted PRs or plan to fix before the release of mpl v3.8 in a couple months)
There remains some need of ensuring seaborn's type hints are consistent with matplotlibs that may incur a mix of changes on either end, feel free to ping me if you have any questions regarding mpl's type hints, happy to help sort out any errors that are spotted.
I did want to make sure you were aware of this change prior to the mpl release to mitigate chances of our release e.g. failing your CI because of type hints being added.

