### PR TITLE
Generalize internal scaling operation

### DIFF
--- a/seaborn/distributions.py
+++ b/seaborn/distributions.py
@@ -26,6 +26,7 @@ from .axisgrid import (
 )
 from .utils import (
     remove_na,
+    _get_transform_functions,
     _kde_support,
     _normalize_kwargs,
     _check_argument,
@@ -487,9 +488,10 @@ class _DistributionPlotter(VectorPlotter):
                 densities[key] *= hist_norm
 
             # Convert edges back to original units for plotting
-            if self._log_scaled(self.data_variable):
-                widths = np.power(10, edges + widths) - np.power(10, edges)
-                edges = np.power(10, edges)
+            ax = self._get_axes(sub_vars)
+            _, inv = _get_transform_functions(ax, self.data_variable)
+            widths = inv(edges + widths) - inv(edges)
+            edges = inv(edges)
 
             # Pack the histogram data and metadata together
             edges = edges + (1 - shrink) / 2 * widths
@@ -809,11 +811,14 @@ class _DistributionPlotter(VectorPlotter):
                 weights=sub_data.get("weights", None),
             )
 
-            # Check for log scaling on the data axis
-            if self._log_scaled("x"):
-                x_edges = np.power(10, x_edges)
-            if self._log_scaled("y"):
-                y_edges = np.power(10, y_edges)
+            # Get the axes for this plot
+            ax = self._get_axes(sub_vars)
+
+            # Invert the scale for the edges
+            _, inv_x = _get_transform_functions(ax, "x")
+            _, inv_y = _get_transform_functions(ax, "y")
+            x_edges = inv_x(x_edges)
+            y_edges = inv_y(y_edges)
 
             # Apply scaling to normalize across groups
             if estimator.stat != "count" and common_norm:
@@ -844,9 +849,6 @@ class _DistributionPlotter(VectorPlotter):
                 thresh = self._quantile_to_level(heights, pthresh)
             if thresh is not None:
                 heights = np.ma.masked_less_equal(heights, thresh)
-
-            # Get the axes for this plot
-            ax = self._get_axes(sub_vars)
 
             # pcolormesh is going to turn the grid off, but we want to keep it
             # I'm not sure if there's a better way to get the grid state
@@ -1093,12 +1095,10 @@ class _DistributionPlotter(VectorPlotter):
                 continue
 
             # Transform the support grid back to the original scale
-            xx, yy = support
-            if self._log_scaled("x"):
-                xx = np.power(10, xx)
-            if self._log_scaled("y"):
-                yy = np.power(10, yy)
-            support = xx, yy
+            ax = self._get_axes(sub_vars)
+            _, inv_x = _get_transform_functions(ax, "x")
+            _, inv_y = _get_transform_functions(ax, "y")
+            support = inv_x(support[0]), inv_y(support[1])
 
             # Apply a scaling factor so that the integral over all subsets is 1
             if common_norm:
@@ -1245,9 +1245,10 @@ class _DistributionPlotter(VectorPlotter):
                 artist_kws["color"] = self._hue_map(sub_vars["hue"])
 
             # Return the data variable to the linear domain
-            # This needs an automatic solution; see GH2409
+            ax = self._get_axes(sub_vars)
+            _, inv = _get_transform_functions(ax, self.data_variable)
+            vals = inv(vals)
             if self._log_scaled(self.data_variable):
-                vals = np.power(10, vals)
                 vals[0] = -np.inf
 
             # Work out the orientation of the plot
@@ -1264,7 +1265,6 @@ class _DistributionPlotter(VectorPlotter):
                 top_edge = 1
 
             # Draw the line for this subset
-            ax = self._get_axes(sub_vars)
             artist, = ax.plot(*plot_args, **artist_kws)
             sticky_edges = getattr(artist.sticky_edges, stat_variable)
             sticky_edges[:] = 0, top_edge
@@ -1327,9 +1327,8 @@ class _DistributionPlotter(VectorPlotter):
         n = len(vector)
 
         # Return data to linear domain
-        # This needs an automatic solution; see GH2409
-        if self._log_scaled(var):
-            vector = np.power(10, vector)
+        _, inv = _get_transform_functions(ax, var)
+        vector = inv(vector)
 
         # We'll always add a single collection with varying colors
         if "hue" in self.variables:

--- a/tests/test_categorical.py
+++ b/tests/test_categorical.py
@@ -3062,12 +3062,13 @@ class TestBeeswarm:
         p = Beeswarm(width=1)
 
         points = np.zeros(10)
-        assert_array_equal(points, p.add_gutters(points, 0))
+        t_fwd = t_inv = lambda x: x
+        assert_array_equal(points, p.add_gutters(points, 0, t_fwd, t_inv))
 
         points = np.array([0, -1, .4, .8])
         msg = r"50.0% of the points cannot be placed.+$"
         with pytest.warns(UserWarning, match=msg):
-            new_points = p.add_gutters(points, 0)
+            new_points = p.add_gutters(points, 0, t_fwd, t_inv)
         assert_array_equal(new_points, np.array([0, -.5, .4, .5]))
 
 


### PR DESCRIPTION
This PR updates most sns functions to use the transforms set on a pre-existing matplotlib axes such that statistics are computed in the visualized space. Previously, support for transformed axes was a little spotty, at most supporting log scales (but not similar scales, like symlog).

```python
f, axs = plt.subplots(1, 4, figsize=(6, 3), sharey=True, layout="constrained")
plots = [sns.lineplot, sns.pointplot, sns.boxplot, sns.violinplot]
for ax, func in zip(axs.flat, funcs):
    ax.set_yscale("symlog")
    plot(diamonds, x="color", y="price", ax=ax)
```
![image](https://github.com/mwaskom/seaborn/assets/315810/925a3e03-9c47-495f-b6ab-3dbba6ac774b)

This also fixes #3352, a bug introduced in the v0.13 dev series when jumping the gun on this functionality.

Arbitrary scales are also now handled properly on the orient axis of categorical plots:

```
f, ax = plt.subplots()
ax.set_xscale("symlog")
sns.boxplot(tips, x=10 ** tips["size"], y="total_bill", hue="sex", native_scale=True)
```
![image](https://github.com/mwaskom/seaborn/assets/315810/a518a149-7ef2-493e-b8c9-8c0904154e99)

The code is fairly messy but, alas, that's rather unavoidable given the architecture underlying the function interface and was a major motivator for the development of the objects interface (and corresponding rearchitecting).