### PR TITLE
Also allow Plot.label to control all paired axes

### DIFF
--- a/seaborn/_core/plot.py
+++ b/seaborn/_core/plot.py
@@ -1088,9 +1088,14 @@ class Plotter:
 
     def _resolve_label(self, p: Plot, var: str, auto_label: str | None) -> str:
 
+        if re.match(r"[xy]\d+", var):
+            key = var if var in p._labels else var[0]
+        else:
+            key = var
+
         label: str
-        if var in p._labels:
-            manual_label = p._labels[var]
+        if key in p._labels:
+            manual_label = p._labels[key]
             if callable(manual_label) and auto_label is not None:
                 label = manual_label(auto_label)
             else:

--- a/tests/_core/test_plot.py
+++ b/tests/_core/test_plot.py
@@ -1751,9 +1751,14 @@ class TestPairInterface:
 
     def test_labels(self, long_df):
 
-        label = "Z"
-        p = Plot(long_df, y="y").pair(x=["x", "z"]).label(x1=label).plot()
-        ax1 = p._figure.axes[1]
+        label = "zed"
+        p = (
+            Plot(long_df, y="y")
+            .pair(x=["x", "z"])
+            .label(x=str.capitalize, x1=label)
+        )
+        ax0, ax1 = p.plot()._figure.axes
+        assert ax0.get_xlabel() == "X"
         assert ax1.get_xlabel() == label
 
 


### PR DESCRIPTION
Follow on to #3458 which didn't cover `Plot.label`. While it probably rarely makes sense to use the exact same label in a paired plot, it may be desired to use a consistent formatting function, e.g.:

```python
(
    so.Plot(planets, x="year")
    .pair(y=["mass", "distance"])
    .label(y=str.capitalize)
    .add(so.Dots())
)
```
<img width=500 src=https://github.com/mwaskom/seaborn/assets/315810/6f52134b-ab77-4ffa-a979-3fc6ac744c85 />