### PR TITLE
Fix nominal color scaling with integer levels

### DIFF
--- a/seaborn/_core/scales.py
+++ b/seaborn/_core/scales.py
@@ -308,9 +308,13 @@ class Nominal(Scale):
             # TODO isin fails when units_seed mixes numbers and strings (numpy error?)
             # but np.isin also does not seem any faster? (Maybe not broadcasting in C)
             # keep = x.isin(units_seed)
-            keep = np.array([x_ in units_seed for x_ in x], bool)
-            out = np.full(len(x), np.nan)
-            out[keep] = axis.convert_units(stringify(x[keep]))
+            values = np.asarray(x, dtype=object)
+            keep = np.array([x_ in units_seed for x_ in values], bool)
+            out = np.full(len(values), np.nan)
+            if prop.variable in ["x", "y"]:
+                out[keep] = axis.convert_units(stringify(values[keep]))
+            else:
+                out[keep] = [units_seed.index(x_) for x_ in values[keep]]
             return out
 
         new._pipeline = [convert_units, prop.get_mapping(new, data)]

--- a/tests/_core/test_plot.py
+++ b/tests/_core/test_plot.py
@@ -645,6 +645,16 @@ class TestScaling:
         expected = mpl.colors.to_rgba_array(c)[:, :3]
         assert_array_equal(m.passed_scales["color"](c), expected)
 
+    def test_nominal_integer_color_scale_multiple_layers(self):
+
+        p = (
+            Plot(x=[1, 2, 3], y=[1, 2, 3], color=[1, 2, 3])
+            .add(Dot())
+            .add(Dot(), x=[1], y=[1], color=[1])
+            .scale(color=Nominal())
+        )
+        p.plot()
+
     @pytest.mark.xfail(
         reason="Need decision on what to do with scale defined for unused variable"
     )


### PR DESCRIPTION
Closes #3375.

This keeps nominal color scales aligned with their level order when integer color values are used across multiple layers. Coordinate scales still use matplotlib unit conversion so shared categorical axes keep their existing behavior.

Tests:
- `python -m pytest tests/_core/test_plot.py::TestScaling::test_nominal_integer_color_scale_multiple_layers tests/_core/test_plot.py::TestScaling::test_pair_categories_shared tests/_core/test_scales.py::TestNominal -q`
- `python -m pytest tests/_core/test_scales.py tests/_core/test_properties.py::TestColor tests/_marks/test_dot.py -q`
- `python -m pytest tests/_core/test_plot.py -q -k "not test_show"`
- `python -m pytest tests/_core -q -k "not test_show"`