### PR TITLE
FIX: handle potential TypeError when determining variable type

### DIFF
--- a/seaborn/_base.py
+++ b/seaborn/_base.py
@@ -1520,8 +1520,13 @@ def variable_type(vector, boolean_type="numeric"):
         warnings.simplefilter(
             action='ignore', category=(FutureWarning, DeprecationWarning)
         )
-        if np.isin(vector, [0, 1]).all():
-            return VariableType(boolean_type)
+        try:
+            if np.isin(vector, [0, 1]).all():
+                return VariableType(boolean_type)
+        except TypeError:
+            # .isin comparison is not guaranteed to be possible under NumPy
+            # casting rules, depending on the (unknown) dtype of 'vector'
+            pass
 
     # Defer to positive pandas tests
     if pd.api.types.is_numeric_dtype(vector):

--- a/seaborn/_core/rules.py
+++ b/seaborn/_core/rules.py
@@ -97,7 +97,12 @@ def variable_type(
                 boolean_dtypes = ["bool"]
             boolean_vector = vector.dtype in boolean_dtypes
         else:
-            boolean_vector = bool(np.isin(vector, [0, 1]).all())
+            try:
+                boolean_vector = bool(np.isin(vector, [0, 1]).all())
+            except TypeError:
+                # .isin comparison is not guaranteed to be possible under NumPy
+                # casting rules, depending on the (unknown) dtype of 'vector'
+                boolean_vector = False
         if boolean_vector:
             return VarType(boolean_type)
 

--- a/tests/_core/test_rules.py
+++ b/tests/_core/test_rules.py
@@ -52,6 +52,11 @@ def test_variable_type():
     assert variable_type(s, boolean_type="categorical") == "categorical"
     assert variable_type(s, boolean_type="boolean") == "boolean"
 
+    # This should arguably be datmetime, but we don't currently handle it correctly
+    # Test is mainly asserting that this doesn't fail on the boolean check.
+    s = pd.timedelta_range(1, periods=3, freq="D").to_series()
+    assert variable_type(s) == "categorical"
+
     s_cat = s.astype("category")
     assert variable_type(s_cat, boolean_type="categorical") == "categorical"
     assert variable_type(s_cat, boolean_type="numeric") == "categorical"
@@ -60,6 +65,9 @@ def test_variable_type():
     s = pd.Series([1, 0, 0])
     assert variable_type(s, boolean_type="boolean") == "boolean"
     assert variable_type(s, boolean_type="boolean", strict_boolean=True) == "numeric"
+
+    s = pd.Series([1, 0, 0])
+    assert variable_type(s, boolean_type="boolean") == "boolean"
 
     s = pd.Series([pd.Timestamp(1), pd.Timestamp(2)])
     assert variable_type(s) == "datetime"

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1508,6 +1508,11 @@ class TestCoreFunc:
         assert variable_type(s.to_numpy()) == "categorical"
         assert variable_type(s.to_list()) == "categorical"
 
+        # This should arguably be datmetime, but we don't currently handle it correctly
+        # Test is mainly asserting that this doesn't fail on the boolean check.
+        s = pd.timedelta_range(1, periods=3, freq="D").to_series()
+        assert variable_type(s) == "categorical"
+
         s = pd.Series([True, False, False])
         assert variable_type(s) == "numeric"
         assert variable_type(s, boolean_type="categorical") == "categorical"


### PR DESCRIPTION
I ran into an issue with Seaborn 0.13.0 that wasn't present in previous versions. The following code works fine in Seaborn 0.12.2 but raises ``numpy.core._exceptions._UFuncInputCastingError`` on 0.13.0.

```
from datetime import timedelta
import seaborn as sns
from matplotlib import pyplot as plt

data = {
    'delta': [timedelta(1), timedelta(5), timedelta(3)],
    'x': [1, 2, 3]
}

sns.scatterplot(data, x='x', y='delta')
plt.show()

```

The reason are numpy's default casting rules and the fact that the check changed from ``np.isin(vector, [0, 1, np.nan]`` to ``np.isin(vector, [0, 1])`` in the latest release. That means that previously the comparison was with ``0.0`` and ``1.0`` as float dtype, because the ``nan`` made NumPy cast the whole test array to float. Now the comparison is against int dtype.

In my opinion, the actual dtypes are not relevant here. But we should not assume that the default casting rules allow that this comparison is possible. Simply because the data type of ``vector`` is not know as the data is provided by the user. 
Therefore, I'd say it is best to handle the ``_UFuncInputCastingError`` (which is a subclass of ``TypeError``) and in that case decide that the data is not binary/boolean. The then remaining checks should not have similar issues.