### PR TITLE
Fix PendingDeprecationWarning in categorical plots

### DIFF
--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -682,7 +682,7 @@ class _CategoricalPlotter(VectorPlotter):
                 # Set width to 0 to avoid going out of domain
                 widths=data["width"] if linear_orient_scale else 0,
                 patch_artist=fill,
-                vert=self.orient == "x",
+                orientation="vertical" if self.orient == "x" else "horizontal",
                 manage_ticks=False,
                 boxprops=boxprops,
                 medianprops=medianprops,


### PR DESCRIPTION
Fixes #3804

The full warning:

```
PendingDeprecationWarning: vert: bool will be deprecated in a future version. Use orientation: {'vertical', 'horizontal'} instead.
```

This is a pending deprecation in mpl since 3.10, will become deprecated in 3.11 ([matplotlib.axes.Axes.bxp](https://matplotlib.org/stable/api/_as_gen/matplotlib.axes.Axes.bxp.html)).

I noticed the usage of `_version_predates` function, please let me know if this change should be also backwards compatible, since `orientation` was added in mpl 3.10.

Edit: I see there's a merged PR to ignore the warning (https://github.com/microsoft/MLOS/pull/900), which could probably be removed by fixing the kwarg.