### PR TITLE
feat(legend): support scalar formatter offsets

### DIFF
--- a/seaborn/_core/plot.py
+++ b/seaborn/_core/plot.py
@@ -25,7 +25,7 @@ from seaborn._marks.base import Mark
 from seaborn._stats.base import Stat
 from seaborn._core.data import PlotData
 from seaborn._core.moves import Move
-from seaborn._core.scales import Scale, Nominal
+from seaborn._core.scales import Scale, Nominal, ContinuousBase
 from seaborn._core.subplots import Subplots
 from seaborn._core.groupby import GroupBy
 from seaborn._core.properties import PROPERTIES, Property
@@ -1569,6 +1569,13 @@ class Plotter:
                         break
                 else:
                     title = self._resolve_label(p, var, data.names[var])
+                    offset = ""
+                    scale = scales[var]
+                    if isinstance(scale, ContinuousBase):
+                        offset = getattr(scale, "_legend_offset", "")
+                    offset = offset.strip()
+                    if offset:
+                        title = f"{title} {offset}"
                     entry = (title, data.ids[var]), [var], (values, labels)
                     schema.append(entry)
 

--- a/seaborn/_core/scales.py
+++ b/seaborn/_core/scales.py
@@ -67,6 +67,7 @@ class Scale:
         self._tick_params = None
         self._label_params = None
         self._legend = None
+        self._legend_offset = ""
 
     def tick(self):
         raise NotImplementedError()
@@ -379,6 +380,17 @@ class ContinuousBase(Scale):
             locs = axis.major.locator()
             locs = locs[(vmin <= locs) & (locs <= vmax)]
             labels = axis.major.formatter.format_ticks(locs)
+            formatter = axis.major.formatter
+            get_offset = getattr(formatter, "get_offset", None)
+            if callable(get_offset):
+                offset_val = getattr(formatter, "offset", 0)
+                if offset_val:
+                    offset_text = get_offset()
+                    new._legend_offset = (
+                        offset_text.strip() if offset_text else ""
+                    )
+                else:
+                    new._legend_offset = ""
             new._legend = list(locs), list(labels)
 
         return new

--- a/seaborn/relational.py
+++ b/seaborn/relational.py
@@ -233,6 +233,7 @@ class _RelationalPlotter(VectorPlotter):
         brief_ticks = 6
 
         # -- Add a legend for hue semantics
