### PR TITLE
Fix tick visibility introspection on matplotlib 3.10

### DIFF
--- a/tests/_core/test_plot.py
+++ b/tests/_core/test_plot.py
@@ -1782,6 +1782,17 @@ class TestPairInterface:
 
 class TestLabelVisibility:
 
+    def has_xaxis_labels(self, ax):
+        if _version_predates(mpl, "3.7"):
+            # mpl3.7 added a getter for tick params, but both yaxis and xaxis return
+            # the same entry of "labelleft" instead of "labelbottom" for xaxis
+            return len(ax.get_xticklabels()) > 0
+        elif _version_predates(mpl, "3.10"):
+            # Then I guess they made it labelbottom in 3.10?
+            return ax.xaxis.get_tick_params()["labelleft"]
+        else:
+            return ax.xaxis.get_tick_params()["labelbottom"]
+
     def test_single_subplot(self, long_df):
 
         x, y = "a", "z"
@@ -1852,12 +1863,7 @@ class TestLabelVisibility:
         for s in subplots[1:]:
             ax = s["ax"]
             assert ax.xaxis.get_label().get_visible()
-            # mpl3.7 added a getter for tick params, but both yaxis and xaxis return
-            # the same entry of "labelleft" instead of  "labelbottom" for xaxis
-            if not _version_predates(mpl, "3.7"):
-                assert ax.xaxis.get_tick_params()["labelleft"]
-            else:
-                assert len(ax.get_xticklabels()) > 0
+            assert self.has_xaxis_labels(ax)
             assert all(t.get_visible() for t in ax.get_xticklabels())
 
         for s in subplots[1:-1]:
@@ -1882,12 +1888,7 @@ class TestLabelVisibility:
         for s in subplots[-2:]:
             ax = s["ax"]
             assert ax.xaxis.get_label().get_visible()
-            # mpl3.7 added a getter for tick params, but both yaxis and xaxis return
-            # the same entry of "labelleft" instead of  "labelbottom" for xaxis
-            if not _version_predates(mpl, "3.7"):
-                assert ax.xaxis.get_tick_params()["labelleft"]
-            else:
-                assert len(ax.get_xticklabels()) > 0
+            assert self.has_xaxis_labels(ax)
             assert all(t.get_visible() for t in ax.get_xticklabels())
 
         for s in subplots[:-2]:


### PR DESCRIPTION
Matplotlib fixed a weird inconsistency in the tick params dict that tests were relying on.