### PR TITLE
Fix minor boxenplot docs misspelling

### DIFF
--- a/doc/_docstrings/boxenplot.ipynb
+++ b/doc/_docstrings/boxenplot.ipynb
@@ -188,7 +188,7 @@
     "tags": []
    },
    "source": [
-    "There are several different approaches for choosing the number of boxes to draw, including a rule based on the confidence level of the percentie estimate:"
+    "There are several different approaches for choosing the number of boxes to draw, including a rule based on the confidence level of the percentile estimate:"
    ]
   },
   {


### PR DESCRIPTION
"percentie" -> "percentile"

Hope this is helpful! Thanks for the library.