+        hue_offset = ""
         brief_hue = self._hue_map.map_type == "numeric" and (
             verbosity == "brief"
             or (verbosity == "auto" and len(self._hue_map.levels) > brief_ticks)
@@ -243,18 +244,33 @@ class _RelationalPlotter(VectorPlotter):
             else:
                 locator = mpl.ticker.MaxNLocator(nbins=brief_ticks)
             limits = min(self._hue_map.levels), max(self._hue_map.levels)
-            hue_levels, hue_formatted_levels = locator_to_legend_entries(
+            hue_levels, hue_formatted_levels, hue_offset = locator_to_legend_entries(
                 locator, limits, self.plot_data["hue"].infer_objects().dtype
             )
         elif self._hue_map.levels is None:
             hue_levels = hue_formatted_levels = []
         else:
-            hue_levels = hue_formatted_levels = self._hue_map.levels
+            hue_levels = self._hue_map.levels
+            if self._hue_map.map_type == "numeric" and len(hue_levels):
+                limits = min(hue_levels), max(hue_levels)
+                locator = mpl.ticker.FixedLocator(hue_levels)
+                hue_levels, hue_formatted_levels, hue_offset = locator_to_legend_entries(
+                    locator, limits, self.plot_data["hue"].infer_objects().dtype
+                )
+            else:
+                hue_formatted_levels = hue_levels
+
+        hue_title = self.variables.get("hue", None)
+        if legend_title and hue_title is not None and legend_title == hue_title and hue_offset:
+            legend_title = f"{legend_title} {hue_offset}"
 
         # Add the hue semantic subtitle
-        if not legend_title and self.variables.get("hue", None) is not None:
-            update((self.variables["hue"], "title"),
-                   self.variables["hue"], **title_kws)
+        if not legend_title and hue_title is not None:
+            subtitle = hue_title
+            if hue_offset:
+                subtitle = f"{subtitle} {hue_offset}"
+            update((hue_title, "title"),
+                   subtitle, **title_kws)
 
         # Add the hue semantic labels
         for level, formatted_level in zip(hue_levels, hue_formatted_levels):
@@ -263,6 +279,7 @@ class _RelationalPlotter(VectorPlotter):
                 update(self.variables["hue"], formatted_level, color=color)
 
         # -- Add a legend for size semantics
+        size_offset = ""
         brief_size = self._size_map.map_type == "numeric" and (
             verbosity == "brief"
             or (verbosity == "auto" and len(self._size_map.levels) > brief_ticks)
@@ -275,18 +292,33 @@ class _RelationalPlotter(VectorPlotter):
                 locator = mpl.ticker.MaxNLocator(nbins=brief_ticks)
             # Define the min/max data values
             limits = min(self._size_map.levels), max(self._size_map.levels)
-            size_levels, size_formatted_levels = locator_to_legend_entries(
+            size_levels, size_formatted_levels, size_offset = locator_to_legend_entries(
                 locator, limits, self.plot_data["size"].infer_objects().dtype
             )
         elif self._size_map.levels is None:
             size_levels = size_formatted_levels = []
         else:
-            size_levels = size_formatted_levels = self._size_map.levels
+            size_levels = self._size_map.levels
+            if self._size_map.map_type == "numeric" and len(size_levels):
+                limits = min(size_levels), max(size_levels)
+                locator = mpl.ticker.FixedLocator(size_levels)
+                size_levels, size_formatted_levels, size_offset = locator_to_legend_entries(
+                    locator, limits, self.plot_data["size"].infer_objects().dtype
+                )
+            else:
+                size_formatted_levels = size_levels
+
+        size_title = self.variables.get("size", None)
+        if legend_title and size_title is not None and legend_title == size_title and size_offset:
+            legend_title = f"{legend_title} {size_offset}"
 
         # Add the size semantic subtitle
-        if not legend_title and self.variables.get("size", None) is not None:
-            update((self.variables["size"], "title"),
-                   self.variables["size"], **title_kws)
+        if not legend_title and size_title is not None:
+            subtitle = size_title
+            if size_offset:
+                subtitle = f"{subtitle} {size_offset}"
+            update((size_title, "title"),
+                   subtitle, **title_kws)
 
         # Add the size semantic labels
         for level, formatted_level in zip(size_levels, size_formatted_levels):

--- a/seaborn/utils.py
+++ b/seaborn/utils.py
@@ -685,7 +685,7 @@ def axes_ticklabels_overlap(ax):
 
 
 def locator_to_legend_entries(locator, limits, dtype):
-    """Return levels and formatted levels for brief numeric legends."""
+    """Return levels, formatted levels, and offset text for numeric legends."""
     raw_levels = locator.tick_values(*limits).astype(dtype)
 
     # The locator can return ticks outside the limits, clip them here
@@ -699,6 +699,8 @@ def locator_to_legend_entries(locator, limits, dtype):
         formatter = mpl.ticker.LogFormatter()
     else:
         formatter = mpl.ticker.ScalarFormatter()
+        formatter.set_useOffset(mpl.rcParams["axes.formatter.useoffset"])
+        formatter.offset_threshold = mpl.rcParams["axes.formatter.offset_threshold"]
     formatter.axis = dummy_axis()
 
     # TODO: The following two lines should be replaced
@@ -707,7 +709,14 @@ def locator_to_legend_entries(locator, limits, dtype):
     formatter.set_locs(raw_levels)
     formatted_levels = [formatter(x) for x in raw_levels]
 
-    return raw_levels, formatted_levels
+    offset_text = ""
+    get_offset = getattr(formatter, "get_offset", None)
+    offset_val = getattr(formatter, "offset", 0)
+    if callable(get_offset) and offset_val:
+        offset = get_offset()
+        offset_text = offset.strip() if offset else ""
+
+    return raw_levels, formatted_levels, offset_text
 
 
 def relative_luminance(color):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -307,32 +307,37 @@ def test_locator_to_legend_entries():
 
     locator = mpl.ticker.MaxNLocator(nbins=3)
     limits = (0.09, 0.4)
-    levels, str_levels = utils.locator_to_legend_entries(
+    levels, str_levels, offset = utils.locator_to_legend_entries(
         locator, limits, float
     )
     assert str_levels == ["0.15", "0.30"]
+    assert offset == ""
 
     limits = (0.8, 0.9)
-    levels, str_levels = utils.locator_to_legend_entries(
+    levels, str_levels, offset = utils.locator_to_legend_entries(
         locator, limits, float
     )
     assert str_levels == ["0.80", "0.84", "0.88"]
+    assert offset == ""
 
     limits = (1, 6)
-    levels, str_levels = utils.locator_to_legend_entries(locator, limits, int)
+    levels, str_levels, offset = utils.locator_to_legend_entries(locator, limits, int)
     assert str_levels == ["2", "4", "6"]
+    assert offset == ""
 
     locator = mpl.ticker.LogLocator(numticks=5)
     limits = (5, 1425)
-    levels, str_levels = utils.locator_to_legend_entries(locator, limits, int)
+    levels, str_levels, offset = utils.locator_to_legend_entries(locator, limits, int)
     if Version(mpl.__version__) >= Version("3.1"):
         assert str_levels == ['10', '100', '1000']
+    assert offset == ""
 
     limits = (0.00003, 0.02)
-    _, str_levels = utils.locator_to_legend_entries(locator, limits, float)
+    _, str_levels, offset = utils.locator_to_legend_entries(locator, limits, float)
     for i, exp in enumerate([4, 3, 2]):
         # Use regex as mpl switched to minus sign, not hyphen, in 3.6
         assert re.match(f"1e.0{exp}", str_levels[i])
+    assert offset == ""
 
 
 def test_move_legend_matplotlib_objects():


### PR DESCRIPTION
## Summary
- cache ScalarFormatter offsets on Continuous scales and append to objects legend titles
- append offset text for numeric hue/size legends in the classic API when ScalarFormatter uses an offset
- add regression tests covering legend offsets for objects and relational scatter plots

## Testing
- pytest tests/test_utils.py
- pytest tests/_core/test_plot.py
- pytest tests/test_relational.py
- flake8 seaborn/_core/scales.py seaborn/utils.py tests/_core/test_plot.py tests/test_relational.py
- flake8 tests/test_utils.py --extend-ignore=E721

References #6