### PR TITLE
[FIX]: Add Support for the `jet` Colormap When Using `seaborn` Color Palettes

### DIFF
--- a/seaborn/palettes.py
+++ b/seaborn/palettes.py
@@ -198,10 +198,6 @@ def color_palette(palette=None, n_colors=None, desat=None, as_cmap=False):
             # Evenly spaced colors in cylindrical Lab space
             palette = husl_palette(n_colors, as_cmap=as_cmap)
 
-        elif palette.lower() == "jet":
-            # Paternalism
-            raise ValueError("No.")
-
         elif palette.startswith("ch:"):
             # Cubehelix palette with params specified in string
             args, kwargs = _parse_cubehelix_args(palette)


### PR DESCRIPTION
# The Issue

This PR resolves #3826.

Running `sns.color_palette(palette="jet", as_cmap=True)` yields a `ValueError("No.")` for seemingly no explainable reason.  [This section of code raises the error](https://github.com/mwaskom/seaborn/blob/86b5481ca47cb46d3b3e079a5ed9b9fb46e315ef/seaborn/palettes.py#L201-L203), and removing it resolves the problem.  While funny, `seaborn` has outgrown these kinds of Easter Eggs, and this behavior is no longer desirable.

# Reproducing the Issue

`seaborn` simply raises an error when a user tries to use the `jet` `matplotlib` colormap.  [All other `matplotlib` colormaps](https://matplotlib.org/stable/gallery/color/colormap_reference.html) are supported, but `jet` (which is a very popular colormap) is not.

## Code That Raises Error

### Lines of Code Raising the Error
```python
import seaborn as sns

desired_color_palette = sns.color_palette(palette="jet", as_cmap=True)
```

### "Real-World" Example Where Using `jet` Raises an Error

```python
import seaborn as sns
import matplotlib.pyplot as plt
import numpy as np
import pandas as pd

np.random.seed(42)
data = pd.DataFrame(np.random.rand(10, 10), columns=[f'Var{i}' for i in range(1, 11)])
corr = data.corr()

desired_color_palette = sns.color_palette(palette="jet", as_cmap=True)

plt.figure(figsize=(10, 8))
sns.heatmap(corr, annot=True, cmap=desired_color_palette, linewidths=0.5, fmt=".2f")
plt.title("Correlation Matrix Heatmap with 'Jet' Colormap")
plt.show()
```

### "Real-World" Example That Works for [Any Other Matplolib Colormap](https://matplotlib.org/stable/gallery/color/colormap_reference.html)

```python
import seaborn as sns
import matplotlib.pyplot as plt
import numpy as np
import pandas as pd

np.random.seed(42)
data = pd.DataFrame(np.random.rand(10, 10), columns=[f'Var{i}' for i in range(1, 11)])
corr = data.corr()

desired_color_palette = sns.color_palette(palette="viridis", as_cmap=True)

plt.figure(figsize=(10, 8))
sns.heatmap(corr, annot=True, cmap=desired_color_palette, linewidths=0.5, fmt=".2f")
plt.title("Correlation Matrix Heatmap with 'Viridis' Colormap")
plt.show()
```

![viridis](https://github.com/user-attachments/assets/f4c620c2-9e68-4010-9c30-d7b5325490ce)


# Fixing the Issue

The [following lines in `seaborn/palettes.py`](https://github.com/mwaskom/seaborn/blob/86b5481ca47cb46d3b3e079a5ed9b9fb46e315ef/seaborn/palettes.py#L201-L203) have been removed.

## Evidence That the Issue Is Resolved

### This Line of Code No Longer Raises the `ValueError("No.")`

```python
import seaborn as sns

desired_color_palette = sns.color_palette(palette="jet", as_cmap=True)
```

### "Real-World" Example That Works with `jet`

```python
import seaborn as sns
import matplotlib.pyplot as plt
import numpy as np
import pandas as pd

np.random.seed(42)
data = pd.DataFrame(np.random.rand(10, 10), columns=[f'Var{i}' for i in range(1, 11)])
corr = data.corr()

desired_color_palette = sns.color_palette(palette="jet", as_cmap=True)

plt.figure(figsize=(10, 8))
sns.heatmap(corr, annot=True, cmap=desired_color_palette, linewidths=0.5, fmt=".2f")
plt.title("Correlation Matrix Heatmap with 'Jet' Colormap")
plt.show()
```

![jet](https://github.com/user-attachments/assets/31453909-f20e-4dbf-978e-3b61877ee01a)


Resolves #3826.