### PR TITLE
Allow move_legend to overwrite the labels

### DIFF
--- a/seaborn/utils.py
+++ b/seaborn/utils.py
@@ -460,6 +460,13 @@ def move_legend(obj, loc, **kwargs):
     handles = get_legend_handles(old_legend)
     labels = [t.get_text() for t in old_legend.get_texts()]
 
+    # Handle the case where the user is trying to override the labels
+    if (new_labels := kwargs.pop("labels", None)) is not None:
+        if len(new_labels) != len(labels):
+            err = "Length of new labels does not match existing legend."
+            raise ValueError(err)
+        labels = new_labels
+
     # Extract legend properties that can be passed to the recreation method
     # (Vexingly, these don't all round-trip)
     legend_kws = inspect.signature(mpl.legend.Legend).parameters

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -436,7 +436,7 @@ def test_move_legend_with_labels(long_df):
     labels = [s.capitalize() for s in order]
     ax = scatterplot(long_df, x="x", y="y", hue="a", hue_order=order)
 
-    handles_before = ax.get_legend().legend_handles
+    handles_before = get_legend_handles(ax.get_legend())
     colors_before = [tuple(h.get_facecolor().squeeze()) for h in handles_before]
     utils.move_legend(ax, "best", labels=labels)
     _draw_figure(ax.figure)
@@ -444,7 +444,7 @@ def test_move_legend_with_labels(long_df):
     texts = [t.get_text() for t in ax.get_legend().get_texts()]
     assert texts == labels
 
-    handles_after = ax.get_legend().legend_handles
+    handles_after = get_legend_handles(ax.get_legend())
     colors_after = [tuple(h.get_facecolor().squeeze()) for h in handles_after]
     assert colors_before == colors_after
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -20,7 +20,7 @@ from pandas.testing import (
     assert_frame_equal,
 )
 
-from seaborn import utils, rcmod
+from seaborn import utils, rcmod, scatterplot
 from seaborn.utils import (
     get_dataset_names,
     get_color_cycle,
@@ -428,6 +428,28 @@ def test_move_legend_input_checks():
 
     with pytest.raises(ValueError):
         utils.move_legend(ax.figure, "best")
+
+
+def test_move_legend_with_labels(long_df):
+
+    order = long_df["a"].unique()
+    labels = [s.capitalize() for s in order]
+    ax = scatterplot(long_df, x="x", y="y", hue="a", hue_order=order)
+
+    handles_before = ax.get_legend().legend_handles
+    colors_before = [tuple(h.get_facecolor().squeeze()) for h in handles_before]
+    utils.move_legend(ax, "best", labels=labels)
+    _draw_figure(ax.figure)
+
+    texts = [t.get_text() for t in ax.get_legend().get_texts()]
+    assert texts == labels
+
+    handles_after = ax.get_legend().legend_handles
+    colors_after = [tuple(h.get_facecolor().squeeze()) for h in handles_after]
+    assert colors_before == colors_after
+
+    with pytest.raises(ValueError, match="Length of new labels"):
+        utils.move_legend(ax, "best", labels=labels[:-1])
 
 
 def check_load_dataset(name):


### PR DESCRIPTION
`move_legend` was not originally expected to also allow changing the labels themselves. Personally I think that doing this is fairly dangerous because you may not always know what order the original labels will appear in. But people try, and due to an odd matplotlib edge case, rather than raising (because labels get passed positionally and as part of the user's keyword arguments), it can produce incorrect legend even when the user's legend would otherwise have been correct.

This PR explicitly handles the case where the user supplies `labels`.

Closes #3079