### PR TITLE
Feature: objects stats ECDF

### DIFF
--- a/doc/_docstrings/objects.ECDF.ipynb
+++ b/doc/_docstrings/objects.ECDF.ipynb
@@ -1,0 +1,117 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dcc1ae12-bba4-4de9-af8d-543b3d65b42b",
+   "metadata": {
+    "tags": [
+     "hide"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "import seaborn.objects as so\n",
+    "from seaborn import load_dataset\n",
+    "penguins = load_dataset(\"penguins\")"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "1042b991-1471-43bd-934c-43caae3cb2fa",
+   "metadata": {},
+   "source": [
+    "This stat estimates transforms observations into a smooth function representing the estimated density:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2406e2aa-7f0f-4a51-af59-4cef827d28d8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "p = so.Plot(penguins, x=\"flipper_length_mm\")\n",
+    "p.add(so.Line(artist_kws={\"drawstyle\": \"steps-pre\"}), so.ECDF())"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "44515f21-683b-420f-967b-4c7568c907d7",
+   "metadata": {},
+   "source": [
+    "Plot the complementary ECDF"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d4e6ba5b-4dd2-4210-8cf0-de057dc71e2a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "p.add(so.Line(artist_kws={\"drawstyle\": \"steps-pre\"}), so.ECDF(complementary=True))"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "fd665fe1-a5e4-4742-adc9-e40615d57d08",
+   "metadata": {},
+   "source": [
+    "Add weights to the ECDF:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9cad5850-879a-475f-9f74-2817d704fff6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "p.add(so.Line(artist_kws={\"drawstyle\": \"steps-pre\"}), so.ECDF(complementary=True),weight=\"body_mass_g\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6bbd1db4-ca4e-4710-a420-43f2c3d4242c",
+   "metadata": {},
+   "source": [
+    "Create a facet and color by species"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "58f63734-5afd-4d90-bbfb-fc39c8d1981f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(\n",
+    "    p.facet(\"sex\")\n",
+    "    .add(so.Line(artist_kws={\"drawstyle\": \"steps-pre\"}), so.ECDF(),color=\"species\")\n",
+    ")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/doc/_docstrings/objects.ECDF.ipynb
+++ b/doc/_docstrings/objects.ECDF.ipynb
@@ -21,7 +21,7 @@
    "id": "1042b991-1471-43bd-934c-43caae3cb2fa",
    "metadata": {},
    "source": [
-    "This stat estimates transforms observations into a smooth function representing the estimated density:"
+    "This stat creates an empirical distribution function stat:"
    ]
   },
   {
@@ -95,9 +95,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "py310",
    "language": "python",
-   "name": "python3"
+   "name": "py310"
   },
   "language_info": {
    "codemirror_mode": {

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -89,6 +89,7 @@ Stat objects
     Count
     Hist
     KDE
+    ECDF
     Perc
     PolyFit
 

--- a/seaborn/_stats/density.py
+++ b/seaborn/_stats/density.py
@@ -78,6 +78,9 @@ class KDE(Stat):
 
     If scipy is installed, its cython-accelerated implementation will be used.
 
+    A weight can be assigned to the points by specifying it as an additional input column
+    in `Plot.add(..., so.KDE(), weight=<column>)`
+
     Examples
     --------
     .. include:: ../docstrings/objects.KDE.rst

--- a/seaborn/_stats/ecdf.py
+++ b/seaborn/_stats/ecdf.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+from dataclasses import dataclass
+import pandas as pd
+from pandas import DataFrame
+from seaborn._core.groupby import GroupBy
+from seaborn._core.scales import Scale
+from seaborn._stats.base import Stat
+from seaborn._statistics import ECDF as _ECDF
+
+
+@dataclass
+class ECDF(Stat):
+    """
+    Compute a empirical distribution function
+
+
+    Parameters
+    ----------
+    stat : {{“proportion”, “percent”, “count”}}
+        Distribution statistic to compute.
+    complementary : bool
+        If True, show the complementary CDF (1 - CDF)
+
+    """
+    stat: str = "proportion"
+    complementary: bool = False
+
+    def __call__(self, data: DataFrame, groupby: GroupBy, orient: str, scales: dict[str, Scale]) -> DataFrame:
+        self._check_param_one_of("stat", ("proportion", "percent", "count"))
+
+        if "weight" not in data:
+            data = data.assign(weight=1)
+
+        def ecdf_transform(data):
+            estimator = _ECDF(stat=self.stat, complementary=self.complementary)
+            y, x = estimator(data[orient],weights=data["weight"])
+            return pd.DataFrame({orient: x, "y": y})
+        
+        return groupby.apply(data, ecdf_transform)
+

--- a/seaborn/_stats/ecdf.py
+++ b/seaborn/_stats/ecdf.py
@@ -40,6 +40,7 @@ class ECDF(Stat):
         def ecdf_transform(data):
             estimator = _ECDF(stat=self.stat, complementary=self.complementary)
             y, x = estimator(data[orient],weights=data["weight"])
+            x[0] = data[orient].min()
             return pd.DataFrame({orient: x, "y": y})
         
         return groupby.apply(data, ecdf_transform)

--- a/seaborn/_stats/ecdf.py
+++ b/seaborn/_stats/ecdf.py
@@ -21,6 +21,9 @@ class ECDF(Stat):
     complementary : bool
         If True, show the complementary CDF (1 - CDF)
 
+    Examples
+    --------
+    .. include:: ../docstrings/objects.ECDF.rst
     """
     stat: str = "proportion"
     complementary: bool = False
@@ -30,7 +33,7 @@ class ECDF(Stat):
 
         if "weight" not in data:
             data = data.assign(weight=1)
-
+        data = data.dropna(subset=[orient, "weight"])
         def ecdf_transform(data):
             estimator = _ECDF(stat=self.stat, complementary=self.complementary)
             y, x = estimator(data[orient],weights=data["weight"])

--- a/seaborn/_stats/ecdf.py
+++ b/seaborn/_stats/ecdf.py
@@ -21,6 +21,9 @@ class ECDF(Stat):
     complementary : bool
         If True, show the complementary CDF (1 - CDF)
 
+    A weight can be assigned to the points by specifying it as an additional input column
+    in `Plot.add(..., so.ECDF(), weight=<column>)`
+
     Examples
     --------
     .. include:: ../docstrings/objects.ECDF.rst

--- a/seaborn/objects.py
+++ b/seaborn/objects.py
@@ -39,6 +39,7 @@ from seaborn._stats.base import Stat  # noqa: F401
 from seaborn._stats.aggregation import Agg, Est  # noqa: F401
 from seaborn._stats.counting import Count, Hist  # noqa: F401
 from seaborn._stats.density import KDE  # noqa: F401
+from seaborn._stats.ecdf import ECDF  # noqa: F401
 from seaborn._stats.order import Perc  # noqa: F401
 from seaborn._stats.regression import PolyFit  # noqa: F401
 


### PR DESCRIPTION
I belive it could be nice to have the option of making ECDF plots using the new objects interface. I therefore propse that and ECDF stat module be added in `_stats`.

In this PR i have:

- Created `seaborn/_stats/ecdf.py` with a basic implementation of an ECDF stat that just calls ECDF from `seaborn._statistics`. It accepts a `stat` and a `complementary` option.
- I added the ECDF to the `seaborn.objects` file.
- I added an example jupyter notebook.



# Example


```python
import seaborn.objects as so
from seaborn import load_dataset
penguins = load_dataset("penguins")
```
This stat estimates transforms observations into a smooth function representing the estimated density:

```python
p = so.Plot(penguins, x="flipper_length_mm")
p.add(so.Line(artist_kws={"drawstyle": "steps-pre"}), so.ECDF())
```
<img width="500" alt="output_2_0" src="https://github.com/user-attachments/assets/df3d546d-e613-4a88-b291-8dd7060e1386" />


Plot the complementary ECDF

```python
p.add(so.Line(artist_kws={"drawstyle": "steps-pre"}), so.ECDF(complementary=True))
```

    
<img width="500" alt="output_4_0" src="https://github.com/user-attachments/assets/61e8d119-6d86-4bf6-8c59-98f4ddaccdeb" />


Add weights to the ECDF:

```python
p.add(so.Line(artist_kws={"drawstyle": "steps-pre"}), so.ECDF(complementary=True),weight="body_mass_g")
```

 
<img width="500" alt="output_6_0" src="https://github.com/user-attachments/assets/3c5f0cf4-dcea-4897-bfc8-4a24a32d6985" />


Create a facet and color by species

```python
(
    p.facet("sex")
    .add(so.Line(artist_kws={"drawstyle": "steps-pre"}), so.ECDF(),color="species")
)
```

    
<img width="500" alt="output_8_0" src="https://github.com/user-attachments/assets/872df661-7cf0-4cd1-a5ba-606aac7daabd" />    
  

---

I have also ensured that the doc can build:

<img width="1476" height="797" alt="image" src="https://github.com/user-attachments/assets/7d8eecc2-a333-477a-a953-c38a29ad740d" />

