### PR TITLE
Fix PairGrid with column multiindex

### DIFF
--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -1472,8 +1472,8 @@ class PairGrid(Grid):
                 for ax in diag_axes[1:]:
                     share_axis(diag_axes[0], ax, "y")
 
-            self.diag_vars = np.array(diag_vars, np.object_)
-            self.diag_axes = np.array(diag_axes, np.object_)
+            self.diag_vars = diag_vars
+            self.diag_axes = diag_axes
 
         if "hue" not in signature(func).parameters:
             return self._map_diag_iter_hue(func, **kwargs)

--- a/tests/test_axisgrid.py
+++ b/tests/test_axisgrid.py
@@ -1422,6 +1422,13 @@ class TestPairGrid:
         with pytest.warns(UserWarning):
             g = ag.pairplot(self.df, hue="a", vars=vars, markers=markers[:-2])
 
+    def test_pairplot_column_multiindex(self):
+
+        cols = pd.MultiIndex.from_arrays([["x", "y"], [1, 2]])
+        df = self.df[["x", "y"]].set_axis(cols, axis=1)
+        g = ag.pairplot(df)
+        assert g.diag_vars == list(cols)
+
     def test_corner_despine(self):
 
         g = ag.PairGrid(self.df, corner=True, despine=False)


### PR DESCRIPTION
Fixes #3406 

I'm not 100% sure why these attributes were originally being case to `ndarray` and this fix does induce a minor API break but I can't really imagine a circumstance where someone would have been doing math on them (they were explicitly cast to object-type anyway) so I can live with it.