### PR TITLE
Improve relational/categorical legends to show non-semantic properties

### DIFF
--- a/examples/heat_scatter.py
+++ b/examples/heat_scatter.py
@@ -6,7 +6,6 @@ _thumb: .5, .5
 
 """
 import seaborn as sns
-from seaborn._compat import get_legend_handles
 sns.set_theme(style="whitegrid")
 
 # Load the brain networks dataset, select subset, and collapse the multi-index
@@ -38,5 +37,3 @@ g.despine(left=True, bottom=True)
 g.ax.margins(.02)
 for label in g.ax.get_xticklabels():
     label.set_rotation(90)
-for artist in get_legend_handles(g.legend):
-    artist.set_edgecolor(".7")

--- a/seaborn/_base.py
+++ b/seaborn/_base.py
@@ -18,6 +18,7 @@ from seaborn.palettes import (
 )
 from seaborn.utils import (
     _check_argument,
+    _version_predates,
     desaturate,
     locator_to_legend_entries,
     get_color_cycle,
@@ -1270,7 +1271,15 @@ class VectorPlotter:
                 if attr in kws:
                     level_kws[attr] = kws[attr]
             artist = func(label=label, **{"color": ".2", **common_kws, **level_kws})
-            ax.add_artist(artist)
+            if _version_predates(mpl, "3.5.0"):
+                if isinstance(artist, mpl.lines.Line2D):
+                    ax.add_line(artist)
+                elif isinstance(artist, mpl.patches.Patch):
+                    ax.add_patch(artist)
+                elif isinstance(artist, mpl.collections.Collection):
+                    ax.add_collection(artist)
+            else:
+                ax.add_artist(artist)
             legend_data[key] = artist
             legend_order.append(key)
 

--- a/seaborn/_base.py
+++ b/seaborn/_base.py
@@ -19,6 +19,7 @@ from seaborn.palettes import (
 from seaborn.utils import (
     _check_argument,
     desaturate,
+    locator_to_legend_entries,
     get_color_cycle,
     remove_na,
 )
@@ -1199,6 +1200,126 @@ class VectorPlotter:
         if not ax.get_ylabel():
             y_visible = any(t.get_visible() for t in ax.get_yticklabels())
             ax.set_ylabel(self.variables.get("y", default_y), visible=y_visible)
+
+    def add_legend_data(self, ax, func=None, common_kws=None, semantic_kws=None):
+        """Add labeled artists to represent the different plot semantics."""
+        verbosity = self.legend
+        if isinstance(verbosity, str) and verbosity not in ["auto", "brief", "full"]:
+            err = "`legend` must be 'auto', 'brief', 'full', or a boolean."
+            raise ValueError(err)
+        elif verbosity is True:
+            verbosity = "auto"
+
+        keys = []
+        legend_kws = {}
+        common_kws = {} if common_kws is None else common_kws
+        semantic_kws = {} if semantic_kws is None else semantic_kws
+
+        # Assign a legend title if there is only going to be one sub-legend,
+        # otherwise, subtitles will be inserted into the texts list with an
+        # invisible handle (which is a hack)
+        titles = {
+            title for title in
+            (self.variables.get(v, None) for v in ["hue", "size", "style"])
+            if title is not None
+        }
+        title = "" if len(titles) != 1 else titles.pop()
+        title_kws = dict(
+            visible=False, color="w", s=0, linewidth=0, marker="", dashes=""
+        )
+
+        def update(var_name, val_name, **kws):
+
+            key = var_name, val_name
+            if key in legend_kws:
+                legend_kws[key].update(**kws)
+            else:
+                keys.append(key)
+                legend_kws[key] = dict(**kws)
+
+        legend_attrs = {"hue": "color", "size": ["linewidth", "s"], "style": None}
+        for var, names in legend_attrs.items():
+            self._update_legend_data(
+                update, var, verbosity, title, title_kws, names, semantic_kws.get(var),
+            )
+
+        if func is None:
+            func = getattr(ax, self._legend_func)
+
+        legend_data = {}
+        legend_order = []
+
+        for key in keys:
+
+            _, label = key
+            kws = legend_kws[key]
+            kws.setdefault("color", ".2")
+            level_kws = {}
+            use_attrs = [
+                *self._legend_attributes,
+                *common_kws,
+                *[attr for var_attrs in semantic_kws.values() for attr in var_attrs],
+            ]
+            for attr in use_attrs:
+                if attr in kws:
+                    level_kws[attr] = kws[attr]
+            artist = func(label=label, **{**common_kws, **level_kws})
+            ax.add_artist(artist)
+            legend_data[key] = artist
+            legend_order.append(key)
+
+        self.legend_title = title
+        self.legend_data = legend_data
+        self.legend_order = legend_order
+
+    def _update_legend_data(
+        self,
+        update,
+        var,
+        verbosity,
+        title,
+        title_kws,
+        attr_names,
+        other_props,
+    ):
+        """Generate legend tick values and formatted labels."""
+        brief_ticks = 6
+        mapper = getattr(self, f"_{var}_map", None)
+        if mapper is None:
+            return
+
+        brief = mapper.map_type == "numeric" and (
+            verbosity == "brief"
+            or (verbosity == "auto" and len(mapper.levels) > brief_ticks)
+        )
+        if brief:
+            if isinstance(mapper.norm, mpl.colors.LogNorm):
+                locator = mpl.ticker.LogLocator(numticks=brief_ticks)
+            else:
+                locator = mpl.ticker.MaxNLocator(nbins=brief_ticks)
+            limits = min(mapper.levels), max(mapper.levels)
+            levels, formatted_levels = locator_to_legend_entries(
+                locator, limits, self.plot_data[var].infer_objects().dtype
+            )
+        elif mapper.levels is None:
+            levels = formatted_levels = []
+        else:
+            levels = formatted_levels = mapper.levels
+
+        if not title and self.variables.get(var, None) is not None:
+            update((self.variables[var], "title"), self.variables[var], **title_kws)
+
+        other_props = {} if other_props is None else other_props
+
+        for level, formatted_level in zip(levels, formatted_levels):
+            if level is not None:
+                attr = mapper(level)
+                if isinstance(attr_names, list):
+                    attr = {name: attr for name in attr_names}
+                elif attr_names is not None:
+                    attr = {attr_names: attr}
+                attr.update({k: v[level] for k, v in other_props.items() if level in v})
+                update(self.variables[var], formatted_level, **attr)
 
     # XXX If the scale_* methods are going to modify the plot_data structure, they
     # can't be called twice. That means that if they are called twice, they should

--- a/seaborn/_base.py
+++ b/seaborn/_base.py
@@ -1244,7 +1244,7 @@ class VectorPlotter:
             )
 
         if func is None:
-            func = getattr(ax, self._legend_func)
+            func = self._legend_func
 
         legend_data = {}
         legend_order = []

--- a/seaborn/_base.py
+++ b/seaborn/_base.py
@@ -1201,7 +1201,9 @@ class VectorPlotter:
             y_visible = any(t.get_visible() for t in ax.get_yticklabels())
             ax.set_ylabel(self.variables.get("y", default_y), visible=y_visible)
 
-    def add_legend_data(self, ax, func=None, common_kws=None, semantic_kws=None):
+    def add_legend_data(
+        self, ax, func=None, common_kws=None, attrs=None, semantic_kws=None,
+    ):
         """Add labeled artists to represent the different plot semantics."""
         verbosity = self.legend
         if isinstance(verbosity, str) and verbosity not in ["auto", "brief", "full"]:
@@ -1237,8 +1239,9 @@ class VectorPlotter:
                 keys.append(key)
                 legend_kws[key] = dict(**kws)
 
-        legend_attrs = {"hue": "color", "size": ["linewidth", "s"], "style": None}
-        for var, names in legend_attrs.items():
+        if attrs is None:
+            attrs = {"hue": "color", "size": ["linewidth", "s"], "style": None}
+        for var, names in attrs.items():
             self._update_legend_data(
                 update, var, verbosity, title, title_kws, names, semantic_kws.get(var),
             )

--- a/seaborn/_base.py
+++ b/seaborn/_base.py
@@ -1203,7 +1203,7 @@ class VectorPlotter:
             ax.set_ylabel(self.variables.get("y", default_y), visible=y_visible)
 
     def add_legend_data(
-        self, ax, func=None, common_kws=None, attrs=None, semantic_kws=None,
+        self, ax, func, common_kws=None, attrs=None, semantic_kws=None,
     ):
         """Add labeled artists to represent the different plot semantics."""
         verbosity = self.legend
@@ -1246,9 +1246,6 @@ class VectorPlotter:
             self._update_legend_data(
                 update, var, verbosity, title, title_kws, names, semantic_kws.get(var),
             )
-
-        if func is None:
-            func = self._legend_func
 
         legend_data = {}
         legend_order = []

--- a/seaborn/_base.py
+++ b/seaborn/_base.py
@@ -1212,8 +1212,8 @@ class VectorPlotter:
 
         keys = []
         legend_kws = {}
-        common_kws = {} if common_kws is None else common_kws
-        semantic_kws = {} if semantic_kws is None else semantic_kws
+        common_kws = {} if common_kws is None else common_kws.copy()
+        semantic_kws = {} if semantic_kws is None else semantic_kws.copy()
 
         # Assign a legend title if there is only going to be one sub-legend,
         # otherwise, subtitles will be inserted into the texts list with an
@@ -1249,11 +1249,14 @@ class VectorPlotter:
         legend_data = {}
         legend_order = []
 
+        # Don't allow color=None so we can set a neutral color for size/style legends
+        if common_kws.get("color", False) is None:
+            common_kws.pop("color")
+
         for key in keys:
 
             _, label = key
             kws = legend_kws[key]
-            kws.setdefault("color", ".2")
             level_kws = {}
             use_attrs = [
                 *self._legend_attributes,
@@ -1263,7 +1266,7 @@ class VectorPlotter:
             for attr in use_attrs:
                 if attr in kws:
                     level_kws[attr] = kws[attr]
-            artist = func(label=label, **{**common_kws, **level_kws})
+            artist = func(label=label, **{"color": ".2", **common_kws, **level_kws})
             ax.add_artist(artist)
             legend_data[key] = artist
             legend_order.append(key)

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -559,7 +559,7 @@ class _CategoricalPlotter(_RelationalPlotter):
                 points.draw = draw.__get__(points)
 
         _draw_figure(ax.figure)
-        self._configure_legend(ax, ax.scatter)
+        self._configure_legend(ax, _scatter_legend_artist, plot_kws)
 
     def plot_boxes(
         self,

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -24,6 +24,7 @@ from seaborn.utils import (
     _default_color,
     _get_transform_functions,
     _normalize_kwargs,
+    _scatter_legend_artist,
     _version_predates,
 )
 from seaborn._statistics import EstimateAggregator, LetterValues
@@ -488,7 +489,7 @@ class _CategoricalPlotter(_RelationalPlotter):
             if "hue" in self.variables:
                 points.set_facecolors(self._hue_map(sub_data["hue"]))
 
-        self._configure_legend(ax, ax.scatter)
+        self._configure_legend(ax, _scatter_legend_artist, common_kws=plot_kws)
 
     def plot_swarms(
         self,

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -2042,7 +2042,7 @@ boxenplot.__doc__ = dedent("""\
 def stripplot(
     data=None, *, x=None, y=None, hue=None, order=None, hue_order=None,
     jitter=True, dodge=False, orient=None, color=None, palette=None,
-    size=5, edgecolor="face", linewidth=0,
+    size=5, edgecolor=default, linewidth=0,
     hue_norm=None, log_scale=None, native_scale=False, formatter=None, legend="auto",
     ax=None, **kwargs
 ):
