### PR TITLE
Change categorical auto gray parameter to "auto", with warning

### DIFF
--- a/tests/test_categorical.py
+++ b/tests/test_categorical.py
@@ -673,6 +673,7 @@ class SharedScatterTests(SharedAxesLevelTests):
             dict(data="long", x="x", color="C3"),
             dict(data="long", y="y", hue="a", jitter=False),
             dict(data="long", x="a", y="y", hue="z", edgecolor="w", linewidth=.5),
+            dict(data="long", x="a", y="y", hue="z", edgecolor="auto", linewidth=.5),
             dict(data="long", x="a_cat", y="y", hue="z"),
             dict(data="long", x="y", y="s", hue="c", orient="h", dodge=True),
             dict(data="long", x="s", y="y", hue="c", native_scale=True),
@@ -990,6 +991,11 @@ class TestBoxPlot(SharedAxesLevelTests):
             assert same_color(box.get_edgecolor(), color)
         for flier in bxp.fliers:
             assert same_color(flier.get_markeredgecolor(), color)
+
+    def test_linecolor_gray_warning(self, long_df):
+
+        with pytest.warns(FutureWarning, match="Use \"auto\" to set automatic"):
+            boxplot(long_df, x="y", linecolor="gray")
 
     def test_saturation(self, long_df):
 


### PR DESCRIPTION
There's a longstanding quirk of the categorical plots where line/edge colors can be specified as `"gray"` which actually triggers an automatic computation of a gray value that complements the main colors in the plot. Since `"gray"` is a valid matplotlib color and it's not very obvious that this is happening, this PR migrates the behavior to `"auto"`, with one release cycle of backwards compatibility and a `FutureWarning`.

```python
sns.boxenplot(tips, x="total_bill", hue="time", linecolor="auto", palette="pastel", gap=.1)
```
<img width=450 src=https://github.com/mwaskom/seaborn/assets/315810/943351a0-a6b8-4d0c-877b-d833ba1b40d7 />