### PR TITLE
Handle common_norm for density stat in Hist

### DIFF
--- a/seaborn/_stats/counting.py
+++ b/seaborn/_stats/counting.py
@@ -172,8 +172,7 @@ class Hist(Stat):
         vals = data[orient]
         weights = data.get("weight", None)
 
-        density = self.stat == "density"
-        hist, edges = np.histogram(vals, **bin_kws, weights=weights, density=density)
+        hist, edges = np.histogram(vals, **bin_kws, weights=weights, density=False)
 
         width = np.diff(edges)
         center = edges[:-1] + width / 2
@@ -183,7 +182,9 @@ class Hist(Stat):
     def _normalize(self, data):
 
         hist = data["count"]
-        if self.stat == "probability" or self.stat == "proportion":
+        if self.stat == "density":
+            hist = hist.astype(float) / (hist.sum() * data["space"])
+        elif self.stat == "probability" or self.stat == "proportion":
             hist = hist.astype(float) / hist.sum()
         elif self.stat == "percent":
             hist = hist.astype(float) / hist.sum() * 100

--- a/tests/_stats/test_counting.py
+++ b/tests/_stats/test_counting.py
@@ -203,6 +203,26 @@ class TestHist:
         for _, out_part in out.groupby("a"):
             assert out_part["y"].sum() == pytest.approx(100)
 
+    def test_common_norm_density_default(self, long_df, triple_args):
+
+        h = Hist(stat="density", common_norm=True)
+        out = h(long_df, *triple_args)
+        assert (out["y"] * out["space"]).sum() == pytest.approx(1)
+
+    def test_common_norm_density_false(self, long_df, triple_args):
+
+        h = Hist(stat="density", common_norm=False)
+        out = h(long_df, *triple_args)
+        for _, out_part in out.groupby(["a", "s"]):
+            assert (out_part["y"] * out_part["space"]).sum() == pytest.approx(1)
+
+    def test_common_norm_density_subset(self, long_df, triple_args):
+
+        h = Hist(stat="density", common_norm=["a"])
+        out = h(long_df, *triple_args)
+        for _, out_part in out.groupby("a"):
+            assert (out_part["y"] * out_part["space"]).sum() == pytest.approx(1)
+
     def test_common_norm_warning(self, long_df, triple_args):
 
         h = Hist(common_norm=["b"])


### PR DESCRIPTION
## Summary

`so.Hist(stat='density', common_norm=True)` was silently ignoring `common_norm` — each group's density was normalized independently instead of across all groups.

The root cause: `_eval()` passed `density=True` to `np.histogram`, which baked in per-group normalization before `_normalize()` (and its `common_norm` grouping logic) ever ran. For every other stat (`percent`, `proportion`, `frequency`), normalization happens inside `_normalize()` where `common_norm` is properly respected — but `density` was the exception.

## Changes

- **`_eval()`**: Always pass `density=False` to `np.histogram` so raw counts are preserved for all stats.
- **`_normalize()`**: Add density normalization (`count / (total_count * bin_width)`) alongside the existing percent/proportion/frequency cases. This way `common_norm` controls the scope of `total_count` for density just like it does for the other stats.

## Test plan

- Added `test_common_norm_density_default` — verifies total area sums to 1 across all groups when `common_norm=True`
- Added `test_common_norm_density_false` — verifies each group individually sums to 1 when `common_norm=False`
- Added `test_common_norm_density_subset` — verifies normalization within subgroups
- All 32 tests in `test_counting.py` pass (29 existing + 3 new)

Closes #3633