### PR TITLE
Fix relplot crash when style argument used with empty dataset

### DIFF
--- a/seaborn/relational.py
+++ b/seaborn/relational.py
@@ -768,18 +768,23 @@ def relplot(
         size_norm = p._size_map.norm
 
     if "style" in p.variables:
-        style_order = p._style_map.levels
+        # When the dataset is empty, seaborn may produce None for style levels.
+        # Iterating over None would raise a TypeError. Ensure style_order is
+        # always iterable by defaulting to an empty list.
+        style_order = p._style_map.levels or []
+
         if markers:
             markers = {k: p._style_map(k, "marker") for k in style_order}
         else:
             markers = None
+
         if dashes:
             dashes = {k: p._style_map(k, "dashes") for k in style_order}
         else:
             dashes = None
     else:
         markers = dashes = style_order = None
-
+   
     # Now extract the data that would be used to draw a single plot
     variables = p.variables
     plot_data = p.plot_data

--- a/test_issue_3870.py
+++ b/test_issue_3870.py
@@ -1,0 +1,6 @@
+import pandas as pd
+import seaborn as sns
+
+empty_df = pd.DataFrame(columns=["x", "y", "style"])
+
+sns.relplot(data=empty_df, x="x", y="y", style="style")


### PR DESCRIPTION
This pull request fixes Issue #3870 where seaborn relplot() fails
when an empty dataset is passed with a style argument.

The issue occurs because style levels can become None when the dataset
is empty, causing a TypeError when the code attempts to iterate over them.

This fix ensures style_order defaults to an empty iterable when style
levels are None, preventing the error.

Tested locally using an empty DataFrame to confirm the function
executes without errors.