### PR TITLE
Add weighted estimation in function interface

### DIFF
--- a/seaborn/_statistics.py
+++ b/seaborn/_statistics.py
@@ -518,7 +518,7 @@ class EstimateAggregator:
         return pd.Series({var: estimate, f"{var}min": err_min, f"{var}max": err_max})
 
 
-class WeightedEstimateAggregator:
+class WeightedAggregator:
 
     def __init__(self, estimator, errorbar=None, **boot_kws):
         """

--- a/seaborn/_stats/aggregation.py
+++ b/seaborn/_stats/aggregation.py
@@ -10,7 +10,7 @@ from seaborn._core.groupby import GroupBy
 from seaborn._stats.base import Stat
 from seaborn._statistics import (
     EstimateAggregator,
-    WeightedEstimateAggregator,
+    WeightedAggregator,
 )
 from seaborn._core.typing import Vector
 
@@ -105,7 +105,7 @@ class Est(Stat):
 
         boot_kws = {"n_boot": self.n_boot, "seed": self.seed}
         if "weight" in data:
-            engine = WeightedEstimateAggregator(self.func, self.errorbar, **boot_kws)
+            engine = WeightedAggregator(self.func, self.errorbar, **boot_kws)
         else:
             engine = EstimateAggregator(self.func, self.errorbar, **boot_kws)
 

--- a/seaborn/relational.py
+++ b/seaborn/relational.py
@@ -694,7 +694,7 @@ Examples
 
 def relplot(
     data=None, *,
-    x=None, y=None, hue=None, size=None, style=None, units=None,
+    x=None, y=None, hue=None, size=None, style=None, units=None, weights=None,
     row=None, col=None, col_wrap=None, row_order=None, col_order=None,
     palette=None, hue_order=None, hue_norm=None,
     sizes=None, size_order=None, size_norm=None,
@@ -732,9 +732,14 @@ def relplot(
     variables = dict(x=x, y=y, hue=hue, size=size, style=style)
     if kind == "line":
         variables["units"] = units
-    elif units is not None:
-        msg = "The `units` parameter of `relplot` has no effect with kind='scatter'"
-        warnings.warn(msg, stacklevel=2)
+        variables["weight"] = weights
+    else:
+        if units is not None:
+            msg = "The `units` parameter has no effect with kind='scatter'."
+            warnings.warn(msg, stacklevel=2)
+        if weights is not None:
+            msg = "The `weights` parameter has no effect with kind='scatter'."
+            warnings.warn(msg, stacklevel=2)
     p = Plotter(
         data=data,
         variables=variables,

--- a/seaborn/relational.py
+++ b/seaborn/relational.py
@@ -792,17 +792,18 @@ def relplot(
 
     # Add the grid semantics onto the plotter
     grid_variables = dict(
-        x=x, y=y, row=row, col=col,
-        hue=hue, size=size, style=style,
+        x=x, y=y, row=row, col=col, hue=hue, size=size, style=style,
     )
     if kind == "line":
-        grid_variables["units"] = units
+        grid_variables.update(units=units, weights=weights)
     p.assign_variables(data, grid_variables)
 
     # Define the named variables for plotting on each facet
     # Rename the variables with a leading underscore to avoid
     # collisions with faceting variable names
     plot_variables = {v: f"_{v}" for v in variables}
+    if "weight" in plot_variables:
+        plot_variables["weights"] = plot_variables.pop("weight")
     plot_kws.update(plot_variables)
 
     # Pass the row/col variables to FacetGrid with their original
@@ -930,6 +931,10 @@ style : vector or key in `data`
     Grouping variable that will produce elements with different styles.
     Can have a numeric dtype but will always be treated as categorical.
 {params.rel.units}
+weights : vector or key in `data`
+    Data values or column used to compute weighted estimation.
+    Note that use of weights currently limits the choice of statistics
+    to a 'mean' estimator and 'ci' errorbar.
 {params.facets.rowcol}
 {params.facets.col_wrap}
 row_order, col_order : lists of strings

--- a/seaborn/relational.py
+++ b/seaborn/relational.py
@@ -17,7 +17,7 @@ from .utils import (
     _normalize_kwargs,
     _scatter_legend_artist,
 )
-from ._statistics import EstimateAggregator
+from ._statistics import EstimateAggregator, WeightedAggregator
 from .axisgrid import FacetGrid, _facet_docs
 from ._docstrings import DocstringComponents, _core_docs
 
@@ -252,7 +252,8 @@ class _LinePlotter(_RelationalPlotter):
             raise ValueError(err.format(self.err_style))
 
         # Initialize the aggregation object
-        agg = EstimateAggregator(
+        weighted = "weight" in self.plot_data
+        agg = (WeightedAggregator if weighted else EstimateAggregator)(
             self.estimator, self.errorbar, n_boot=self.n_boot, seed=self.seed,
         )
 
@@ -464,7 +465,7 @@ class _ScatterPlotter(_RelationalPlotter):
 
 def lineplot(
     data=None, *,
-    x=None, y=None, hue=None, size=None, style=None, units=None,
+    x=None, y=None, hue=None, size=None, style=None, units=None, weights=None,
     palette=None, hue_order=None, hue_norm=None,
     sizes=None, size_order=None, size_norm=None,
     dashes=True, markers=None, style_order=None,
@@ -478,7 +479,9 @@ def lineplot(
 
     p = _LinePlotter(
         data=data,
-        variables=dict(x=x, y=y, hue=hue, size=size, style=style, units=units),
+        variables=dict(
+            x=x, y=y, hue=hue, size=size, style=style, units=units, weight=weights
+        ),
         estimator=estimator, n_boot=n_boot, seed=seed, errorbar=errorbar,
         sort=sort, orient=orient, err_style=err_style, err_kws=err_kws,
         legend=legend,
@@ -536,6 +539,10 @@ style : vector or key in `data`
     and/or markers. Can have a numeric dtype but will always be treated
     as categorical.
 {params.rel.units}
+weights : vector or key in `data`
+    Data values or column used to compute weighted estimation.
+    Note that use of weights currently limits the choice of statistics
+    to a 'mean' estimator and 'ci' errorbar.
 {params.core.palette}
 {params.core.hue_order}
 {params.core.hue_norm}

--- a/tests/test_categorical.py
+++ b/tests/test_categorical.py
@@ -3147,6 +3147,12 @@ class TestCatPlot(CategoricalFixture):
         g2 = catplot(self.df, x="g", y="y", hue="g", legend=True)
         assert g2._legend is not None
 
+    def test_weights_warning(self, long_df):
+
+        with pytest.warns(UserWarning, match="The `weights` parameter"):
+            g = catplot(long_df, x="a", y="y", weights="z")
+        assert g.ax is not None
+
 
 class TestBeeswarm:
 

--- a/tests/test_categorical.py
+++ b/tests/test_categorical.py
@@ -2131,6 +2131,13 @@ class TestBarPlot(SharedAggTests):
         for i, bar in enumerate(ax.patches):
             assert bar.get_height() == approx(agg_df[order[i]])
 
+    def test_weighted_estimate(self, long_df):
+
+        ax = barplot(long_df, y="y", weights="x")
+        height = ax.patches[0].get_height()
+        expected = np.average(long_df["y"], weights=long_df["x"])
+        assert height == expected
+
     def test_estimate_log_transform(self, long_df):
 
         ax = mpl.figure.Figure().subplots()
@@ -2489,6 +2496,13 @@ class TestPointPlot(SharedAggTests):
         order = categorical_order(long_df[agg_var])
         for i, xy in enumerate(ax.lines[0].get_xydata()):
             assert tuple(xy) == approx((i, agg_df[order[i]]))
+
+    def test_weighted_estimate(self, long_df):
+
+        ax = pointplot(long_df, y="y", weights="x")
+        val = ax.lines[0].get_ydata().item()
+        expected = np.average(long_df["y"], weights=long_df["x"])
+        assert val == expected
 
     def test_estimate_log_transform(self, long_df):
 

--- a/tests/test_relational.py
+++ b/tests/test_relational.py
@@ -582,8 +582,8 @@ class TestRelationalPlotter(Helpers):
 
         g = relplot(data=long_df, x="a", y="y", weights="x", kind="line")
         ydata = g.ax.lines[0].get_ydata()
-        for i, label in enumerate(g.ax.get_xticklabels()):
-            pos_df = long_df[long_df["a"] == label.get_text()]
+        for i, level in enumerate(categorical_order(long_df["a"])):
+            pos_df = long_df[long_df["a"] == level]
             expected = np.average(pos_df["y"], weights=pos_df["x"])
             assert ydata[i] == pytest.approx(expected)
 
@@ -1072,8 +1072,8 @@ class TestLinePlotter(SharedAxesLevelTests, Helpers):
 
         ax = lineplot(long_df, x="a", y="y", weights="x")
         vals = ax.lines[0].get_ydata()
-        for i, label in enumerate(ax.get_xticklabels()):
-            pos_df = long_df.loc[long_df["a"] == label.get_text()]
+        for i, level in enumerate(categorical_order(long_df["a"])):
+            pos_df = long_df[long_df["a"] == level]
             expected = np.average(pos_df["y"], weights=pos_df["x"])
             assert vals[i] == pytest.approx(expected)
 

--- a/tests/test_relational.py
+++ b/tests/test_relational.py
@@ -578,6 +578,15 @@ class TestRelationalPlotter(Helpers):
             expected_paths = [paths[val] for val in grp_df["a"]]
             assert self.paths_equal(points.get_paths(), expected_paths)
 
+    def test_relplot_weighted_estimator(self, long_df):
+
+        g = relplot(data=long_df, x="a", y="y", weights="x", kind="line")
+        ydata = g.ax.lines[0].get_ydata()
+        for i, label in enumerate(g.ax.get_xticklabels()):
+            pos_df = long_df[long_df["a"] == label.get_text()]
+            expected = np.average(pos_df["y"], weights=pos_df["x"])
+            assert ydata[i] == pytest.approx(expected)
+
     def test_relplot_stringy_numerics(self, long_df):
 
         long_df["x_str"] = long_df["x"].astype(str)
@@ -1063,8 +1072,8 @@ class TestLinePlotter(SharedAxesLevelTests, Helpers):
 
         ax = lineplot(long_df, x="a", y="y", weights="x")
         vals = ax.lines[0].get_ydata()
-        for i, a in enumerate(ax.get_xticklabels()):
-            pos_df = long_df.loc[long_df["a"] == a.get_text()]
+        for i, label in enumerate(ax.get_xticklabels()):
+            pos_df = long_df.loc[long_df["a"] == label.get_text()]
             expected = np.average(pos_df["y"], weights=pos_df["x"])
             assert vals[i] == pytest.approx(expected)
 

--- a/tests/test_relational.py
+++ b/tests/test_relational.py
@@ -1055,6 +1055,15 @@ class TestLinePlotter(SharedAxesLevelTests, Helpers):
         ax.clear()
         p.plot(ax, {})
 
+    def test_weights(self, long_df):
+
+        ax = lineplot(long_df, x="a", y="y", weights="x")
+        vals = ax.lines[0].get_ydata()
+        for i, a in enumerate(ax.get_xticklabels()):
+            pos_df = long_df.loc[long_df["a"] == a.get_text()]
+            expected = np.average(pos_df["y"], weights=pos_df["x"])
+            assert vals[i] == pytest.approx(expected)
+
     def test_non_aggregated_data(self):
 
         x = [1, 2, 3, 4]

--- a/tests/test_relational.py
+++ b/tests/test_relational.py
@@ -668,10 +668,14 @@ class TestRelationalPlotter(Helpers):
         )
         assert g.axes.shape == (1, len(col_data.unique()))
 
-    def test_relplot_scatter_units(self, long_df):
+    def test_relplot_scatter_unused_variables(self, long_df):
 
         with pytest.warns(UserWarning, match="The `units` parameter"):
             g = relplot(long_df, x="x", y="y", units="a")
+        assert g.ax is not None
+
+        with pytest.warns(UserWarning, match="The `weights` parameter"):
+            g = relplot(long_df, x="x", y="y", weights="x")
         assert g.ax is not None
 
     def test_ax_kwarg_removal(self, long_df):

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -15,7 +15,7 @@ from seaborn._statistics import (
     ECDF,
     EstimateAggregator,
     LetterValues,
-    WeightedEstimateAggregator,
+    WeightedAggregator,
     _validate_errorbar_arg,
     _no_scipy,
 )
@@ -633,12 +633,12 @@ class TestEstimateAggregator:
                 _validate_errorbar_arg(arg)
 
 
-class TestWeightedEstimateAggregator:
+class TestWeightedAggregator:
 
     def test_weighted_mean(self, long_df):
 
         long_df["weight"] = long_df["x"]
-        est = WeightedEstimateAggregator("mean")
+        est = WeightedAggregator("mean")
         out = est(long_df, "y")
         expected = np.average(long_df["y"], weights=long_df["weight"])
         assert_array_equal(out["y"], expected)
@@ -648,7 +648,7 @@ class TestWeightedEstimateAggregator:
     def test_weighted_ci(self, long_df):
 
         long_df["weight"] = long_df["x"]
-        est = WeightedEstimateAggregator("mean", "ci")
+        est = WeightedAggregator("mean", "ci")
         out = est(long_df, "y")
         expected = np.average(long_df["y"], weights=long_df["weight"])
         assert_array_equal(out["y"], expected)
@@ -658,12 +658,12 @@ class TestWeightedEstimateAggregator:
     def test_limited_estimator(self):
 
         with pytest.raises(ValueError, match="Weighted estimator must be 'mean'"):
-            WeightedEstimateAggregator("median")
+            WeightedAggregator("median")
 
     def test_limited_ci(self):
 
         with pytest.raises(ValueError, match="Error bar method must be 'ci'"):
-            WeightedEstimateAggregator("mean", "sd")
+            WeightedAggregator("mean", "sd")
 
 
 class TestLetterValues:


### PR DESCRIPTION
Follow-on to #3580

This adds `weights` as an option in `lineplot`, `barplot`, `pointplot`, along with the corresponding figure-level functions.

Note that we are going to have to live with the unfortunate contrast between `weights=` in the function interface and `weight=` in the object interface. That maintains local consistency (the distribution plot functions already use `weights`, while the objects interface has a strong singular parameter name convention) at the cost of global consistency. Given that the parameter naming scheme already differs between the two interfaces, I suppose that I can live with it.

As in `objects.Est`, the use of `weights` currently limits the statistical options to `estimator="mean", errorbar="ci"`. We'd need to add support for other estimators/errorbars on a case-by-case basis. Note that we shouldn't need to make changes in the interface functions to do so as all of the input checking logic is handled by the underlying statistical objects.

We may want to add `weights` to violinplot as well. That would look fairly different so it can go in a separate PR. I haven't investigated how complicated it would be. I think that weighted box/boxenplots are probably out of scope.

Closes #3563 