### PR TITLE
Change how pandoc gets installed in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,7 +35,8 @@ jobs:
 
       - name: Install pandoc
         run: |
-          sudo apt-get install pandoc
+          wget https://github.com/jgm/pandoc/releases/download/3.1.11/pandoc-3.1.11-1-amd64.deb
+          sudo dpkg -i pandoc-3.1.11-1-amd64.deb
 
       - name: Cache datasets
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,6 +16,7 @@ env:
   NB_KERNEL: python
   MPLBACKEND: Agg
   SEABORN_DATA: ${{ github.workspace }}/seaborn-data
+  PYDEVD_DISABLE_FILE_VALIDATION: 1
 
 jobs:
   build-docs:


### PR DESCRIPTION
apt-get installs a very old version (https://github.com/jgm/pandoc/issues/8881) of pandoc

In the CI doc build, we get a number of warning messages related to this, some warning messages that I don't otherwise see when I build docs locally (so, maybe related to this) and increasingly-common flakes.

This PR follows the official pandoc instructions to get a newer version: https://pandoc.org/installing.html

It is a little manual based on the github issue linked above, there may be some progress on updating the version in the linux repositories. We should revisit in the future.