### PR TITLE
Cleanup compat code for obsolete versions of dependencies

### DIFF
--- a/seaborn/_base.py
+++ b/seaborn/_base.py
@@ -1160,11 +1160,7 @@ class VectorPlotter:
         # For categorical y, we want the "first" level to be at the top of the axis
         if self.var_types.get("y", None) == "categorical":
             for ax in ax_list:
-                try:
-                    ax.yaxis.set_inverted(True)
-                except AttributeError:  # mpl < 3.1
-                    if not ax.yaxis_inverted():
-                        ax.invert_yaxis()
+                ax.yaxis.set_inverted(True)
 
         # TODO -- Add axes labels
 

--- a/seaborn/_compat.py
+++ b/seaborn/_compat.py
@@ -7,22 +7,6 @@ from matplotlib.figure import Figure
 from seaborn.utils import _version_predates
 
 
-def MarkerStyle(marker=None, fillstyle=None):
-    """
-    Allow MarkerStyle to accept a MarkerStyle object as parameter.
-
-    Supports matplotlib < 3.3.0
-    https://github.com/matplotlib/matplotlib/pull/16692
-
-    """
-    if isinstance(marker, mpl.markers.MarkerStyle):
-        if fillstyle is None:
-            return marker
-        else:
-            marker = marker.get_marker()
-    return mpl.markers.MarkerStyle(marker, fillstyle)
-
-
 def norm_from_scale(scale, norm):
     """Produce a Normalize object given a Scale and min/max domain limits."""
     # This is an internal maplotlib function that simplifies things to access

--- a/seaborn/_core/plot.py
+++ b/seaborn/_core/plot.py
@@ -858,7 +858,7 @@ class Plot:
 
     # TODO def legend (ugh)
 
-    def theme(self, *args: dict[str, Any]) -> Plot:
+    def theme(self, config: dict[str, Any], /) -> Plot:
         """
         Control the appearance of elements in the plot.
 
@@ -880,13 +880,7 @@ class Plot:
         """
         new = self._clone()
 
-        # We can skip this whole block on Python 3.8+ with positional-only syntax
-        nargs = len(args)
-        if nargs != 1:
-            err = f"theme() takes 1 positional argument, but {nargs} were given"
-            raise TypeError(err)
-
-        rc = mpl.RcParams(args[0])
+        rc = mpl.RcParams(config)
         new._theme.update(rc)
 
         return new

--- a/seaborn/_core/properties.py
+++ b/seaborn/_core/properties.py
@@ -3,24 +3,19 @@ import itertools
 import warnings
 
 import numpy as np
+from numpy.typing import ArrayLike
 from pandas import Series
 import matplotlib as mpl
 from matplotlib.colors import to_rgb, to_rgba, to_rgba_array
+from matplotlib.markers import MarkerStyle
 from matplotlib.path import Path
 
 from seaborn._core.scales import Scale, Boolean, Continuous, Nominal, Temporal
 from seaborn._core.rules import categorical_order, variable_type
-from seaborn._compat import MarkerStyle
 from seaborn.palettes import QUAL_PALETTES, color_palette, blend_palette
 from seaborn.utils import get_color_cycle
 
 from typing import Any, Callable, Tuple, List, Union, Optional
-
-try:
-    from numpy.typing import ArrayLike
-except ImportError:
-    # numpy<1.20.0 (Jan 2021)
-    ArrayLike = Any
 
 RGBTuple = Tuple[float, float, float]
 RGBATuple = Tuple[float, float, float, float]

