### PR TITLE
Normalize matplotlib kwargs in scatterplot / lineplot

### DIFF
--- a/seaborn/relational.py
+++ b/seaborn/relational.py
@@ -14,6 +14,7 @@ from .utils import (
     _default_color,
     _deprecate_ci,
     _get_transform_functions,
+    _normalize_kwargs,
     _scatter_legend_artist,
 )
 from ._statistics import EstimateAggregator
@@ -236,8 +237,9 @@ class _LinePlotter(_RelationalPlotter):
         # gotten from the corresponding matplotlib function, and calling the
         # function will advance the axes property cycle.
 
-        kws.setdefault("markeredgewidth", kws.pop("mew", .75))
-        kws.setdefault("markeredgecolor", kws.pop("mec", "w"))
+        kws = _normalize_kwargs(kws, mpl.lines.Line2D)
+        kws.setdefault("markeredgewidth", 0.75)
+        kws.setdefault("markeredgecolor", "w")
 
         # Set default error kwargs
         err_kws = self.err_kws.copy()
@@ -396,6 +398,8 @@ class _ScatterPlotter(_RelationalPlotter):
         data = self.comp_data.dropna()
         if data.empty:
             return
+
+        kws = _normalize_kwargs(kws, mpl.collections.PathCollection)
 
         # Define the vectors of x and y positions
         empty = np.full(len(data), np.nan)

--- a/tests/test_relational.py
+++ b/tests/test_relational.py
@@ -1732,6 +1732,12 @@ class TestScatterPlotter(SharedAxesLevelTests, Helpers):
             warnings.simplefilter("error")
             scatterplot(data=long_df, x="x", y="y", marker="+")
 
+    def test_short_form_kwargs(self, long_df):
+
+        ax = scatterplot(data=long_df, x="x", y="y", ec="g")
+        pts = ax.collections[0]
+        assert same_color(pts.get_edgecolors().squeeze(), "g")
+
     def test_scatterplot_vs_relplot(self, long_df, long_semantics):
 
         ax = scatterplot(data=long_df, **long_semantics)


### PR DESCRIPTION
Matplotlib 3.8 makes `scatter` raise when both long and short forms of arguments are passed (e.g. `edgecolor` and `ec`); previously one was silently ignored (I think?).

This is probably a marginal QOL improvement for matplotlib users but has broken the seaborn tests, as `scatterplot` sets a default edge color using the long-form argument but an example in the docs demonstrates the short-form example

This PR uses keyword argument normalization upstream of where seaborn sets its defaults. The whole situation is kind of a mess and this is just a localized bandaid, but it should get the tests green and marginally improve seaborn usability.