### PR TITLE
Add `scipy-stubs` as dev dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dev = [
     "flake8",
     "mypy",
     "pandas-stubs",
-    "scipy-stubs",
+    "scipy-stubs; python_version>='3.10'",
     "pre-commit",
     "flit",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dev = [
     "flake8",
     "mypy",
     "pandas-stubs",
+    "scipy-stubs",
     "pre-commit",
     "flit",
 ]


### PR DESCRIPTION
I noticed that `pandas-stubs` was already in the list, so I figured that you might also be interested in [`scipy-stubs`](https://github.com/scipy/scipy-stubs) :)