### PR TITLE
Fix unnecessary ValueError in PairPlot: Caused by unrelated duplicated columns not used in `vars`

### DIFF
--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -1261,7 +1261,7 @@ class PairGrid(Grid):
         if vars is not None:    # user provide vars
             x_vars = list(vars)
             y_vars = list(vars)
-            if len(set(vars))<len(x_vars):
+            if len(set(vars)) < len(x_vars):
                 # Does not crash, only causes unexpected figures.
                 # Do not take efforts to specify duplicants.
                 warnings.warn(f"Duplicated items in vars: {x_vars}")
@@ -1270,16 +1270,18 @@ class PairGrid(Grid):
                 condensed_vars = x_vars
                 # Use condensed_vars to avoid duplicated items in vars
                 # causing duplicates in data.loc[:, vars].columns.
-            selected_columns = data.loc[:,condensed_vars].columns
+            selected_columns = data.loc[:, condensed_vars].columns
             if not selected_columns.is_unique:
                 # Crash if duplicated columns are selected in vars.
                 # Specify duplicants since we raise an Error.
+                dupe_cols = selected_columns[selected_columns.duplicated()]
                 raise ValueError(
-                    f"Columns: {selected_columns[selected_columns.duplicated()]} are duplicated.")
+                    f"Columns: {dupe_cols} are duplicated.")
         else:
             if not data.columns.is_unique:
+                dupe_cols = data.columns[data.columns.duplicated()]
                 raise ValueError(
-                    f"Columns: {data.columns[data.columns.duplicated()]} are duplicated.")
+                    f"Columns: {dupe_cols} are duplicated.")
             numeric_cols = self._find_numeric_cols(data)
             if hue in numeric_cols:
                 numeric_cols.remove(hue)

--- a/tests/test_axisgrid.py
+++ b/tests/test_axisgrid.py
@@ -785,6 +785,34 @@ class TestPairGrid:
         assert hue in g.x_vars
         assert hue in g.y_vars
 
