### PR TITLE
Treat binwidth as approximate to avoid dropping outermost datapoints

### DIFF
--- a/seaborn/_stats/counting.py
+++ b/seaborn/_stats/counting.py
@@ -66,6 +66,8 @@ class Hist(Stat):
         of bins, or the bin breaks. Passed to :func:`numpy.histogram_bin_edges`.
     binwidth : float
         Width of each bin; overrides `bins` but can be used with `binrange`.
+        Note that if `binwidth` does not evenly divide the bin range, the actual
+        bin width used will be only approximately equal to the parameter value.
     binrange : (min, max)
         Lowest and highest value for bin edges; can be used with either
         `bins` (when a number) or `binwidth`. Defaults to data extremes.
@@ -129,10 +131,9 @@ class Hist(Stat):
 
         if discrete:
             bin_edges = np.arange(start - .5, stop + 1.5)
-        elif binwidth is not None:
-            step = binwidth
-            bin_edges = np.arange(start, stop + step, step)
         else:
+            if binwidth is not None:
+                bins = int(round((stop - start) / binwidth))
             bin_edges = np.histogram_bin_edges(vals, bins, binrange, weight)
 
         # TODO warning or cap on too many bins?

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -1745,7 +1745,7 @@ class TestHistPlotUnivariate(SharedAxesLevelTests):
     def test_log_scale_explicit(self, rng):
 
         x = rng.lognormal(0, 2, 1000)
-        ax = histplot(x, log_scale=True, binwidth=1)
+        ax = histplot(x, log_scale=True, binrange=(-3, 3), binwidth=1)
 
         bar_widths = [b.get_width() for b in ax.patches]
         steps = np.divide(bar_widths[1:], bar_widths[:-1])
@@ -1757,7 +1757,7 @@ class TestHistPlotUnivariate(SharedAxesLevelTests):
 
         f, ax = plt.subplots()
         ax.set_xscale("log")
-        histplot(x, binwidth=1, ax=ax)
+        histplot(x, binrange=(-3, 3), binwidth=1, ax=ax)
 
         bar_widths = [b.get_width() for b in ax.patches]
         steps = np.divide(bar_widths[1:], bar_widths[:-1])


### PR DESCRIPTION
This PR changes the interpretation of the `binwidth` parameter in `histplot` and `objects.Hist`.

With the previous implementation, floating point errors could cause the largest datapoint(s) to be silently dropped. The solution here is to always honor the bin range (either the explicit as specified through `binrange` or implicit as computed from the data range) and to make the actual bin width only approximately equal to the `binwidth` parameter when `binwidth` does not evenly divide it.

I could not think of a simple + robust solution to detect and handle floating point issues while also reliably honoring expected bin ranges, and I think that the expected violation of expectations will be smaller this way, although it is a minor API change. In most cases it should not be noticeable.

Fixes #3220