### PR TITLE
Fix FutureWarning for observed parameter in groupby

### DIFF
--- a/seaborn/relational.py
+++ b/seaborn/relational.py
@@ -310,7 +310,7 @@ class _LinePlotter(_RelationalPlotter):
 
             if "units" in self.variables:   # XXX why not add to grouping variables?
                 lines = []
-                for _, unit_data in sub_data.groupby("units"):
+                for _, unit_data in sub_data.groupby("units", observed=False):
                     lines.extend(ax.plot(unit_data["x"], unit_data["y"], **kws))
             else:
                 lines = ax.plot(sub_data["x"], sub_data["y"], **kws)


### PR DESCRIPTION
## Summary

Fix FutureWarning triggered when using `relplot` with the `units` parameter on categorical data.

Closes #3891

## Changes

Added `observed=False` parameter to `groupby("units")` call in `relational.py` (line 313) to explicitly set the behavior and suppress the FutureWarning from pandas 2.2.0+.

## Details

Since pandas 2.2.0, the default value of `observed` in `groupby` is deprecated and will change to `True` in a future version. This PR explicitly sets `observed=False` to maintain the current behavior and eliminate the warning.

**Before:**
```python
for _, unit_data in sub_data.groupby("units"):
```

**After:**
```python
for _, unit_data in sub_data.groupby("units", observed=False):
```