### PR TITLE
Support polars and other data libraries via dataframe interchange

### DIFF
--- a/seaborn/_base.py
+++ b/seaborn/_base.py
@@ -703,6 +703,9 @@ class VectorPlotter:
                 data, **variables,
             )
         else:
+            # When dealing with long-form input, use the newer PlotData
+            # object (internal but introduced for the objects interface)
+            # to centralize / standardize data consumption logic.
             self.input_format = "long"
             plot_data = PlotData(data, variables)
             frame = plot_data.frame

--- a/seaborn/_core/data.py
+++ b/seaborn/_core/data.py
@@ -61,7 +61,12 @@ class PlotData:
         self.names = names
         self.ids = ids
 
-        self.frames = {}  # TODO this is a hack, remove
+        # The reason we possibly have a dictionary of frames is to support the
+        # Plot.pair operation, post scaling, where each x/y variable needs its
+        # own frame. This feels pretty clumsy and there are a bunch of places in
+        # the client code with awkard if frame / elif frames constructions.
+        # It would be great to have a cleaner abstraction here.
+        self.frames = {}
 
         self.source_data = data
         self.source_vars = variables

--- a/seaborn/_core/data.py
+++ b/seaborn/_core/data.py
@@ -282,7 +282,7 @@ def convert_dataframe_to_pandas(data: object) -> pd.DataFrame:
         )
         raise TypeError(msg)
 
