### PR TITLE
TST: Make test_index_alignment_between_series less brittle

### DIFF
--- a/tests/_core/test_data.py
+++ b/tests/_core/test_data.py
@@ -187,8 +187,9 @@ class TestPlotData:
 
         p = PlotData(None, {"x": x, "y": y})
 
-        x_col_expected = pd.Series([10, 20, 30, np.nan, np.nan], np.arange(1, 6))
-        y_col_expected = pd.Series([np.nan, np.nan, 300, 400, 500], np.arange(1, 6))
+        idx_expected = [1, 2, 3, 4, 5]
+        x_col_expected = pd.Series([10, 20, 30, np.nan, np.nan], idx_expected)
+        y_col_expected = pd.Series([np.nan, np.nan, 300, 400, 500], idx_expected)
         assert_vector_equal(p.frame["x"], x_col_expected)
         assert_vector_equal(p.frame["y"], y_col_expected)
 


### PR DESCRIPTION
`test_index_alignment_between_series` fails on Windows but passes on Linux. The reason is that the indices of the expected Series are created using the default dtype of an integer np.arange which is int64 on Linux but int32 on Windows (see for instance https://stackoverflow.com/questions/36278590/numpy-array-dtype-is-coming-as-int32-by-default-in-a-windows-10-64-bit-machine). The DataFrame default RangeIndex is always of dtype int64.  

With this PR, the range is created with an explicit dtype to make the test independent of the default integer type.