+    def test_duplicates_in_df_columns_without_vars(self):
+        # should fail with clear msg
+        df_with_dupe = self.df.copy()
+        df_with_dupe.columns = ["x", "y", "y"]
+        with pytest.raises(ValueError, match=r"Columns: .* are duplicated\."):
+            a = ag.PairGrid(df_with_dupe)
+
+    def test_duplicates_in_df_columns_with_related_vars(self):
+        # should fail with clear msg
+        df_with_dupe = self.df.copy()
+        df_with_dupe.columns = ["x", "y", "y"]
+        with pytest.raises(ValueError, match=r"Columns: .* are duplicated\."):
+            a = ag.PairGrid(df_with_dupe,vars = ['x','y'])
+    
+    def test_duplicated_vars(self):
+        # should only warn
+        with pytest.warns(UserWarning, match=r"Duplicated items in vars: .*"):
+            a = ag.PairGrid(self.df,vars = ['x','y','y'])
+
+    def test_duplicates_in_df_columns_with_not_related_vars(self):
+        # should pass
+        df_with_dupe = pd.concat([self.df["x"], self.df["y"], self.df["z"], self.df["x"]], axis=1)
+        df_with_dupe.columns = ["x", "y", "z", "z"]
+        a = ag.PairGrid(df_with_dupe,vars = ['x','y'])
+
+        
+        
+
     @pytest.mark.parametrize(
         "x_vars, y_vars",
         [

--- a/tests/test_axisgrid.py
+++ b/tests/test_axisgrid.py
@@ -787,31 +787,29 @@ class TestPairGrid:
 
     def test_duplicates_in_df_columns_without_vars(self):
         # should fail with clear msg
-        df_with_dupe = self.df.loc[:,["x", "y", "z"]].copy()
+        df_with_dupe = self.df.loc[:, ["x", "y", "z"]].copy()
         df_with_dupe.columns = ["x", "y", "y"]
         with pytest.raises(ValueError, match=r"Columns: .* are duplicated\."):
-            a = ag.PairGrid(df_with_dupe)
+            ag.PairGrid(df_with_dupe)
 
     def test_duplicates_in_df_columns_with_related_vars(self):
         # should fail with clear msg
-        df_with_dupe = self.df.loc[:,["x", "y", "z"]].copy()
+        df_with_dupe = self.df.loc[:, ["x", "y", "z"]].copy()
         df_with_dupe.columns = ["x", "y", "y"]
         with pytest.raises(ValueError, match=r"Columns: .* are duplicated\."):
-            a = ag.PairGrid(df_with_dupe,vars = ['x','y'])
-    
+            ag.PairGrid(df_with_dupe, vars=['x', 'y'])
+
     def test_duplicated_vars(self):
         # should only warn
         with pytest.warns(UserWarning, match=r"Duplicated items in vars: .*"):
-            a = ag.PairGrid(self.df,vars = ['x','y','y'])
+            ag.PairGrid(self.df, vars=['x', 'y', 'y'])
 
     def test_duplicates_in_df_columns_with_not_related_vars(self):
         # should pass
-        df_with_dupe = pd.concat([self.df["x"], self.df["y"], self.df["z"], self.df["x"]], axis=1)
+        df_with_dupe = pd.concat(
+            [self.df["x"], self.df["y"], self.df["z"], self.df["x"]], axis=1)
         df_with_dupe.columns = ["x", "y", "z", "z"]
-        a = ag.PairGrid(df_with_dupe,vars = ['x','y'])
-
-        
-        
+        ag.PairGrid(df_with_dupe, vars=['x', 'y'])
 
     @pytest.mark.parametrize(
         "x_vars, y_vars",

--- a/tests/test_axisgrid.py
+++ b/tests/test_axisgrid.py
@@ -787,14 +787,14 @@ class TestPairGrid:
 
     def test_duplicates_in_df_columns_without_vars(self):
         # should fail with clear msg
-        df_with_dupe = self.df.copy()
+        df_with_dupe = self.df.loc[:,["x", "y", "z"]].copy()
         df_with_dupe.columns = ["x", "y", "y"]
         with pytest.raises(ValueError, match=r"Columns: .* are duplicated\."):
             a = ag.PairGrid(df_with_dupe)
 
     def test_duplicates_in_df_columns_with_related_vars(self):
         # should fail with clear msg
-        df_with_dupe = self.df.copy()
+        df_with_dupe = self.df.loc[:,["x", "y", "z"]].copy()
         df_with_dupe.columns = ["x", "y", "y"]
         with pytest.raises(ValueError, match=r"Columns: .* are duplicated\."):
             a = ag.PairGrid(df_with_dupe,vars = ['x','y'])


### PR DESCRIPTION
A simple demo:
```
import seaborn as sns
df = pd.DataFrame(dict(x=rs.normal(size=60),
                           y=rs.randint(0, 4, size=(60)),
                           z=rs.gamma(3, size=60),
                           z2=rs.gamma(6, size=60),
                           }
df_with_dupe = df.copy()
df_with_dupe.columns = ["x", "y", "z", "z"] #sometimes by mistake, or the z/z2 are not important
sns.pairplot(df_with_dupe, vars=['x', 'y'])  # raise ValueError
```

The Traceback:
```
> Traceback (most recent call last):
>   File "/data1/home/----/plotReferenceMap.py", line 153, in <module>
>     sns.pairplot(df_merge,
>   File "/data1/home/--/lib/python3.9/site-packages/seaborn/axisgrid.py", line 2119, in pairplot
>     grid = PairGrid(data, vars=vars, x_vars=x_vars, y_vars=y_vars, hue=hue,
>   File "/data1/home/--/lib/python3.9/site-packages/seaborn/axisgrid.py", line 1251, in __init__
>     numeric_cols = self._find_numeric_cols(data)
>   File "/data1/home/--/lib/python3.9/site-packages/seaborn/axisgrid.py", line 1674, in _find_numeric_cols
>     if variable_type(data[col]) == "numeric":
>   File "/data1/home/--/lib/python3.9/site-packages/seaborn/_base.py", line 1498, in variable_type
>     vector = pd.Series(vector)
>   File "/data1/home/--/lib/python3.9/site-packages/pandas/core/series.py", line 367, in __init__
>     if is_empty_data(data) and dtype is None:
>   File "/data1/home/--/lib/python3.9/site-packages/pandas/core/construction.py", line 818, in is_empty_data
>     is_simple_empty = is_list_like_without_dtype and not data
>   File "/data1/home/--/lib/python3.9/site-packages/pandas/core/generic.py", line 1527, in __nonzero__
>     raise ValueError(
> ValueError: The truth value of a DataFrame is ambiguous. Use a.empty, a.bool(), a.item(), a.any() or a.all().
```
The error happens inside self._find_numeric_cols(data), which is unnecessary when `vars` is provided. So I skip it and extend to some other similar scenarios:


1. no duplication in df.columns, but duplications in `vars`: Gives a simple warning. It just generates unexpected figures but does not crash.
2. duplication in df.columns, and one of the duplicants is included in `vars`: raise ValueError in PairGrid Class, specify the related duplicants.
3. duplication in df.columns, and `vars` is not provided: raise ValueError in PairGrid Class, specify the all duplicants.

These tests are all concluded in the test_axisgrid.py

Please let me know if any other modifications are needed.

