### PR TITLE
Avoid a matplotlib warning for strip/swarmplot with unfilled marker

### DIFF
--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -27,6 +27,7 @@ from seaborn.utils import (
     _scatter_legend_artist,
     _version_predates,
 )
+from seaborn._compat import MarkerStyle
 from seaborn._statistics import EstimateAggregator, LetterValues
 from seaborn.palettes import light_palette
 from seaborn.axisgrid import FacetGrid, _facet_docs
@@ -481,6 +482,9 @@ class _CategoricalPlotter(VectorPlotter):
         ax = self.ax
         dodge_move = jitter_move = 0
 
+        if "marker" in plot_kws and not MarkerStyle(plot_kws["marker"]).is_filled():
+            plot_kws.pop("edgecolor", None)
+
         for sub_vars, sub_data in self.iter_data(iter_vars,
                                                  from_comp_data=True,
                                                  allow_empty=True):
@@ -521,6 +525,9 @@ class _CategoricalPlotter(VectorPlotter):
         point_collections = {}
         dodge_move = 0
 
+        if "marker" in plot_kws and not MarkerStyle(plot_kws["marker"]).is_filled():
+            plot_kws.pop("edgecolor", None)
+
         for sub_vars, sub_data in self.iter_data(iter_vars,
                                                  from_comp_data=True,
                                                  allow_empty=True):
@@ -534,6 +541,7 @@ class _CategoricalPlotter(VectorPlotter):
                 sub_data[self.orient] = sub_data[self.orient] + dodge_move
 
             self._invert_scale(ax, sub_data)
+
             points = ax.scatter(sub_data["x"], sub_data["y"], color=color, **plot_kws)
             if "hue" in self.variables:
                 points.set_facecolors(self._hue_map(sub_data["hue"]))

--- a/tests/test_categorical.py
+++ b/tests/test_categorical.py
@@ -1,5 +1,6 @@
 import itertools
 from functools import partial
+import warnings
 
 import numpy as np
 import pandas as pd
@@ -255,6 +256,15 @@ class SharedScatterTests(SharedAxesLevelTests):
         self.func(x=long_df["y"], c=long_df["y"], cmap=cmap)
         _draw_figure(ax.figure)
         assert_array_equal(ax.collections[0].get_facecolors(), colors)
+
+    def test_unfilled_marker(self, long_df):
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            ax = self.func(long_df, x="y", y="a", marker="x", color="r")
+            for points in ax.collections:
+                assert same_color(points.get_facecolors().squeeze(), "r")
+                assert same_color(points.get_edgecolors().squeeze(), "r")
 
     @pytest.mark.parametrize(
         "orient,data_type", [


### PR DESCRIPTION
We set `edgecolor` by default in these plots but matplotlib warns about that being ignored since we also have `color`. Not actually a problem for us, but better to avoid the non-actionable warning.