### PR TITLE
Fix ZeroDivisionError in pointplot when dodge=True and a single hue level exists

### DIFF
--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -1221,12 +1221,16 @@ class _CategoricalPlotter(VectorPlotter):
                 .reset_index()
             )
 
-            if dodge:
+            if dodge and n_hue_levels > 1:
                 hue_idx = self._hue_map.levels.index(sub_vars["hue"])
                 step_size = dodge / (n_hue_levels - 1)
                 offset = -dodge / 2 + step_size * hue_idx
                 agg_data[self.orient] += offset * self._native_width
+            else:
+                agg_data[self.orient] += 0
 
+            self._invert_scale(ax, agg_data)
+            
             self._invert_scale(ax, agg_data)
 
             sub_kws = plot_kws.copy()

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -1230,8 +1230,6 @@ class _CategoricalPlotter(VectorPlotter):
                 agg_data[self.orient] += 0
 
             self._invert_scale(ax, agg_data)
-            
-            self._invert_scale(ax, agg_data)
 
             sub_kws = plot_kws.copy()
             sub_kws.update(


### PR DESCRIPTION
This PR fixes a ZeroDivisionError in sns.pointplot that occurs when dodge=True and the dataset contains only a single hue level. The issue arises because step_size is calculated using (n_hue_levels - 1), which results in a division by zero when n_hue_levels == 1.

Changes Made:
Updated categorical.py to prevent division by zero in the dodge calculation by adding a conditional check:
      if n_hue_levels > 1:
          step_size = dodge / (n_hue_levels - 1)
      else:
          step_size = 0  # Prevents division by zero when only one hue level exists

This ensures that when there is only one hue level, the dodge offset remains 0, preventing unnecessary adjustments.

Issue Reference:
Fixes #3825

Testing:
Verified that pointplot no longer raises an error when dodge=True with a single hue level.