### PR TITLE
Change get_linestyle to get_dashes for Collections

### DIFF
--- a/tests/_marks/test_line.py
+++ b/tests/_marks/test_line.py
@@ -181,7 +181,7 @@ class TestPaths:
 
         assert same_color(lines.get_color().squeeze(), m.color)
         assert lines.get_linewidth().item() == m.linewidth
-        assert lines.get_linestyle()[0] == (0, list(m.linestyle))
+        assert lines.get_dashes()[0] == (0, list(m.linestyle))
 
     def test_mapped_properties(self):
 


### PR DESCRIPTION
There is an upcoming change in Matplotlib that unifies the return of `get_linestyle`. Instead, based on the current tests, one should use `get_dashes`. (Will produce a warning for a few releases and then return the linestyle string as other artists.)

~Also added a test as there is `get_dashes` for lines (now).~ Too long since I did the MPL PR clearly, but there will be a `get_dashes` as part of the PR.

(Couldn't run the tests locally because of issues with pywintypes so please bear with me in case it is not working out of the box...)