### PR TITLE
DOC: Fix README links for PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Online documentation is available at [seaborn.pydata.org](https://seaborn.pydata
 
 The docs include a [tutorial](https://seaborn.pydata.org/tutorial.html), [example gallery](https://seaborn.pydata.org/examples/index.html), [API reference](https://seaborn.pydata.org/api.html), [FAQ](https://seaborn.pydata.org/faq), and other useful information.
 
-To build the documentation locally, please refer to [`doc/README.md`](doc/README.md).
+To build the documentation locally, please refer to [`doc/README.md`](https://github.com/mwaskom/seaborn/blob/master/doc/README.md).
 
 Dependencies
 ------------
@@ -60,7 +60,7 @@ Testing seaborn requires installing additional dependencies; they can be install
 
 To test the code, run `make test` in the source directory. This will exercise the unit tests (using [pytest](https://docs.pytest.org/)) and generate a coverage report.
 
-Code style is enforced with `flake8` using the settings in the [`setup.cfg`](./setup.cfg) file. Run `make lint` to check. Alternately, you can use `pre-commit` to automatically run lint checks on any files you are committing: just run `pre-commit install` to set it up, and then commit as usual going forward.
+Code style is enforced with `flake8` using the settings in the [`setup.cfg`](https://github.com/mwaskom/seaborn/blob/master/setup.cfg) file. Run `make lint` to check. Alternately, you can use `pre-commit` to automatically run lint checks on any files you are committing: just run `pre-commit install` to set it up, and then commit as usual going forward.
 
 Development
 -----------


### PR DESCRIPTION
Change relative links to absolute GitHub URLs so they work correctly when rendered on PyPI.

The links to doc/README.md and setup.cfg were using relative paths which don't resolve correctly on PyPI, leading to 404 errors.

Fixes #3899