### PR TITLE
Proposal for Beeswarm to overlap points when out of space

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ htmlcov/
 .DS_Store
 notes/
 notebooks/
+mytest.py
+*.png


### PR DESCRIPTION
Added option (keep_gutters) to Beeswarm plots (swarmplot, catplot) which when set to False, will iteratively decrease the distance between the points by 10% until no more gutters are present.

## Example 1
```python
plt.figure(figsize=(4, 4)) # set figure size
swarmplot(data=tips, x="size", y="total_bill", hue="size", alpha=0.7, palette='viridis', keep_gutters=False)
```
![betterbeeswarm](https://github.com/user-attachments/assets/1b7d452e-10c7-4103-a7ce-14d2d58c34a1)

## Example 2
```python
catplot(
    data=tips, kind="swarm", x="time", y="total_bill", hue="sex",
    col="day", aspect=0.6, height=2.5, alpha=0.7, size=5, keep_gutters=False)
```
![betterbeeswarm_cat](https://github.com/user-attachments/assets/6899d32a-f7ad-4785-8b32-55ced5f32f27)