-    if _version_predates(pd, "2.0.2 "):
+    if _version_predates(pd, "2.0.2"):
         msg = (
             "DataFrame interchange with pandas<2.0.2 has some known issues. "
             f"You are using pandas {pd.__version__}. "

--- a/seaborn/_core/data.py
+++ b/seaborn/_core/data.py
@@ -304,6 +304,12 @@ def convert_dataframe_to_pandas(data: object) -> pd.DataFrame:
         warnings.warn(msg, stacklevel=2)
 
     try:
+        # This is going to convert all columns in the input dataframe, even though
+        # we may only need one or two of them. It would be more efficient to select
+        # the columns that are going to be used in the plot prior to interchange.
+        # Solving that in general is a hard problem, especially with the objects
+        # interface where variables passed in Plot() may only be referenced later
+        # in Plot.add(). But noting here in case this seems to be a bottleneck.
         return pd.api.interchange.from_dataframe(data)
     except Exception as err:
         msg = (

--- a/seaborn/_core/data.py
+++ b/seaborn/_core/data.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 
 from collections.abc import Mapping, Sized
 from typing import cast
+import warnings
 
 import pandas as pd
 from pandas import DataFrame
 
 from seaborn._core.typing import DataSource, VariableSpec, ColumnName
+from seaborn.utils import _version_predates
 
 
 class PlotData:
@@ -273,12 +275,21 @@ def convert_dataframe_to_pandas(data: object) -> pd.DataFrame:
         return data
     if not hasattr(pd.api, "interchange"):
         msg = (
-            "Support for non-pandas DataFrame objects requires a version of pandas"
+            "Support for non-pandas DataFrame objects requires a version of pandas "
             "that implements the DataFrame interchange protocol. Please upgrade "
             "your pandas version or coerce your data to pandas before passing "
             "it to seaborn."
         )
         raise TypeError(msg)
+
+    if _version_predates(pd, "2.0.2 "):
+        msg = (
+            "DataFrame interchange with pandas<2.0.2 has some known issues. "
+            f"You are using pandas {pd.__version__}. "
+            "Continuing, but it is recommended to carefully inspect the results and to "
+            "consider upgrading."
+        )
+        warnings.warn(msg, stacklevel=2)
 
     try:
         return pd.api.interchange.from_dataframe(data)

--- a/seaborn/_core/plot.py
+++ b/seaborn/_core/plot.py
@@ -346,9 +346,10 @@ class Plot:
             err = "Plot() accepts no more than 3 positional arguments (data, x, y)."
             raise TypeError(err)
 
-        # TODO need some clearer way to differentiate data / vector here
-        # (There might be an abstract DataFrame class to use here?)
-        if isinstance(args[0], (abc.Mapping, pd.DataFrame)):
+        if (
+            isinstance(args[0], (abc.Mapping, pd.DataFrame))
+            or hasattr(args[0], "__dataframe__")
+        ):
             if data is not None:
                 raise TypeError("`data` given by both name and position.")
             data, args = args[0], args[1:]

--- a/seaborn/_core/typing.py
+++ b/seaborn/_core/typing.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
+from collections.abc import Iterable, Mapping
 from datetime import date, datetime, timedelta
-from typing import Any, Optional, Union, Mapping, Tuple, List, Dict
-from collections.abc import Hashable, Iterable
+from typing import Any, Optional, Union, Tuple, List, Dict
 
 from numpy import ndarray  # TODO use ArrayLike?
-from pandas import DataFrame, Series, Index, Timestamp, Timedelta
+from pandas import Series, Index, Timestamp, Timedelta
 from matplotlib.colors import Colormap, Normalize
 
 
@@ -17,7 +17,11 @@ Vector = Union[Series, Index, ndarray]
 VariableSpec = Union[ColumnName, Vector, None]
 VariableSpecList = Union[List[VariableSpec], Index, None]
 
-DataSource = Union[DataFrame, Mapping[Hashable, Vector], None]
+# A DataSource can be an object implementing __dataframe__, or a Mapping
+# (and is optional in all contexts where it is used).
+# I don't think there's an abc for "has __dataframe__", so we type as object
+# but keep the (slightly odd) Union alias for better user-facing annotations.
+DataSource = Union[object, Mapping, None]
 
 OrderSpec = Union[Iterable, None]  # TODO technically str is iterable
 NormSpec = Union[Tuple[Optional[float], Optional[float]], Normalize, None]

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -10,6 +10,7 @@ import matplotlib as mpl
 import matplotlib.pyplot as plt
 
 from ._base import VectorPlotter, variable_type, categorical_order
+from ._core.data import handle_data_source
 from ._compat import share_axis, get_legend_handles
 from . import utils
 from .utils import (
@@ -374,6 +375,7 @@ class FacetGrid(Grid):
     ):
 
         super().__init__()
+        data = handle_data_source(data)
 
         # Determine the hue facet layer information
         hue_var = hue
@@ -1240,6 +1242,7 @@ class PairGrid(Grid):
         """
 
         super().__init__()
+        data = handle_data_source(data)
 
         # Sort out the variables that define the grid
         numeric_cols = self._find_numeric_cols(data)

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -2593,10 +2593,10 @@ def countplot(
 
     if x is None and y is not None:
         orient = "y"
-        x = 1
+        x = 1 if list(y) else None
     elif x is not None and y is None:
         orient = "x"
-        y = 1
+        y = 1 if list(x) else None
     elif x is not None and y is not None:
         raise TypeError("Cannot pass values for both `x` and `y`.")
 

--- a/seaborn/distributions.py
+++ b/seaborn/distributions.py
@@ -2012,6 +2012,7 @@ def rugplot(
             x = data
         elif axis == "y":
             y = data
+        data = None
         msg = textwrap.dedent(f"""\n
         The `axis` parameter has been deprecated; use the `{axis}` parameter instead.
         Please update your code; this will become an error in seaborn v0.13.0.

--- a/tests/_core/test_data.py
+++ b/tests/_core/test_data.py
@@ -144,7 +144,7 @@ class TestPlotData:
             PlotData(long_df, {"x": "x", "y": vector})
 
     @pytest.mark.parametrize(
-        "arg", [[], np.array([]), pd.DataFrame()],
+        "arg", [{}, pd.DataFrame()],
     )
     def test_empty_data_input(self, arg):
 
@@ -397,3 +397,43 @@ class TestPlotData:
         p = PlotData(d1, {"x": "a"}).join(d2, {"y": "a"}).join(None, {"y": "a"})
         assert_vector_equal(p.frame["x"], d1["a"])
         assert_vector_equal(p.frame["y"], d1["a"])
+
+    def test_bad_type(self, flat_list):
+
+        err = "Data source must be a DataFrame or Mapping"
+        with pytest.raises(TypeError, match=err):
+            PlotData(flat_list, {})
+
+    @pytest.mark.skipif(
+        condition=not hasattr(pd.api, "interchange"),
+        reason="Tests behavior assuming support for dataframe interchange"
+    )
+    def test_data_interchange(self, mock_long_df, long_df):
+
+        variables = {"x": "x", "y": "z", "color": "a"}
+        p = PlotData(mock_long_df, variables)
+        for var, col in variables.items():
+            assert_vector_equal(p.frame[var], long_df[col])
+
+        p = PlotData(mock_long_df, {**variables, "color": long_df["a"]})
+        for var, col in variables.items():
+            assert_vector_equal(p.frame[var], long_df[col])
+
+    @pytest.mark.skipif(
+        condition=not hasattr(pd.api, "interchange"),
+        reason="Tests behavior assuming support for dataframe interchange"
+    )
+    def test_data_interchange_failure(self, mock_long_df):
+
+        mock_long_df._data = None  # Break __dataframe__()
+        with pytest.raises(RuntimeError, match="Encountered an exception"):
+            PlotData(mock_long_df, {"x": "x"})
+
+    @pytest.mark.skipif(
+        condition=hasattr(pd.api, "interchange"),
+        reason="Tests graceful failure without support for dataframe interchange"
+    )
+    def test_data_interchange_support_test(self, mock_long_df):
+
+        with pytest.raises(TypeError, match="Support for non-pandas DataFrame"):
+            PlotData(mock_long_df, {"x": "x"})

--- a/tests/_core/test_plot.py
+++ b/tests/_core/test_plot.py
@@ -170,6 +170,15 @@ class TestInit:
         assert p._data.source_data is None
         assert list(p._data.source_vars) == ["x"]
 
+    @pytest.mark.skipif(
+        condition=not hasattr(pd.api, "interchange"),
+        reason="Tests behavior assuming support for dataframe interchange"
+    )
+    def test_positional_interchangeable_dataframe(self, mock_long_df, long_df):
+
+        p = Plot(mock_long_df, x="x")
+        assert_frame_equal(p._data.source_data, long_df)
+
     def test_positional_too_many(self, long_df):
 
         err = r"Plot\(\) accepts no more than 3 positional arguments \(data, x, y\)"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -178,3 +178,19 @@ def object_df(rng, long_df):
 def null_series(flat_series):
 
     return pd.Series(index=flat_series.index, dtype='float64')
+
+
+class MockInterchangeableDataFrame:
+    # Mock object that is not a pandas.DataFrame but that can
+    # be converted to one via the DataFrame exchange protocol
+    def __init__(self, data):
+        self._data = data
+
+    def __dataframe__(self, *args, **kwargs):
+        return self._data.__dataframe__(*args, **kwargs)
+
+
+@pytest.fixture
+def mock_long_df(long_df):
+
+    return MockInterchangeableDataFrame(long_df)

--- a/tests/test_axisgrid.py
+++ b/tests/test_axisgrid.py
@@ -707,6 +707,15 @@ class TestFacetGrid:
                     assert mpl.colors.same_color(tick.tick2line.get_color(), color)
                     assert tick.get_pad() == pad
 
+    def test_data_interchange(self, mock_long_df, long_df):
+
+        g = ag.FacetGrid(mock_long_df, col="a", row="b")
+        g.map(scatterplot, "x", "y")
+
+        assert g.axes.shape == (long_df["b"].nunique(), long_df["a"].nunique())
+        for ax in g.axes.flat:
+            assert len(ax.collections) == 1
+
 
 class TestPairGrid:
 
@@ -1461,6 +1470,14 @@ class TestPairGrid:
                     assert mpl.colors.same_color(tick.tick1line.get_color(), color)
                     assert mpl.colors.same_color(tick.tick2line.get_color(), color)
                     assert tick.get_pad() == pad
+
+    def test_data_interchange(self, mock_long_df, long_df):
+
+        g = ag.PairGrid(mock_long_df, vars=["x", "y", "z"], hue="a")
+        g.map(scatterplot)
+        assert g.axes.shape == (3, 3)
+        for ax in g.axes.flat:
+            assert len(ax.collections) == long_df["a"].nunique() + 1
 
 
 class TestJointGrid:

--- a/tests/test_axisgrid.py
+++ b/tests/test_axisgrid.py
@@ -707,6 +707,10 @@ class TestFacetGrid:
                     assert mpl.colors.same_color(tick.tick2line.get_color(), color)
                     assert tick.get_pad() == pad
 
+    @pytest.mark.skipif(
+        condition=not hasattr(pd.api, "interchange"),
+        reason="Tests behavior assuming support for dataframe interchange"
+    )
     def test_data_interchange(self, mock_long_df, long_df):
 
         g = ag.FacetGrid(mock_long_df, col="a", row="b")
@@ -1471,6 +1475,10 @@ class TestPairGrid:
                     assert mpl.colors.same_color(tick.tick2line.get_color(), color)
                     assert tick.get_pad() == pad
 
+    @pytest.mark.skipif(
+        condition=not hasattr(pd.api, "interchange"),
+        reason="Tests behavior assuming support for dataframe interchange"
+    )
     def test_data_interchange(self, mock_long_df, long_df):
 
         g = ag.PairGrid(mock_long_df, vars=["x", "y", "z"], hue="a")

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -757,7 +757,7 @@ class TestVectorPlotter:
         p = VectorPlotter()
         p.assign_variables(data=long_df, variables={"x": name})
         assert_array_equal(p.plot_data["x"], long_df[name])
-        assert p.variables["x"] == name
+        assert p.variables["x"] == str(name)
 
     def test_long_hierarchical_index(self, rng):
 
@@ -771,7 +771,7 @@ class TestVectorPlotter:
         p = VectorPlotter()
         p.assign_variables(data=df, variables={var: name})
         assert_array_equal(p.plot_data[var], df[name])
-        assert p.variables[var] == name
+        assert p.variables[var] == str(name)
 
     def test_long_scalar_and_data(self, long_df):
 
@@ -788,7 +788,7 @@ class TestVectorPlotter:
 
     def test_long_unknown_error(self, long_df):
 
-        err = "Could not interpret value `what` for parameter `hue`"
+        err = "Could not interpret value `what` for `hue`"
         with pytest.raises(ValueError, match=err):
             VectorPlotter(data=long_df, variables={"x": "x", "hue": "what"})
 


### PR DESCRIPTION
This PR leverages the [dataframe interchange protocol](https://data-apis.org/dataframe-protocol/latest/index.html) to let seaborn consume objects from other dataframe libraries, such as polars.

Dataframes are converted to pandas objects upon consumption, and that is what is used internally by seaborn, so seaborn's statistical operations don't take advantage of any parallelism / out of core / etc. functionality offered by these libraries. While that would be ideal, I don't see it happening any time soon. 

Nevertheless, this should make it easy to prep data in a library of choice and then pipe it to seaborn without thinking too much about the representation.

For testing, my approach is to use a simple mock object that is not (by inheritance) a pandas DataFrame, but that does "support" the interchange protocol. I think this is sufficient, with the assumption that pandas / other data libraries will together correctly implement the dataframe interchange itself. Testing whether that works correctly feels out of scope for seaborn's unit tests.

I wouldn't be surprised to learn of various edge cases as this roles out to people using alternative dataframe libraries heavily (I only did some light testing with polars using toy datasets) so we'll address those as they happen.

Thanks to @MarcoGorelli for getting the ball rolling with #3340 and advising on the approach.
Closes #3368 