### PR TITLE
Respect common_norm for the density stat in so.Hist

### DIFF
--- a/seaborn/_stats/counting.py
+++ b/seaborn/_stats/counting.py
@@ -172,8 +172,7 @@ class Hist(Stat):
         vals = data[orient]
         weights = data.get("weight", None)
 
-        density = self.stat == "density"
-        hist, edges = np.histogram(vals, **bin_kws, weights=weights, density=density)
+        hist, edges = np.histogram(vals, **bin_kws, weights=weights)
 
         width = np.diff(edges)
         center = edges[:-1] + width / 2
@@ -189,6 +188,8 @@ class Hist(Stat):
             hist = hist.astype(float) / hist.sum() * 100
         elif self.stat == "frequency":
             hist = hist.astype(float) / data["space"]
+        elif self.stat == "density":
+            hist = hist.astype(float) / (hist.sum() * data["space"])
 
         if self.cumulative:
             if self.stat in ["density", "frequency"]:

--- a/tests/_stats/test_counting.py
+++ b/tests/_stats/test_counting.py
@@ -203,6 +203,19 @@ class TestHist:
         for _, out_part in out.groupby("a"):
             assert out_part["y"].sum() == pytest.approx(100)
 
+    def test_common_norm_density(self, long_df, triple_args):
+
+        h = Hist(stat="density", common_norm=True)
+        out = h(long_df, *triple_args)
+        assert (out["y"] * out["space"]).sum() == pytest.approx(1)
+
+    def test_common_norm_density_false(self, long_df, triple_args):
+
+        h = Hist(stat="density", common_norm=False)
+        out = h(long_df, *triple_args)
+        for _, out_part in out.groupby(["a", "s"]):
+            assert (out_part["y"] * out_part["space"]).sum() == pytest.approx(1)
+
     def test_common_norm_warning(self, long_df, triple_args):
 
         h = Hist(common_norm=["b"])


### PR DESCRIPTION
## Problem

`so.Hist(stat="density")` ignores `common_norm`. When data is split into groups, every group is normalized to area 1 independently, regardless of `common_norm`. `sns.histplot` scales each group by its share of the total, so the two interfaces disagree (#3633).

```python
from seaborn._core.groupby import GroupBy
from seaborn._stats.counting import Hist
import numpy as np, pandas as pd

class Scale: scale_type = "continuous"
df = pd.DataFrame({"x": np.r_[np.zeros(100), np.ones(900)],
                   "grp": ["a"]*100 + ["b"]*900})
args = (GroupBy(["grp"]), "x", {"x": Scale()})

def areas(cn):
    out = Hist(stat="density", common_norm=cn, bins=8)(df, *args)
    return {k: round((s["density"]*s["space"]).sum(), 2) for k, s in out.groupby("grp")}

# before this PR:
areas(True)   # {'a': 1.0, 'b': 1.0}   <- common_norm ignored
areas(False)  # {'a': 1.0, 'b': 1.0}
```

## Root cause

Density was computed inside `np.histogram(..., density=True)` in `_eval`, which runs per group — so each group was normalized to area 1 before `common_norm` was ever applied. `_normalize` (which the `common_norm` groupby dispatches over) had no density branch.

## Fix

Compute raw counts in `_eval` and move density normalization into `_normalize` alongside `frequency`, so the `common_norm` groupby controls the scope:

```
density_i = count_i / (N_norm * width_i)
```

- `common_norm=True` → `N_norm` is the total across all groups (areas sum to 1).
- `common_norm=False` → `N_norm` is the per-group count (each area is 1), matching previous and `histplot` behavior.

After the fix: `areas(True)` → `{'a': 0.1, 'b': 0.9}`, `areas(False)` → `{'a': 1.0, 'b': 1.0}`.

## Tests

Adds regression tests for density + `common_norm` True/False, which were previously uncovered (existing `common_norm` tests only covered `stat="percent"`).
