### PR TITLE
Add gap/fill parameters to barplot and countplot

### DIFF
--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -3023,8 +3023,8 @@ pointplot.__doc__ = dedent("""\
 
 def countplot(
     data=None, *, x=None, y=None, hue=None, order=None, hue_order=None,
-    orient=None, color=None, palette=None, saturation=.75, hue_norm=None,
-    stat="count", width=.8, dodge="auto", native_scale=False, formatter=None,
+    orient=None, color=None, palette=None, saturation=.75, fill=True, hue_norm=None,
+    stat="count", width=.8, dodge="auto", gap=0, native_scale=False, formatter=None,
     legend="auto", ax=None, **kwargs
 ):
 
@@ -3065,6 +3065,7 @@ def countplot(
     hue_order = p._palette_without_hue_backcompat(palette, hue_order)
     palette, hue_order = p._hue_backcompat(color, palette, hue_order)
 
+    saturation = saturation if fill else 1
     p.map_hue(palette=palette, order=hue_order, norm=hue_norm, saturation=saturation)
     color = _default_color(ax.bar, hue, color, kwargs, saturation)
 
@@ -3084,7 +3085,9 @@ def countplot(
         aggregator=aggregator,
         dodge=dodge,
         width=width,
+        gap=gap,
         color=color,
+        fill=fill,
         capsize=0,
         err_kws={},
         plot_kws=kwargs,
@@ -3460,11 +3463,16 @@ def catplot(
                 denom = 100 if stat == "percent" else 1
                 p.plot_data[count_axis] /= len(p.plot_data) / denom
 
+            gap = kwargs.pop("gap", 0)
+            fill = kwargs.pop("fill", True)
+
             p.plot_bars(
                 aggregator=aggregator,
                 dodge=dodge,
                 width=width,
+                gap=gap,
                 color=color,
+                fill=fill,
                 capsize=0,
                 err_kws={},
                 plot_kws=kwargs,

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -1077,7 +1077,6 @@ class _CategoricalPlotterNew(_RelationalPlotter):
         if not fill:
             plot_kws.setdefault("linewidth", 1.5 * mpl.rcParams["lines.linewidth"])
 
-        err_color = err_kws.pop("color", ".26")
         err_kws.setdefault("linewidth", 1.5 * mpl.rcParams["lines.linewidth"])
 
         for sub_vars, sub_data in self.iter_data(iter_vars,
@@ -1113,21 +1112,22 @@ class _CategoricalPlotterNew(_RelationalPlotter):
                     y=agg_data["edge"], width=agg_data["x"], height=agg_data["width"]
                 )
 
-            maincolor = self._hue_map(sub_vars["hue"]) if "hue" in sub_vars else color
+            main_color = self._hue_map(sub_vars["hue"]) if "hue" in sub_vars else color
 
             # Set both color and facecolor for property cycle logic
             kws["align"] = "edge"
             if fill:
-                kws.update(color=maincolor, facecolor=maincolor)
-                err_kws.update(color=err_color)
+                kws.update(color=main_color, facecolor=main_color)
             else:
-                kws.update(color=maincolor, edgecolor=maincolor, facecolor="none")
-                err_kws.update(color=maincolor)
+                kws.update(color=main_color, edgecolor=main_color, facecolor="none")
 
             bar_func(**{**kws, **plot_kws})
 
             if aggregator.error_method is not None:
-                self.plot_errorbars(ax, agg_data, capsize, err_kws.copy())
+                self.plot_errorbars(
+                    ax, agg_data, capsize,
+                    {"color": ".26" if fill else main_color, **err_kws}
+                )
 
         self._configure_legend(ax, ax.fill_between)
 

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -1075,7 +1075,7 @@ class _CategoricalPlotterNew(_RelationalPlotter):
             capsize = capsize / len(self._hue_map.levels)
 
         if not fill:
-            plot_kws.setdefault("linewidth", mpl.rcParams["lines.linewidth"])
+            plot_kws.setdefault("linewidth", 1.5 * mpl.rcParams["lines.linewidth"])
 
         err_color = err_kws.pop("color", ".26")
         err_kws.setdefault("linewidth", 1.5 * mpl.rcParams["lines.linewidth"])

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -3425,19 +3425,22 @@ def catplot(
             aggregator = EstimateAggregator(
                 estimator, errorbar, n_boot=n_boot, seed=seed
             )
-
             err_kws, capsize = p._err_kws_backcompat(
                 _normalize_kwargs(kwargs.pop("err_kws", {}), mpl.lines.Line2D),
                 errcolor=kwargs.pop("errcolor", deprecated),
                 errwidth=kwargs.pop("errwidth", deprecated),
                 capsize=kwargs.pop("capsize", 0),
             )
+            gap = kwargs.pop("gap", 0)
+            fill = kwargs.pop("fill", True)
 
             p.plot_bars(
                 aggregator=aggregator,
                 dodge=dodge,
                 width=width,
+                gap=gap,
                 color=color,
+                fill=fill,
                 capsize=capsize,
                 err_kws=err_kws,
                 plot_kws=kwargs,

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -2829,13 +2829,15 @@ barplot.__doc__ = dedent("""\
     {color}
     {palette}
     {saturation}
+    {fill}
     {hue_norm}
     {width}
-    {capsize}
     {dodge}
+    {gap}
     {native_scale}
     {formatter}
     {legend}
+    {capsize}
     {err_kws}
     {ci}
     {errcolor}

--- a/tests/test_categorical.py
+++ b/tests/test_categorical.py
@@ -2282,11 +2282,12 @@ class TestBarPlot(SharedAggTests):
             assert bar.get_facecolor() == kwargs["facecolor"]
             assert bar.get_rasterized() == kwargs["rasterized"]
 
-    def test_err_kws(self):
+    @pytest.mark.parametrize("fill", [True, False])
+    def test_err_kws(self, fill):
 
         x, y = ["a", "b", "c"], [1, 2, 3]
         err_kws = dict(color=(1, 1, .5, .5), linewidth=5)
-        ax = barplot(x=x, y=y, err_kws=err_kws)
+        ax = barplot(x=x, y=y, fill=fill, err_kws=err_kws)
         for line in ax.lines:
             assert line.get_color() == err_kws["color"]
             assert line.get_linewidth() == err_kws["linewidth"]

--- a/tests/test_categorical.py
+++ b/tests/test_categorical.py
@@ -2017,6 +2017,16 @@ class TestBarPlot(SharedAggTests):
             assert bar.get_width() == approx(0.8 / 2)
             assert same_color(bar.get_facecolor(), f"C{i // 2}")
 
+    def test_gap(self):
+
+        x = ["a", "b", "a", "b"]
+        y = [1, 2, 3, 4]
+        hue = ["x", "x", "y", "y"]
+
+        ax = barplot(x=x, y=y, hue=hue, gap=.25)
+        for i, bar in enumerate(ax.patches):
+            assert bar.get_width() == approx(0.8 / 2 * .75)
+
     def test_hue_undodged(self):
 
         x = ["a", "b", "a", "b"]
@@ -2050,6 +2060,17 @@ class TestBarPlot(SharedAggTests):
         assert colors[0] == colors[1]
         assert colors[1] != colors[2]
         assert colors[2] == colors[3]
+
+    def test_fill(self):
+
+        x = ["a", "b", "a", "b"]
+        y = [1, 2, 3, 4]
+        hue = ["x", "x", "y", "y"]
+
+        ax = barplot(x=x, y=y, hue=hue, fill=False)
+        for i, bar in enumerate(ax.patches):
+            assert same_color(bar.get_edgecolor(), f"C{i // 2}")
+            assert same_color(bar.get_facecolor(), (0, 0, 0, 0))
 
     def test_xy_native_scale(self):
 
@@ -2284,7 +2305,7 @@ class TestBarPlot(SharedAggTests):
             dict(data=None, x="s", y="y", hue="a"),
             dict(data="long", x="a", y="y", hue="s"),
             dict(data="long", x="a", y="y", units="c"),
-            dict(data="null", x="a", y="y", hue="a"),
+            dict(data="null", x="a", y="y", hue="a", gap=.1, fill=False),
             dict(data="long", x="s", y="y", hue="a", native_scale=True),
             dict(data="long", x="d", y="y", hue="a", native_scale=True),
             dict(data="long", x="a", y="y", errorbar=("pi", 50)),


### PR DESCRIPTION
Aligns the new/refactored bar plots with features recently added to `boxplot` and `countplot`:

```python
sns.barplot(tips, x="day", y="total_bill", hue="sex", fill=False, gap=.2)
```
![image](https://github.com/mwaskom/seaborn/assets/315810/d041d545-81a5-4f8a-816d-2e30967bc707)
