### PR TITLE
seaborn.barplot: Fix typo in docs

### DIFF
--- a/doc/_docstrings/barplot.ipynb
+++ b/doc/_docstrings/barplot.ipynb
@@ -22,7 +22,7 @@
    "id": "b53b65b8-5670-4905-aa39-36db04f4b813",
    "metadata": {},
    "source": [
-    "With long data, assign `x` and `y` to group by a categorical varaible and plot aggregated values, with confidence intervals:"
+    "With long data, assign `x` and `y` to group by a categorical variable and plot aggregated values, with confidence intervals:"
    ]
   },
   {


### PR DESCRIPTION
This PR aims to fix a typo in the documentation of `seaborn.barplot`.