### PR TITLE
DOC: Fix typo in include directive

### DIFF
--- a/seaborn/palettes.py
+++ b/seaborn/palettes.py
@@ -388,7 +388,7 @@ def mpl_palette(name, n_colors=6, as_cmap=False):
 
     Examples
     --------
-    .. include: ../docstrings/mpl_palette.rst
+    .. include:: ../docstrings/mpl_palette.rst
 
     """
     if name.endswith("_d"):

--- a/seaborn/regression.py
+++ b/seaborn/regression.py
@@ -836,7 +836,7 @@ regplot.__doc__ = dedent("""\
     Examples
     --------
 
-    .. include: ../docstrings/regplot.rst
+    .. include:: ../docstrings/regplot.rst
 
     """).format(**_regression_docs)
 


### PR DESCRIPTION
The missing second colon prevented the examples for `regplot` and `mpl_palette` from being included in the documentation.

![image](https://user-images.githubusercontent.com/19879328/236911555-94a0f7a3-abf0-4add-b464-d382e5337fa6.png)
