### PR TITLE
Fix: Add dummy widgets to suppress NameError and warn about missing ipywidgets

### DIFF
--- a/seaborn/widgets.py
+++ b/seaborn/widgets.py
@@ -9,6 +9,15 @@ except ImportError:
         msg = "Interactive palettes require `ipywidgets`, which is not installed."
         raise ImportError(msg)
 
+    class FloatSlider:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    class IntSlider:
+        def __init__(self, *args, **kwargs):
+            pass
+
+
 from .miscplot import palplot
 from .palettes import (color_palette, dark_palette, light_palette,
                        diverging_palette, cubehelix_palette)


### PR DESCRIPTION
<small>I'm running the latest seaborn (0.13.2) on Mac OS 14.2.1 (x86_64), Python 3.12.4.</small>

## The issue
When a user attempts to use widgets from widgets.py module without having ipywidgets installed, the intended ImportError is not raised because of a NameError raised moments before that.

Steps to reproduce:

<details>
  <summary>1. Set up a fresh virtualenv.</summary>

```shell
$ pip freeze
setuptools==72.1.0
wheel==0.43.0
```

</details>

<details><summary>2. Install seaborn (skip ipywidgets).</summary>

```shell
$ pip install seaborn
...
$ pip freeze
contourpy==1.2.1
cycler==0.12.1
fonttools==4.53.1
kiwisolver==1.4.5
matplotlib==3.9.2
numpy==2.0.1
packaging==24.1
pandas==2.2.2
pillow==10.4.0
pyparsing==3.1.2
python-dateutil==2.9.0.post0
pytz==2024.1
seaborn==0.13.2
setuptools==72.1.0
six==1.16.0
tzdata==2024.1
wheel==0.43.0

```
</details>

3. Attempt to use one of the colormap widgets.

```shell
$ python -c "import seaborn; seaborn.choose_colorbrewer_palette('quatlitative')"                                                                                                                                                                  (test-seaborn-fresh)
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "<redacted>/anaconda3/envs/test-seaborn-setup/lib/python3.12/site-packages/seaborn/widgets.py", line 134, in choose_colorbrewer_palette
    desat=FloatSlider(min=0, max=1, value=1)):
          ^^^^^^^^^^^
NameError: name 'FloatSlider' is not defined
```
</details>

## Root cause
The widgets.py module wraps imports from `ipywidgets` with a try/except clause ([link](https://github.com/mwaskom/seaborn/blob/master/seaborn/widgets.py#L5-L10)). When the user doesn't have ipywidgets installed, the `interact` function is patched to raise an `ImportError` and notify the user on the missing module upon invocation.

The local functions defined later in the module are guarded using the wrapper:
```
@interact
def choose_sequential(name=opts, n=(2, 18),
    desat=FloatSlider(min=0, max=1, value=1),
    variant=variants):
```
Unfortunately, such function definitions already attempt to use the members of the ipywidgets module to define the default values for parameters (in this case the `FloatSlider` is used to define a default for `desat`). This prevents the user from seeing the intended `ImportError` and presents them with a `NameError` instead like the one reproduced above.

## Resolution
This PR fixes the issue by defining dummy `FloatSlider` and `IntSlider` classes which do not raise exceptions when instantiated. This allows the patched `@interact` to handle the missing ipywidgets scenario gracefully.

After applying the changes suggested in this PR the `ImportError` is raised as intended.
```shell
$ python -c "import seaborn; seaborn.choose_colorbrewer_palette('quatlitative')"

Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "<redacted>/seaborn/seaborn/widgets.py", line 141, in choose_colorbrewer_palette
    @interact
     ^^^^^^^^
  File "<redacted>/seaborn/seaborn/widgets.py", line 10, in interact
    raise ImportError(msg)
ImportError: Interactive palettes require `ipywidgets`, which is not installed.
```

P.S. Thanks a lot for seaborn! :)