### PR TITLE
fix: bin width < half spread  #3646

### DIFF
--- a/examples/histogram_binning_options.py
+++ b/examples/histogram_binning_options.py
@@ -1,0 +1,50 @@
+"""
+Histogram binning options on data that does not fit the bin size.
+=================================================================
+
+"""
+import pandas as pd
+
+import seaborn as sns
+import matplotlib.pyplot as plt
+
+if __name__ == '__main__':
+    df_round_up = pd.DataFrame({"x": list(range(58))})
+    df_round_down = pd.DataFrame({"x": list(range(52))})
+    n_plots = 4
+
+    fig, ax = plt.subplots(n_plots, 2, figsize=(5 * 2, 5 * n_plots))
+    fig.suptitle("Histogram binning options\nrange(58) and range(52)")
+    fig.tight_layout()
+
+    hist_n_bins_ru = sns.histplot(df_round_up,
+                                  x="x", bins=10, ax=ax[0][0])
+    hist_n_bins_ru.set_title("bins=10")
+    hist_n_bins_rd = sns.histplot(df_round_down,
+                                  x="x", bins=10, ax=ax[0][1])
+    hist_n_bins_rd.set_title("bins=10")
+
+    hist_binwidth_ru = sns.histplot(df_round_up,
+                                    x="x", binwidth=10, ax=ax[1][0])
+    hist_binwidth_ru.set_title("binwidth=10")
+    hist_binwidth_rd = sns.histplot(df_round_down,
+                                    x="x", binwidth=10, ax=ax[1][1])
+    hist_binwidth_rd.set_title("binwidth=10")
+
+    hist_binrange_ru = sns.histplot(df_round_up,
+                                    x="x", binrange=(0, 60), ax=ax[2][0])
+    hist_binrange_ru.set_title("binrange=(0, 60)")
+    hist_binrange_rd = sns.histplot(df_round_down,
+                                    x="x", binrange=(0, 60), ax=ax[2][1])
+    hist_binrange_rd.set_title("binrange=(0, 60)")
+
+    hist_binrange_and_width_ru = sns.histplot(df_round_up,
+                                              x="x", binwidth=10,
+                                              binrange=(0, 60), ax=ax[3][0])
+    hist_binrange_and_width_ru.set_title("bw=10, br=(0, 60)")
+    hist_binrange_and_width_rd = sns.histplot(df_round_down,
+                                              x="x", binwidth=10,
+                                              binrange=(0, 60), ax=ax[3][1])
+    hist_binrange_and_width_rd.set_title("bw=10, br=(0, 60)")
+
+    plt.savefig("output_files/binning_options.svg")

--- a/seaborn/_stats/counting.py
+++ b/seaborn/_stats/counting.py
@@ -11,7 +11,6 @@ from seaborn._core.scales import Scale
 from seaborn._stats.base import Stat
 
 from typing import TYPE_CHECKING
-
 if TYPE_CHECKING:
     from numpy.typing import ArrayLike
 
@@ -33,8 +32,9 @@ class Count(Stat):
     group_by_orient: ClassVar[bool] = True
 
     def __call__(
-            self, data: DataFrame, groupby: GroupBy, orient: str, scales: dict[str, Scale],
+        self, data: DataFrame, groupby: GroupBy, orient: str, scales: dict[str, Scale],
     ) -> DataFrame:
+
         var = {"x": "y", "y": "x"}[orient]
         res = (
             groupby
@@ -199,7 +199,7 @@ class Hist(Stat):
         return data.assign(**{self.stat: hist})
 
     def __call__(
-            self, data: DataFrame, groupby: GroupBy, orient: str, scales: dict[str, Scale],
+        self, data: DataFrame, groupby: GroupBy, orient: str, scales: dict[str, Scale],
     ) -> DataFrame:
 
         scale_type = scales[orient].__class__.__name__.lower()

--- a/seaborn/_stats/counting.py
+++ b/seaborn/_stats/counting.py
@@ -133,7 +133,7 @@ class Hist(Stat):
             bin_edges = np.arange(start - .5, stop + 1.5)
         else:
             if binwidth is not None:
-                bins = int(round((stop - start) / binwidth))
+                bins = int(np.ceil((stop - start) / binwidth))
             bin_edges = np.histogram_bin_edges(vals, bins, binrange, weight)
 
         # TODO warning or cap on too many bins?

--- a/seaborn/_stats/counting.py
+++ b/seaborn/_stats/counting.py
@@ -11,6 +11,7 @@ from seaborn._core.scales import Scale
 from seaborn._stats.base import Stat
 
 from typing import TYPE_CHECKING
+
 if TYPE_CHECKING:
     from numpy.typing import ArrayLike
 
@@ -32,9 +33,8 @@ class Count(Stat):
     group_by_orient: ClassVar[bool] = True
 
     def __call__(
-        self, data: DataFrame, groupby: GroupBy, orient: str, scales: dict[str, Scale],
+            self, data: DataFrame, groupby: GroupBy, orient: str, scales: dict[str, Scale],
     ) -> DataFrame:
-
         var = {"x": "y", "y": "x"}[orient]
         res = (
             groupby
@@ -133,7 +133,7 @@ class Hist(Stat):
             bin_edges = np.arange(start - .5, stop + 1.5)
         else:
             if binwidth is not None:
-                bins = int(np.ceil((stop - start) / binwidth))
+                bins = max(int(round((stop - start) / binwidth)), 1)
             bin_edges = np.histogram_bin_edges(vals, bins, binrange, weight)
 
         # TODO warning or cap on too many bins?
@@ -199,7 +199,7 @@ class Hist(Stat):
         return data.assign(**{self.stat: hist})
 
     def __call__(
-        self, data: DataFrame, groupby: GroupBy, orient: str, scales: dict[str, Scale],
+            self, data: DataFrame, groupby: GroupBy, orient: str, scales: dict[str, Scale],
     ) -> DataFrame:
 
         scale_type = scales[orient].__class__.__name__.lower()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -137,6 +137,18 @@ def long_df(rng):
 
 
 @pytest.fixture
+def mini_bin_df(rng):
+    n = 100
+    df1 = pd.DataFrame({"x": rng.uniform(0, 100, n // 2),
+                        "a": "a",
+                        "b": "x"})
+    df2 = pd.DataFrame({"x": rng.uniform(0, 1, n // 2),
+                        "a": "b",
+                        "b": "y"})
+    return pd.concat([df1, df2])
+
+
+@pytest.fixture
 def long_dict(long_df):
 
     return long_df.to_dict()

--- a/tests/test_axisgrid.py
+++ b/tests/test_axisgrid.py
@@ -721,6 +721,10 @@ class TestFacetGrid:
         for ax in g.axes.flat:
             assert len(ax.collections) == 1
 
+    def test_histplot_with_mini_bin(self, mini_bin_df):
+        grid = ag.FacetGrid(mini_bin_df, col='b', col_wrap=2, hue="a")
+        grid.map(histplot, "x", binwidth=10)
+
 
 class TestPairGrid:
 


### PR DESCRIPTION
prevents edge-case when a bin only has elements with spread < 0.5*bin_width .

I would personally prefer this option, with ceil instead of min(1,..).
This would alter previous behavior for binning in general( creating an additional bin in ~50% of cases),I would be interested to know if that is acceptable here or if you would like to use the min approach instead.