### PR TITLE
Fix crash with custom tick formatters/locators and Est()

### DIFF
--- a/seaborn/_core/scales.py
+++ b/seaborn/_core/scales.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 import re
-from copy import copy
+from copy import copy, deepcopy
 from collections.abc import Sequence
 from dataclasses import dataclass
 from functools import partial
@@ -85,6 +85,17 @@ class Scale:
 
         major_locator, minor_locator = self._get_locators(**self._tick_params)
         major_formatter = self._get_formatter(major_locator, **self._label_params)
+
+        # Deepcopy locators and formatter so that each scale setup gets
+        # independent instances. Without this, scales for derived coordinate
+        # variables (e.g. ymin/ymax from Est) share locator/formatter objects
+        # with the main variable's scale, and the locator's internal axis
+        # reference gets overwritten to point at a PseudoAxis that lacks
+        # required attributes like _view_interval. See GH#3585.
+        major_locator = deepcopy(major_locator)
+        if minor_locator is not None:
+            minor_locator = deepcopy(minor_locator)
+        major_formatter = deepcopy(major_formatter)
 
         class InternalScale(mpl.scale.FuncScale):
             def set_default_locators_and_formatters(self, axis):
@@ -909,6 +920,7 @@ class PseudoAxis:
         # It appears that this needs to be initialized this way on matplotlib 3.1,
         # but not later versions. It is unclear whether there are any issues with it.
         self._data_interval = None, None
+        self._view_interval = None, None
 
         scale.set_default_locators_and_formatters(self)
         # self.set_default_intervals()  Is this ever needed?


### PR DESCRIPTION
## Summary

Fixes #3585

When using `so.Est()` with custom matplotlib formatters (e.g. `PercentFormatter`) or locators (e.g. `LogLocator`), the plot crashes with `AttributeError: 'PseudoAxis' object has no attribute '_view_interval'` (or `'_get_shared_axis'`).

The root cause is that `_get_scale()` returns locator/formatter instances that are shared across multiple calls to `_setup()`. When a scale is set up for derived coordinate variables like `ymin`/`ymax` (which happens with `Est()`), a `PseudoAxis` is created internally, and `set_default_locators_and_formatters` overwrites the shared locator's axis reference to point at this `PseudoAxis`. The main variable's scale then tries to use the locator, which now references a `PseudoAxis` that lacks attributes like `_view_interval`.

## Changes

- **Deepcopy locators and formatter in `_get_scale()`** so each scale setup gets independent instances that won't interfere with each other
- **Initialize `_view_interval` in `PseudoAxis.__init__`** as a defensive measure, matching the existing pattern for `_data_interval`

## Test plan

- [x] Verified fix with both reproduction cases from the issue (`PercentFormatter` and `LogLocator` with `Est()`)
- [x] Full test suite passes (2361 passed, 14 skipped, 6 xfailed)