### PR TITLE
Fix typo

### DIFF
--- a/doc/_docstrings/histplot.ipynb
+++ b/doc/_docstrings/histplot.ipynb
@@ -312,7 +312,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Step functions, esepcially when unfilled, make it easy to compare cumulative histograms:"
+    "Step functions, especially when unfilled, make it easy to compare cumulative histograms:"
    ]
   },
   {


### PR DESCRIPTION
Fix a typo in the `histplot` documentation.