### PR TITLE
[Fix] Objects interface - use axis preconfigured label position

### DIFF
--- a/seaborn/_core/plot.py
+++ b/seaborn/_core/plot.py
@@ -1154,7 +1154,8 @@ class Plotter:
                 # axis / tick labels can be shown on interior shared axes if desired
 
                 axis_obj = getattr(ax, f"{axis}axis")
-                visible_side = {"x": "bottom", "y": "left"}.get(axis)
+                # This allows correct handling for twin{x/y} axises (GH 3614)
+                visible_side = axis_obj.get_label_position()
                 show_axis_label = (
                     sub[visible_side]
                     or not p._pair_spec.get("cross", True)
@@ -1172,8 +1173,9 @@ class Plotter:
                     )
                 )
                 for group in ("major", "minor"):
-                    side = {"x": "bottom", "y": "left"}[axis]
-                    axis_obj.set_tick_params(**{f"label{side}": show_tick_labels})
+                    axis_obj.set_tick_params(
+                        **{f"label{visible_side}": show_tick_labels}
+                    )
                     for t in getattr(axis_obj, f"get_{group}ticklabels")():
                         t.set_visible(show_tick_labels)
 

--- a/tests/_core/test_plot.py
+++ b/tests/_core/test_plot.py
@@ -1124,6 +1124,24 @@ class TestPlotting:
         p = Plot([1], [2]).on(ax).add(m).plot()
         assert m.passed_axes == [ax]
         assert p._figure is ax.figure
+        assert ax.yaxis.get_label_position() == "left"
+        assert ax.yaxis.get_ticks_position() == "left"
+        assert ax.xaxis.get_label_position() == "bottom"
+        assert ax.xaxis.get_ticks_position() == "bottom"
+
+    @pytest.mark.parametrize("axis,exp_position", [("x", "top"), ("y", "right")])
+    def test_on_secondary_axes(self, axis, exp_position):
+
+        ax = mpl.figure.Figure().subplots()
+        twinned_ax = {"x": "y", "y": "x"}[axis]
+        ax2 = getattr(ax, f"twin{twinned_ax}")()
+        m = MockMark()
+        p = Plot([1], [2]).on(ax2).add(m).plot()
+        assert m.passed_axes == [ax2]
+        assert p._figure is ax2.figure
+        targetaxis = getattr(ax2, f"{axis}axis")
+        assert targetaxis.get_label_position() == exp_position
+        assert targetaxis.get_ticks_position() == exp_position
 
     @pytest.mark.parametrize("facet", [True, False])
     def test_on_figure(self, facet):


### PR DESCRIPTION
Issue #3614 describes an incorrect behavior of labeling/ticking of yaxis in the case of using secondary axis (through twin axes). In twin axes (instantiated through `ax.twin{x|y}`), the source axes are duplicated in a manner that makes one axis (for example xaxis) shared with the other (but its label is hidden), while the other axis is visible, but its ticks are plotted on the opposing side (for example yaxis using the right side for labeling and ticking). Prior to this PR, seaboard objects figure setup code assumes that yaxis uses the left side, and xaxis uses the bottom side.

This PR changes the way plot setup is labeling/ticking the relevant axis, and pulls the label location information directly from the axis objects. This way, it correctly labels axis that already set the label to the opposing side (top/right; compared to the common bottom/left axis labeling).

Fixes #3614 (attached its reprex after this PR).

![3614](https://github.com/mwaskom/seaborn/assets/13831112/51e48689-bd2d-460a-bd61-2661672d2584)
