### PR TITLE
Mask nonpositive values with log_scale and ignore inf data in histogram range

### DIFF
--- a/seaborn/_base.py
+++ b/seaborn/_base.py
@@ -1152,9 +1152,9 @@ class VectorPlotter:
                 for ax in ax_list:
                     set_scale = getattr(ax, f"set_{axis}scale")
                     if scale is True:
-                        set_scale("log")
+                        set_scale("log", nonpositive="mask")
                     else:
-                        set_scale("log", base=scale)
+                        set_scale("log", base=scale, nonpositive="mask")
 
         # For categorical y, we want the "first" level to be at the top of the axis
         if self.var_types.get("y", None) == "categorical":

--- a/seaborn/_stats/counting.py
+++ b/seaborn/_stats/counting.py
@@ -120,7 +120,7 @@ class Hist(Stat):
 
     def _define_bin_edges(self, vals, weight, bins, binwidth, binrange, discrete):
         """Inner function that takes bin parameters as arguments."""
-        vals = vals.dropna()
+        vals = vals.replace(-np.inf, np.nan).replace(np.inf, np.nan).dropna()
 
         if binrange is None:
             start, stop = vals.min(), vals.max()

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -1445,6 +1445,13 @@ class TestHistPlotUnivariate(SharedAxesLevelTests):
             assert_array_almost_equal(start, wide_df[col].min())
             assert_array_almost_equal(stop, wide_df[col].max())
 
+    def test_range_with_inf(self, rng):
+
+        x = rng.normal(0, 1, 20)
+        ax = histplot([-np.inf, *x])
+        leftmost_edge = min(p.get_x() for p in ax.patches)
+        assert leftmost_edge == x.min()
+
     def test_weights_with_missing(self, null_df):
 
         ax = histplot(null_df, x="x", weights="s", bins=5)


### PR DESCRIPTION
Two related updates in one PR:

When handling the `log_scale` option by setting a matplotlib axes scale, use `nonpositive="mask"` so that nonpositive values are dropped rather than set to an arbitrarily small value. This avoids surprises where the small value is aggregated, which are actively wrong.

A consequence is that bar plots on a log value scale no longer magically "work" and require the user to explicitly set a `bottom` value. This is unfortunately but IMO a reasonable tradeoff; bar plots on a log value scale are sort of an anti-pattern anyway IMO and this does require one to be thoughtful about what that means and where the bar should start. Ultimately one is going to be surprised either way and I lean towards the plot being surprisingly empty over the plot having surprisingly wrong values.

A downstream but technically independent update here is that histogram computation now ignores infinite values when computing the default range. This is another behavior where you could argue multiple sides (previously it raised an exception) but silently ignoring infinite values is more consistent with what happens elsewhere in matplotlib and seaborn.