### PR TITLE
Remove reference to deprecated numpy error class in tests

### DIFF
--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -1038,9 +1038,6 @@ class TestKDEPlotBivariate:
 
     def test_weights(self, rng):
 
-        import warnings
-        warnings.simplefilter("error", np.VisibleDeprecationWarning)
-
         n = 100
         x, y = rng.multivariate_normal([1, 3], [(.2, .5), (.5, 2)], n).T
         hue = np.repeat([0, 1], n // 2)


### PR DESCRIPTION
For numpy 2.0 compatibility; see #3683 