### PR TITLE
Fix the type of `Plot.add` `transforms` argument to accept `Move`, not `Mark`

### DIFF
--- a/seaborn/_core/plot.py
+++ b/seaborn/_core/plot.py
@@ -485,7 +485,7 @@ class Plot:
     def add(
         self,
         mark: Mark,
-        *transforms: Stat | Mark,
+        *transforms: Stat | Move,
         orient: str | None = None,
         legend: bool = True,
         data: DataSource = None,


### PR DESCRIPTION
Fixes the type in accordance with the intention of #2948. Presumably, this was just an autocomplete typo since docs and functionality all specify `Move` rather than `Mark`.