### PR TITLE
Add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,10 +5,8 @@ privately. **Do not disclose it as a public issue.** This gives me time to work 
 to fix the issue before public exposure, reducing the chance that the exploit will be
 used before a patch is released.
 
-You may submit the report in the following ways:
-
-- send an email to mwaskom@gmail.com; and/or
-- send me a [private vulnerability report](https://github.com/mwaskom/seaborn/security/advisories/new)
+You may submit the report by filling out
+[this form](https://github.com/mwaskom/seaborn/security/advisories/new).
 
 Please provide the following information in your report:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+# Security Policy
+
+If you have discovered a security vulnerability in this project, please report it
+privately. **Do not disclose it as a public issue.** This gives me time to work with you
+to fix the issue before public exposure, reducing the chance that the exploit will be
+used before a patch is released.
+
+You may submit the report in the following ways:
+
+- send an email to mwaskom@gmail.com; and/or
+- send me a [private vulnerability report](https://github.com/mwaskom/seaborn/security/advisories/new)
+
+Please provide the following information in your report:
+
+- A description of the vulnerability and its impact
+- How to reproduce the issue
+
+This project is maintained by a single maintainer on a reasonable-effort basis. As such,
+I ask that you give me 90 days to work on a fix before public exposure.


### PR DESCRIPTION
Fixes #3343.

As described in the issue, this PR adds a security policy for seaborn.

The policy currently uses an email I found in the pyproject.toml file. It also suggests using GitHub's private reporting feature (must be enabled in the project settings). Let me know if you'd rather use just one means of reporting and/or change the email.

The policy also contains a 90-day remediation timeline, which I adopted because it's pretty common. But let me know if you'd rather change that (or anything else!).