### PR TITLE
doc typo fix in data structures tutorial

### DIFF
--- a/doc/_tutorial/data_structure.ipynb
+++ b/doc/_tutorial/data_structure.ipynb
@@ -19,7 +19,7 @@
     "As a data visualization library, seaborn requires that you provide it with data. This chapter explains the various ways to accomplish that task. Seaborn supports several different dataset formats, and most functions accept data represented with objects from the `pandas <https://pandas.pydata.org/>`_ or `numpy <https://numpy.org/>`_ libraries as well as built-in Python types like lists and dictionaries. Understanding the usage patterns associated with these different options will help you quickly create useful visualizations for nearly any dataset.\n",
     "\n",
     ".. note::\n",
-    "   As of current writing (v0.13.0), the full breadth of options covered here are supported by most, but not all, of the functions in seaborn. Namely, a few older functinos (e.g., :func:`lmplot` and :func:`regplot`) anre more limited in what they accept."
+    "   As of current writing (v0.13.0), the full breadth of options covered here are supported by most, but not all, of the functions in seaborn. Namely, a few older functinos (e.g., :func:`lmplot` and :func:`regplot`) are more limited in what they accept."
    ]
   },
   {

--- a/doc/_tutorial/data_structure.ipynb
+++ b/doc/_tutorial/data_structure.ipynb
@@ -19,7 +19,7 @@
     "As a data visualization library, seaborn requires that you provide it with data. This chapter explains the various ways to accomplish that task. Seaborn supports several different dataset formats, and most functions accept data represented with objects from the `pandas <https://pandas.pydata.org/>`_ or `numpy <https://numpy.org/>`_ libraries as well as built-in Python types like lists and dictionaries. Understanding the usage patterns associated with these different options will help you quickly create useful visualizations for nearly any dataset.\n",
     "\n",
     ".. note::\n",
-    "   As of current writing (v0.13.0), the full breadth of options covered here are supported by most, but not all, of the functions in seaborn. Namely, a few older functinos (e.g., :func:`lmplot` and :func:`regplot`) are more limited in what they accept."
+    "   As of current writing (v0.13.0), the full breadth of options covered here are supported by most, but not all, of the functions in seaborn. Namely, a few older functions (e.g., :func:`lmplot` and :func:`regplot`) are more limited in what they accept."
    ]
   },
   {


### PR DESCRIPTION
Fix small typo in data structure tutorial.

The doc previously said "a few older functions anre more limited".

I changed it to "a few older functions are more limited".