### PR TITLE
Allow custom figure for subplot grid in axisgrid

### DIFF
--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -1690,10 +1690,15 @@ class JointGrid(_BaseGrid):
         height=6, ratio=5, space=.2,
         palette=None, hue_order=None, hue_norm=None,
         dropna=False, xlim=None, ylim=None, marginal_ticks=False,
+        f=None,
     ):
 
         # Set up the subplot grid
-        f = plt.figure(figsize=(height, height))
+        if f is None:
+            f = plt.figure(figsize=(height, height))
+            custom_fig = False
+        else:
+            custom_fig = True
         gs = plt.GridSpec(ratio + 1, ratio + 1)
 
         ax_joint = f.add_subplot(gs[1:, :-1])
@@ -1763,7 +1768,8 @@ class JointGrid(_BaseGrid):
         for axes in [ax_marg_x, ax_marg_y]:
             for axis in [axes.xaxis, axes.yaxis]:
                 axis.label.set_visible(False)
-        f.tight_layout()
+        if not custom_fig:
+            f.tight_layout()
         f.subplots_adjust(hspace=space, wspace=space)
 
     def _inject_kwargs(self, func, kws, params):

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -2191,7 +2191,7 @@ def jointplot(
     data=None, *, x=None, y=None, hue=None, kind="scatter",
     height=6, ratio=5, space=.2, dropna=False, xlim=None, ylim=None,
     color=None, palette=None, hue_order=None, hue_norm=None, marginal_ticks=False,
-    joint_kws=None, marginal_kws=None,
+    joint_kws=None, marginal_kws=None, f=None,
     **kwargs
 ):
     # Avoid circular imports
@@ -2251,6 +2251,7 @@ def jointplot(
         palette=palette, hue_order=hue_order, hue_norm=hue_norm,
         dropna=dropna, height=height, ratio=ratio, space=space,
         xlim=xlim, ylim=ylim, marginal_ticks=marginal_ticks,
+        f=f,
     )
 
     if grid.hue is not None:


### PR DESCRIPTION
Allow figure-level JointGrid plot to be defined on already-existing (sub)figure.

MWE:
```
fig=plt.figure()
subfigs=fig.subfigures(2) # 2 subfig rows
J = sns.JointGrid(data=df, x=x,y=y, f=subfigs[0]) # init JointGrid on subfigure
J.plot(sns.scatterplot, sns.boxplot) # plot: joint, marginals
ax=subfigs[1].subplots() # some other data
# ax.plot([1,2,3],[4,9,3]) # other data
plt.show()
```
we could also add this option to the convenience function `sns.jointplot` (extra kwargs are not passed to JointGrid init) 
with a default None figure.

related
https://github.com/mwaskom/seaborn/issues/399
https://github.com/mwaskom/seaborn/issues/2059