### PR TITLE
seaborn.pointplot: Fix typos in examples of documentation

### DIFF
--- a/doc/_docstrings/pointplot.ipynb
+++ b/doc/_docstrings/pointplot.ipynb
@@ -22,7 +22,7 @@
    "id": "f25d3647-9fad-47b2-b49d-db6f5b5c3795",
    "metadata": {},
    "source": [
-    "Group by a categorical varaible and plot aggregated values, with confidence intervals:"
+    "Group by a categorical variable and plot aggregated values, with confidence intervals:"
    ]
   },
   {
@@ -138,7 +138,7 @@
    "id": "00273ada-cd12-410a-a268-38243d6514ae",
    "metadata": {},
    "source": [
-    "Dodge by a specific amount, relative to the width alloted for each level:"
+    "Dodge by a specific amount, relative to the width allotted for each level:"
    ]
   },
   {
@@ -164,7 +164,7 @@
    "id": "e205e7c8-6b11-44e6-b43f-7416c427215d",
    "metadata": {},
    "source": [
-    "When variables are not explicity assigned and the dataset is two-dimensional, the plot will aggregate over each column:"
+    "When variables are not explicitly assigned and the dataset is two-dimensional, the plot will aggregate over each column:"
    ]
   },
   {


### PR DESCRIPTION
This PR aims to fix a few typos in the examples of the documentation of [`pointplot`](https://seaborn.pydata.org/generated/seaborn.pointplot.html).