### PR TITLE
fix: replace mutable default arguments with None + initialization guards

### DIFF
--- a/seaborn/_base.py
+++ b/seaborn/_base.py
@@ -623,7 +623,9 @@ class VectorPlotter:
 
     _default_size_range = 1, 2  # Unused but needed in tests, ugh
 
-    def __init__(self, data=None, variables={}):
+    def __init__(self, data=None, variables=None):
+        if variables is None:
+            variables = {}
 
         self._var_levels = {}
         # var_ordered is relevant only for categorical axis variables, and may
@@ -663,8 +665,10 @@ class VectorPlotter:
                 self._var_levels[var] = map_obj.levels
         return self._var_levels
 
-    def assign_variables(self, data=None, variables={}):
+    def assign_variables(self, data=None, variables=None):
         """Define plot variables, optionally using lookup from `data`."""
+        if variables is None:
+            variables = {}
         x = variables.get("x", None)
         y = variables.get("y", None)
 

--- a/seaborn/external/docscrape.py
+++ b/seaborn/external/docscrape.py
@@ -161,7 +161,9 @@ class NumpyDocString(Mapping):
         'index': {}
     }
 
-    def __init__(self, docstring, config={}):
+    def __init__(self, docstring, config=None):
+        if config is None:
+            config = {}
         orig_docstring = docstring
         docstring = textwrap.dedent(docstring).split('\n')
 
@@ -579,7 +581,9 @@ def header(text, style='-'):
 
 
 class FunctionDoc(NumpyDocString):
-    def __init__(self, func, role='func', doc=None, config={}):
+    def __init__(self, func, role='func', doc=None, config=None):
+        if config is None:
+            config = {}
         self._f = func
         self._role = role  # e.g. "func" or "meth"
 

--- a/seaborn/relational.py
+++ b/seaborn/relational.py
@@ -384,7 +384,9 @@ class _ScatterPlotter(_RelationalPlotter):
 
     _legend_attributes = ["color", "s", "marker"]
 
-    def __init__(self, *, data=None, variables={}, legend=None):
+    def __init__(self, *, data=None, variables=None, legend=None):
+        if variables is None:
+            variables = {}
 
         # TODO this is messy, we want the mapping to be agnostic about
         # the kind of plot to draw, but for the time being we need to set


### PR DESCRIPTION
## Summary

Using mutable objects (`{}` or `[]`) as default argument values is a well-known Python anti-pattern. The default value is created **once** at function definition time and shared across all calls that use the default — meaning mutations in one call can silently affect subsequent calls.

## Changes

Fixed 5 occurrences across 3 files:

**`seaborn/_base.py`**
- `VectorPlotter.__init__(self, data=None, variables={})` → `variables=None`
- `VectorPlotter.assign_variables(self, data=None, variables={})` → `variables=None`

**`seaborn/relational.py`**
- `_ScatterPlotter.__init__(self, *, data=None, variables={}, legend=None)` → `variables=None`

**`seaborn/external/docscrape.py`**
- `NumpyDocString.__init__(self, docstring, config={})` → `config=None`
- `FunctionDoc.__init__(self, func, role='func', doc=None, config={})` → `config=None`

Each fix replaces the mutable default with `None` and adds the standard Python idiom at the top of the function body:

```python
if param is None:
    param = {}
```

## Testing

No behavior change for callers that pass explicit values. Callers relying on the default now get a fresh `{}` each call, which is the correct and expected behavior.