### PR TITLE
Fix tick labels disappearing with FacetGrid.set_<x|y>ticklabels

### DIFF
--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -915,11 +915,14 @@ class FacetGrid(Grid):
 
     def set_xticklabels(self, labels=None, step=None, **kwargs):
         """Set x axis tick labels of the grid."""
+        if self._sharex:
+            curr_labels = next(self._bottom_axes).get_xticklabels()
         for ax in self.axes.flat:
             curr_ticks = ax.get_xticks()
             ax.set_xticks(curr_ticks)
             if labels is None:
-                curr_labels = [label.get_text() for label in ax.get_xticklabels()]
+                if not self._sharex:
+                    curr_labels = [label.get_text() for label in ax.get_xticklabels()]
                 if step is not None:
                     xticks = ax.get_xticks()[::step]
                     curr_labels = curr_labels[::step]
@@ -931,11 +934,14 @@ class FacetGrid(Grid):
 
     def set_yticklabels(self, labels=None, **kwargs):
         """Set y axis tick labels on the left column of the grid."""
+        if self._sharey:
+            curr_labels = next(self._left_axes).get_yticklabels()
         for ax in self.axes.flat:
             curr_ticks = ax.get_yticks()
             ax.set_yticks(curr_ticks)
             if labels is None:
-                curr_labels = [label.get_text() for label in ax.get_yticklabels()]
+                if not self._sharey:
+                    curr_labels = [label.get_text() for label in ax.get_yticklabels()]
                 ax.set_yticklabels(curr_labels, **kwargs)
             else:
                 ax.set_yticklabels(labels, **kwargs)

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -915,17 +915,22 @@ class FacetGrid(Grid):
 
     def set_xticklabels(self, labels=None, step=None, **kwargs):
         """Set x axis tick labels of the grid."""
-        if self._sharex:
-            curr_labels = [
-                label.get_text()
-                for label in next(self._bottom_axes).get_xticklabels()
-            ]
-        for ax in self.axes.flat:
-            curr_ticks = ax.get_xticks()
+        def get_axes():
+            if self._sharex in (True, "col"):
+                return self._bottom_axes
+            return self.axes.flat
+
+        curr_axes_ticks = [
+            ax.get_xticks()
+            for ax in get_axes()
+        ]
+        for ax, curr_ticks in zip(
+            get_axes(),
+            curr_axes_ticks
+        ):
             ax.set_xticks(curr_ticks)
             if labels is None:
-                if not self._sharex:
-                    curr_labels = [label.get_text() for label in ax.get_xticklabels()]
+                curr_labels = [label.get_text() for label in ax.get_xticklabels()]
                 if step is not None:
                     xticks = ax.get_xticks()[::step]
                     curr_labels = curr_labels[::step]
@@ -937,17 +942,15 @@ class FacetGrid(Grid):
 
     def set_yticklabels(self, labels=None, **kwargs):
         """Set y axis tick labels on the left column of the grid."""
-        if self._sharey:
-            curr_labels = [
-                label.get_text()
-                for label in next(self._left_axes).get_yticklabels()
-            ]
-        for ax in self.axes.flat:
+        if self._sharey in (True, "row"):
+            axes = self._left_axes
+        else:
+            axes = self.axes.flat
+        for ax in axes:
             curr_ticks = ax.get_yticks()
             ax.set_yticks(curr_ticks)
             if labels is None:
-                if not self._sharey:
-                    curr_labels = [label.get_text() for label in ax.get_yticklabels()]
+                curr_labels = [label.get_text() for label in ax.get_yticklabels()]
                 ax.set_yticklabels(curr_labels, **kwargs)
             else:
                 ax.set_yticklabels(labels, **kwargs)

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -916,7 +916,10 @@ class FacetGrid(Grid):
     def set_xticklabels(self, labels=None, step=None, **kwargs):
         """Set x axis tick labels of the grid."""
         if self._sharex:
-            curr_labels = next(self._bottom_axes).get_xticklabels()
+            curr_labels = [
+                label.get_text()
+                for label in next(self._bottom_axes).get_xticklabels()
+            ]
         for ax in self.axes.flat:
             curr_ticks = ax.get_xticks()
             ax.set_xticks(curr_ticks)
@@ -935,7 +938,10 @@ class FacetGrid(Grid):
     def set_yticklabels(self, labels=None, **kwargs):
         """Set y axis tick labels on the left column of the grid."""
         if self._sharey:
-            curr_labels = next(self._left_axes).get_yticklabels()
+            curr_labels = [
+                label.get_text()
+                for label in next(self._left_axes).get_yticklabels()
+            ]
         for ax in self.axes.flat:
             curr_ticks = ax.get_yticks()
             ax.set_yticks(curr_ticks)

--- a/tests/test_axisgrid.py
+++ b/tests/test_axisgrid.py
@@ -522,14 +522,24 @@ class TestFacetGrid:
 
         g = ag.FacetGrid(self.df, col="d", col_wrap=5)
         g.map(plt.plot, "x", "y")
