### PR TITLE
Add extent to Plot.layout configuration

### DIFF
--- a/doc/_docstrings/objects.Plot.layout.ipynb
+++ b/doc/_docstrings/objects.Plot.layout.ipynb
@@ -70,9 +70,27 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "d61054d1-dcef-4e11-9802-394bcc633f9f",
+   "metadata": {},
+   "source": [
+    "With `extent`, you can control the size of the plot relative to the underlying figure. Because the notebook display adapts the figure background to the plot, this appears only to change the plot size in a notebook context. But it can be useful when saving or displaying through a `pyplot` GUI window:"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "781ff58c-b805-4e93-8cae-be0442e273ea",
+   "id": "1b5d5969-2925-474f-8e3c-99e4f90a7a2b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "p.layout(extent=[0, 0, .8, 1]).show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e5c41b7d-a064-4406-8571-a544b194f3dc",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/seaborn/_compat.py
+++ b/seaborn/_compat.py
@@ -1,5 +1,9 @@
+from __future__ import annotations
+from typing import Literal
+
 import numpy as np
 import matplotlib as mpl
+from matplotlib.figure import Figure
 from seaborn.utils import _version_predates
 
 
@@ -84,19 +88,31 @@ def register_colormap(name, cmap):
         mpl.cm.register_cmap(name, cmap)
 
 
-def set_layout_engine(fig, engine):
+def set_layout_engine(
+    fig: Figure,
+    engine: Literal["constrained", "compressed", "tight", "none"],
+) -> None:
     """Handle changes to auto layout engine interface in 3.6"""
     if hasattr(fig, "set_layout_engine"):
         fig.set_layout_engine(engine)
     else:
         # _version_predates(mpl, 3.6)
         if engine == "tight":
-            fig.set_tight_layout(True)
+            fig.set_tight_layout(True)  # type: ignore  # predates typing
         elif engine == "constrained":
-            fig.set_constrained_layout(True)
+            fig.set_constrained_layout(True)  # type: ignore
         elif engine == "none":
-            fig.set_tight_layout(False)
-            fig.set_constrained_layout(False)
+            fig.set_tight_layout(False)  # type: ignore
+            fig.set_constrained_layout(False)  # type: ignore
+
+
+def get_layout_engine(fig: Figure) -> mpl.layout_engine.LayoutEngine | None:
+    """Handle changes to auto layout engine interface in 3.6"""
+    if hasattr(fig, "get_layout_engine"):
+        return fig.get_layout_engine()
+    else:
+        # _version_predates(mpl, 3.6)
+        return None
 
 
 def share_axis(ax0, ax1, which):

--- a/seaborn/_core/plot.py
+++ b/seaborn/_core/plot.py
@@ -826,13 +826,14 @@ class Plot:
         size : (width, height)
             Size of the resulting figure, in inches. Size is inclusive of legend when
             using pyplot, but not otherwise.
-        engine : {{"tight", "constrained", None}}
+        engine : {{"tight", "constrained", "none"}}
             Name of method for automatically adjusting the layout to remove overlap.
             The default depends on whether :meth:`Plot.on` is used.
         extent : (left, bottom, right, top)
-            Boundaries of the plot layout, in fractions of the figure size.
-            Note: the extent includes of axis decorations when using a layout engine,
-            but it is exclusive when `engine=None`.
+            Boundaries of the plot layout, in fractions of the figure size. Takes
+            effect through the layout engine; exact results will vary across engines.
+            Note: the extent includes axis decorations when using a layout engine,
+            but it is exclusive of them when `engine="none"`.
 
         Examples
         --------

--- a/seaborn/_core/plot.py
+++ b/seaborn/_core/plot.py
@@ -40,7 +40,7 @@ from seaborn._core.typing import (
 )
 from seaborn._core.exceptions import PlotSpecError
 from seaborn._core.rules import categorical_order
-from seaborn._compat import set_layout_engine
+from seaborn._compat import get_layout_engine, set_layout_engine
 from seaborn.rcmod import axes_style, plotting_context
 from seaborn.palettes import color_palette
 
@@ -1811,7 +1811,7 @@ class Plotter:
             set_layout_engine(self._figure, "tight")
 
         if (extent := p._layout_spec.get("extent")) is not None:
-            engine = self._figure.get_layout_engine()
+            engine = get_layout_engine(self._figure)
             if engine is None:
                 self._figure.subplots_adjust(*extent)
             else:

--- a/seaborn/_core/plot.py
+++ b/seaborn/_core/plot.py
@@ -810,7 +810,7 @@ class Plot:
         *,
         size: tuple[float, float] | Default = default,
         engine: str | None | Default = default,
-        corners: tuple[float, float, float, float] | Default = default,
+        extent: tuple[float, float, float, float] | Default = default,
     ) -> Plot:
         """
         Control the figure size and layout.
@@ -829,10 +829,10 @@ class Plot:
         engine : {{"tight", "constrained", None}}
             Name of method for automatically adjusting the layout to remove overlap.
             The default depends on whether :meth:`Plot.on` is used.
-        corners : (left, bottom, right, top)
-            Position of the layout corners, in fractions of the figure size.
-            Corners are inclusive of axis decorations when using a layout engine,
-            but they are exclusive when `engine=None`.
+        extent : (left, bottom, right, top)
+            Boundaries of the plot layout, in fractions of the figure size.
+            Note: the extent includes of axis decorations when using a layout engine,
+            but it is exclusive when `engine=None`.
 
         Examples
         --------
@@ -850,8 +850,8 @@ class Plot:
             new._figure_spec["figsize"] = size
         if engine is not default:
             new._layout_spec["engine"] = engine
-        if corners is not default:
-            new._layout_spec["corners"] = corners
+        if extent is not default:
+            new._layout_spec["extent"] = extent
 
         return new
 
@@ -1810,13 +1810,13 @@ class Plotter:
             # TODO either way, make configurable
             set_layout_engine(self._figure, "tight")
 
-        if (corners := p._layout_spec.get("corners")) is not None:
+        if (extent := p._layout_spec.get("extent")) is not None:
             engine = self._figure.get_layout_engine()
             if engine is None:
-                self._figure.subplots_adjust(*corners)
+                self._figure.subplots_adjust(*extent)
             else:
                 # Note the different parameterization for the layout engine rect...
-                left, bottom, right, top = corners
+                left, bottom, right, top = extent
                 width, height = right - left, top - bottom
                 try:
                     # The base LayoutEngine.set method doesn't have rect= so we need

--- a/seaborn/_core/subplots.py
+++ b/seaborn/_core/subplots.py
@@ -144,7 +144,7 @@ class Subplots:
         pair_spec: PairSpec,
         pyplot: bool = False,
         figure_kws: dict | None = None,
-        target: Axes | Figure | SubFigure = None,
+        target: Axes | Figure | SubFigure | None = None,
     ) -> Figure:
         """Initialize matplotlib objects and add seaborn-relevant metadata."""
         # TODO reduce need to pass pair_spec here?

--- a/tests/_core/test_plot.py
+++ b/tests/_core/test_plot.py
@@ -1091,11 +1091,19 @@ class TestPlotting:
         p = Plot().layout(size=size).plot()
         assert tuple(p._figure.get_size_inches()) == size
 
+    @pytest.mark.skipif(
+        _version_predates(mpl, "3.6"),
+        reason="mpl<3.6 does not have get_layout_engine",
+    )
     def test_layout_extent(self):
 
         p = Plot().layout(extent=(.1, .2, .6, 1)).plot()
         assert p._figure.get_layout_engine().get()["rect"] == [.1, .2, .5, .8]
 
+    @pytest.mark.skipif(
+        _version_predates(mpl, "3.6"),
+        reason="mpl<3.6 does not have get_layout_engine",
+    )
     def test_constrained_layout_extent(self):
 
         p = Plot().layout(engine="constrained", extent=(.1, .2, .6, 1)).plot()

--- a/tests/_core/test_plot.py
+++ b/tests/_core/test_plot.py
@@ -1091,19 +1091,19 @@ class TestPlotting:
         p = Plot().layout(size=size).plot()
         assert tuple(p._figure.get_size_inches()) == size
 
-    def test_layout_corners(self):
+    def test_layout_extent(self):
 
-        p = Plot().layout(corners=(.1, .2, .6, 1)).plot()
+        p = Plot().layout(extent=(.1, .2, .6, 1)).plot()
         assert p._figure.get_layout_engine().get()["rect"] == [.1, .2, .5, .8]
 
-    def test_constrained_layout_corners(self):
+    def test_constrained_layout_extent(self):
 
-        p = Plot().layout(engine="constrained", corners=(.1, .2, .6, 1)).plot()
+        p = Plot().layout(engine="constrained", extent=(.1, .2, .6, 1)).plot()
         assert p._figure.get_layout_engine().get()["rect"] == [.1, .2, .5, .8]
 
-    def test_base_layout_corners(self):
+    def test_base_layout_extent(self):
 
-        p = Plot().layout(engine=None, corners=(.1, .2, .6, 1)).plot()
+        p = Plot().layout(engine=None, extent=(.1, .2, .6, 1)).plot()
         assert p._figure.subplotpars.left == 0.1
         assert p._figure.subplotpars.right == 0.6
         assert p._figure.subplotpars.bottom == 0.2

--- a/tests/_core/test_plot.py
+++ b/tests/_core/test_plot.py
@@ -1091,6 +1091,24 @@ class TestPlotting:
         p = Plot().layout(size=size).plot()
         assert tuple(p._figure.get_size_inches()) == size
 
+    def test_layout_corners(self):
+
+        p = Plot().layout(corners=(.1, .2, .6, 1)).plot()
+        assert p._figure.get_layout_engine().get()["rect"] == [.1, .2, .5, .8]
+
+    def test_constrained_layout_corners(self):
+
+        p = Plot().layout(engine="constrained", corners=(.1, .2, .6, 1)).plot()
+        assert p._figure.get_layout_engine().get()["rect"] == [.1, .2, .5, .8]
+
+    def test_base_layout_corners(self):
+
+        p = Plot().layout(engine=None, corners=(.1, .2, .6, 1)).plot()
+        assert p._figure.subplotpars.left == 0.1
+        assert p._figure.subplotpars.right == 0.6
+        assert p._figure.subplotpars.bottom == 0.2
+        assert p._figure.subplotpars.top == 1
+
     def test_on_axes(self):
 
         ax = mpl.figure.Figure().subplots()


### PR DESCRIPTION
This PR adds the `extent` parameter to `Plot.layout`.

While part of incremental progress towards full fine-grained layout customization through `Plot` methods, this update also helps ease some temporary pains. Namely, it may be useful for keeping the legend "outside" of the plot when using `Plot.show`. Recall that the legend is set to be interior to the figure boundary when `Plot.show` is called — hence, when `pyplot` is used to display the plot — to avoid extending past the boundaries of the `pyplot` window:

```python
(
    so.Plot(tips, x="total_bill", y="tip")
    .add(so.Dot(), label="Some dots")
    .show()
)
```
<img width=350 src=https://github.com/mwaskom/seaborn/assets/315810/e567de90-6a7d-495d-ad0e-1490424b8774/>

Setting the right boundary of the extent to <1 leaves room for the legend:

```python
(
    so.Plot(tips, x="total_bill", y="tip")
    .add(so.Dot(), label="Some dots")
    .layout(extent=(0, 0, .8, 1))
    .show()
)
```
<img width=350 src=https://github.com/mwaskom/seaborn/assets/315810/8057e727-4d13-4198-86ad-b80e019cac09)>

Getting the position right may require a little fiddling based on the width of the legend itself. This isn't a perfect fix for legend positioning in `so.Plot`, just workaround (as a special case of a generally-useful configuration).