### PR TITLE
Add support for weights in objects.Est

### DIFF
--- a/doc/_docstrings/objects.Est.ipynb
+++ b/doc/_docstrings/objects.Est.ipynb
@@ -110,9 +110,27 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "df807ef8-b5fb-4eac-b539-1bd4e797ddc2",
+   "metadata": {},
+   "source": [
+    "To compute a weighted estimate (and confidence interval), assign a `weight` variable in the layer where you use the stat:"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "5e4a0594-e1ee-4f72-971e-3763dd626e8b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "p.add(so.Range(), so.Est(), weight=\"price\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0d0c34d7-fb76-44cf-9079-3ec7f45741d0",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/seaborn/_stats/aggregation.py
+++ b/seaborn/_stats/aggregation.py
@@ -64,7 +64,7 @@ class Est(Stat):
 
     - **weight**: When passed to a layer that uses this stat, a weighted estimate
       will be computed. Note that use of weights currently limits the choice of
-      estimator error bar method  to `"mean"` and `"ci"`, respectively.
+      function and error bar method  to `"mean"` and `"ci"`, respectively.
 
     Parameters
     ----------

--- a/seaborn/_stats/aggregation.py
+++ b/seaborn/_stats/aggregation.py
@@ -8,7 +8,10 @@ from pandas import DataFrame
 from seaborn._core.scales import Scale
 from seaborn._core.groupby import GroupBy
 from seaborn._stats.base import Stat
-from seaborn._statistics import EstimateAggregator
+from seaborn._statistics import (
+    EstimateAggregator,
+    WeightedEstimateAggregator,
+)
 from seaborn._core.typing import Vector
 
 
@@ -54,8 +57,14 @@ class Est(Stat):
     """
     Calculate a point estimate and error bar interval.
 
-    For additional information about the various `errorbar` choices, see
-    the :doc:`errorbar tutorial </tutorial/error_bars>`.
+    For more information about the various `errorbar` choices, see the
+    :doc:`errorbar tutorial </tutorial/error_bars>`.
+
+    Additional variables:
+
+    - **weight**: When passed to a layer that uses this stat, a weighted estimate
+      will be computed. Note that use of weights currently limits the choice of
+      estimator error bar method  to `"mean"` and `"ci"`, respectively.
 
     Parameters
     ----------
@@ -95,7 +104,10 @@ class Est(Stat):
     ) -> DataFrame:
 
         boot_kws = {"n_boot": self.n_boot, "seed": self.seed}
-        engine = EstimateAggregator(self.func, self.errorbar, **boot_kws)
+        if "weight" in data:
+            engine = WeightedEstimateAggregator(self.func, self.errorbar, **boot_kws)
+        else:
+            engine = EstimateAggregator(self.func, self.errorbar, **boot_kws)
 
         var = {"x": "y", "y": "x"}[orient]
         res = (

--- a/tests/_stats/test_aggregation.py
+++ b/tests/_stats/test_aggregation.py
@@ -115,6 +115,17 @@ class TestEst(AggregationFixtures):
         expected = est.assign(ymin=grouped.min()["y"], ymax=grouped.max()["y"])
         assert_frame_equal(res, expected)
 
+    def test_weighted_mean(self, df, rng):
+
+        weights = rng.uniform(0, 5, len(df))
+        gb = self.get_groupby(df[["x", "y"]], "x")
+        df = df.assign(weight=weights)
+        res = Est("mean")(df, gb, "x", {})
+        for _, res_row in res.iterrows():
+            rows = df[df["x"] == res_row["x"]]
+            expected = np.average(rows["y"], weights=rows["weight"])
+            assert res_row["y"] == expected
+
     def test_seed(self, df):
 
         ori = "x"

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -15,6 +15,7 @@ from seaborn._statistics import (
     ECDF,
     EstimateAggregator,
     LetterValues,
+    WeightedEstimateAggregator,
     _validate_errorbar_arg,
     _no_scipy,
 )
@@ -630,6 +631,39 @@ class TestEstimateAggregator:
         for arg, exception in bad_args:
             with pytest.raises(exception, match="`errorbar` must be"):
                 _validate_errorbar_arg(arg)
+
+
+class TestWeightedEstimateAggregator:
+
+    def test_weighted_mean(self, long_df):
+
+        long_df["weight"] = long_df["x"]
+        est = WeightedEstimateAggregator("mean")
+        out = est(long_df, "y")
+        expected = np.average(long_df["y"], weights=long_df["weight"])
+        assert_array_equal(out["y"], expected)
+        assert_array_equal(out["ymin"], np.nan)
+        assert_array_equal(out["ymax"], np.nan)
+
+    def test_weighted_ci(self, long_df):
+
+        long_df["weight"] = long_df["x"]
+        est = WeightedEstimateAggregator("mean", "ci")
+        out = est(long_df, "y")
+        expected = np.average(long_df["y"], weights=long_df["weight"])
+        assert_array_equal(out["y"], expected)
+        assert (out["ymin"] <= out["y"]).all()
+        assert (out["ymax"] >= out["y"]).all()
+
+    def test_limited_estimator(self):
+
+        with pytest.raises(ValueError, match="Weighted estimator must be 'mean'"):
+            WeightedEstimateAggregator("median")
+
+    def test_limited_ci(self):
+
+        with pytest.raises(ValueError, match="Error bar method must be 'ci'"):
+            WeightedEstimateAggregator("mean", "sd")
 
 
 class TestLetterValues:


### PR DESCRIPTION
This PR enhances `seaborn.objects.Est` to support a weighted mean, with confidence intervals:

```python
diamonds = sns.load_dataset("diamonds")
(
    so.Plot(diamonds, x="color", y="price")
    .add(so.Dot(), so.Est(), weight="carat")
    .add(so.Range(), so.Est(), weight="carat")
)
```
<img width=500 src=https://github.com/mwaskom/seaborn/assets/315810/310e6a70-e6c3-4259-aeeb-3676d46dd75a/>

(I don't know that this plot makes any particular sense, but it demonstrates how you'd use it...)

It is using `np.average` under the hood.

Currently support is limited to `func="mean", errorbar=("ci", ...)`.  There may be other estimators / error bar methods were it makes sense to compute a weighted version (e.g. weighted median/percentiles) although we would need to implement those in seaborn as I don't believe there's an implementation in our dependencies. I think this is fine and probably satisfies the majority of use cases; we can expand support later if there's enough interest.

(As a side note, we should probably error when `func != "mean"` and `errorbar=("se", ...)` since we don't generically compute the parameteric standard error of whatever estimator is passed).

See previous discussion in #3563, which is about the function interface. I actually think that it will be relatively straightforward to add first-class support in the function interface too on top of these changes. I might follow up here or maybe do that in another PR...

