### PR TITLE
Update tests for matplotlib 3.8.0rc1

### DIFF
--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -252,7 +252,7 @@ class _HeatMapper:
         height, width = self.annot_data.shape
         xpos, ypos = np.meshgrid(np.arange(width) + .5, np.arange(height) + .5)
         for x, y, m, color, val in zip(xpos.flat, ypos.flat,
-                                       mesh.get_array(), mesh.get_facecolors(),
+                                       mesh.get_array().flat, mesh.get_facecolors(),
                                        self.annot_data.flat):
             if m is not np.ma.masked:
                 lum = relative_luminance(color)

--- a/tests/_core/test_scales.py
+++ b/tests/_core/test_scales.py
@@ -191,9 +191,11 @@ class TestContinuous:
 
         n = 3
         a = self.setup_ticks(x, count=2, minor=n)
-        # I am not sure why matplotlib's minor ticks include the
-        # largest major location but exclude the smalllest one ...
-        expected = np.linspace(0, 1, n + 2)[1:]
+        expected = np.linspace(0, 1, n + 2)
+        if _version_predates(mpl, "3.8.0rc1"):
+            # I am not sure why matplotlib <3.8  minor ticks include the
+            # largest major location but exclude the smalllest one ...
+            expected = expected[1:]
         assert_array_equal(a.minor.locator(), expected)
 
     def test_log_tick_default(self, x):


### PR DESCRIPTION
This is mostly a generalization of the tests to work with both old and new matplotlib

The only production code change is adding `.flat` to one line in the matrix annotation code, all other changes are test-only.

Mostly the test changes were allowing the collection being found to be a `QuadContourSet`, as well as allowing outputs like colors or coordinates to be sequences instead of singular values, or adding `.flat` to values which now get returned as input-shaped arrays instead of automatically flattened arrays.

I was able to avoid version checking for most things, aside from the minor tick expected value and explicitly checking the expected type in `ax.collections`. Though there are some version-checks by proxy of `isinstance` checks.

I did add a boolean flag to shift the filtering of empty paths from the test to the helper function for `get_contour_coords`, this is only used in one test for now, but made for a backwards compatible filtering step.

`get_contour_coords` will now return non-rectangular grids (Not actually clear to me that this is _new_) so some tests have additional loops before calling `assert_array_equal` I added assertions that the lengths were the same to avoid `zip` dropping the fact that one list was longer.


I have tested with both matplotlib v3.8.x (the backport branch for the 3.8 series) as well as released 3.7.2.

In my dev environment I am seing some numpy warnings (which are elevated to errors for 2 tests), but other than that all tests pass.
