### PR TITLE
fix: use PyCapsule Interface instead of Dataframe Interchange Protocol

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dev = [
     "mypy",
     "pandas-stubs",
     "pre-commit",
+    "pyarrow",
     "flit",
 ]
 docs = [

--- a/seaborn/_core/plot.py
+++ b/seaborn/_core/plot.py
@@ -349,7 +349,7 @@ class Plot:
 
         if (
             isinstance(args[0], (abc.Mapping, pd.DataFrame))
-            or hasattr(args[0], "__dataframe__")
+            or hasattr(args[0], "__arrow_c_stream__")
         ):
             if data is not None:
                 raise TypeError("`data` given by both name and position.")

--- a/seaborn/_core/typing.py
+++ b/seaborn/_core/typing.py
@@ -17,9 +17,9 @@ Vector = Union[Series, Index, ndarray]
 VariableSpec = Union[ColumnName, Vector, None]
 VariableSpecList = Union[List[VariableSpec], Index, None]
 
-# A DataSource can be an object implementing __dataframe__, or a Mapping
+# A DataSource can be an object implementing __arrow_c_stream__, or a Mapping
 # (and is optional in all contexts where it is used).
-# I don't think there's an abc for "has __dataframe__", so we type as object
+# I don't think there's an abc for "has __arrow_c_stream__", so we type as object
 # but keep the (slightly odd) Union alias for better user-facing annotations.
 DataSource = Union[object, Mapping, None]
 

--- a/tests/_core/test_plot.py
+++ b/tests/_core/test_plot.py
@@ -170,11 +170,11 @@ class TestInit:
         assert p._data.source_data is None
         assert list(p._data.source_vars) == ["x"]
 
-    @pytest.mark.skipif(
-        condition=not hasattr(pd.api, "interchange"),
-        reason="Tests behavior assuming support for dataframe interchange"
-    )
     def test_positional_interchangeable_dataframe(self, mock_long_df, long_df):
+        pytest.importorskip(
+            'pyarrow', '14.0',
+            reason="Tests behavior assuming support for PyCapsule Interface"
+        )
 
         p = Plot(mock_long_df, x="x")
         assert_frame_equal(p._data.source_data, long_df)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -188,11 +188,12 @@ class MockInterchangeableDataFrame:
     def __init__(self, data):
         self._data = data
 
-    def __dataframe__(self, *args, **kwargs):
-        return self._data.__dataframe__(*args, **kwargs)
+    def __arrow_c_stream__(self, *args, **kwargs):
+        return self._data.__arrow_c_stream__()
 
 
 @pytest.fixture
 def mock_long_df(long_df):
+    import pyarrow
 
-    return MockInterchangeableDataFrame(long_df)
+    return MockInterchangeableDataFrame(pyarrow.Table.from_pandas(long_df))

--- a/tests/test_axisgrid.py
+++ b/tests/test_axisgrid.py
@@ -708,11 +708,11 @@ class TestFacetGrid:
                     assert mpl.colors.same_color(tick.tick2line.get_color(), color)
                     assert tick.get_pad() == pad
 
-    @pytest.mark.skipif(
-        condition=not hasattr(pd.api, "interchange"),
-        reason="Tests behavior assuming support for dataframe interchange"
-    )
     def test_data_interchange(self, mock_long_df, long_df):
+        pytest.importorskip(
+            'pyarrow', '14.0',
+            reason="Tests behavior assuming support for PyCapsule Interface"
+        )
 
         g = ag.FacetGrid(mock_long_df, col="a", row="b")
         g.map(scatterplot, "x", "y")
@@ -1477,11 +1477,11 @@ class TestPairGrid:
                     assert mpl.colors.same_color(tick.tick2line.get_color(), color)
                     assert tick.get_pad() == pad
 
-    @pytest.mark.skipif(
-        condition=not hasattr(pd.api, "interchange"),
-        reason="Tests behavior assuming support for dataframe interchange"
-    )
     def test_data_interchange(self, mock_long_df, long_df):
+        pytest.importorskip(
+            'pyarrow', '14.0',
+            reason="Tests behavior assuming support for PyCapsule Interface"
+        )
 
         g = ag.PairGrid(mock_long_df, vars=["x", "y", "z"], hue="a")
         g.map(scatterplot)


### PR DESCRIPTION
closes #3756 
closes https://github.com/mwaskom/seaborn/issues/3533
I'm hoping that this can supersede https://github.com/mwaskom/seaborn/pull/3534

This means that you get support for quite a lot more, e.g.:

- **DuckDB**:

![image](https://github.com/user-attachments/assets/46377d56-347f-4ccd-a547-cc830c385703)

- **cuDF** (their interchange protocol implementation is currently broken anyway https://github.com/rapidsai/cudf/issues/17282)

- **Polars**: it fixes the issue reported in #3533, because the PyCapsule interface actually supports nested data types:

![image](https://github.com/user-attachments/assets/bd190d75-8a35-47e0-b4d1-ee18b588a4ff)

In addition, this has **no effect on existing pandas users**, as there's already an early return for pandas https://github.com/MarcoGorelli/seaborn/blob/0bd85071284d45f38cbf419b8cf1efb2179eda24/seaborn/_core/data.py#L284-L285

---

I'm sorry for having introduced the Interchange Protocol in the first place. It's turned out to be fairly problematic, see https://github.com/pandas-dev/pandas/issues/56732#issuecomment-2466301769 as the associated discussion for more context

---

cc @willayd for comments