### PR TITLE
Address some upcoming deprecations

### DIFF
--- a/seaborn/_compat.py
+++ b/seaborn/_compat.py
@@ -121,3 +121,9 @@ def groupby_apply_include_groups(val):
     if _version_predates(pd, "2.2.0"):
         return {}
     return {"include_groups": val}
+
+
+def get_converter(axis):
+    if _version_predates(mpl, "3.10.0"):
+        return axis.converter
+    return axis.get_converter()

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -626,6 +626,8 @@ class _CategoricalPlotter(VectorPlotter):
         props["whisker"].setdefault("solid_capstyle", "butt")
         props["flier"].setdefault("markersize", fliersize)
 
+        orientation = {"x": "vertical", "y": "horizontal"}[self.orient]
+
         ax = self.ax
 
         for sub_vars, sub_data in self.iter_data(iter_vars,
@@ -682,14 +684,19 @@ class _CategoricalPlotter(VectorPlotter):
                 # Set width to 0 to avoid going out of domain
                 widths=data["width"] if linear_orient_scale else 0,
                 patch_artist=fill,
-                vert=self.orient == "x",
                 manage_ticks=False,
                 boxprops=boxprops,
                 medianprops=medianprops,
                 whiskerprops=whiskerprops,
                 flierprops=flierprops,
                 capprops=capprops,
-                # Added in matplotlib 3.6.0; see below
+                # Added in matplotlib 3.10; see below
+                # orientation=orientation
+                **(
+                    {"vert": orientation == "x"} if _version_predates(mpl, "3.10.0")
+                    else {"orientation": orientation}
+                ),
+                # added in matplotlib 3.6.0; see below
                 # capwidths=capwidth,
                 **(
                     {} if _version_predates(mpl, "3.6.0")

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -693,7 +693,8 @@ class _CategoricalPlotter(VectorPlotter):
                 # Added in matplotlib 3.10; see below
                 # orientation=orientation
                 **(
-                    {"vert": orientation == "x"} if _version_predates(mpl, "3.10.0")
+                    {"vert": orientation == "vertical"}
+                    if _version_predates(mpl, "3.10.0")
                     else {"orientation": orientation}
                 ),
                 # added in matplotlib 3.6.0; see below

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -9,7 +9,7 @@ from numpy.testing import assert_array_equal, assert_array_almost_equal
 from pandas.testing import assert_frame_equal
 
 from seaborn.axisgrid import FacetGrid
-from seaborn._compat import get_colormap
+from seaborn._compat import get_colormap, get_converter
 from seaborn._base import (
     SemanticMapping,
     HueMapping,
@@ -1130,14 +1130,14 @@ class TestVectorPlotter:
         _, ax = plt.subplots()
         p = VectorPlotter(data=long_df, variables={"x": "x", "y": "t"})
         p._attach(ax)
-        assert ax.xaxis.converter is None
-        assert "Date" in ax.yaxis.converter.__class__.__name__
+        assert get_converter(ax.xaxis) is None
+        assert "Date" in get_converter(ax.yaxis).__class__.__name__
 
         _, ax = plt.subplots()
         p = VectorPlotter(data=long_df, variables={"x": "a", "y": "y"})
         p._attach(ax)
-        assert "CategoryConverter" in ax.xaxis.converter.__class__.__name__
-        assert ax.yaxis.converter is None
+        assert "CategoryConverter" in get_converter(ax.xaxis).__class__.__name__
+        assert get_converter(ax.yaxis) is None
 
     def test_attach_facets(self, long_df):
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -454,7 +454,7 @@ class TestSizeMapping:
     def test_array_palette_deprecation(self, long_df):
 
         p = VectorPlotter(long_df, {"y": "y", "hue": "s"})
-        pal = mpl.cm.Blues([.3, .8])[:, :3]
+        pal = mpl.cm.Blues([.3, .5, .8])[:, :3]
         with pytest.warns(UserWarning, match="Numpy array is not a supported type"):
             m = HueMapping(p, pal)
         assert m.palette == pal.tolist()

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1340,7 +1340,6 @@ class TestVectorPlotter:
             ["numeric", "category", "datetime"],
         )
     )
-    @pytest.mark.parametrize("NA,var_type")
     def comp_data_missing_fixture(self, request):
 
         # This fixture holds the logic for parameterizing

--- a/tests/test_categorical.py
+++ b/tests/test_categorical.py
@@ -1206,7 +1206,7 @@ class TestBoxenPlot(SharedAxesLevelTests, SharedPatchArtistTests):
 
         assert verts[pos_idx].min().round(4) >= np.round(pos - width / 2, 4)
         assert verts[pos_idx].max().round(4) <= np.round(pos + width / 2, 4)
-        assert np.in1d(
+        assert np.isin(
             np.percentile(data, [25, 75]).round(4), verts[val_idx].round(4).flat
         ).all()
         assert_array_equal(verts[val_idx, 1:, 0], verts[val_idx, :-1, 2])


### PR DESCRIPTION
- Address deprecation of `vert=` in `plt.bxp` (used in `sns.boxplot`; closes #3804, closes #3819)
- Address deprecation of the `.converter` attribute on matplotlib `Axis` objects (only used in tests)
- Address deprecation of `np.in1d` (only used in tests)
- Address deprecation of `pytest.mark` + `pytest.parameterize` (only used in tests)
- Prevent tests from tripping internal deprecation warning