### PR TITLE
BUG: allow defaultdict palettes for missing hue levels

### DIFF
--- a/seaborn/_base.py
+++ b/seaborn/_base.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 import warnings
 import itertools
 from copy import copy
-from collections import UserString
+from collections import UserString, defaultdict
 from collections.abc import Iterable, Sequence, Mapping
 from numbers import Number
 from datetime import datetime
@@ -229,7 +229,10 @@ class HueMapping(SemanticMapping):
         if isinstance(palette, dict):
 
             missing = set(levels) - set(palette)
-            if any(missing):
+            if missing and (
+                not isinstance(palette, defaultdict)
+                or palette.default_factory is None
+            ):
                 err = "The palette dictionary is missing keys: {}"
                 raise ValueError(err.format(missing))
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,4 +1,5 @@
 import itertools
+from collections import defaultdict
 import numpy as np
 import pandas as pd
 import matplotlib as mpl
@@ -127,6 +128,21 @@ class TestHueMapping:
 
         # Test dict with missing keys
         palette = dict(zip(wide_df.columns[:-1], colors))
+        with pytest.raises(ValueError):
+            HueMapping(p, palette=palette)
+
+        # Test defaultdict with missing keys
+        default_color = "black"
+        palette = defaultdict(
+            lambda: default_color,
+            dict(zip(wide_df.columns[:-1], colors)),
+        )
+        m = HueMapping(p, palette=palette)
+        assert m.lookup_table == palette
+        assert mpl.colors.same_color(m(wide_df.columns[-1]), default_color)
+
+        # Test defaultdict without default factory still errors on missing keys
+        palette = defaultdict(None, dict(zip(wide_df.columns[:-1], colors)))
         with pytest.raises(ValueError):
             HueMapping(p, palette=palette)
 


### PR DESCRIPTION
Closes #3632.

This PR allows `defaultdict` palette mappings to provide colors for hue levels
that are not explicitly present in the mapping.

Regular dict palettes keep the existing behavior and still raise a `ValueError`
when required hue levels are missing. The new behavior is limited to
`defaultdict` palettes with a default factory.

Tests added:
- defaultdict palette with a missing hue level
- default color lookup for the missing level
- existing missing-key error behavior for regular dict palettes
- defaultdict without a default factory still raising on missing keys

Validation:
- `python -m pytest tests/test_base.py -k "palette or hue or mapping"`
- `python -m pytest tests/test_base.py`
- `python -m pytest tests/test_distributions.py -k "histplot or palette or hue"`
- `git diff --check`

AI assistance disclosure:
I used ChatGPT/Codex to help identify the issue, inspect likely implementation/test
locations, and draft an initial local patch. I reviewed the issue, final diff,
and local test results before submitting.
