### PR TITLE
Replacement of obsolete np.in1d with np.isin.

### DIFF
--- a/tests/test_categorical.py
+++ b/tests/test_categorical.py
@@ -1206,7 +1206,7 @@ class TestBoxenPlot(SharedAxesLevelTests, SharedPatchArtistTests):
 
         assert verts[pos_idx].min().round(4) >= np.round(pos - width / 2, 4)
         assert verts[pos_idx].max().round(4) <= np.round(pos + width / 2, 4)
-        assert np.in1d(
+        assert np.isin(
             np.percentile(data, [25, 75]).round(4), verts[val_idx].round(4).flat
         ).all()
         assert_array_equal(verts[val_idx, 1:, 0], verts[val_idx, :-1, 2])


### PR DESCRIPTION
This PR removes the warning:
```
tests/test_categorical.py: 35 warnings
  /home/runner/work/seaborn/seaborn/tests/test_categorical.py:1209: DeprecationWarning: `in1d` is deprecated. Use `np.isin` instead.
    assert np.in1d(
```
Replacement of obsolete [np.in1d](https://numpy.org/doc/stable/reference/generated/numpy.in1d.html) with np.isin.