### PR TITLE
Fix capitalization for countplot stat label and add test

### DIFF
--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -2669,7 +2669,7 @@ def countplot(
         p.plot_data[count_axis] = 1
 
     _check_argument("stat", ["count", "percent", "probability", "proportion"], stat)
-    p.variables[count_axis] = stat
+    p.variables[count_axis] = stat.capitalize()
     if stat != "count":
         denom = 100 if stat == "percent" else 1
         p.plot_data[count_axis] /= len(p.plot_data) / denom

--- a/tests/test_categorical.py
+++ b/tests/test_categorical.py
@@ -3259,3 +3259,14 @@ class TestBoxPlotContainer:
         children = container.get_children()
         for child in children:
             assert isinstance(child, mpl.artist.Artist)
+
+
+def test_countplot_stat_label_capitalization():
+    import seaborn as sns
+    import matplotlib.pyplot as plt
+
+    data = sns.load_dataset("iris")
+    ax = sns.countplot(data=data, x="sepal_width", stat="count")
+
+    assert ax.get_ylabel() == "Count"
+    plt.close()  # Cleanup


### PR DESCRIPTION
This PR fixes the capitalization issue for the `stat` label in the `countplot` function. 
Additionally, a test (`test_countplot_stat_label_capitalization`) has been added to validate the fix.
