### PR TITLE
proper `share{x/y} = row/col` support when `col_wrap=True`

### DIFF
--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -485,6 +485,10 @@ class FacetGrid(Grid):
             if sharey:
                 subplot_kws["sharey"] = axes[0]
             for i in range(1, n_axes):
+                if sharey == "row":
+                    subplot_kws["sharey"] = axes[int(i // ncol * ncol)]
+                if sharex == "col":
+                    subplot_kws["sharey"] = axes[int(i % ncol)]
                 axes[i] = fig.add_subplot(nrow, ncol, i + 1, **subplot_kws)
 
             axes_dict = dict(zip(col_names, axes))


### PR DESCRIPTION
Possible fix for #3671. I would be happy to also add some unit tests if deemed necessary.