### PR TITLE
Fix histplot with weights and array bins

### DIFF
--- a/seaborn/distributions.py
+++ b/seaborn/distributions.py
@@ -401,6 +401,7 @@ class _DistributionPlotter(VectorPlotter):
 
         auto_bins_with_weights = (
             "weights" in self.variables
+            and isinstance(estimate_kws["bins"], str)
             and estimate_kws["bins"] == "auto"
             and estimate_kws["binwidth"] is None
             and not estimate_kws["discrete"]

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -1461,6 +1461,19 @@ class TestHistPlotUnivariate(SharedAxesLevelTests):
         total_weight = null_df[["x", "s"]].dropna()["s"].sum()
         assert sum(bar_heights) == pytest.approx(total_weight)
 
+    def test_weights_with_array_bins(self):
+
+        x = np.linspace(.05, .95, 10)
+        weights = np.ones_like(x)
+        bins = np.linspace(0, 1, 11)
+
+        ax = histplot(x=x, weights=weights, bins=bins)
+
+        assert len(ax.patches) == len(bins) - 1
+        assert sum(bar.get_height() for bar in ax.patches) == pytest.approx(
+            weights.sum()
+        )
+
     def test_weight_norm(self, rng):
 
         vals = rng.normal(0, 1, 50)


### PR DESCRIPTION
Fixes #3801.

This updates the weighted-histogram auto-bin warning guard so it only compares `bins` with `"auto"` when `bins` is a string. Explicit bin edges provided as a NumPy array are now passed through to the histogram estimator instead of raising an ambiguous truth-value error.

Added a regression test covering `histplot(x=..., weights=..., bins=np.array(...))`.

Verification:

- `python -m pytest tests/test_distributions.py::TestHistPlotUnivariate::test_weights_with_array_bins -q`
- `MPLBACKEND=Agg python -m pytest tests/test_distributions.py::TestHistPlotUnivariate -q`
- `MPLBACKEND=Agg python -m pytest tests/test_distributions.py::TestHistPlotUnivariate::test_weights_with_missing tests/test_distributions.py::TestHistPlotUnivariate::test_weight_norm tests/test_distributions.py::TestHistPlotUnivariate::test_weights_with_array_bins -q`
- `MPLBACKEND=Agg python -m pytest tests/test_statistics.py::TestHistogram::test_array_bins -q`
- `git diff --check`
