### PR TITLE
added a dict return to choose_diverging_pallete function

### DIFF
--- a/seaborn/widgets.py
+++ b/seaborn/widgets.py
@@ -310,7 +310,7 @@ def choose_light_palette(input="husl", as_cmap=False):
     return pal
 
 
-def choose_diverging_palette(as_cmap=False):
+def choose_diverging_palette(as_cmap=False, as_dict=False):
     """Launch an interactive widget to choose a diverging color palette.
 
     This corresponds with the :func:`diverging_palette` function. This kind
@@ -339,6 +339,7 @@ def choose_diverging_palette(as_cmap=False):
 
     """
     pal = []
+    pal_dict = {}
     if as_cmap:
         cmap = _init_mutable_colormap()
 
@@ -356,6 +357,13 @@ def choose_diverging_palette(as_cmap=False):
         n=(2, 16),
         center=["light", "dark"]
     ):
+        pal_dict['h_neg'] = h_neg
+        pal_dict['h_pos'] = h_pos
+        pal_dict['s'] = s
+        pal_dict['l'] = l
+        pal_dict['sep'] = sep
+        pal_dict['center'] = center
+
         if as_cmap:
             colors = diverging_palette(h_neg, h_pos, s, l, sep, 256, center)
             _update_lut(cmap, colors)
@@ -363,8 +371,9 @@ def choose_diverging_palette(as_cmap=False):
         else:
             pal[:] = diverging_palette(h_neg, h_pos, s, l, sep, n, center)
             palplot(pal)
-
-    if as_cmap:
+    if as_dict:
+        return pal_dict
+    elif as_cmap:
         return cmap
     return pal
 


### PR DESCRIPTION
Title: Fix Incompatibility Between seaborn.diverging_palette and seaborn.choose_diverging_palette()
Description:
I noticed a divergence between the functions seaborn.diverging_palette and seaborn.choose_diverging_palette() in Seaborn. Specifically, while the documentation for seaborn.diverging_palette references seaborn.choose_diverging_palette() as a tool for selecting a palette interactively, the output from choose_diverging_palette() is not directly compatible with diverging_palette().

Issue:
Function Reference: The documentation suggests that the interactive palette created using choose_diverging_palette() can be passed directly to diverging_palette(). However, attempting to do so leads to errors or unexpected behavior because the output format of choose_diverging_palette() does not match the expected input for diverging_palette().
Impact: This issue may cause confusion among users and disrupt workflows that rely on seamless integration between these two functions.
Proposed Solution:
Documentation Update: Clarify the documentation for seaborn.diverging_palette to accurately describe the relationship between these two functions and how to correctly use the output from choose_diverging_palette() with diverging_palette().
Function Compatibility: Consider updating choose_diverging_palette() to return a format that is directly compatible with diverging_palette(), or provide a helper function to convert the output appropriately.
Additional Notes:
I have attached a small example illustrating the issue and how it can be resolved.
Please let me know if there are additional tests or documentation changes you would like to see in this PR.
Thank you for considering this update.

This draft highlights the key issue, suggests a potential solution, and invites further discussion or feedback. Feel free to adjust it according to the specifics of your findings and any particular changes you're proposing.






