### PR TITLE
pairplot: check whether data supports dataframe API

### DIFF
--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -2099,7 +2099,7 @@ def pairplot(
                "please update your code.")
         warnings.warn(msg, UserWarning)
 
-    if not isinstance(data, pd.DataFrame):
+    if not hasattr(data, '__dataframe__'):
         raise TypeError(
             f"'data' must be pandas DataFrame object, not: {type(data)}")
 


### PR DESCRIPTION
Currently, `pairplot()`, unlike other plotting functions, requires that the data is a `pd.DataFrame`. This prevents the function from working with objects that are fully compatible with DataFrame, but are of a different class. By changing the check to requiring the presence of a `__dataframe__` attribute, this is resolved.

For me, the main reason to submit this PR is to make seaborn fully compatible with [DataMatrix 2.0](https://github.com/open-cogsci/datamatrix/tree/2.0). (Right now, `pairplot()` is the only plot still failing.)