### PR TITLE
MAINT: remove obsolete matplotlib version compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ requires-python = ">=3.8"
 dependencies = [
     "numpy>=1.20,!=1.24.0",
     "pandas>=1.2",
-    "matplotlib>=3.3,!=3.6.1",
+    "matplotlib>=3.4,!=3.6.1",
 ]
 
 [project.optional-dependencies]

--- a/seaborn/_compat.py
+++ b/seaborn/_compat.py
@@ -67,24 +67,6 @@ def norm_from_scale(scale, norm):
     return new_norm
 
 
-def scale_factory(scale, axis, **kwargs):
-    """
-    Backwards compatability for creation of independent scales.
-
-    Matplotlib scales require an Axis object for instantiation on < 3.4.
-    But the axis is not used, aside from extraction of the axis_name in LogScale.
-
-    """
-    if isinstance(scale, str):
-        class Axis:
-            axis_name = axis
-        axis = Axis()
-
-    scale = mpl.scale.scale_factory(scale, axis, **kwargs)
-
-    return scale
-
-
 def get_colormap(name):
     """Handle changes to matplotlib colormap interface in 3.6."""
     try:

--- a/seaborn/_core/plot.py
+++ b/seaborn/_core/plot.py
@@ -27,7 +27,7 @@ from seaborn._marks.base import Mark
 from seaborn._stats.base import Stat
 from seaborn._core.data import PlotData
 from seaborn._core.moves import Move
-from seaborn._core.scales import Scale, Nominal
+from seaborn._core.scales import Scale
 from seaborn._core.subplots import Subplots
 from seaborn._core.groupby import GroupBy
 from seaborn._core.properties import PROPERTIES, Property
@@ -43,7 +43,6 @@ from seaborn._core.rules import categorical_order
 from seaborn._compat import set_layout_engine
 from seaborn.rcmod import axes_style, plotting_context
 from seaborn.palettes import color_palette
-from seaborn.utils import _version_predates
 
 from typing import TYPE_CHECKING, TypedDict
 if TYPE_CHECKING:

--- a/seaborn/_core/plot.py
+++ b/seaborn/_core/plot.py
@@ -40,7 +40,7 @@ from seaborn._core.typing import (
 )
 from seaborn._core.exceptions import PlotSpecError
 from seaborn._core.rules import categorical_order
-from seaborn._compat import set_scale_obj, set_layout_engine
+from seaborn._compat import set_layout_engine
 from seaborn.rcmod import axes_style, plotting_context
 from seaborn.palettes import color_palette
 from seaborn.utils import _version_predates