@@ -2811,8 +2811,7 @@ def catplot(
         if saturation < 1:
             color = desaturate(color, saturation)
 
-    edgecolor = kwargs.pop("edgecolor", "face" if kind == "strip" else "auto")
-    edgecolor = p._complement_color(edgecolor, color, p._hue_map)
+    edgecolor = p._complement_color(kwargs.pop("edgecolor", default), color, p._hue_map)
 
     width = kwargs.pop("width", 0.8)
     dodge = kwargs.pop("dodge", False if kind in undodged_kinds else "auto")

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -13,9 +13,8 @@ from matplotlib.patches import Rectangle
 import matplotlib.pyplot as plt
 
 from seaborn._core.typing import default, deprecated
-from seaborn._base import infer_orient, categorical_order
+from seaborn._base import VectorPlotter, infer_orient, categorical_order
 from seaborn._stats.density import KDE
-from seaborn.relational import _RelationalPlotter
 from seaborn import utils
 from seaborn.utils import (
     desaturate,
@@ -41,9 +40,7 @@ __all__ = [
 ]
 
 
-# Subclassing _RelationalPlotter for the legend machinery,
-# but probably should move that more centrally
-class _CategoricalPlotter(_RelationalPlotter):
+class _CategoricalPlotter(VectorPlotter):
 
     wide_structure = {"x": "@columns", "y": "@values"}
     flat_structure = {"y": "@values"}
@@ -65,13 +62,13 @@ class _CategoricalPlotter(_RelationalPlotter):
 
         # This method takes care of some bookkeeping that is necessary because the
         # original categorical plots (prior to the 2021 refactor) had some rules that
-        # don't fit exactly into the logic of _core. It may be wise to have a second
+        # don't fit exactly into VectorPlotter logic. It may be wise to have a second
         # round of refactoring that moves the logic deeper, but this will keep things
         # relatively sensible for now.
 
         # For wide data, orient determines assignment to x/y differently from the
-        # wide_structure rules in _core. If we do decide to make orient part of the
-        # _core variable assignment, we'll want to figure out how to express that.
+        # default VectorPlotter rules. If we do decide to make orient part of the
+        # _base variable assignment, we'll want to figure out how to express that.
         if self.input_format == "wide" and orient in ["h", "y"]:
             self.plot_data = self.plot_data.rename(columns={"x": "y", "y": "x"})
             orig_variables = set(self.variables)
@@ -87,7 +84,7 @@ class _CategoricalPlotter(_RelationalPlotter):
                 self.var_types["x"] = orig_y_type
 
         # The concept of an "orientation" is important to the original categorical
-        # plots, but there's no provision for it in _core, so we need to do it here.
+        # plots, but there's no provision for it in VectorPlotter, so we need it here.
         # Note that it could be useful for the other functions in at least two ways
         # (orienting a univariate distribution plot from long-form data and selecting
         # the aggregation axis in lineplot), so we may want to eventually refactor it.

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -45,7 +45,6 @@ class _CategoricalPlotter(VectorPlotter):
     wide_structure = {"x": "@columns", "y": "@values"}
     flat_structure = {"y": "@values"}
 
-    _legend_func = "scatter"
     _legend_attributes = ["color"]
 
     def __init__(

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -402,7 +402,7 @@ class _CategoricalPlotter(VectorPlotter):
             show_legend = bool(self.legend)
 
         if show_legend:
-            self.add_legend_data(ax, func, common_kws, semantic_kws)
+            self.add_legend_data(ax, func, common_kws, semantic_kws=semantic_kws)
             handles, _ = ax.get_legend_handles_labels()
             if handles:
                 ax.legend(title=self.legend_title)

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -22,6 +22,7 @@ from seaborn.utils import (
     _check_argument,
     _draw_figure,
     _default_color,
+    _get_patch_legend_artist,
     _get_transform_functions,
     _normalize_kwargs,
     _scatter_legend_artist,
@@ -713,12 +714,8 @@ class _CategoricalPlotter(_RelationalPlotter):
 
             ax.add_container(BoxPlotContainer(artists))
 
-        patch_kws = props["box"].copy()
-        if not fill:
-            patch_kws["facecolor"] = (1, 1, 1, 0)
-        else:
-            patch_kws["edgecolor"] = linecolor
-        self._configure_legend(ax, ax.fill_between, patch_kws)
+        legend_artist = _get_patch_legend_artist(fill)
+        self._configure_legend(ax, legend_artist, boxprops)
 
     def plot_boxens(
         self,
@@ -857,12 +854,9 @@ class _CategoricalPlotter(_RelationalPlotter):
 
         ax.autoscale_view(scalex=self.orient == "y", scaley=self.orient == "x")
 
-        patch_kws = box_kws.copy()
-        if not fill:
-            patch_kws["facecolor"] = (1, 1, 1, 0)
-        else:
-            patch_kws["edgecolor"] = linecolor
-        self._configure_legend(ax, ax.fill_between, patch_kws)
+        legend_artist = _get_patch_legend_artist(fill)
+        common_kws = {**box_kws, "linewidth": linewidth, "edgecolor": linecolor}
+        self._configure_legend(ax, legend_artist, common_kws)
 
     def plot_violins(
         self,
@@ -1136,7 +1130,9 @@ class _CategoricalPlotter(_RelationalPlotter):
                 }
                 ax.plot(invx(x2), invy(y2), **dot_kws)
 
-        self._configure_legend(ax, ax.fill_between)  # TODO, patch_kws)
+        legend_artist = _get_patch_legend_artist(fill)
+        common_kws = {**plot_kws, "linewidth": linewidth, "edgecolor": linecolor}
+        self._configure_legend(ax, legend_artist, common_kws)
 
     def plot_points(
         self,
@@ -1213,8 +1209,9 @@ class _CategoricalPlotter(_RelationalPlotter):
             if aggregator.error_method is not None:
                 self.plot_errorbars(ax, agg_data, capsize, sub_err_kws)
 
+        legend_artist = partial(mpl.lines.Line2D, [], [])
         semantic_kws = {"hue": {"marker": markers, "linestyle": linestyles}}
-        self._configure_legend(ax, ax.plot, sub_kws, semantic_kws)
+        self._configure_legend(ax, legend_artist, sub_kws, semantic_kws)
 
     def plot_bars(
         self,
@@ -1295,7 +1292,8 @@ class _CategoricalPlotter(_RelationalPlotter):
                     {"color": ".26" if fill else main_color, **err_kws}
                 )
 
-        self._configure_legend(ax, ax.fill_between)
+        legend_artist = _get_patch_legend_artist(fill)
+        self._configure_legend(ax, legend_artist, plot_kws)
 
     def plot_errorbars(self, ax, data, capsize, err_kws):
 

--- a/seaborn/relational.py
+++ b/seaborn/relational.py
@@ -830,7 +830,7 @@ def relplot(
         keys = ["c", "color", "alpha", "m", "marker"]
         if kind == "scatter":
             legend_artist = _scatter_legend_artist
-            keys += ["s", "facecolor", "fc", "edgecolor", "ec"]
+            keys += ["s", "facecolor", "fc", "edgecolor", "ec", "linewidth", "lw"]
         else:
             legend_artist = partial(mpl.lines.Line2D, xdata=[], ydata=[])
             keys += [

--- a/seaborn/relational.py
+++ b/seaborn/relational.py
@@ -364,7 +364,8 @@ class _LinePlotter(_RelationalPlotter):
         self._add_axis_labels(ax)
         if self.legend:
             legend_artist = partial(mpl.lines.Line2D, xdata=[], ydata=[])
-            self.add_legend_data(ax, legend_artist, common_kws=kws)
+            attrs = {"hue": "color", "size": "linewidth", "style": None}
+            self.add_legend_data(ax, legend_artist, kws, attrs)
             handles, _ = ax.get_legend_handles_labels()
             if handles:
                 legend = ax.legend(title=self.legend_title)
@@ -449,7 +450,8 @@ class _ScatterPlotter(_RelationalPlotter):
         # Finalize the axes details
         self._add_axis_labels(ax)
         if self.legend:
-            self.add_legend_data(ax, _scatter_legend_artist, kws)
+            attrs = {"hue": "color", "size": "s", "style": None}
+            self.add_legend_data(ax, _scatter_legend_artist, kws, attrs)
             handles, _ = ax.get_legend_handles_labels()
             if handles:
                 legend = ax.legend(title=self.legend_title)
@@ -842,7 +844,12 @@ def relplot(
             ]
 
         common_kws = {k: v for k, v in kwargs.items() if k in keys}
-        p.add_legend_data(g.axes.flat[0], legend_artist, common_kws)
+        attrs = {"hue": "color", "style": None}
+        if kind == "scatter":
+            attrs["size"] = "s"
+        elif kind == "line":
+            attrs["size"] = "linewidth"
+        p.add_legend_data(g.axes.flat[0], legend_artist, common_kws, attrs)
         if p.legend_data:
             g.add_legend(legend_data=p.legend_data,
                          label_order=p.legend_order,

--- a/seaborn/relational.py
+++ b/seaborn/relational.py
@@ -10,7 +10,6 @@ from ._base import (
     VectorPlotter,
 )
 from .utils import (
-    locator_to_legend_entries,
     adjust_legend_subtitles,
     _default_color,
     _deprecate_ci,
@@ -191,126 +190,6 @@ class _RelationalPlotter(VectorPlotter):
 
     # TODO where best to define default parameters?
     sort = True
-
-    def add_legend_data(self, ax, func=None, common_kws=None, semantic_kws=None):
-        """Add labeled artists to represent the different plot semantics."""
-        verbosity = self.legend
-        if isinstance(verbosity, str) and verbosity not in ["auto", "brief", "full"]:
-            err = "`legend` must be 'auto', 'brief', 'full', or a boolean."
-            raise ValueError(err)
-        elif verbosity is True:
-            verbosity = "auto"
-
-        keys = []
-        legend_kws = {}
-        common_kws = {} if common_kws is None else common_kws
-        semantic_kws = {} if semantic_kws is None else semantic_kws
-
-        # Assign a legend title if there is only going to be one sub-legend,
-        # otherwise, subtitles will be inserted into the texts list with an
-        # invisible handle (which is a hack)
-        titles = {
-            title for title in
-            (self.variables.get(v, None) for v in ["hue", "size", "style"])
-            if title is not None
-        }
-        title = "" if len(titles) != 1 else titles.pop()
-        title_kws = dict(
-            visible=False, color="w", s=0, linewidth=0, marker="", dashes=""
-        )
-
-        def update(var_name, val_name, **kws):
-
-            key = var_name, val_name
-            if key in legend_kws:
-                legend_kws[key].update(**kws)
-            else:
-                keys.append(key)
-                legend_kws[key] = dict(**kws)
-
-        legend_attrs = {"hue": "color", "size": ["linewidth", "s"], "style": None}
-        for var, names in legend_attrs.items():
-            self._update_legend_data(
-                update, var, verbosity, title, title_kws, names, semantic_kws.get(var),
-            )
-
-        if func is None:
-            func = getattr(ax, self._legend_func)
-
-        legend_data = {}
-        legend_order = []
-
-        for key in keys:
-
-            _, label = key
-            kws = legend_kws[key]
-            kws.setdefault("color", ".2")
-            level_kws = {}
-            use_attrs = [
-                *self._legend_attributes,
-                *common_kws,
-                *[attr for var_attrs in semantic_kws.values() for attr in var_attrs],
-            ]
-            for attr in use_attrs:
-                if attr in kws:
-                    level_kws[attr] = kws[attr]
-            artist = func(label=label, **{**common_kws, **level_kws})
-            ax.add_artist(artist)
-            legend_data[key] = artist
-            legend_order.append(key)
-
-        self.legend_title = title
-        self.legend_data = legend_data
-        self.legend_order = legend_order
-
-    def _update_legend_data(
-        self,
-        update,
-        var,
-        verbosity,
-        title,
-        title_kws,
-        attr_names,
-        other_props,
-    ):
-
-        brief_ticks = 6
-        mapper = getattr(self, f"_{var}_map", None)
-        if mapper is None:
-            return
-
-        brief = mapper.map_type == "numeric" and (
-            verbosity == "brief"
-            or (verbosity == "auto" and len(mapper.levels) > brief_ticks)
-        )
-        if brief:
-            if isinstance(mapper.norm, mpl.colors.LogNorm):
-                locator = mpl.ticker.LogLocator(numticks=brief_ticks)
-            else:
-                locator = mpl.ticker.MaxNLocator(nbins=brief_ticks)
-            limits = min(mapper.levels), max(mapper.levels)
-            levels, formatted_levels = locator_to_legend_entries(
-                locator, limits, self.plot_data[var].infer_objects().dtype
-            )
-        elif mapper.levels is None:
-            levels = formatted_levels = []
-        else:
-            levels = formatted_levels = mapper.levels
-
-        if not title and self.variables.get(var, None) is not None:
-            update((self.variables[var], "title"), self.variables[var], **title_kws)
-
-        other_props = {} if other_props is None else other_props
-
-        for level, formatted_level in zip(levels, formatted_levels):
-            if level is not None:
-                attr = mapper(level)
-                if isinstance(attr_names, list):
-                    attr = {name: attr for name in attr_names}
-                elif attr_names is not None:
-                    attr = {attr_names: attr}
-                attr.update({k: v[level] for k, v in other_props.items() if level in v})
-                update(self.variables[var], formatted_level, **attr)
 
 
 class _LinePlotter(_RelationalPlotter):

--- a/seaborn/relational.py
+++ b/seaborn/relational.py
@@ -821,11 +821,28 @@ def relplot(
         # Replace the original plot data so the legend uses numeric data with
         # the correct type, since we force a categorical mapping above.
         p.plot_data = plot_data
-        legend_artist = (
-            _scatter_legend_artist if kind == "scatter"
-            else partial(mpl.lines.Line2D, xdata=[], ydata=[])
-        )
-        p.add_legend_data(g.axes.flat[0], legend_artist)
+
+        # Handle the additional non-semantic keyword arguments out here.
+        # We're selective because some kwargs may be seaborn function specific
+        # and not relevant to the matplotlib artists going into the legend.
+        # Ideally, we will have a better solution where we don't need to re-make
+        # the legend out here and will have parity with the axes-level functions.
+        keys = ["c", "color", "alpha", "m", "marker"]
+        if kind == "scatter":
+            legend_artist = _scatter_legend_artist
+            keys += ["s", "facecolor", "fc", "edgecolor", "ec"]
+        else:
+            legend_artist = partial(mpl.lines.Line2D, xdata=[], ydata=[])
+            keys += [
+                "markersize", "ms",
+                "markeredgewidth", "mew",
+                "markeredgecolor", "mec",
+                "linestyle", "ls",
+                "linewidth", "lw",
+            ]
+
+        common_kws = {k: v for k, v in kwargs.items() if k in keys}
+        p.add_legend_data(g.axes.flat[0], legend_artist, common_kws)
         if p.legend_data:
             g.add_legend(legend_data=p.legend_data,
                          label_order=p.legend_order,

--- a/seaborn/relational.py
+++ b/seaborn/relational.py
@@ -1,3 +1,4 @@
+from functools import partial
 import warnings
 
 import numpy as np
@@ -253,9 +254,8 @@ class _RelationalPlotter(VectorPlotter):
             for attr in use_attrs:
                 if attr in kws:
                     level_kws[attr] = kws[attr]
-            artist = func([], [], label=label, **{**common_kws, **level_kws})
-            if func.__name__ == "plot":
-                artist = artist[0]
+            artist = func(label=label, **{**common_kws, **level_kws})
+            ax.add_artist(artist)
             legend_data[key] = artist
             legend_order.append(key)
 
@@ -484,7 +484,8 @@ class _LinePlotter(_RelationalPlotter):
         # Finalize the axes details
         self._add_axis_labels(ax)
         if self.legend:
-            self.add_legend_data(ax)
+            artist_func = partial(mpl.lines.Line2D, xdata=[], ydata=[])
+            self.add_legend_data(ax, func=artist_func, common_kws=kws)
             handles, _ = ax.get_legend_handles_labels()
             if handles:
                 legend = ax.legend(title=self.legend_title)

--- a/seaborn/relational.py
+++ b/seaborn/relational.py
@@ -195,7 +195,6 @@ class _RelationalPlotter(VectorPlotter):
 class _LinePlotter(_RelationalPlotter):
 
     _legend_attributes = ["color", "linewidth", "marker", "dashes"]
-    _legend_func = "plot"
 
     def __init__(
         self, *,
@@ -370,11 +369,13 @@ class _LinePlotter(_RelationalPlotter):
                 legend = ax.legend(title=self.legend_title)
                 adjust_legend_subtitles(legend)
 
+    def _legend_func(self, **kwargs):
+        return mpl.lines.Line2D([], [], **kwargs)
+
 
 class _ScatterPlotter(_RelationalPlotter):
 
     _legend_attributes = ["color", "s", "marker"]
-    _legend_func = "scatter"
 
     def __init__(self, *, data=None, variables={}, legend=None):
 
@@ -453,6 +454,15 @@ class _ScatterPlotter(_RelationalPlotter):
             if handles:
                 legend = ax.legend(title=self.legend_title)
                 adjust_legend_subtitles(legend)
+
+    def _legend_func(self, **kwargs):
+        kwargs.setdefault("marker", "o")
+        kwargs.pop("linewidth", None)  # TODO actually use
+        kwargs.update(
+            # TODO fix this elsewhere so we're not passing `s`
+            ms=np.sqrt(kwargs.pop("s", mpl.rcParams["lines.markersize"] ** 2)),
+        )
+        return mpl.lines.Line2D([], [], linestyle="", **kwargs)
 
 
 def lineplot(

--- a/seaborn/utils.py
+++ b/seaborn/utils.py
@@ -921,3 +921,20 @@ def _scatter_legend_artist(**kws):
     }
 
     return mpl.lines.Line2D([], [], **line_kws)
+
+
+def _get_patch_legend_artist(fill):
+
+    def legend_artist(**kws):
+
+        color = kws.pop("color", None)
+        if color is not None:
+            if fill:
+                kws["facecolor"] = color
+            else:
+                kws["edgecolor"] = color
+                kws["facecolor"] = "none"
+
+        return mpl.patches.Rectangle((0, 0), 0, 0, **kws)
+
+    return legend_artist

--- a/seaborn/utils.py
+++ b/seaborn/utils.py
@@ -906,19 +906,23 @@ def _version_predates(lib: ModuleType, version: str) -> bool:
 def _scatter_legend_artist(**kws):
 
     kws = _normalize_kwargs(kws, mpl.collections.PathCollection)
-    if kws.get("edgecolor") == "face":
-        kws["edgecolor"] = kws.get("facecolor", kws["color"])
 
+    edgecolor = kws.pop("edgecolor", None)
     rc = mpl.rcParams
     line_kws = {
         "linestyle": "",
         "marker": kws.pop("marker", "o"),
         "markersize": np.sqrt(kws.pop("s", rc["lines.markersize"] ** 2)),
         "markerfacecolor": kws.pop("facecolor", kws.get("color")),
-        "markeredgecolor": kws.pop("edgecolor", "none"),
         "markeredgewidth": kws.pop("linewidth", 0),
         **kws,
     }
+
+    if edgecolor is not None:
+        if edgecolor == "face":
+            line_kws["markeredgecolor"] = line_kws["markerfacecolor"]
+        else:
+            line_kws["markeredgecolor"] = edgecolor
 
     return mpl.lines.Line2D([], [], **line_kws)
 

--- a/seaborn/utils.py
+++ b/seaborn/utils.py
@@ -901,3 +901,18 @@ def _disable_autolayout():
 def _version_predates(lib: ModuleType, version: str) -> bool:
     """Helper function for checking version compatibility."""
     return Version(lib.__version__) < Version(version)
+
+
+def _scatter_legend_artist(**kws):
+
+    rc = mpl.rcParams
+    line_kws = {
+        "linestyle": "",
+        "marker": kws.pop("marker", "o"),
+        "markersize": np.sqrt(kws.pop("s", rc["lines.markersize"] ** 2)),
+        "markeredgecolor": kws.pop("edgecolor"),
+        "markeredgewidth": kws.pop("linewidth"),
+        **kws,
+    }
+
+    return mpl.lines.Line2D([], [], **line_kws)

--- a/seaborn/utils.py
+++ b/seaborn/utils.py
@@ -905,11 +905,16 @@ def _version_predates(lib: ModuleType, version: str) -> bool:
 
 def _scatter_legend_artist(**kws):
 
+    kws = _normalize_kwargs(kws, mpl.collections.PathCollection)
+    if kws["edgecolor"] == "face":
+        kws["edgecolor"] = kws.get("facecolor", kws["color"])
+
     rc = mpl.rcParams
     line_kws = {
         "linestyle": "",
         "marker": kws.pop("marker", "o"),
         "markersize": np.sqrt(kws.pop("s", rc["lines.markersize"] ** 2)),
+        "markerfacecolor": kws.pop("facecolor", kws.get("color")),
         "markeredgecolor": kws.pop("edgecolor"),
         "markeredgewidth": kws.pop("linewidth"),
         **kws,

--- a/seaborn/utils.py
+++ b/seaborn/utils.py
@@ -906,7 +906,7 @@ def _version_predates(lib: ModuleType, version: str) -> bool:
 def _scatter_legend_artist(**kws):
 
     kws = _normalize_kwargs(kws, mpl.collections.PathCollection)
-    if kws["edgecolor"] == "face":
+    if kws.get("edgecolor") == "face":
         kws["edgecolor"] = kws.get("facecolor", kws["color"])
 
     rc = mpl.rcParams
@@ -915,8 +915,8 @@ def _scatter_legend_artist(**kws):
         "marker": kws.pop("marker", "o"),
         "markersize": np.sqrt(kws.pop("s", rc["lines.markersize"] ** 2)),
         "markerfacecolor": kws.pop("facecolor", kws.get("color")),
-        "markeredgecolor": kws.pop("edgecolor"),
-        "markeredgewidth": kws.pop("linewidth"),
+        "markeredgecolor": kws.pop("edgecolor", "none"),
+        "markeredgewidth": kws.pop("linewidth", 0),
         **kws,
     }
 

--- a/tests/test_axisgrid.py
+++ b/tests/test_axisgrid.py
@@ -1428,8 +1428,8 @@ class TestPairGrid:
         vars = ["x", "y", "z"]
         markers = ["o", "X", "s"]
         g = ag.pairplot(self.df, hue="a", vars=vars, markers=markers)
-        m1 = get_legend_handles(g._legend)[0].get_paths()[0]
-        m2 = get_legend_handles(g._legend)[1].get_paths()[0]
+        m1 = get_legend_handles(g._legend)[0].get_marker()
+        m2 = get_legend_handles(g._legend)[1].get_marker()
         assert m1 != m2
 
         with pytest.warns(UserWarning):
@@ -1485,7 +1485,8 @@ class TestPairGrid:
         g.map(scatterplot)
         assert g.axes.shape == (3, 3)
         for ax in g.axes.flat:
-            assert len(ax.collections) == long_df["a"].nunique() + 1
+            pts = ax.collections[0].get_offsets()
+            assert len(pts) == len(long_df)
 
 
 class TestJointGrid:

--- a/tests/test_axisgrid.py
+++ b/tests/test_axisgrid.py
@@ -14,6 +14,7 @@ from seaborn.palettes import color_palette
 from seaborn.relational import scatterplot
 from seaborn.distributions import histplot, kdeplot, distplot
 from seaborn.categorical import pointplot
+from seaborn.utils import _version_predates
 from seaborn import axisgrid as ag
 from seaborn._testing import (
     assert_plots_equal,
@@ -1423,6 +1424,7 @@ class TestPairGrid:
 
         assert_plots_equal(ax1, ax2, labels=False)
 
+    @pytest.mark.skipif(_version_predates(mpl, "3.7.0"), reason="Matplotlib bug")
     def test_pairplot_markers(self):
 
         vars = ["x", "y", "z"]

--- a/tests/test_categorical.py
+++ b/tests/test_categorical.py
@@ -1891,7 +1891,7 @@ class TestBarPlot(SharedAggTests):
         x, y = ["a", "b", "c"], [1, 2, 3]
         hue = ["x", "x", "y"]
 
-        ax = barplot(x=x, y=y, hue=hue, saturation=1)
+        ax = barplot(x=x, y=y, hue=hue, saturation=1, legend=False)
         for i, bar in enumerate(ax.patches):
             assert bar.get_x() + bar.get_width() / 2 == approx(i)
             assert bar.get_y() == 0
@@ -1916,7 +1916,7 @@ class TestBarPlot(SharedAggTests):
         y = [1, 2, 3, 4]
         hue = ["x", "x", "y", "y"]
 
-        ax = barplot(x=x, y=y, hue=hue, saturation=1)
+        ax = barplot(x=x, y=y, hue=hue, saturation=1, legend=False)
         for i, bar in enumerate(ax.patches):
             sign = 1 if i // 2 else -1
             assert (
@@ -1934,7 +1934,7 @@ class TestBarPlot(SharedAggTests):
         y = [1, 2, 3, 4]
         hue = ["x", "x", "y", "y"]
 
-        ax = barplot(x=x, y=y, hue=hue, gap=.25)
+        ax = barplot(x=x, y=y, hue=hue, gap=.25, legend=False)
         for i, bar in enumerate(ax.patches):
             assert bar.get_width() == approx(0.8 / 2 * .75)
 
@@ -1944,7 +1944,7 @@ class TestBarPlot(SharedAggTests):
         y = [1, 2, 3, 4]
         hue = ["x", "x", "y", "y"]
 
-        ax = barplot(x=x, y=y, hue=hue, saturation=1, dodge=False)
+        ax = barplot(x=x, y=y, hue=hue, saturation=1, dodge=False, legend=False)
         for i, bar in enumerate(ax.patches):
             assert bar.get_x() + bar.get_width() / 2 == approx(i % 2)
             assert bar.get_y() == 0
@@ -1978,7 +1978,7 @@ class TestBarPlot(SharedAggTests):
         y = [1, 2, 3, 4]
         hue = ["x", "x", "y", "y"]
 
-        ax = barplot(x=x, y=y, hue=hue, fill=False)
+        ax = barplot(x=x, y=y, hue=hue, fill=False, legend=False)
         for i, bar in enumerate(ax.patches):
             assert same_color(bar.get_edgecolor(), f"C{i // 2}")
             assert same_color(bar.get_facecolor(), (0, 0, 0, 0))
@@ -2729,7 +2729,7 @@ class TestCountPlot:
         hue = ["x", "y", "y", "x", "x", "x"]
         counts = [1, 3, 2, 0]
 
-        ax = countplot(x=vals, hue=hue, saturation=1)
+        ax = countplot(x=vals, hue=hue, saturation=1, legend=False)
         for i, bar in enumerate(ax.patches):
             sign = 1 if i // 2 else -1
             assert (
@@ -2869,8 +2869,8 @@ class TestCatPlot(CategoricalFixture):
         assert len(g.ax.lines) == want_elements
 
         g = cat.catplot(x="g", y="y", hue="h", data=self.df, kind="bar")
-        want_elements = self.g.unique().size * self.h.unique().size
-        assert len(g.ax.patches) == want_elements
+        want_elements = self.g.nunique() * self.h.nunique()
+        assert len(g.ax.patches) == (want_elements + self.h.nunique())
         assert len(g.ax.lines) == want_elements
 
         g = cat.catplot(x="g", data=self.df, kind="count")
@@ -2879,7 +2879,7 @@ class TestCatPlot(CategoricalFixture):
         assert len(g.ax.lines) == 0
 
         g = cat.catplot(x="g", hue="h", data=self.df, kind="count")
-        want_elements = self.g.unique().size * self.h.unique().size
+        want_elements = self.g.nunique() * self.h.nunique() + self.h.nunique()
         assert len(g.ax.patches) == want_elements
         assert len(g.ax.lines) == 0
 
@@ -2892,7 +2892,7 @@ class TestCatPlot(CategoricalFixture):
         assert len(self.get_box_artists(g.ax)) == want_artists
 
         g = cat.catplot(x="g", y="y", hue="h", data=self.df, kind="box")
-        want_artists = self.g.unique().size * self.h.unique().size
+        want_artists = self.g.nunique() * self.h.nunique()
         assert len(self.get_box_artists(g.ax)) == want_artists
 
         g = cat.catplot(x="g", y="y", data=self.df,
@@ -2902,8 +2902,8 @@ class TestCatPlot(CategoricalFixture):
 
         g = cat.catplot(x="g", y="y", hue="h", data=self.df,
                         kind="violin", inner=None)
-        want_elements = self.g.unique().size * self.h.unique().size
-        assert len(g.ax.collections) == want_elements + self.h.unique().size
+        want_elements = self.g.nunique() * self.h.nunique()
+        assert len(g.ax.collections) == want_elements
 
         g = cat.catplot(x="g", y="y", data=self.df, kind="strip")
         want_elements = self.g.unique().size
@@ -2912,7 +2912,7 @@ class TestCatPlot(CategoricalFixture):
             assert same_color(strip.get_facecolors(), "C0")
 
         g = cat.catplot(x="g", y="y", hue="h", data=self.df, kind="strip")
-        want_elements = self.g.unique().size + self.h.unique().size
+        want_elements = self.g.nunique()
         assert len(g.ax.collections) == want_elements
 
     def test_bad_plot_kind_error(self):
@@ -2954,13 +2954,15 @@ class TestCatPlot(CategoricalFixture):
         plt.close("all")
 
         ax = cat.pointplot(x="g", y="y", data=self.df, color="purple")
-        g = cat.catplot(x="g", y="y", data=self.df, color="purple")
+        g = cat.catplot(x="g", y="y", data=self.df, color="purple", kind="point")
         for l1, l2 in zip(ax.lines, g.ax.lines):
             assert l1.get_color() == l2.get_color()
         plt.close("all")
 
         ax = cat.pointplot(x="g", y="y", data=self.df, palette="Set2", hue="h")
-        g = cat.catplot(x="g", y="y", data=self.df, palette="Set2", hue="h")
+        g = cat.catplot(
+            x="g", y="y", data=self.df, palette="Set2", hue="h", kind="point"
+        )
         for l1, l2 in zip(ax.lines, g.ax.lines):
             assert l1.get_color() == l2.get_color()
         plt.close("all")

--- a/tests/test_relational.py
+++ b/tests/test_relational.py
@@ -693,6 +693,35 @@ class TestRelationalPlotter(Helpers):
         for line in ax.get_lines():
             assert line.is_dashed()
 
+    def test_legend_attributes_hue(self, long_df):
+
+        kws = {"s": 50, "linewidth": 1, "marker": "X"}
+        g = relplot(long_df, x="x", y="y", hue="a", **kws)
+        palette = color_palette()
+        for i, pt in enumerate(get_legend_handles(g.legend)):
+            assert same_color(pt.get_color(), palette[i])
+            assert pt.get_markersize() == np.sqrt(kws["s"])
+            assert pt.get_markeredgewidth() == kws["linewidth"]
+            assert pt.get_marker() == kws["marker"]
+
+    def test_legend_attributes_style(self, long_df):
+
+        kws = {"s": 50, "linewidth": 1, "color": "r"}
+        g = relplot(long_df, x="x", y="y", style="a", **kws)
+        for pt in get_legend_handles(g.legend):
+            assert pt.get_markersize() == np.sqrt(kws["s"])
+            assert pt.get_markeredgewidth() == kws["linewidth"]
+            assert same_color(pt.get_color(), "r")
+
+    def test_legend_attributes_hue_and_style(self, long_df):
+
+        kws = {"s": 50, "linewidth": 1}
+        g = relplot(long_df, x="x", y="y", hue="a", style="b", **kws)
+        for pt in get_legend_handles(g.legend):
+            if pt.get_label() not in ["a", "b"]:
+                assert pt.get_markersize() == np.sqrt(kws["s"])
+                assert pt.get_markeredgewidth() == kws["linewidth"]
+
 
 class TestLinePlotter(SharedAxesLevelTests, Helpers):
 
@@ -1139,6 +1168,34 @@ class TestLinePlotter(SharedAxesLevelTests, Helpers):
         ax = lineplot(data=wide_df, ax=ax1)
         assert ax is ax1
 
+    def test_legend_attributes_with_hue(self, long_df):
+
+        kws = {"marker": "o", "linewidth": 3}
+        ax = lineplot(long_df, x="x", y="y", hue="a", **kws)
+        palette = color_palette()
+        for i, line in enumerate(get_legend_handles(ax.get_legend())):
+            assert same_color(line.get_color(), palette[i])
+            assert line.get_linewidth() == kws["linewidth"]
+            assert line.get_marker() == kws["marker"]
+
+    def test_legend_attributes_with_style(self, long_df):
+
+        kws = {"color": "r", "marker": "o", "linewidth": 3}
+        ax = lineplot(long_df, x="x", y="y", style="a", **kws)
+        for line in get_legend_handles(ax.get_legend()):
+            assert same_color(line.get_color(), kws["color"])
+            assert line.get_marker() == kws["marker"]
+            assert line.get_linewidth() == kws["linewidth"]
+
+    def test_legend_attributes_with_hue_and_style(self, long_df):
+
+        kws = {"marker": "o", "linewidth": 3}
+        ax = lineplot(long_df, x="x", y="y", hue="a", style="b", **kws)
+        for line in get_legend_handles(ax.get_legend()):
+            if line.get_label() not in ["a", "b"]:
+                assert line.get_marker() == kws["marker"]
+                assert line.get_linewidth() == kws["linewidth"]
+
     def test_lineplot_vs_relplot(self, long_df, long_semantics):
 
         ax = lineplot(data=long_df, legend=False, **long_semantics)
@@ -1402,6 +1459,35 @@ class TestScatterPlotter(SharedAxesLevelTests, Helpers):
         ax = scatterplot(x=x, y=y, size=z, legend="brief")
         _, labels = ax.get_legend_handles_labels()
         assert len(labels) < len(set(z))
+
+    def test_legend_attributes_hue(self, long_df):
+
+        kws = {"s": 50, "linewidth": 1, "marker": "X"}
+        ax = scatterplot(long_df, x="x", y="y", hue="a", **kws)
+        palette = color_palette()
+        for i, pt in enumerate(get_legend_handles(ax.get_legend())):
+            assert same_color(pt.get_color(), palette[i])
+            assert pt.get_markersize() == np.sqrt(kws["s"])
+            assert pt.get_markeredgewidth() == kws["linewidth"]
+            assert pt.get_marker() == kws["marker"]
+
+    def test_legend_attributes_style(self, long_df):
+
+        kws = {"s": 50, "linewidth": 1, "color": "r"}
+        ax = scatterplot(long_df, x="x", y="y", style="a", **kws)
+        for pt in get_legend_handles(ax.get_legend()):
+            assert pt.get_markersize() == np.sqrt(kws["s"])
+            assert pt.get_markeredgewidth() == kws["linewidth"]
+            assert same_color(pt.get_color(), "r")
+
+    def test_legend_attributes_hue_and_style(self, long_df):
+
+        kws = {"s": 50, "linewidth": 1}
+        ax = scatterplot(long_df, x="x", y="y", hue="a", style="b", **kws)
+        for pt in get_legend_handles(ax.get_legend()):
+            if pt.get_label() not in ["a", "b"]:
+                assert pt.get_markersize() == np.sqrt(kws["s"])
+                assert pt.get_markeredgewidth() == kws["linewidth"]
 
     def test_legend_value_error(self, long_df):
 

--- a/tests/test_relational.py
+++ b/tests/test_relational.py
@@ -1141,8 +1141,8 @@ class TestLinePlotter(SharedAxesLevelTests, Helpers):
 
     def test_lineplot_vs_relplot(self, long_df, long_semantics):
 
-        ax = lineplot(data=long_df, **long_semantics)
-        g = relplot(data=long_df, kind="line", **long_semantics)
+        ax = lineplot(data=long_df, legend=False, **long_semantics)
+        g = relplot(data=long_df, kind="line", legend=False, **long_semantics)
 
         lin_lines = ax.lines
         rel_lines = g.ax.lines

--- a/tests/test_relational.py
+++ b/tests/test_relational.py
@@ -21,7 +21,7 @@ from seaborn.relational import (
     scatterplot
 )
 
-from seaborn.utils import _draw_figure
+from seaborn.utils import _draw_figure, _version_predates
 from seaborn._compat import get_colormap, get_legend_handles
 from seaborn._testing import assert_plots_equal
 
@@ -702,7 +702,8 @@ class TestRelationalPlotter(Helpers):
             assert same_color(pt.get_color(), palette[i])
             assert pt.get_markersize() == np.sqrt(kws["s"])
             assert pt.get_markeredgewidth() == kws["linewidth"]
-            assert pt.get_marker() == kws["marker"]
+            if not _version_predates(mpl, "3.7.0"):
+                assert pt.get_marker() == kws["marker"]
 
     def test_legend_attributes_style(self, long_df):
 
@@ -1176,7 +1177,8 @@ class TestLinePlotter(SharedAxesLevelTests, Helpers):
         for i, line in enumerate(get_legend_handles(ax.get_legend())):
             assert same_color(line.get_color(), palette[i])
             assert line.get_linewidth() == kws["linewidth"]
-            assert line.get_marker() == kws["marker"]
+            if not _version_predates(mpl, "3.7.0"):
+                assert line.get_marker() == kws["marker"]
 
     def test_legend_attributes_with_style(self, long_df):
 
@@ -1184,7 +1186,8 @@ class TestLinePlotter(SharedAxesLevelTests, Helpers):
         ax = lineplot(long_df, x="x", y="y", style="a", **kws)
         for line in get_legend_handles(ax.get_legend()):
             assert same_color(line.get_color(), kws["color"])
-            assert line.get_marker() == kws["marker"]
+            if not _version_predates(mpl, "3.7.0"):
+                assert line.get_marker() == kws["marker"]
             assert line.get_linewidth() == kws["linewidth"]
 
     def test_legend_attributes_with_hue_and_style(self, long_df):
@@ -1193,7 +1196,8 @@ class TestLinePlotter(SharedAxesLevelTests, Helpers):
         ax = lineplot(long_df, x="x", y="y", hue="a", style="b", **kws)
         for line in get_legend_handles(ax.get_legend()):
             if line.get_label() not in ["a", "b"]:
-                assert line.get_marker() == kws["marker"]
+                if not _version_predates(mpl, "3.7.0"):
+                    assert line.get_marker() == kws["marker"]
                 assert line.get_linewidth() == kws["linewidth"]
 
     def test_lineplot_vs_relplot(self, long_df, long_semantics):
@@ -1469,7 +1473,10 @@ class TestScatterPlotter(SharedAxesLevelTests, Helpers):
             assert same_color(pt.get_color(), palette[i])
             assert pt.get_markersize() == np.sqrt(kws["s"])
             assert pt.get_markeredgewidth() == kws["linewidth"]
-            assert pt.get_marker() == kws["marker"]
+            if not _version_predates(mpl, "3.7.0"):
+                # This attribute is empty on older matplotlibs
+                # but the legend looks correct so I assume it is a bug
+                assert pt.get_marker() == kws["marker"]
 
     def test_legend_attributes_style(self, long_df):
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -437,7 +437,7 @@ def test_move_legend_with_labels(long_df):
     ax = scatterplot(long_df, x="x", y="y", hue="a", hue_order=order)
 
     handles_before = get_legend_handles(ax.get_legend())
-    colors_before = [tuple(h.get_facecolor().squeeze()) for h in handles_before]
+    colors_before = [h.get_markerfacecolor() for h in handles_before]
     utils.move_legend(ax, "best", labels=labels)
     _draw_figure(ax.figure)
 
@@ -445,7 +445,7 @@ def test_move_legend_with_labels(long_df):
     assert texts == labels
 
     handles_after = get_legend_handles(ax.get_legend())
-    colors_after = [tuple(h.get_facecolor().squeeze()) for h in handles_after]
+    colors_after = [h.get_markerfacecolor() for h in handles_after]
     assert colors_before == colors_after
 
     with pytest.raises(ValueError, match="Length of new labels"):


### PR DESCRIPTION
This PR does a lot of things (blah) but the main goal is that the legends for relational / categorical plots should better represent additional (non-semantic) properties of the artists in the plot.

Examples:
```python
sns.boxplot(tips, x="total_bill", y="time", hue="sex", gap=.1, fill=False, linewidth=3)
```
<img width=450 src=https://github.com/mwaskom/seaborn/assets/315810/93cfd467-5d77-40c2-9f83-58369a580cca k/>

```python
sns.scatterplot(tips, x="total_bill", y="tip", hue="sex", size="time", marker="x", linewidth=1)
```
<img width=450 src=https://github.com/mwaskom/seaborn/assets/315810/9902d10b-aa8c-4879-81d9-62120fcc6178/>

```python
sns.violinplot(tips, x="total_bill", y="day", hue="sex", linewidth=1, linestyle="--")
```
<img width=450 src=https://github.com/mwaskom/seaborn/assets/315810/fadf977c-9667-41d6-9890-1d04f8b2e6f6/>

There are some important internal changes, notably that scatter plot legends (including strip/swarm plots) now use a `Line2D` artist for the legend handle.

This was a much requested feature but I think it's not without its downsides. For example the following plot is arguably less interpretable / useful than the previous behavior:

```python
sns.scatterplot(diamonds, x="carat", y="price", hue="cut", alpha=.2, s=5)
```
<img width=450 src=https://github.com/mwaskom/seaborn/assets/315810/5b9b50db-3d75-426b-8f43-62647d6d8bb0/>

I'm not sure what to say about this exactly but it's probably out of scope to add additional API to separately configure the legend artists to each plotting function. It is at least possible to work around by modifying the legend artists, e.g.

```python
for handle in ax.get_legend().legend_handles:
    handle.set_markersize(5)
    handle.set_alpha(.8)
```

It would also not surprise me to learn that this introduces new edge-cases where users are passing keyword arguments that the legend artists don't know how to handle. I have tried to rule out as many as I could but believe that we'll need to let community usage (ideally during an RC phase!) surface any remaining issues.

This addresses a number of open issues:
- Closes #2861 (itself a meta-issue for a number of related reports)
- Closes #2355
- Supersedes and closes #2873