### PR TITLE
pandas 2.0 compat: address is_categorical_dtype deprecation

### DIFF
--- a/seaborn/_core/rules.py
+++ b/seaborn/_core/rules.py
@@ -67,7 +67,7 @@ def variable_type(
     """
 
     # If a categorical dtype is set, infer categorical
-    if pd.api.types.is_categorical_dtype(vector):
+    if isinstance(getattr(vector, 'dtype', None), pd.CategoricalDtype):
         return VarType("categorical")
 
     # Special-case all-na data, which is always "numeric"

--- a/seaborn/_oldcore.py
+++ b/seaborn/_oldcore.py
@@ -1497,7 +1497,7 @@ def variable_type(vector, boolean_type="numeric"):
     """
 
     # If a categorical dtype is set, infer categorical
-    if pd.api.types.is_categorical_dtype(vector):
+    if isinstance(getattr(vector, 'dtype', None), pd.CategoricalDtype):
         return VariableType("categorical")
 
     # Special-case all-na data, which is always "numeric"


### PR DESCRIPTION
this shows up in the outputs from https://github.com/mwaskom/seaborn/pull/3340