### PR TITLE
Fix to the issue issue #3922

### DIFF
--- a/seaborn/_base.py
+++ b/seaborn/_base.py
@@ -836,6 +836,15 @@ class VectorPlotter:
     def map_hue(self, palette=None, order=None, norm=None, saturation=1):
         mapping = HueMapping(self, palette, order, norm, saturation)
         self._hue_map = mapping
+        if (
+            "hue" in self.plot_data
+            and self._hue_map.map_type == "categorical"
+            and self._hue_map.levels is not None
+        ):
+            self.plot_data["hue"] = pd.Categorical(
+                self.plot_data["hue"],
+                categories=self._hue_map.levels,
+            )
 
     def map_size(self, sizes=None, order=None, norm=None):
         mapping = SizeMapping(self, sizes, order, norm)


### PR DESCRIPTION
### Title
Fix of  `hue_order` which get ignored in categorical plots when `hue` is a pandas Categorical
I observed this issue only in `pd.Categorical`
### Description of the bug
When a pandas `Categorical` column is used for `hue` with `hue_order` is provided, `violinplot` ignore the user’s order and draw  the hue levels based on `CategoricalDtype`. Therefore, Order is reversed. 
### Solution
My solution is to manually add a check to ensure that  integrity of `hue_order` thus  fixing the bug. 