@@ -462,16 +462,12 @@ class Plot:
 
         """
         accepted_types: tuple  # Allow tuple of various length
-        if hasattr(mpl.figure, "SubFigure"):  # Added in mpl 3.4
-            accepted_types = (
-                mpl.axes.Axes, mpl.figure.SubFigure, mpl.figure.Figure
-            )
-            accepted_types_str = (
-                f"{mpl.axes.Axes}, {mpl.figure.SubFigure}, or {mpl.figure.Figure}"
-            )
-        else:
-            accepted_types = mpl.axes.Axes, mpl.figure.Figure
-            accepted_types_str = f"{mpl.axes.Axes} or {mpl.figure.Figure}"
+        accepted_types = (
+            mpl.axes.Axes, mpl.figure.SubFigure, mpl.figure.Figure
+        )
+        accepted_types_str = (
+            f"{mpl.axes.Axes}, {mpl.figure.SubFigure}, or {mpl.figure.Figure}"
+        )
 
         if not isinstance(target, accepted_types):
             err = (
@@ -1369,19 +1365,6 @@ class Plotter:
                 share_state = self._subplots.subplot_spec[f"share{axis}"]
                 subplots = [view for view in self._subplots if view[axis] == coord]
 
-            # Shared categorical axes are broken on matplotlib<3.4.0.
-            # https://github.com/matplotlib/matplotlib/pull/18308
-            # This only affects us when sharing *paired* axes. This is a novel/niche
-            # behavior, so we will raise rather than hack together a workaround.
-            if axis is not None and _version_predates(mpl, "3.4"):
-                paired_axis = axis in p._pair_spec.get("structure", {})
-                cat_scale = isinstance(scale, Nominal)
-                ok_dim = {"x": "col", "y": "row"}[axis]
-                shared_axes = share_state not in [False, "none", ok_dim]
-                if paired_axis and cat_scale and shared_axes:
-                    err = "Sharing paired categorical axes requires matplotlib>=3.4.0"
-                    raise RuntimeError(err)
-
             if scale is None:
                 self._scales[var] = Scale._identity()
             else:
@@ -1407,7 +1390,7 @@ class Plotter:
                 axis_obj = getattr(view["ax"], f"{axis}axis")
                 seed_values = self._get_subplot_data(var_df, var, view, share_state)
                 view_scale = scale._setup(seed_values, prop, axis=axis_obj)
-                set_scale_obj(view["ax"], axis, view_scale._matplotlib_scale)
+                view["ax"].set(**{f"{axis}scale": view_scale._matplotlib_scale})
 
                 for layer, new_series in zip(layers, transformed_data):
                     layer_df = layer["data"].frame

--- a/seaborn/_core/scales.py
+++ b/seaborn/_core/scales.py
@@ -278,8 +278,6 @@ class Nominal(Scale):
         # major_formatter = new._get_formatter(major_locator, **new._label_params)
 
         class CatScale(mpl.scale.LinearScale):
-            name = None  # To work around mpl<3.4 compat issues
-
             def set_default_locators_and_formatters(self, axis):
                 ...
                 # axis.set_major_locator(major_locator)

--- a/seaborn/_core/subplots.py
+++ b/seaborn/_core/subplots.py
@@ -158,11 +158,8 @@ class Subplots:
                 err = " ".join([
                     "Cannot create multiple subplots after calling `Plot.on` with",
                     f"a {mpl.axes.Axes} object.",
+                    f" You may want to use a {mpl.figure.SubFigure} instead.",
                 ])
-                try:
-                    err += f" You may want to use a {mpl.figure.SubFigure} instead."
-                except AttributeError:  # SubFigure added in mpl 3.4
-                    pass
                 raise RuntimeError(err)
 
             self._subplot_list = [{

--- a/seaborn/_core/subplots.py
+++ b/seaborn/_core/subplots.py
@@ -176,10 +176,7 @@ class Subplots:
             self._figure = target.figure
             return self._figure
 
-        elif (
-            hasattr(mpl.figure, "SubFigure")  # Added in mpl 3.4
-            and isinstance(target, mpl.figure.SubFigure)
-        ):
+        elif isinstance(target, mpl.figure.SubFigure):
             figure = target.figure
         elif isinstance(target, mpl.figure.Figure):
             figure = target

--- a/seaborn/_marks/bar.py
+++ b/seaborn/_marks/bar.py
@@ -16,7 +16,6 @@ from seaborn._marks.base import (
     resolve_color,
     document_properties
 )
-from seaborn.utils import _version_predates
 
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:

--- a/seaborn/_marks/bar.py
+++ b/seaborn/_marks/bar.py
@@ -170,11 +170,8 @@ class Bar(BarBase):
                 ax.add_patch(bar)
 
             # Add a container which is useful for, e.g. Axes.bar_label
-            if _version_predates(mpl, "3.4"):
-                container_kws = {}
-            else:
-                orientation = {"x": "vertical", "y": "horizontal"}[orient]
-                container_kws = dict(datavalues=vals, orientation=orientation)
+            orientation = {"x": "vertical", "y": "horizontal"}[orient]
+            container_kws = dict(datavalues=vals, orientation=orientation)
             container = mpl.container.BarContainer(bars, **container_kws)
             ax.add_container(container)
 

--- a/tests/_core/test_plot.py
+++ b/tests/_core/test_plot.py
@@ -579,10 +579,6 @@ class TestScaling:
         assert_vector_equal(m.passed_data[0]["x"], pd.Series([0., 1.], [0, 1]))
         assert_vector_equal(m.passed_data[1]["x"], pd.Series([0., 1.], [0, 1]))
 
-    @pytest.mark.xfail(
-        _version_predates(mpl, "3.4.0"),
-        reason="Sharing paired categorical axes requires matplotlib>3.4.0"
-    )
     def test_pair_categories_shared(self):
 
         data = [("a", "a"), ("b", "c")]
@@ -1115,10 +1111,6 @@ class TestPlotting:
         assert m.passed_axes == f.axes
         assert p._figure is f
 
-    @pytest.mark.skipif(
-        _version_predates(mpl, "3.4"),
-        reason="mpl<3.4 does not have SubFigure",
-    )
     @pytest.mark.parametrize("facet", [True, False])
     def test_on_subfigure(self, facet):
 

--- a/tests/_core/test_properties.py
+++ b/tests/_core/test_properties.py
@@ -250,9 +250,8 @@ class TestColor(DataFixtures):
         assert f("#123456") == to_rgb("#123456")
         assert f("#12345678") == to_rgba("#12345678")
 
-        if not _version_predates(mpl, "3.4.0"):
-            assert f("#123") == to_rgb("#123")
-            assert f("#1234") == to_rgba("#1234")
+        assert f("#123") == to_rgb("#123")
+        assert f("#1234") == to_rgba("#1234")
 
 
 class ObjectPropertyBase(DataFixtures):

--- a/tests/_core/test_properties.py
+++ b/tests/_core/test_properties.py
@@ -7,7 +7,6 @@ from matplotlib.colors import same_color, to_rgb, to_rgba
 import pytest
 from numpy.testing import assert_array_equal
 
-from seaborn.utils import _version_predates
 from seaborn._core.rules import categorical_order
 from seaborn._core.scales import Nominal, Continuous, Boolean
 from seaborn._core.properties import (

--- a/tests/_core/test_scales.py
+++ b/tests/_core/test_scales.py
@@ -571,10 +571,6 @@ class TestNominal:
         s = Nominal()._setup(x, Coordinate())
         assert_array_equal(s(x), [])
 
-    @pytest.mark.skipif(
-        _version_predates(mpl, "3.4.0"),
-        reason="Test failing on older matplotlib for unclear reasons",
-    )
     def test_finalize(self, x):
 
         ax = mpl.figure.Figure().subplots()

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -611,8 +611,6 @@ class TestRegressionPlots:
         npt.assert_array_equal(red, red_scatter.get_facecolors()[0, :3])
         npt.assert_array_equal(blue, blue_scatter.get_facecolors()[0, :3])
 
-    @pytest.mark.skipif(_version_predates(mpl, "3.4"),
-                        reason="MPL bug #15967")
     @pytest.mark.parametrize("sharex", [True, False])
     def test_lmplot_facet_truncate(self, sharex):
 

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -16,7 +16,6 @@ except ImportError:
     _no_statsmodels = True
 
 from seaborn import regression as lm
-from seaborn.utils import _version_predates
 from seaborn.palettes import color_palette
 
 rs = np.random.RandomState(0)


### PR DESCRIPTION
PR #3393 updated the minimally supported matplotlib version to 3.4. This PR removes code handling (and metadata) of matplotlib versions that are < 3.4. Note that prior to this PR, public package metadata of seaborn 0.13 allows matplotlib 3.3 and above as valid dependencies but pinned version for ci is 3.4.