### PR TITLE
BUGFIX: line_kws.color is of no effect in distribution plot

### DIFF
--- a/seaborn/distributions.py
+++ b/seaborn/distributions.py
@@ -647,7 +647,8 @@ class _DistributionPlotter(VectorPlotter):
                     line_args = density, support
                     sticky_x, sticky_y = (0, np.inf), None
 
-                line_kws["color"] = to_rgba(sub_color, 1)
+                line_color = line_kws.get('color', sub_color)
+                line_kws["color"] = to_rgba(line_color, 1)
                 line, = ax.plot(
                     *line_args, **line_kws,
                 )


### PR DESCRIPTION
In the distribution plot (such as `seaborn.histplot`), both `color` and `line_kws['color']` parameters are allowed to be passed to control the colors of bars and lines, respectively. However, current codes directly take the line color from the bar color while ignoring the `line_kws['color']`. This pull request fixes this by looking at `line_kws['color']` first, and adopting bar color only if the line color is not manually set.