### PR TITLE
Update old mpl color tutorial link

### DIFF
--- a/doc/_tutorial/color_palettes.ipynb
+++ b/doc/_tutorial/color_palettes.ipynb
@@ -975,7 +975,7 @@
    "source": [
     "As you can see, there are many options for using color in your visualizations. Seaborn tries both to use good defaults and to offer a lot of flexibility.\n",
     "\n",
-    "This discussion is only the beginning, and there are a number of good resources for learning more about techniques for using color in visualizations. One great example is this `series of blog posts <https://earthobservatory.nasa.gov/blogs/elegantfigures/2013/08/05/subtleties-of-color-part-1-of-6/>`_ from the NASA Earth Observatory. The matplotlib docs also have a `nice tutorial <https://matplotlib.org/users/colormaps.html>`_ that illustrates some of the perceptual properties of their colormaps."
+    "This discussion is only the beginning, and there are a number of good resources for learning more about techniques for using color in visualizations. One great example is this `series of blog posts <https://earthobservatory.nasa.gov/blogs/elegantfigures/2013/08/05/subtleties-of-color-part-1-of-6/>`_ from the NASA Earth Observatory. The matplotlib docs also have a `nice tutorial <https://matplotlib.org/stable/users/explain/colors/colormaps.html>`_ that illustrates some of the perceptual properties of their colormaps."
    ]
   }
  ],


### PR DESCRIPTION
The old link https://matplotlib.org/2.0.2/users/colormaps.html is marked by matplotlib as out of date, so this replaces it with the new link https://matplotlib.org/stable/users/explain/colors/colormaps.html that seems to have basically the same information (although it did get shuffled around a wee bit).