### PR TITLE
Nullify edgecolor if facecolor is null, preserve input color otherwise

### DIFF
--- a/seaborn/relational.py
+++ b/seaborn/relational.py
@@ -441,6 +441,11 @@ class _ScatterPlotter(_RelationalPlotter):
 
         if "hue" in self.variables:
             points.set_facecolors(self._hue_map(data["hue"]))
+            # nullify edgecolor when facecolor is null, preserve value in kws otherwise
+            points.set_edgecolors([
+                c if c[3] == 0 else kws['edgecolor']
+                for c in points.get_facecolors()
+            ])
 
         if "size" in self.variables:
             points.set_sizes(self._size_map(data["size"]))


### PR DESCRIPTION
In connection with #3728 and #3601 added logic to `relational._ScatterPlotter.plot` such that:

- Marker with null `facecolor` also have null `edgecolor`.
- Value supplied through parameter `edgecolor`, including default white, is retained for all other markers.