### PR TITLE
FIX: Enable xticklabels for all bottom axes

### DIFF
--- a/seaborn/_core/plot.py
+++ b/seaborn/_core/plot.py
@@ -1177,8 +1177,8 @@ class Plotter:
                     )
                 )
                 for group in ("major", "minor"):
-                    side = {"x":"bottom", "y":"left"}[axis]
-                    axis_obj.set_tick_params(**{f"label{side}":show_tick_labels})
+                    side = {"x": "bottom", "y": "left"}[axis]
+                    axis_obj.set_tick_params(**{f"label{side}": show_tick_labels})
                     for t in getattr(axis_obj, f"get_{group}ticklabels")():
                         t.set_visible(show_tick_labels)
 

--- a/seaborn/_core/plot.py
+++ b/seaborn/_core/plot.py
@@ -1177,6 +1177,7 @@ class Plotter:
                     )
                 )
                 for group in ("major", "minor"):
+                    axis_obj.set_tick_params(labelbottom=show_tick_labels)
                     for t in getattr(axis_obj, f"get_{group}ticklabels")():
                         t.set_visible(show_tick_labels)
 

--- a/seaborn/_core/plot.py
+++ b/seaborn/_core/plot.py
@@ -1177,7 +1177,8 @@ class Plotter:
                     )
                 )
                 for group in ("major", "minor"):
-                    axis_obj.set_tick_params(labelbottom=show_tick_labels)
+                    side = {"x":"bottom", "y":"left"}[axis]
+                    axis_obj.set_tick_params(**{f"label{side}":show_tick_labels})
                     for t in getattr(axis_obj, f"get_{group}ticklabels")():
                         t.set_visible(show_tick_labels)
 

--- a/tests/_core/test_plot.py
+++ b/tests/_core/test_plot.py
@@ -1852,6 +1852,12 @@ class TestLabelVisibility:
         for s in subplots[1:]:
             ax = s["ax"]
             assert ax.xaxis.get_label().get_visible()
+            # mpl3.7 added a getter for tick params, but both yaxis and xaxis return
+            # the same entry of "labelleft" instead of  "labelbottom" for xaxis
+            if not _version_predates(mpl, "3.7"):
+                assert ax.xaxis.get_tick_params()["labelleft"]
+            else:
+                assert len(ax.get_xticklabels()) > 0
             assert all(t.get_visible() for t in ax.get_xticklabels())
 
         for s in subplots[1:-1]:
@@ -1876,6 +1882,12 @@ class TestLabelVisibility:
         for s in subplots[-2:]:
             ax = s["ax"]
             assert ax.xaxis.get_label().get_visible()
+            # mpl3.7 added a getter for tick params, but both yaxis and xaxis return
+            # the same entry of "labelleft" instead of  "labelbottom" for xaxis
+            if not _version_predates(mpl, "3.7"):
+                assert ax.xaxis.get_tick_params()["labelleft"]
+            else:
+                assert len(ax.get_xticklabels()) > 0
             assert all(t.get_visible() for t in ax.get_xticklabels())
 
         for s in subplots[:-2]:


### PR DESCRIPTION
Prior to this change, wrapped faceted plots (with shared axis) are created by deletion of some axes from a larger rectangular grid, so axes that are not on the bottom row lose their tick labels. Current code makes sure that all xtick labels are visible, but doesn't ensure that they're on. The proposed PR makes sure all "bottom" axes have their xticklabels on.  
Fixes #3548 :
![Screenshot 2023-12-22 at 12 43 57](https://github.com/mwaskom/seaborn/assets/13831112/642840f7-89aa-4092-bc7a-eeb3c7794d84)
