### PR TITLE
Add the concept of a "layer legend" to so.Plot

### DIFF
--- a/doc/_docstrings/objects.Plot.add.ipynb
+++ b/doc/_docstrings/objects.Plot.add.ipynb
@@ -19,7 +19,14 @@
   {
    "cell_type": "raw",
    "id": "33cd5d3c-d3ad-4e3b-bdac-350f8e104594",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "raw_mimetype": "",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "Every layer must be defined with a :class:`Mark`:"
    ]
@@ -175,7 +182,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "45690aaa-1abf-40ae-be3b-1ab648f8be62",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "(\n",
@@ -186,10 +199,52 @@
    ]
   },
   {
+   "cell_type": "raw",
+   "id": "e62f9e80-bfba-4516-a43a-a265dc35eb79",
+   "metadata": {
+    "editable": true,
+    "raw_mimetype": "",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "Providing a `label` will annotate the layer in the plot's legend:"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "a403012a-e895-4e5b-b690-dc27efbeccad",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "(\n",
+    "    so.Plot(tips, x=\"size\")\n",
+    "    .add(so.Line(color=\"C1\"), so.Agg(), y=\"total_bill\", label=\"Bill\")\n",
+    "    .add(so.Line(color=\"C2\"), so.Agg(), y=\"tip\", label=\"Tip\")\n",
+    "    .label(y=\"Value\")\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c14526a4-37bb-4f4c-84fa-e5c556eee5c2",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": []
   }

--- a/doc/_docstrings/objects.Plot.label.ipynb
+++ b/doc/_docstrings/objects.Plot.label.ipynb
@@ -5,6 +5,10 @@
    "execution_count": null,
    "id": "9252d5a5-8af1-4f99-b799-ee044329fb23",
    "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
     "tags": [
      "hide"
     ]
@@ -19,7 +23,14 @@
   {
    "cell_type": "raw",
    "id": "fb32137a-e882-4222-9463-b8cf0ee1c8bd",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "raw_mimetype": "",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "Use strings to override default labels:"
    ]
@@ -28,7 +39,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "65b4320e-6fb9-48ed-9132-53b0d21b85e6",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "p = (\n",
@@ -41,7 +58,14 @@
   {
    "cell_type": "raw",
    "id": "a39626d2-76f5-40a9-a3fd-6f44dd69bd30",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "raw_mimetype": "",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "Pass a function to *modify* the default label:"
    ]
@@ -50,7 +74,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "c3540c54-1c91-4d55-8f58-cd758abbe2fd",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "p.label(color=str.capitalize)"
@@ -59,7 +89,13 @@
   {
    "cell_type": "markdown",
    "id": "68f3b321-0755-4ef1-a9e6-bcff61a9178d",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "Use this method to set the title for a single-axes plot:"
    ]
@@ -68,7 +104,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "12d23c6e-781f-4b5c-a6b0-3ea0317ab7fb",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "p.label(title=\"Penguin species exhibit distinct bill shapes\")"
@@ -77,7 +119,13 @@
   {
    "cell_type": "markdown",
    "id": "8e0bcb80-0929-4ab9-b5c0-13bb3d8e4484",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "When faceting, the `title` parameter will modify default titles:"
    ]
@@ -86,7 +134,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "da1516b7-b823-41c0-b251-01bdecb6a4e6",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "p.facet(\"sex\").label(title=str.upper)"
@@ -95,7 +149,13 @@
   {
    "cell_type": "markdown",
    "id": "bb439eae-6cc3-4a6c-bef2-b4b7746edbd1",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "And the `col`/`row` parameters will add labels to the title for each facet:"
    ]
@@ -104,7 +164,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "e0d49ba9-0507-4358-b477-2e0253f0df8f",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "p.facet(\"sex\").label(col=\"Sex:\")"
@@ -113,7 +179,13 @@
   {
    "cell_type": "markdown",
    "id": "99471c06-1b1a-4ef5-844c-5f4aa8f322f5",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "If more customization is needed, a format string can work well:"
    ]
@@ -122,7 +194,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "848be3a3-5a2c-4b98-918f-825257be85ae",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "p.facet(\"sex\").label(title=\"{} penguins\".format)"
@@ -132,7 +210,65 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "94012def-dd7c-48f4-8830-f77a3bf7299b",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "p"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "e9b669e9-fd3d-4292-9c8d-e5fb093932b2",
+   "metadata": {
+    "editable": true,
+    "raw_mimetype": "",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "When adding labels for each layer, the `legend=` parameter sets the title for the legend:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "78d22763-3f92-4be1-bc3f-bc24ad39da70",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "(\n",
+    "    so.Plot(penguins, x=\"species\")\n",
+    "    .add(so.Line(color=\"C1\"), so.Agg(), y=\"bill_length_mm\", label=\"length\")\n",
+    "    .add(so.Line(color=\"C2\"), so.Agg(), y=\"bill_depth_mm\", label=\"depth\")\n",
+    "    .label(legend=\"Measurement\")\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5c7a7b91-bb5c-4bf5-99f8-719a220e3b36",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": []
   }

--- a/seaborn/_marks/base.py
+++ b/seaborn/_marks/base.py
@@ -224,7 +224,7 @@ class Mark:
 
     def _legend_artist(
         self, variables: list[str], value: Any, scales: dict[str, Scale],
-    ) -> Artist:
+    ) -> Artist | None:
 
         return None
 

--- a/tests/_core/test_plot.py
+++ b/tests/_core/test_plot.py
@@ -2127,6 +2127,30 @@ class TestLegend:
         for text in legend.texts:
             assert float(text.get_text()) > 1e7
 
+    def test_layer_legend(self, xy):
+
+        p = Plot(**xy).add(MockMark(), label="a").add(MockMark(), label="b").plot()
+        legend = p._figure.legends[0]
+        assert legend.texts
+        for text, expected in zip(legend.texts, "ab"):
+            assert text.get_text() == expected
+
+    def test_layer_legend_with_scale_legend(self, xy):
+
+        s = pd.Series(["a", "b", "a", "c"], name="s")
+        p = Plot(**xy, color=s).add(MockMark(), label="x").plot()
+
+        legend = p._figure.legends[0]
+        texts = [t.get_text() for t in legend.findobj(mpl.text.Text)]
+        assert "x" in texts
+        for val in s.unique():
+            assert val in texts
+
+    def test_layer_legend_title(self, xy):
+
+        p = Plot(**xy).add(MockMark(), label="x").label(legend="layer").plot()
+        assert p._figure.legends[0].get_title().get_text() == "layer"
+
 
 class TestDefaultObject:
 


### PR DESCRIPTION
This provides an alternate way to provide information about what different artists mean. It is similar to how `label=` is used when passed to a specific matplotlib axes.

For example, you can use it to gloss artists that represent different kinds of values:

```python
(
    so.Plot(tips, x="total_bill", y="tip")
    .add(so.Dots(), label="Data")
    .add(so.Line(), so.PolyFit(), label="Model")
)
```
<img width=500 src="https://github.com/mwaskom/seaborn/assets/315810/93d291ef-4472-43b0-a542-01ad5bdb2162" />

It is also useful for plotting multiple variables in cases where it would be awkward to reshape the data source to long-form:

```python
(
    so.Plot(tips, x="size")
    .add(so.Dots(color="C1"), so.Jitter(), y="total_bill", label="Bill")
    .add(so.Dots(color="C2"), so.Jitter(), y="tip", label="Tip")
    .label(legend="Source")
)
```
<img width=500 src="https://github.com/mwaskom/seaborn/assets/315810/6089df37-9a10-4d03-9161-75e76f246ad4" />


Closes #3046 