### PR TITLE
Add a missing raise in kdeplot and slightly improve lmplot signature

### DIFF
--- a/seaborn/distributions.py
+++ b/seaborn/distributions.py
@@ -1593,7 +1593,7 @@ def kdeplot(
     # Handle (past) deprecation of `data2`
     if "data2" in kwargs:
         msg = "`data2` has been removed (replaced by `y`); please update your code."
-        TypeError(msg)
+        raise TypeError(msg)
 
     # Handle deprecation of `vertical`
     vertical = kwargs.pop("vertical", None)

--- a/seaborn/regression.py
+++ b/seaborn/regression.py
@@ -574,7 +574,7 @@ _regression_docs.update(_facet_docs)
 
 
 def lmplot(
-    data=None, *,
+    data, *,
     x=None, y=None, hue=None, col=None, row=None,
     palette=None, col_wrap=None, height=5, aspect=1, markers="o",
     sharex=None, sharey=None, hue_order=None, col_order=None, row_order=None,

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -920,6 +920,10 @@ class TestKDEPlotUnivariate(SharedAxesLevelTests):
 
         assert ax.legend_ is None
 
+    def test_replaced_kws(self, long_df):
+        with pytest.raises(TypeError, match=r"`data2` has been removed"):
+            kdeplot(data=long_df, x="x", data2="y")
+
 
 class TestKDEPlotBivariate:
 


### PR DESCRIPTION
I noticed these while working on the stubs at typeshed. They felt small enough to include in a single PR.

1. There is a missing `raise ` before `TypeError(msg)` in `kdeplot`
2. The `data` parameter of `lmplot` is required but it has a default of `None`. 20 lines later there is a check that raises a `TypeError` if `data is None`. Removing the default makes sense here to signal to the user that they must pass this argument. It also has two more advantages. The first is that your IDE will now helpfully yell at you if you don't pass the argument. The second is minor but it will allow us to keep running the stub tests for this function at typeshed where we removed the default which made the stub go out of sync with the runtime implementation so we had to skip its tests to pass CI. Note that there is no user facing change here as calling the function without passing `data` still raises a `TypeError` with a clear message.