### PR TITLE
Deprecate accepting an array-typed palette, which is not intentional

### DIFF
--- a/seaborn/_base.py
+++ b/seaborn/_base.py
@@ -108,6 +108,15 @@ class HueMapping(SemanticMapping):
 
         data = plotter.plot_data.get("hue", pd.Series(dtype=float))
 
+        if isinstance(palette, np.ndarray):
+            msg = (
+                "Numpy array is not a supported type for `palette`. "
+                "Please convert your palette to a list. "
+                "This will become an error in v0.14"
+            )
+            warnings.warn(msg, stacklevel=4)
+            palette = palette.tolist()
+
         if data.isna().all():
             if palette is not None:
                 msg = "Ignoring `palette` because no `hue` variable has been assigned."

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -451,6 +451,14 @@ class TestSizeMapping:
         with pytest.raises(ValueError):
             SizeMapping(p, sizes="bad_size")
 
+    def test_array_palette_deprecation(self, long_df):
+
+        p = VectorPlotter(long_df, {"y": "y", "hue": "s"})
+        pal = mpl.cm.Blues([.3, .8])[:, :3]
+        with pytest.warns(UserWarning, match="Numpy array is not a supported type"):
+            m = HueMapping(p, pal)
+        assert m.palette == pal.tolist()
+
 
 class TestStyleMapping:
 


### PR DESCRIPTION
Closes #3450

We don't document ndarray as a valid type for `palette` but it has worked by happenstance previously. Some changes in numpy are causing one of the operations we perform on the palette object to break. This PR (1) works around those numpy changes by catching array types and coercing them to lists, and (2) fires a warning about upcoming removal of support of array-typed palettes.

Note that arrays are already disallowed in the objects interface:
```
TypeError: Scale values for color with a Nominal mapping must be string, list, tuple, or dict; not <class 'numpy.ndarray'>.
```