### PR TITLE
Avoid error when determining type of variable containing pd.NA

### DIFF
--- a/seaborn/_core/rules.py
+++ b/seaborn/_core/rules.py
@@ -94,7 +94,7 @@ def variable_type(
                 boolean_dtypes = ["bool"]
             boolean_vector = vector.dtype in boolean_dtypes
         else:
-            boolean_vector = bool(np.isin(vector, [0, 1, np.nan]).all())
+            boolean_vector = bool(np.isin(vector.dropna(), [0, 1]).all())
         if boolean_vector:
             return VarType(boolean_type)
 

--- a/seaborn/_oldcore.py
+++ b/seaborn/_oldcore.py
@@ -1495,9 +1495,10 @@ def variable_type(vector, boolean_type="numeric"):
     var_type : 'numeric', 'categorical', or 'datetime'
         Name identifying the type of data in the vector.
     """
+    vector = pd.Series(vector)
 
     # If a categorical dtype is set, infer categorical
-    if isinstance(getattr(vector, 'dtype', None), pd.CategoricalDtype):
+    if isinstance(vector.dtype, pd.CategoricalDtype):
         return VariableType("categorical")
 
     # Special-case all-na data, which is always "numeric"
@@ -1516,7 +1517,7 @@ def variable_type(vector, boolean_type="numeric"):
         warnings.simplefilter(
             action='ignore', category=(FutureWarning, DeprecationWarning)
         )
-        if np.isin(vector, [0, 1, np.nan]).all():
+        if np.isin(vector.dropna(), [0, 1]).all():
             return VariableType(boolean_type)
 
     # Defer to positive pandas tests

--- a/tests/_core/test_rules.py
+++ b/tests/_core/test_rules.py
@@ -28,8 +28,6 @@ def test_variable_type():
     assert variable_type(s) == "numeric"
     assert variable_type(s.astype(int)) == "numeric"
     assert variable_type(s.astype(object)) == "numeric"
-    assert variable_type(s.to_numpy()) == "numeric"
-    assert variable_type(s.to_list()) == "numeric"
 
     s = pd.Series([1, 2, 3, np.nan], dtype=object)
     assert variable_type(s) == "numeric"
@@ -42,8 +40,6 @@ def test_variable_type():
 
     s = pd.Series(["1", "2", "3"])
     assert variable_type(s) == "categorical"
-    assert variable_type(s.to_numpy()) == "categorical"
-    assert variable_type(s.to_list()) == "categorical"
 
     s = pd.Series([True, False, False])
     assert variable_type(s) == "numeric"
@@ -62,8 +58,6 @@ def test_variable_type():
     s = pd.Series([pd.Timestamp(1), pd.Timestamp(2)])
     assert variable_type(s) == "datetime"
     assert variable_type(s.astype(object)) == "datetime"
-    assert variable_type(s.to_numpy()) == "datetime"
-    assert variable_type(s.to_list()) == "datetime"
 
 
 def test_categorical_order():


### PR DESCRIPTION
Addresses an issue introduced with the release of numpy 1.25.0

See https://github.com/pandas-dev/pandas/issues/50124 for some more context.