### PR TITLE
Squash a large number of warnings in the tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,5 @@ exclude = ["doc/_static/*.svg"]
 
 [tool.pytest.ini_options]
 filterwarnings = [
-   "error",
    "ignore:The --rsyncdir command line argument and rsyncdirs config variable are deprecated.:DeprecationWarning",
  ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,3 +61,9 @@ Docs = "http://seaborn.pydata.org"
 
 [tool.flit.sdist]
 exclude = ["doc/_static/*.svg"]
+
+[tool.pytest.ini_options]
+filterwarnings = [
+   "error",
+   "ignore:The --rsyncdir command line argument and rsyncdirs config variable are deprecated.:DeprecationWarning",
+ ]

--- a/seaborn/_base.py
+++ b/seaborn/_base.py
@@ -1654,10 +1654,7 @@ def categorical_order(vector, order=None):
                 order = vector.cat.categories
             except (TypeError, AttributeError):
 
-                try:
-                    order = vector.unique()
-                except AttributeError:
-                    order = pd.unique(vector)
+                order = pd.Series(vector).unique()
 
                 if variable_type(vector) == "numeric":
                     order = np.sort(order)

--- a/seaborn/_base.py
+++ b/seaborn/_base.py
@@ -947,7 +947,7 @@ class VectorPlotter:
         if grouping_vars:
 
             grouped_data = data.groupby(
-                grouping_vars, sort=False, as_index=False
+                grouping_vars, sort=False, as_index=False, observed=False,
             )
 
             grouping_keys = []

--- a/seaborn/_core/plot.py
+++ b/seaborn/_core/plot.py
@@ -1618,7 +1618,9 @@ class Plotter:
                         yield subplot_keys, axes_df.copy(), view["ax"]
                     continue
 
-                grouped_df = axes_df.groupby(grouping_vars, sort=False, as_index=False)
+                grouped_df = axes_df.groupby(
+                    grouping_vars, sort=False, as_index=False, observed=False,
+                )
 
                 for key in itertools.product(*grouping_keys):
 

--- a/seaborn/_core/properties.py
+++ b/seaborn/_core/properties.py
@@ -367,7 +367,7 @@ class ObjectProperty(Property):
             values = values[::-1]
 
         def mapping(x):
-            ixs = np.asarray(x, np.intp)
+            ixs = np.asarray(np.nan_to_num(x), np.intp)
             return [
                 values[ix] if np.isfinite(x_i) else self.null_value
                 for x_i, ix in zip(x, ixs)
@@ -691,7 +691,7 @@ class Color(Property):
         def mapping(x):
 
             use = np.isfinite(x)
-            x = np.asarray(x).astype(bool)
+            x = np.asarray(np.nan_to_num(x)).astype(bool)
             out = np.full((len(x), colors.shape[1]), np.nan)
             out[x & use] = colors[0]
             out[~x & use] = colors[1]
@@ -772,7 +772,7 @@ class Fill(Property):
             values = values[::-1]
 
         def mapping(x):
-            ixs = np.asarray(x, np.intp)
+            ixs = np.asarray(np.nan_to_num(x), np.intp)
             return [
                 values[ix] if np.isfinite(x_i) else False
                 for x_i, ix in zip(x, ixs)

--- a/seaborn/_core/properties.py
+++ b/seaborn/_core/properties.py
@@ -676,7 +676,7 @@ class Color(Property):
         colors = self._get_values(scale, levels)
 
         def mapping(x):
-            ixs = np.asarray(x, np.intp)
+            ixs = np.asarray(np.nan_to_num(x), np.intp)
             use = np.isfinite(x)
             out = np.full((len(ixs), colors.shape[1]), np.nan)
             out[use] = np.take(colors, ixs[use], axis=0)

--- a/seaborn/_stats/counting.py
+++ b/seaborn/_stats/counting.py
@@ -35,11 +35,10 @@ class Count(Stat):
         self, data: DataFrame, groupby: GroupBy, orient: str, scales: dict[str, Scale],
     ) -> DataFrame:
 
-        var = {"x": "y", "y": "x"}.get(orient)
-        data[var] = data[orient]
+        var = {"x": "y", "y": "x"}[orient]
         res = (
             groupby
-            .agg(data, {var: len})
+            .agg(data.assign(**{var: data[orient]}), {var: len})
             .dropna(subset=["x", "y"])
             .reset_index(drop=True)
         )

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -960,12 +960,15 @@ class _CategoricalPlotter(_RelationalPlotter):
             max_density = {key: common_max_density for key in norm_keys}
             max_count = {key: common_max_count for key in norm_keys}
         else:
-            max_density = {
-                key: np.nanmax([
-                    v["density"].max() for v in violin_data
-                    if vars_to_key(v["sub_vars"]) == key
-                ]) for key in norm_keys
-            }
+            with warnings.catch_warnings():
+                # Ignore warning when all violins are singular; it's not important
+                warnings.filterwarnings('ignore', "All-NaN (slice|axis) encountered")
+                max_density = {
+                    key: np.nanmax([
+                        v["density"].max() for v in violin_data
+                        if vars_to_key(v["sub_vars"]) == key
+                    ]) for key in norm_keys
+                }
             max_count = {
                 key: np.nanmax([
                     len(v["observations"]) for v in violin_data

--- a/seaborn/distributions.py
+++ b/seaborn/distributions.py
@@ -1172,16 +1172,14 @@ class _DistributionPlotter(VectorPlotter):
             density = densities[key]
             xx, yy = supports[key]
 
-            label = contour_kws.pop("label", None)
+            # Pop the label kwarg which is unused by contour_func (but warns)
+            contour_kws.pop("label", None)
 
             cset = contour_func(
                 xx, yy, density,
                 levels=draw_levels[key],
                 **contour_kws,
             )
-
-            if "hue" not in self.variables:
-                cset.collections[0].set_label(label)
 
             # Add a color bar representing the contour heights
             # Note: this shows iso densities, not iso proportions

--- a/tests/_stats/test_density.py
+++ b/tests/_stats/test_density.py
@@ -195,7 +195,7 @@ class TestKDE:
 
         val, ori = "xy"
         df["weight"] = 1
-        df = df[[ori, "weight"]]
+        df = df[[ori, "weight"]].astype(float)
         df.loc[:4, col] = np.nan
         gb = self.get_groupby(df, ori)
         res = KDE()(df, gb, ori, {})

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -159,6 +159,7 @@ def null_df(rng, long_df):
 
     df = long_df.copy()
     for col in df:
+        df[col] = df[col].astype(float)
         idx = rng.permutation(df.index)[:10]
         df.loc[idx, col] = np.nan
     return df

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -159,7 +159,8 @@ def null_df(rng, long_df):
 
     df = long_df.copy()
     for col in df:
-        df[col] = df[col].astype(float)
+        if pd.api.types.is_integer_dtype(df[col]):
+            df[col] = df[col].astype(float)
         idx = rng.permutation(df.index)[:10]
         df.loc[idx, col] = np.nan
     return df

--- a/tests/test_categorical.py
+++ b/tests/test_categorical.py
@@ -1757,7 +1757,6 @@ class TestViolinPlot(SharedAxesLevelTests):
             dict(data="long", x="a", y="y", inner="points"),
             dict(data="long", x="a", y="y", hue="b", inner="quartiles", split=True),
             dict(data="long", x="a", y="y", density_norm="count", common_norm=True),
-            dict(data="long", x="a", y="y", bw=2),
             dict(data="long", x="a", y="y", bw_adjust=2),
         ]
     )

--- a/tests/test_categorical.py
+++ b/tests/test_categorical.py
@@ -2390,7 +2390,8 @@ class TestPointPlot(SharedAggTests):
         assert_array_equal(line.get_xdata(), x)
         assert_array_equal(line.get_ydata(), y)
 
-    @pytest.mark.parametrize("estimator", ["mean", np.mean])
+    # Use lambda around np.mean to avoid uninformative pandas deprecation warning
+    @pytest.mark.parametrize("estimator", ["mean", lambda x: np.mean(x)])
     def test_estimate(self, long_df, estimator):
 
         agg_var, val_var = "a", "y"

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -41,9 +41,9 @@ from seaborn._testing import (
 
 
 def get_contour_coords(c, filter_empty=False):
-    """Provide compatability for change in contour artist type in mpl3.5."""
-    # See https://github.com/matplotlib/matplotlib/issues/20906
+    """Provide compatability for change in contour artist types."""
     if isinstance(c, mpl.collections.LineCollection):
+        # See https://github.com/matplotlib/matplotlib/issues/20906
         return c.get_segments()
     elif isinstance(c, (mpl.collections.PathCollection, mpl.contour.QuadContourSet)):
         return [
@@ -53,9 +53,9 @@ def get_contour_coords(c, filter_empty=False):
 
 
 def get_contour_color(c):
-    """Provide compatability for change in contour artist type in mpl3.5."""
-    # See https://github.com/matplotlib/matplotlib/issues/20906
+    """Provide compatability for change in contour artist types."""
     if isinstance(c, mpl.collections.LineCollection):
+        # See https://github.com/matplotlib/matplotlib/issues/20906
         return c.get_color()
     elif isinstance(c, (mpl.collections.PathCollection, mpl.contour.QuadContourSet)):
         if c.get_facecolor().size:
@@ -2437,14 +2437,20 @@ class TestDisPlot:
         x, y = rng.normal(0, 1, (2, 100))
         z = [0] * 80 + [1] * 20
 
+        def count_contours(ax):
+            if _version_predates(mpl, "3.8.0rc1"):
+                return sum(bool(get_contour_coords(c)) for c in ax.collections)
+            else:
+                return sum(bool(p.vertices.size) for p in ax.collections[0].get_paths())
+
         g = displot(x=x, y=y, col=z, kind="kde", levels=10)
-        l1 = sum(bool(get_contour_coords(c)) for c in g.axes.flat[0].collections)
-        l2 = sum(bool(get_contour_coords(c)) for c in g.axes.flat[1].collections)
+        l1 = count_contours(g.axes.flat[0])
+        l2 = count_contours(g.axes.flat[1])
         assert l1 > l2
 
         g = displot(x=x, y=y, col=z, kind="kde", levels=10, common_norm=False)
-        l1 = sum(bool(get_contour_coords(c)) for c in g.axes.flat[0].collections)
-        l2 = sum(bool(get_contour_coords(c)) for c in g.axes.flat[1].collections)
+        l1 = count_contours(g.axes.flat[0])
+        l2 = count_contours(g.axes.flat[1])
         assert l1 == l2
 
     def test_bivariate_hist_norm(self, rng):


### PR DESCRIPTION
Various small edits to:

- Maintain forward compatibility with upcoming changes in dependencies
- Avoid triggering some numpy warnings around missing data and discrete mapping logic
- Silence a couple of innocuous warnings there's no clear way to work around

All that remains here are https://github.com/matplotlib/matplotlib/pull/26300, https://github.com/matplotlib/matplotlib/issues/26596 and ~https://github.com/pytest-dev/pytest-xdist/issues/840~ (decided to ignore the latter in the test config, since there's no apparent movement towards dealing with it upstream despite lots of reports).