+        x_texts = [
+            [l.get_text() for l in ax.get_xticklabels()]
+            for ax in g._bottom_axes
+        ]
+        y_texts = [
+            [l.get_text() for l in ax.get_yticklabels()]
+            for ax in g._left_axes
+        ]
         g.set_xticklabels(rotation=45)
         g.set_yticklabels(rotation=75)
-        for ax in g._bottom_axes:
-            for l in ax.get_xticklabels():
+        for ax, texts in zip(g._bottom_axes, x_texts):
+            for l, text in zip(ax.get_xticklabels(), texts):
                 assert l.get_rotation() == 45
-        for ax in g._left_axes:
-            for l in ax.get_yticklabels():
+                assert l.get_text() == text
+        for ax, texts in zip(g._left_axes, y_texts):
+            for l, text in zip(ax.get_yticklabels(), texts):
                 assert l.get_rotation() == 75
+                assert l.get_text() == text
 
     def test_set_axis_labels(self):
 

--- a/tests/test_axisgrid.py
+++ b/tests/test_axisgrid.py
@@ -522,21 +522,77 @@ class TestFacetGrid:
 
         g = ag.FacetGrid(self.df, col="d", col_wrap=5)
         g.map(plt.plot, "x", "y")
+        step=2
+        expected = [
+            [label.get_text() for label in ax.get_xticklabels()[::step]]
+            for ax in g.axes.flat
+        ]
+        g.set_xticklabels(step=step)
+        got = [
+            [label.get_text() for label in ax.get_xticklabels()]
+            for ax in g.axes.flat
+        ]
+        assert expected == got
+
+        g = ag.FacetGrid(self.df, col="d", col_wrap=5)
+        g.map(plt.plot, "x", "y")
         x_texts = [
             [l.get_text() for l in ax.get_xticklabels()]
-            for ax in g._bottom_axes
+            for ax in g.axes.flat
         ]
         y_texts = [
             [l.get_text() for l in ax.get_yticklabels()]
-            for ax in g._left_axes
+            for ax in g.axes.flat
         ]
         g.set_xticklabels(rotation=45)
         g.set_yticklabels(rotation=75)
-        for ax, texts in zip(g._bottom_axes, x_texts):
+        for ax, texts in zip(g.axes.flat, x_texts):
             for l, text in zip(ax.get_xticklabels(), texts):
                 assert l.get_rotation() == 45
                 assert l.get_text() == text
-        for ax, texts in zip(g._left_axes, y_texts):
+        for ax, texts in zip(g.axes.flat, y_texts):
+            for l, text in zip(ax.get_yticklabels(), texts):
+                assert l.get_rotation() == 75
+                assert l.get_text() == text
+        
+        g = ag.FacetGrid(self.df, row="c", col="d", sharex="row", sharey="col")
+        g.map(plt.plot, "x", "y")
+        x_texts = [
+            [l.get_text() for l in ax.get_xticklabels()]
+            for ax in g.axes.flat
+        ]
+        y_texts = [
+            [l.get_text() for l in ax.get_yticklabels()]
+            for ax in g.axes.flat
+        ]
+        g.set_xticklabels(rotation=45)
+        g.set_yticklabels(rotation=75)
+        for ax, texts in zip(g.axes.flat, x_texts):
+            for l, text in zip(ax.get_xticklabels(), texts):
+                assert l.get_rotation() == 45
+                assert l.get_text() == text
+        for ax, texts in zip(g.axes.flat, y_texts):
+            for l, text in zip(ax.get_yticklabels(), texts):
+                assert l.get_rotation() == 75
+                assert l.get_text() == text
+
+        g = ag.FacetGrid(self.df, row="c", col="d", sharex="col", sharey="row")
+        g.map(plt.plot, "x", "y")
+        x_texts = [
+            [l.get_text() for l in ax.get_xticklabels()]
+            for ax in g.axes.flat
+        ]
+        y_texts = [
+            [l.get_text() for l in ax.get_yticklabels()]
+            for ax in g.axes.flat
+        ]
+        g.set_xticklabels(rotation=45)
+        g.set_yticklabels(rotation=75)
+        for ax, texts in zip(g.axes.flat, x_texts):
+            for l, text in zip(ax.get_xticklabels(), texts):
+                assert l.get_rotation() == 45
+                assert l.get_text() == text
+        for ax, texts in zip(g.axes.flat, y_texts):
             for l, text in zip(ax.get_yticklabels(), texts):
                 assert l.get_rotation() == 75
                 assert l.get_text() == text


### PR DESCRIPTION
Resolves #3341 

When `sharex` or `sharey` is true, only the bottom or left axes get the tick labels. This causes issues when `set_xticklabels` or `set_yticklabels` is called without labels (a common case is using the `rotation` argument to rotate the current labels) and can result in those axes losing their tick labels.

~~This PR resolves this issue by getting the current tick labels before any operations occur.~~ Edit: Upon further investigation for cases with `share<x|y>=<"col"|"row">` and the discovery of a related bug when `set_xticklabels` has the `step` argument, the solution has been updated.

This PR resolves this issue by ensuring only the relevant axes are modified. It also ensures the correct number of ticks are selected by slicing the original sequence of ticks when `set_xticklabels` has the `step` argument.

Related: #1716 #1598 