### PR TITLE
DOC: Fix some typos

### DIFF
--- a/doc/_tutorial/color_palettes.ipynb
+++ b/doc/_tutorial/color_palettes.ipynb
@@ -855,7 +855,7 @@
     "Diverging color palettes\n",
     "------------------------\n",
     "\n",
-    "The third class of color palettes is called \"diverging\". These are used for data where both large low and high values are interesting and span a midpoint value (often 0) that should be demphasized. The rules for choosing good diverging palettes are similar to good sequential palettes, except now there should be two dominant hues in the colormap, one at (or near) each pole. It's also important that the starting values are of similar brightness and saturation.\n",
+    "The third class of color palettes is called \"diverging\". These are used for data where both large low and high values are interesting and span a midpoint value (often 0) that should be de-emphasized. The rules for choosing good diverging palettes are similar to good sequential palettes, except now there should be two dominant hues in the colormap, one at (or near) each pole. It's also important that the starting values are of similar brightness and saturation.\n",
     "\n",
     "Perceptually uniform diverging palettes\n",
     "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n",

--- a/doc/_tutorial/distributions.ipynb
+++ b/doc/_tutorial/distributions.ipynb
@@ -708,7 +708,7 @@
     "Plotting joint and marginal distributions\n",
     "^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
     "\n",
-    "The first is :func:`jointplot`, which augments a bivariate relatonal or distribution plot with the marginal distributions of the two variables. By default, :func:`jointplot` represents the bivariate distribution using :func:`scatterplot` and the marginal distributions using :func:`histplot`:"
+    "The first is :func:`jointplot`, which augments a bivariate relational or distribution plot with the marginal distributions of the two variables. By default, :func:`jointplot` represents the bivariate distribution using :func:`scatterplot` and the marginal distributions using :func:`histplot`:"
    ]
   },
   {

--- a/doc/_tutorial/objects_interface.ipynb
+++ b/doc/_tutorial/objects_interface.ipynb
@@ -577,7 +577,7 @@
    "id": "295013b3-7d91-4a59-b63b-fe50e642954c",
    "metadata": {},
    "source": [
-    "To recap, there are three ways to specify the value of a mark property: (1) by mapping a variable in all layers, (2) by mapping a variable in a specific layer, and (3) by setting the property directy:"
+    "To recap, there are three ways to specify the value of a mark property: (1) by mapping a variable in all layers, (2) by mapping a variable in a specific layer, and (3) by setting the property directly:"
    ]
   },
   {
@@ -1052,7 +1052,7 @@
    "id": "475d5157-5e88-473e-991f-528219ed3744",
    "metadata": {},
    "source": [
-    "To change the theme for all :class:`Plot` instances, update the settings in :attr:`Plot.config:"
+    "To change the theme for all :class:`Plot` instances, update the settings in :attr:`Plot.config`:"
    ]
   },
   {

--- a/doc/_tutorial/properties.ipynb
+++ b/doc/_tutorial/properties.ipynb
@@ -48,7 +48,7 @@
     "x, y, xmin, xmax, ymin, ymax\n",
     "~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n",
     "\n",
-    "Coordinate properties determine where a mark is drawn on a plot. Canonically, the `x` coordinate is the horizontal positon and the `y` coordinate is the vertical position. Some marks accept a span (i.e., `min`, `max`) parameterization for one or both variables. Others may accept `x` and `y` but also use a `baseline` parameter to show a span. The layer's `orient` parameter determines how this works.\n",
+    "Coordinate properties determine where a mark is drawn on a plot. Canonically, the `x` coordinate is the horizontal position and the `y` coordinate is the vertical position. Some marks accept a span (i.e., `min`, `max`) parameterization for one or both variables. Others may accept `x` and `y` but also use a `baseline` parameter to show a span. The layer's `orient` parameter determines how this works.\n",
     "\n",
     "If a variable does not contain numeric data, its scale will apply a conversion so that data can be drawn on a screen. For instance, :class:`Nominal` scales assign an integer index to each distinct category, and :class:`Temporal` scales represent dates as the number of days from a reference \"epoch\":"
    ]
@@ -674,7 +674,7 @@
     "linestyle, edgestyle\n",
     "~~~~~~~~~~~~~~~~~~~~\n",
     "\n",
-    "The `linestyle` property is relevant to line marks, and the `edgestyle` propety is relevant to a number of marks with \"edges. Both properties determine the \"dashing\" of a line in terms of on-off segments.\n",
+    "The `linestyle` property is relevant to line marks, and the `edgestyle` property is relevant to a number of marks with \"edges. Both properties determine the \"dashing\" of a line in terms of on-off segments.\n",
     "\n",
     "Dashes can be specified with a small number of shorthand codes (`'-'`, `'--'`, `'-.'`, and `':'`) or programatically using `(on, off, ...)` tuples. In the tuple specification, the unit is equal to the linewidth:"
    ]

--- a/seaborn/_marks/bar.py
+++ b/seaborn/_marks/bar.py
@@ -183,7 +183,7 @@ class Bar(BarBase):
 @dataclass
 class Bars(BarBase):
     """
-    A faster bar mark with defaults more suitable histograms.
+    A faster bar mark with defaults more suitable for histograms.
 
     See also
     --------


### PR DESCRIPTION
There are also varying spellings for
* program***m***atically/programatically (6 and 2 occurences, repsectively)
* paramet***e***rize/parametrize (6 and 5 occurences, the latter is the version used by `pytest`)

I guess this is an American vs British spelling thing, not sure which version you want to stick with?

