### PR TITLE
Try pinning pillow to fix ci

### DIFF
--- a/ci/deps_pinned.txt
+++ b/ci/deps_pinned.txt
@@ -3,3 +3,4 @@ pandas~=1.2.0
 matplotlib~=3.4.0
 scipy~=1.7.0
 statsmodels~=0.12.0
+pillow~=10.3.0


### PR DESCRIPTION
Seems like they added numpy 2 compatibility but broke compatibility with older numpys.