### PR TITLE
TST: Adjust results for Matplotlib 3.11

### DIFF
--- a/tests/test_categorical.py
+++ b/tests/test_categorical.py
@@ -664,7 +664,7 @@ class SharedScatterTests(SharedAxesLevelTests):
         ax.set_xscale("log")
         self.func(x=x)
         vals = ax.collections[0].get_offsets()[:, 0]
-        assert_array_equal(x, vals)
+        assert_array_almost_equal(x, vals)
 
         y = [1, 2, 3, 4]
 
@@ -681,7 +681,7 @@ class SharedScatterTests(SharedAxesLevelTests):
         ax.set_yscale("log")
         self.func(x=x, y=y, orient="h", native_scale=True)
         cat_points = ax.collections[0].get_offsets().copy()[:, 1]
-        assert np.ptp(np.log10(cat_points)) <= .8
+        assert np.ptp(np.log10(cat_points)) <= 0.8 + 1e-14
 
     @pytest.mark.parametrize(
         "kwargs",

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -1017,7 +1017,7 @@ class TestKDEPlotBivariate:
         for c1, c2 in zip(ax1.collections, ax2.collections):
             assert len(get_contour_coords(c1)) == len(get_contour_coords(c2))
             for arr1, arr2 in zip(get_contour_coords(c1), get_contour_coords(c2)):
-                assert_array_equal(arr1, arr2)
+                assert_array_almost_equal(arr1, arr2)
 
     def test_bandwidth(self, rng):
 

--- a/tests/test_relational.py
+++ b/tests/test_relational.py
@@ -1121,7 +1121,7 @@ class TestLinePlotter(SharedAxesLevelTests, Helpers):
 
         lineplot(x=x, y=y)
         line = ax.lines[0]
-        assert_array_equal(line.get_xdata(), x)
+        assert_array_almost_equal(line.get_xdata(), x)
         assert_array_equal(line.get_ydata(), y)
 
         f, ax = plt.subplots()
@@ -1133,11 +1133,11 @@ class TestLinePlotter(SharedAxesLevelTests, Helpers):
 
         lineplot(x=x, y=y, err_style="bars", errorbar=("pi", 100))
         line = ax.lines[0]
-        assert line.get_ydata()[1] == 10
+        assert line.get_ydata()[1] == pytest.approx(10)
 
         ebars = ax.collections[0].get_segments()
-        assert_array_equal(ebars[0][:, 1], y[:2])
-        assert_array_equal(ebars[1][:, 1], y[2:])
+        assert_array_almost_equal(ebars[0][:, 1], y[:2])
+        assert_array_almost_equal(ebars[1][:, 1], y[2:])
 
     def test_axis_labels(self, long_df):
 


### PR DESCRIPTION
Log scaling underwent some optimization, which produces slightly different results, but still within some small floating-point tolerance.