### PR TITLE
FIX #3537 Disabling the legend based on the x-axis and hue values

### DIFF
--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -2763,6 +2763,10 @@ def catplot(
         elif x is not None and y is not None:
             raise ValueError("Cannot pass values for both `x` and `y`.")
 
+    # Check for x and hue values are same
+    if x == hue:
+        legend = False
+
     p = Plotter(
         data=data,
         variables=dict(x=x, y=y, hue=hue, row=row, col=col, units=units),

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -2763,10 +2763,6 @@ def catplot(
         elif x is not None and y is not None:
             raise ValueError("Cannot pass values for both `x` and `y`.")
 
-    # Check for x or y and hue values are same
-    if x == hue or y == hue:
-        legend = False
-
     p = Plotter(
         data=data,
         variables=dict(x=x, y=y, hue=hue, row=row, col=col, units=units),
@@ -3100,7 +3096,18 @@ def catplot(
         ax.legend_ = None
 
     if legend and "hue" in p.variables and p.input_format == "long":
-        g.add_legend(title=p.variables.get("hue"), label_order=hue_order)
+        # Obtaining the column names for hue, x, and y.
+        hue_value = p.variables.get("hue")
+        x_value = p.variables.get("x")
+        y_value = p.variables.get("y")
+        # Obtaining the datatype of hue
+        hue_type = p.var_types.get("hue")
+        if legend == 'auto' and hue_value in {x_value, y_value} and hue_type != 'numeric':
+            # Setting the title of hue to None if hue matches "x" or "y", or if the data type of "hue" is numeric.
+            title_hue = None
+        else:
+            title_hue = hue_value
+        g.add_legend(title=title_hue, label_order=hue_order)
 
     if data is not None:
         # Replace the dataframe on the FacetGrid for any subsequent maps

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -2763,8 +2763,8 @@ def catplot(
         elif x is not None and y is not None:
             raise ValueError("Cannot pass values for both `x` and `y`.")
 
-    # Check for x and hue values are same
-    if x == hue:
+    # Check for x or y and hue values are same
+    if x == hue or y == hue:
         legend = False
 
     p = Plotter(

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -409,12 +409,10 @@ class _CategoricalPlotter(VectorPlotter):
                     data[col] = inv(data[col])
 
     def _configure_legend(self, ax, func, common_kws=None, semantic_kws=None):
-
         if self.legend == "auto":
             show_legend = not self._redundant_hue and self.input_format != "wide"
         else:
             show_legend = bool(self.legend)
-
         if show_legend:
             self.add_legend_data(ax, func, common_kws, semantic_kws=semantic_kws)
             handles, _ = ax.get_legend_handles_labels()
@@ -3095,21 +3093,12 @@ def catplot(
         g._update_legend_data(ax)
         ax.legend_ = None
 
-    if legend and "hue" in p.variables and p.input_format == "long":
-        # Obtaining the column names for hue, x, and y.
-        hue_value = p.variables.get("hue")
-        x_value = p.variables.get("x")
-        y_value = p.variables.get("y")
-        # Obtaining the datatype of hue
-        hue_type = p.var_types.get("hue")
-        if legend == 'auto' and hue_value in {x_value, y_value} \
-                and hue_type != 'numeric':
-            # Setting the title of hue to None if hue matches "x" or
-            # "y", or if the data type of "hue" is numeric.
-            title_hue = None
-        else:
-            title_hue = hue_value
-        g.add_legend(title=title_hue, label_order=hue_order)
+    if legend == "auto":
+        show_legend = not p._redundant_hue and p.input_format != "wide"
+    else:
+        show_legend = bool(legend)
+    if show_legend:
+        g.add_legend(title=p.variables.get("hue"), label_order=hue_order)
 
     if data is not None:
         # Replace the dataframe on the FacetGrid for any subsequent maps

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -3102,8 +3102,10 @@ def catplot(
         y_value = p.variables.get("y")
         # Obtaining the datatype of hue
         hue_type = p.var_types.get("hue")
-        if legend == 'auto' and hue_value in {x_value, y_value} and hue_type != 'numeric':
-            # Setting the title of hue to None if hue matches "x" or "y", or if the data type of "hue" is numeric.
+        if legend == 'auto' and hue_value in {x_value, y_value} \
+                and hue_type != 'numeric':
+            # Setting the title of hue to None if hue matches "x" or
+            # "y", or if the data type of "hue" is numeric.
             title_hue = None
         else:
             title_hue = hue_value

--- a/tests/test_categorical.py
+++ b/tests/test_categorical.py
@@ -3125,6 +3125,10 @@ class TestCatPlot(CategoricalFixture):
         with pytest.raises(ValueError, match="Invalid `kind`: 'wrong'"):
             catplot(long_df, kind="wrong")
 
+    def test_no_legend_with_auto(self):
+
+        g = catplot(self.df, x="g", y="y", hue="g", legend='auto')
+        assert g._legend is None
 
 class TestBeeswarm:
 

--- a/tests/test_categorical.py
+++ b/tests/test_categorical.py
@@ -3125,10 +3125,14 @@ class TestCatPlot(CategoricalFixture):
         with pytest.raises(ValueError, match="Invalid `kind`: 'wrong'"):
             catplot(long_df, kind="wrong")
 
-    def test_no_legend_with_auto(self):
+    def test_legend_with_auto(self):
 
-        g = catplot(self.df, x="g", y="y", hue="g", legend='auto')
-        assert g._legend is None
+        g1 = catplot(self.df, x="g", y="y", hue="g", legend='auto')
+        assert g1._legend is None
+
+        g2 = catplot(self.df, x="g", y="y", hue="g", legend=True)
+        assert g2._legend is not None
+
 
 class TestBeeswarm:
 


### PR DESCRIPTION
Disable legend in case of redundancy
`sns.catplot(tips, x="day", y="total_bill", hue="day", col="sex", row="smoker", kind="box", height=3)`

![image](https://github.com/mwaskom/seaborn/assets/20552376/2a22e4f2-d00b-4c61-b4fd-b4bee67ac602)
