### PR TITLE
Test for datetime input on jointplot, code to pass test (#3664)

### DIFF
--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -1704,6 +1704,7 @@ class JointGrid(_BaseGrid):
         self.ax_joint = ax_joint
         self.ax_marg_x = ax_marg_x
         self.ax_marg_y = ax_marg_y
+        self.is_datetime_x = False
 
         # Turn off tick visibility for the measure axis on the marginal plots
         plt.setp(ax_marg_x.get_xticklabels(), visible=False)
@@ -1736,6 +1737,9 @@ class JointGrid(_BaseGrid):
             vector = plot_data.get(var, None)
             if vector is not None:
                 vector = vector.rename(p.variables.get(var, None))
+            if np.issubdtype(vector, np.datetime64):
+                vector = vector.astype(int)
+                self.is_datetime_x = True
             return vector
 
         self.x = get_var("x")
@@ -1832,6 +1836,14 @@ class JointGrid(_BaseGrid):
             func(x=self.x, y=self.y, **kwargs)
         else:
             func(self.x, self.y, **kwargs)
+
+        if self.is_datetime_x:
+            xtick_arr = self.ax_joint.get_xticks()
+            date_label = xtick_arr.astype("datetime64[ns]")
+            date_label = [str(dt)[0:10] for dt in date_label]
+            self.ax_joint.set_xticks(self.ax_joint.get_xticks())
+            self.ax_joint.set_xticklabels(date_label, rotation=45)
+            self._figure.tight_layout()
 
         return self
 

--- a/seaborn/distributions.py
+++ b/seaborn/distributions.py
@@ -2376,6 +2376,8 @@ def _freedman_diaconis_bins(a):
     """Calculate number of hist bins using Freedman-Diaconis rule."""
     # From https://stats.stackexchange.com/questions/798/
     a = np.asarray(a)
+    if a.dtype.type == np.datetime64:
+        a = a.astype(np.int64)
     if len(a) < 2:
         return 1
     iqr = np.subtract.reduce(np.nanpercentile(a, [75, 25]))

--- a/tests/test_axisgrid.py
+++ b/tests/test_axisgrid.py
@@ -1878,3 +1878,9 @@ class TestJointPlot:
         with pytest.warns(UserWarning):
             g = ag.jointplot(data=long_df, x="x", y="y", ax=ax)
         assert g.ax_joint.collections
+
+    def test_datetime_input(self):
+        dates = np.array(
+            ["2023-01-01", "2023-01-02", "2023-01-03"], dtype="datetime64[ns]"
+        )
+        ag.jointplot(x=dates, y=[1, 2, 3], kind="hex")


### PR DESCRIPTION
The initial error comes from the `_freedman_diaconis_bins` function, which I fixed with a straightforward check on data type. However, once the code got through that hurdle, it runs into a more complicated blocker with an overflow error derived from matplotlib's handling of dates as integer. I get around the overflow issue with some manipulation of the object state, but some of the fix is admittedly imperfect. Nonetheless, this code alleviates the original problem seen with `datetime64[ns]` handling, see plot below for example code and plot:

```python
import numpy as np
from seaborn import axisgrid as ag

dates = np.arange("2024-01-01", "2024-04-01", dtype="datetime64[D]").astype("datetime64[ns]")
random_dates = np.random.choice(dates, size=1000)
y = np.random.normal(size=1000)
plot = ag.jointplot(x=random_dates, y=y, kind="hex")

plot.fig.savefig("out.png")
```

![out](https://github.com/user-attachments/assets/8a93868d-eea4-4156-b1e2-7144d8b04f87)