### PR TITLE
fix: correct tuple/list inconsistency in Boolean and Nominal scales

### DIFF
--- a/seaborn/_core/properties.py
+++ b/seaborn/_core/properties.py
@@ -262,7 +262,8 @@ class IntervalProperty(Property):
                 raise TypeError(err)
 
             vmin, vmax = self._forward([vmin, vmax])
-            values = list(self._inverse(np.linspace(vmax, vmin, len(levels))))
+            #Change from vmax->vmin to vmin->vmax ordering
+            values = list(self._inverse(np.linspace(vmin, vmax, len(levels))))
 
         return values
 


### PR DESCRIPTION

- Fixes #3861 
- Ensures consistent behavior between tuples and lists in Boolean/Nominal scales
- Changed `np.linspace(vmax, vmin, ...)` to `np.linspace(vmin, vmax, ...)` in `IntervalProperty._get_values()`
- Ensures consistent behavior between tuples and lists in Boolean/Nominal scales