--- a/seaborn/_statistics.py
+++ b/seaborn/_statistics.py
@@ -25,6 +25,7 @@ The classes should behave roughly in the style of scikit-learn.
 
 """
 from numbers import Number
+from statistics import NormalDist
 import numpy as np
 import pandas as pd
 try:
@@ -35,7 +36,7 @@ except ImportError:
     _no_scipy = True
 
 from .algorithms import bootstrap
-from .utils import _check_argument, _normal_quantile_func
+from .utils import _check_argument
 
 
 class KDE:
@@ -627,7 +628,8 @@ class LetterValues:
         elif self.k_depth == "proportion":
             k = int(np.log2(n)) - int(np.log2(n * self.outlier_prop)) + 1
         elif self.k_depth == "trustworthy":
-            point_conf = 2 * _normal_quantile_func(1 - self.trust_alpha / 2) ** 2
+            normal_quantile_func = np.vectorize(NormalDist().inv_cdf)
+            point_conf = 2 * normal_quantile_func(1 - self.trust_alpha / 2) ** 2
             k = int(np.log2(n / point_conf)) + 1
         else:
             # Allow having k directly specified as input

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -8,7 +8,9 @@ import numpy as np
 import pandas as pd
 
 import matplotlib as mpl
+from matplotlib.cbook import normalize_kwargs
 from matplotlib.collections import PatchCollection
+from matplotlib.markers import MarkerStyle
 from matplotlib.patches import Rectangle
 import matplotlib.pyplot as plt
 
@@ -23,11 +25,9 @@ from seaborn.utils import (
     _default_color,
     _get_patch_legend_artist,
     _get_transform_functions,
-    _normalize_kwargs,
     _scatter_legend_artist,
     _version_predates,
 )
-from seaborn._compat import MarkerStyle
 from seaborn._statistics import (
     EstimateAggregator,
     LetterValues,
@@ -605,7 +605,7 @@ class _CategoricalPlotter(VectorPlotter):
         value_var = {"x": "y", "y": "x"}[self.orient]
 
         def get_props(element, artist=mpl.lines.Line2D):
-            return _normalize_kwargs(plot_kws.pop(f"{element}props", {}), artist)
+            return normalize_kwargs(plot_kws.pop(f"{element}props", {}), artist)
 
         if not fill and linewidth is None:
             linewidth = mpl.rcParams["lines.linewidth"]
@@ -1175,7 +1175,7 @@ class _CategoricalPlotter(VectorPlotter):
         agg_var = {"x": "y", "y": "x"}[self.orient]
         iter_vars = ["hue"]
 
-        plot_kws = _normalize_kwargs(plot_kws, mpl.lines.Line2D)
+        plot_kws = normalize_kwargs(plot_kws, mpl.lines.Line2D)
         plot_kws.setdefault("linewidth", mpl.rcParams["lines.linewidth"] * 1.8)
         plot_kws.setdefault("markeredgewidth", plot_kws["linewidth"] * 0.75)
         plot_kws.setdefault("markersize", plot_kws["linewidth"] * np.sqrt(2 * np.pi))
@@ -2371,7 +2371,7 @@ def barplot(
 
     agg_cls = WeightedAggregator if "weight" in p.plot_data else EstimateAggregator
     aggregator = agg_cls(estimator, errorbar, n_boot=n_boot, seed=seed)
-    err_kws = {} if err_kws is None else _normalize_kwargs(err_kws, mpl.lines.Line2D)
+    err_kws = {} if err_kws is None else normalize_kwargs(err_kws, mpl.lines.Line2D)
 
     # Deprecations to remove in v0.15.0.
     err_kws, capsize = p._err_kws_backcompat(err_kws, errcolor, errwidth, capsize)
@@ -2506,7 +2506,7 @@ def pointplot(
 
     agg_cls = WeightedAggregator if "weight" in p.plot_data else EstimateAggregator
     aggregator = agg_cls(estimator, errorbar, n_boot=n_boot, seed=seed)
-    err_kws = {} if err_kws is None else _normalize_kwargs(err_kws, mpl.lines.Line2D)
+    err_kws = {} if err_kws is None else normalize_kwargs(err_kws, mpl.lines.Line2D)
 
     # Deprecations to remove in v0.15.0.
     p._point_kwargs_backcompat(scale, join, kwargs)
@@ -2848,7 +2848,7 @@ def catplot(
             color = desaturate(color, saturation)
 
     if kind in ["strip", "swarm"]:
-        kwargs = _normalize_kwargs(kwargs, mpl.collections.PathCollection)
+        kwargs = normalize_kwargs(kwargs, mpl.collections.PathCollection)
         kwargs["edgecolor"] = p._complement_color(
             kwargs.pop("edgecolor", default), color, p._hue_map
         )
@@ -3023,14 +3023,14 @@ def catplot(
         # Deprecations to remove in v0.15.0.
         # TODO Uncomment when removing deprecation backcompat
         # capsize = kwargs.pop("capsize", 0)
-        # err_kws = _normalize_kwargs(kwargs.pop("err_kws", {}), mpl.lines.Line2D)
+        # err_kws = normalize_kwargs(kwargs.pop("err_kws", {}), mpl.lines.Line2D)
         p._point_kwargs_backcompat(
             kwargs.pop("scale", deprecated),
             kwargs.pop("join", deprecated),
             kwargs
         )
         err_kws, capsize = p._err_kws_backcompat(
-            _normalize_kwargs(kwargs.pop("err_kws", {}), mpl.lines.Line2D),
+            normalize_kwargs(kwargs.pop("err_kws", {}), mpl.lines.Line2D),
             None,
             errwidth=kwargs.pop("errwidth", deprecated),
             capsize=kwargs.pop("capsize", 0),
@@ -3052,7 +3052,7 @@ def catplot(
         aggregator = agg_cls(estimator, errorbar, n_boot=n_boot, seed=seed)
 
         err_kws, capsize = p._err_kws_backcompat(
-            _normalize_kwargs(kwargs.pop("err_kws", {}), mpl.lines.Line2D),
+            normalize_kwargs(kwargs.pop("err_kws", {}), mpl.lines.Line2D),
             errcolor=kwargs.pop("errcolor", deprecated),
             errwidth=kwargs.pop("errwidth", deprecated),
             capsize=kwargs.pop("capsize", 0),

--- a/seaborn/distributions.py
+++ b/seaborn/distributions.py
@@ -10,6 +10,7 @@ import pandas as pd
 import matplotlib as mpl
 import matplotlib.pyplot as plt
 import matplotlib.transforms as tx
+from matplotlib.cbook import normalize_kwargs
 from matplotlib.colors import to_rgba
 from matplotlib.collections import LineCollection
 
@@ -28,7 +29,6 @@ from .utils import (
     remove_na,
     _get_transform_functions,
     _kde_support,
-    _normalize_kwargs,
     _check_argument,
     _assign_default_kwargs,
     _default_color,
@@ -171,7 +171,7 @@ class _DistributionPlotter(VectorPlotter):
         """Handle differences between artists in filled/unfilled plots."""
         kws = kws.copy()
         if fill:
-            kws = _normalize_kwargs(kws, mpl.collections.PolyCollection)
+            kws = normalize_kwargs(kws, mpl.collections.PolyCollection)
             kws.setdefault("facecolor", to_rgba(color, alpha))
 
             if element == "bars":
@@ -916,7 +916,7 @@ class _DistributionPlotter(VectorPlotter):
             artist = mpl.collections.PolyCollection
         else:
             artist = mpl.lines.Line2D
-        plot_kws = _normalize_kwargs(plot_kws, artist)
+        plot_kws = normalize_kwargs(plot_kws, artist)
 
         # Input checking
         _check_argument("multiple", ["layer", "stack", "fill"], multiple)

--- a/seaborn/relational.py
+++ b/seaborn/relational.py
@@ -5,6 +5,7 @@ import numpy as np
 import pandas as pd
 import matplotlib as mpl
 import matplotlib.pyplot as plt
+from matplotlib.cbook import normalize_kwargs
 
 from ._base import (
     VectorPlotter,
@@ -14,7 +15,6 @@ from .utils import (
     _default_color,
     _deprecate_ci,
     _get_transform_functions,
-    _normalize_kwargs,
     _scatter_legend_artist,
 )
 from ._statistics import EstimateAggregator, WeightedAggregator
@@ -237,7 +237,7 @@ class _LinePlotter(_RelationalPlotter):
         # gotten from the corresponding matplotlib function, and calling the
         # function will advance the axes property cycle.
 
-        kws = _normalize_kwargs(kws, mpl.lines.Line2D)
+        kws = normalize_kwargs(kws, mpl.lines.Line2D)
         kws.setdefault("markeredgewidth", 0.75)
         kws.setdefault("markeredgecolor", "w")
 
@@ -400,7 +400,7 @@ class _ScatterPlotter(_RelationalPlotter):
         if data.empty:
             return
 
-        kws = _normalize_kwargs(kws, mpl.collections.PathCollection)
+        kws = normalize_kwargs(kws, mpl.collections.PathCollection)
 
         # Define the vectors of x and y positions
         empty = np.full(len(data), np.nan)

--- a/tests/_core/test_plot.py
+++ b/tests/_core/test_plot.py
@@ -934,7 +934,7 @@ class TestPlotting:
     def test_theme_error(self):
 
         p = Plot()
-        with pytest.raises(TypeError, match=r"theme\(\) takes 1 positional"):
+        with pytest.raises(TypeError, match=r"theme\(\) takes 2 positional"):
             p.theme("arg1", "arg2")
 
     def test_theme_validation(self):

--- a/tests/_core/test_properties.py
+++ b/tests/_core/test_properties.py
@@ -3,6 +3,7 @@ import numpy as np
 import pandas as pd
 import matplotlib as mpl
 from matplotlib.colors import same_color, to_rgb, to_rgba
+from matplotlib.markers import MarkerStyle
 
 import pytest
 from numpy.testing import assert_array_equal
@@ -20,7 +21,7 @@ from seaborn._core.properties import (
     Marker,
     PointSize,
 )
-from seaborn._compat import MarkerStyle, get_colormap
+from seaborn._compat import get_colormap
 from seaborn.palettes import color_palette
 
 
@@ -357,6 +358,17 @@ class TestMarker(ObjectPropertyBase):
     prop = Marker
     values = ["o", (5, 2, 0), MarkerStyle("^")]
     standardized_values = [MarkerStyle(x) for x in values]
+
+    def assert_equal(self, a, b):
+        a_path, b_path = a.get_path(), b.get_path()
+        assert_array_equal(a_path.vertices, b_path.vertices)
+        assert_array_equal(a_path.codes, b_path.codes)
+        assert a_path.simplify_threshold == b_path.simplify_threshold
+        assert a_path.should_simplify == b_path.should_simplify
+
+        assert a.get_joinstyle() == b.get_joinstyle()
+        assert a.get_transform().to_values() == b.get_transform().to_values()
+        assert a.get_fillstyle() == b.get_fillstyle()
 
     def unpack(self, x):
         return (

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -387,8 +387,6 @@ class TestHeatmap:
         assert len(f.axes) == 2
         plt.close(f)
 
-    @pytest.mark.xfail(mpl.__version__ == "3.1.1",
-                       reason="matplotlib 3.1.1 bug")
     def test_heatmap_axes(self):
 
         ax = mat.heatmap(self.df_norm)
@@ -443,10 +441,7 @@ class TestHeatmap:
     def test_square_aspect(self):
 
         ax = mat.heatmap(self.df_norm, square=True)
-        obs_aspect = ax.get_aspect()
-        # mpl>3.3 returns 1 for setting "equal" aspect
-        # so test for the two possible equal outcomes
-        assert obs_aspect == "equal" or obs_aspect == 1
+        npt.assert_equal(ax.get_aspect(), 1)
 
     def test_mask_validation(self):
 
@@ -679,8 +674,6 @@ class TestDendrogram:
 
         assert len(ax.collections[0].get_paths()) == len(d.dependent_coord)
 
-    @pytest.mark.xfail(mpl.__version__ == "3.1.1",
-                       reason="matplotlib 3.1.1 bug")
     def test_dendrogram_rotate(self):
         kws = self.default_kws.copy()
         kws['rotate'] = True


### PR DESCRIPTION
This PR removes compatibility code for features from matplotlib<1.4, numpy<1.20, and Python<3.8 as these versions are now obsolete according to the dependencies listed in pyrpoject.toml. There is one test change that was necessary, please see inline comment for explanation.