### PR TITLE
Improve build instructions for docs

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -10,3 +10,20 @@ After you're set up, run `make notebooks html` from the `doc` directory to conve
 Run `make clean` to delete the built site and all intermediate files. Run `make -C docstrings clean` or `make -C tutorial clean` to remove intermediate files for the API or tutorial components.
 
 If your goal is to obtain an offline copy of the docs for a released version, it may be easier to clone the [website repository](https://github.com/seaborn/seaborn.github.io) or to download a zipfile corresponding to a [specific version](https://github.com/seaborn/seaborn.github.io/tags).
+
+# Commands
+
+```bash
+pyenv install 3.12
+pyenv global 3.12
+python -m venv .venv
+. .venv/bin/activate
+pip install seaborn[stats,docs]
+# sudo dnf install -y python3-ipykernel
+python -m ipykernel install --user --name=myenv --display-name "Python (myenv)"
+jupyter-kernelspec list
+export NB_KERNEL="myenv"
+make notebooks latexpdf 
+```
+
+Here is an example of the built PDF: https://codeberg.org/jipmelon/t/src/branch/main/seaborn.pdf


### PR DESCRIPTION
These are the commands I used to create a PDF. LaTeX errors, yet a 1000-page PDF is there in all its goodness. I think the important things to point out for users like me wanting to build from source are:
1. use Python 3.12
2. Run `python -m ipykernel install --user --name=myenv --display-name "Python (myenv)"`
3. `make latexpdf` may be unsupported, but it works! (it would also be nice to provide a download link for it, it is much appreciated rather than having to build each time with high risk of failing :) )