### PR TITLE
Bump minimal dependency versions per NEP29

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,12 +45,12 @@ docs = [
     "numpydoc==1.6.0",
     "nbconvert==7.17.1",
     "ipykernel==7.3.0",
-    "sphinx==5.3.0",
+    "sphinx==5.3.0",  # Important: do not adjust this pin
     "sphinx-copybutton==0.5.2",
     "sphinx-issues==5.0.1",
     "sphinx-design==0.6.0",
     "pyyaml==6.0.3",
-    "pydata_sphinx_theme==0.10.0rc2",
+    "pydata_sphinx_theme==0.10.0rc2",  # Important: do not adjust this pin
 ]
 dev = [
     {include-group = "test"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,15 +19,15 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "numpy>=1.26",
-    "pandas>=2.0.2",
-    "matplotlib>=3.8",
+    "numpy>=2.0",
+    "pandas>=2.2",
+    "matplotlib>=3.9",
 ]
 
 [project.optional-dependencies]
 stats = [
-    "scipy>=1.11",
-    "statsmodels>=0.14",
+    "scipy>=1.14",
+    "statsmodels>=0.14.3",
 ]
 
 [dependency-groups]

--- a/seaborn/_base.py
+++ b/seaborn/_base.py
@@ -18,7 +18,6 @@ from seaborn.palettes import (
 )
 from seaborn.utils import (
     _check_argument,
-    _version_predates,
     desaturate,
     locator_to_legend_entries,
     get_color_cycle,
@@ -941,11 +940,8 @@ class VectorPlotter:
 
             for key in iter_keys:
 
-                pd_key = (
-                    key[0] if len(key) == 1 and _version_predates(pd, "2.2.0") else key
-                )
                 try:
-                    data_subset = grouped_data.get_group(pd_key)
+                    data_subset = grouped_data.get_group(key)
                 except KeyError:
                     # XXX we are adding this to allow backwards compatibility
                     # with the empty artists that old categorical plots would
@@ -1264,15 +1260,7 @@ class VectorPlotter:
                 if attr in kws:
                     level_kws[attr] = kws[attr]
             artist = func(label=label, **{"color": ".2", **common_kws, **level_kws})
-            if _version_predates(mpl, "3.5.0"):
-                if isinstance(artist, mpl.lines.Line2D):
-                    ax.add_line(artist)
-                elif isinstance(artist, mpl.patches.Patch):
-                    ax.add_patch(artist)
-                elif isinstance(artist, mpl.collections.Collection):
-                    ax.add_collection(artist)
-            else:
-                ax.add_artist(artist)
+            ax.add_artist(artist)
             legend_data[key] = artist
             legend_order.append(key)
 

--- a/seaborn/_compat.py
+++ b/seaborn/_compat.py
@@ -1,10 +1,7 @@
 from __future__ import annotations
-from typing import Literal
 
 import numpy as np
-import pandas as pd
 import matplotlib as mpl
-from matplotlib.figure import Figure
 from seaborn.utils import _version_predates
 
 
@@ -57,69 +54,25 @@ def norm_from_scale(scale, norm):
 
 
 def get_colormap(name):
-    """Handle changes to matplotlib colormap interface in 3.6."""
-    try:
-        return mpl.colormaps[name]
-    except AttributeError:
-        return mpl.cm.get_cmap(name)
+    return mpl.colormaps[name]
 
 
 def register_colormap(name, cmap):
-    """Handle changes to matplotlib colormap interface in 3.6."""
-    try:
-        if name not in mpl.colormaps:
-            mpl.colormaps.register(cmap, name=name)
-    except AttributeError:
-        mpl.cm.register_cmap(name, cmap)
-
-
-def set_layout_engine(
-    fig: Figure,
-    engine: Literal["constrained", "compressed", "tight", "none"],
-) -> None:
-    """Handle changes to auto layout engine interface in 3.6"""
-    if hasattr(fig, "set_layout_engine"):
-        fig.set_layout_engine(engine)
-    else:
-        # _version_predates(mpl, 3.6)
-        if engine == "tight":
-            fig.set_tight_layout(True)  # type: ignore  # predates typing
-        elif engine == "constrained":
-            fig.set_constrained_layout(True)  # type: ignore
-        elif engine == "none":
-            fig.set_tight_layout(False)  # type: ignore
-            fig.set_constrained_layout(False)  # type: ignore
-
-
-def get_layout_engine(fig: Figure) -> mpl.layout_engine.LayoutEngine | None:
-    """Handle changes to auto layout engine interface in 3.6"""
-    if hasattr(fig, "get_layout_engine"):
-        return fig.get_layout_engine()
-    else:
-        # _version_predates(mpl, 3.6)
-        return None
+    if name not in mpl.colormaps:
+        mpl.colormaps.register(cmap, name=name)
 
 
 def share_axis(ax0, ax1, which):
     """Handle changes to post-hoc axis sharing."""
-    if _version_predates(mpl, "3.5"):
-        group = getattr(ax0, f"get_shared_{which}_axes")()
-        group.join(ax1, ax0)
-    else:
-        getattr(ax1, f"share{which}")(ax0)
+    getattr(ax1, f"share{which}")(ax0)
 
 
 def get_legend_handles(legend):
     """Handle legendHandles attribute rename."""
-    if _version_predates(mpl, "3.7"):
-        return legend.legendHandles
-    else:
-        return legend.legend_handles
+    return legend.legend_handles
 
 
 def groupby_apply_include_groups(val):
-    if _version_predates(pd, "2.2.0"):
-        return {}
     return {"include_groups": val}
 
 

--- a/seaborn/_core/plot.py
+++ b/seaborn/_core/plot.py
@@ -40,8 +40,6 @@ from seaborn._core.typing import (
 )
 from seaborn._core.exceptions import PlotSpecError
 from seaborn._core.rules import categorical_order
-from seaborn._compat import get_layout_engine, set_layout_engine
-from seaborn.utils import _version_predates
 from seaborn.rcmod import axes_style, plotting_context
 from seaborn.palettes import color_palette
 
@@ -1638,12 +1636,8 @@ class Plotter:
 
                 for key in itertools.product(*grouping_keys):
 
-                    pd_key = (
-                        key[0] if len(key) == 1 and _version_predates(pd, "2.2.0")
-                        else key
-                    )
                     try:
-                        df_subset = grouped_df.get_group(pd_key)
+                        df_subset = grouped_df.get_group(key)
                     except KeyError:
                         # TODO (from initial work on categorical plots refactor)
                         # We are adding this to allow backwards compatability
@@ -1801,16 +1795,16 @@ class Plotter:
 
         if (engine_name := p._layout_spec.get("engine", default)) is not default:
             # None is a valid arg for Figure.set_layout_engine, hence `default`
-            set_layout_engine(self._figure, engine_name)
+            self._figure.set_layout_engine(engine_name)
         elif p._target is None:
             # Don't modify the layout engine if the user supplied their own
             # matplotlib figure and didn't specify an engine through Plot
             # TODO switch default to "constrained"?
             # TODO either way, make configurable
-            set_layout_engine(self._figure, "tight")
+            self._figure.set_layout_engine("tight")
 
         if (extent := p._layout_spec.get("extent")) is not None:
-            engine = get_layout_engine(self._figure)
+            engine = self._figure.get_layout_engine()
             if engine is None:
                 self._figure.subplots_adjust(*extent)
             else:

--- a/seaborn/_stats/order.py
+++ b/seaborn/_stats/order.py
@@ -13,7 +13,6 @@ from pandas import DataFrame
 from seaborn._core.scales import Scale
 from seaborn._core.groupby import GroupBy
 from seaborn._stats.base import Stat
-from seaborn.utils import _version_predates
 
 
 # From https://github.com/numpy/numpy/blob/main/numpy/lib/function_base.pyi
@@ -64,10 +63,7 @@ class Perc(Stat):
         k = list(np.linspace(0, 100, self.k)) if isinstance(self.k, int) else self.k
         method = cast(_MethodKind, self.method)
         values = data[var].dropna()
-        if _version_predates(np, "1.22"):
-            res = np.percentile(values, k, interpolation=method)  # type: ignore
-        else:
-            res = np.percentile(data[var].dropna(), k, method=method)
+        res = np.percentile(values, k, method=method)
         return DataFrame({var: res, "percentile": k})
 
     def __call__(

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -697,12 +697,7 @@ class _CategoricalPlotter(VectorPlotter):
                     if _version_predates(mpl, "3.10.0")
                     else {"orientation": orientation}
                 ),
-                # added in matplotlib 3.6.0; see below
-                # capwidths=capwidth,
-                **(
-                    {} if _version_predates(mpl, "3.6.0")
-                    else {"capwidths": capwidth}
-                )
+                capwidths=capwidth,
             )
             boxplot_kws = {**default_kws, **plot_kws}
             artists = ax.bxp(**boxplot_kws)

--- a/tests/_core/test_plot.py
+++ b/tests/_core/test_plot.py
@@ -1091,19 +1091,11 @@ class TestPlotting:
         p = Plot().layout(size=size).plot()
         assert tuple(p._figure.get_size_inches()) == size
 
-    @pytest.mark.skipif(
-        _version_predates(mpl, "3.6"),
-        reason="mpl<3.6 does not have get_layout_engine",
-    )
     def test_layout_extent(self):
 
         p = Plot().layout(extent=(.1, .2, .6, 1)).plot()
         assert p._figure.get_layout_engine().get()["rect"] == [.1, .2, .5, .8]
 
-    @pytest.mark.skipif(
-        _version_predates(mpl, "3.6"),
-        reason="mpl<3.6 does not have get_layout_engine",
-    )
     def test_constrained_layout_extent(self):
 
         p = Plot().layout(engine="constrained", extent=(.1, .2, .6, 1)).plot()
@@ -1168,10 +1160,6 @@ class TestPlotting:
         with pytest.raises(RuntimeError, match="Cannot create multiple subplots"):
             p2.plot()
 
-    @pytest.mark.skipif(
-        _version_predates(mpl, "3.6"),
-        reason="Requires newer matplotlib layout engine API"
-    )
     def test_on_layout_algo_default(self):
 
         class MockEngine(mpl.layout_engine.ConstrainedLayoutEngine):
@@ -1182,10 +1170,6 @@ class TestPlotting:
         layout_engine = p._figure.get_layout_engine()
         assert layout_engine.__class__.__name__ == "MockEngine"
 
-    @pytest.mark.skipif(
-        _version_predates(mpl, "3.6"),
-        reason="Requires newer matplotlib layout engine API"
-    )
     def test_on_layout_algo_spec(self):
 
         f = mpl.figure.Figure(layout="constrained")
@@ -1783,12 +1767,8 @@ class TestPairInterface:
 class TestLabelVisibility:
 
     def has_xaxis_labels(self, ax):
-        if _version_predates(mpl, "3.7"):
-            # mpl3.7 added a getter for tick params, but both yaxis and xaxis return
-            # the same entry of "labelleft" instead of "labelbottom" for xaxis
-            return len(ax.get_xticklabels()) > 0
-        elif _version_predates(mpl, "3.10"):
-            # Then I guess they made it labelbottom in 3.10?
+        if _version_predates(mpl, "3.10"):
+            # They made it labelbottom in 3.10?
             return ax.xaxis.get_tick_params()["labelleft"]
         else:
             return ax.xaxis.get_tick_params()["labelbottom"]
@@ -2118,10 +2098,9 @@ class TestLegend:
         labels = [t.get_text() for t in legend.get_texts()]
         assert labels == names
 
-        if not _version_predates(mpl, "3.5"):
-            contents = legend.get_children()[0]
-            assert len(contents.findobj(mpl.lines.Line2D)) == len(names)
-            assert len(contents.findobj(mpl.patches.Patch)) == len(names)
+        contents = legend.get_children()[0]
+        assert len(contents.findobj(mpl.lines.Line2D)) == len(names)
+        assert len(contents.findobj(mpl.patches.Patch)) == len(names)
 
     def test_three_layers(self, xy):
 

--- a/tests/_core/test_scales.py
+++ b/tests/_core/test_scales.py
@@ -25,7 +25,6 @@ from seaborn._core.properties import (
     Fill,
 )
 from seaborn.palettes import color_palette
-from seaborn.utils import _version_predates
 
 
 class TestContinuous:
@@ -192,10 +191,6 @@ class TestContinuous:
         n = 3
         a = self.setup_ticks(x, count=2, minor=n)
         expected = np.linspace(0, 1, n + 2)
-        if _version_predates(mpl, "3.8.0rc1"):
-            # I am not sure why matplotlib <3.8  minor ticks include the
-            # largest major location but exclude the smalllest one ...
-            expected = expected[1:]
         assert_array_equal(a.minor.locator(), expected)
 
     def test_log_tick_default(self, x):

--- a/tests/_stats/test_order.py
+++ b/tests/_stats/test_order.py
@@ -7,7 +7,6 @@ from numpy.testing import assert_array_equal
 
 from seaborn._core.groupby import GroupBy
 from seaborn._stats.order import Perc
-from seaborn.utils import _version_predates
 
 
 class Fixtures:
@@ -58,10 +57,7 @@ class TestPerc(Fixtures):
         method = "nearest"
         res = Perc(k=5, method=method)(df, gb, ori, {})
         percentiles = [0, 25, 50, 75, 100]
-        if _version_predates(np, "1.22.0"):
-            expected = np.percentile(df["y"], percentiles, interpolation=method)
-        else:
-            expected = np.percentile(df["y"], percentiles, method=method)
+        expected = np.percentile(df["y"], percentiles, method=method)
         assert_array_equal(res["y"], expected)
 
     def test_grouped(self, df, rng):

--- a/tests/test_axisgrid.py
+++ b/tests/test_axisgrid.py
@@ -14,7 +14,6 @@ from seaborn.palettes import color_palette
 from seaborn.relational import scatterplot
 from seaborn.distributions import histplot, kdeplot, distplot
 from seaborn.categorical import pointplot
-from seaborn.utils import _version_predates
 from seaborn import axisgrid as ag
 from seaborn._testing import (
     assert_plots_equal,
@@ -1424,7 +1423,6 @@ class TestPairGrid:
 
         assert_plots_equal(ax1, ax2, labels=False)
 
-    @pytest.mark.skipif(_version_predates(mpl, "3.7.0"), reason="Matplotlib bug")
     def test_pairplot_markers(self):
 
         vars = ["x", "y", "z"]

--- a/tests/test_categorical.py
+++ b/tests/test_categorical.py
@@ -36,7 +36,7 @@ from seaborn.categorical import (
     violinplot,
 )
 from seaborn.palettes import color_palette
-from seaborn.utils import _draw_figure, _version_predates, desaturate
+from seaborn.utils import _draw_figure, desaturate
 
 
 PLOT_FUNCS = [
@@ -2616,10 +2616,6 @@ class TestPointPlot(SharedAggTests):
             assert same_color(line.get_color(), kws["color"])
             assert line.get_linewidth() == kws["linewidth"]
 
-    @pytest.mark.skipif(
-        _version_predates(mpl, "3.6"),
-        reason="Legend handle missing marker property"
-    )
     def test_legend_contents(self):
 
         x, y = ["a", "a", "b", "b"], [1, 2, 3, 4]
@@ -2633,10 +2629,6 @@ class TestPointPlot(SharedAggTests):
             assert handle.get_linestyle() == "-"
             assert same_color(handle.get_color(), f"C{i}")
 
-    @pytest.mark.skipif(
-        _version_predates(mpl, "3.6"),
-        reason="Legend handle missing marker property"
-    )
     def test_legend_set_props(self):
 
         x, y = ["a", "a", "b", "b"], [1, 2, 3, 4]
@@ -2648,10 +2640,6 @@ class TestPointPlot(SharedAggTests):
             assert handle.get_marker() == kws["marker"]
             assert handle.get_linewidth() == kws["linewidth"]
 
-    @pytest.mark.skipif(
-        _version_predates(mpl, "3.6"),
-        reason="Legend handle missing marker property"
-    )
     def test_legend_synced_props(self):
 
         x, y = ["a", "a", "b", "b"], [1, 2, 3, 4]
@@ -2934,11 +2922,8 @@ class CategoricalFixture:
 
     def get_box_artists(self, ax):
 
-        if _version_predates(mpl, "3.5.0b0"):
-            return ax.artists
-        else:
-            # Exclude labeled patches, which are for the legend
-            return [p for p in ax.patches if not p.get_label()]
+        # Exclude labeled patches, which are for the legend
+        return [p for p in ax.patches if not p.get_label()]
 
 
 class TestCatPlot(CategoricalFixture):

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -31,7 +31,6 @@ from seaborn.distributions import (
     kdeplot,
     rugplot,
 )
-from seaborn.utils import _version_predates
 from seaborn.axisgrid import FacetGrid
 from seaborn._testing import (
     assert_plots_equal,
@@ -41,27 +40,19 @@ from seaborn._testing import (
 
 
 def get_contour_coords(c, filter_empty=False):
-    """Provide compatability for change in contour artist types."""
-    if isinstance(c, mpl.collections.LineCollection):
-        # See https://github.com/matplotlib/matplotlib/issues/20906
-        return c.get_segments()
-    elif isinstance(c, (mpl.collections.PathCollection, mpl.contour.QuadContourSet)):
-        return [
-            p.vertices[:np.argmax(p.codes) + 1] for p in c.get_paths()
-            if len(p) or not filter_empty
-        ]
+    """Provide access to contour path coordinates."""
+    return [
+        p.vertices[:np.argmax(p.codes) + 1] for p in c.get_paths()
+        if len(p) or not filter_empty
+    ]
 
 
 def get_contour_color(c):
-    """Provide compatability for change in contour artist types."""
-    if isinstance(c, mpl.collections.LineCollection):
-        # See https://github.com/matplotlib/matplotlib/issues/20906
-        return c.get_color()
-    elif isinstance(c, (mpl.collections.PathCollection, mpl.contour.QuadContourSet)):
-        if c.get_facecolor().size:
-            return c.get_facecolor()
-        else:
-            return c.get_edgecolor()
+    """Provide access to contour artist color."""
+    if c.get_facecolor().size:
+        return c.get_facecolor()
+    else:
+        return c.get_edgecolor()
 
 
 class TestDistPlot:
@@ -907,9 +898,6 @@ class TestKDEPlotUnivariate(SharedAxesLevelTests):
             assert label.get_text() == level
 
         legend_artists = ax.legend_.findobj(mpl.lines.Line2D)
-        if _version_predates(mpl, "3.5.0b0"):
-            # https://github.com/matplotlib/matplotlib/pull/20699
-            legend_artists = legend_artists[::2]
         palette = color_palette()
         for artist, color in zip(legend_artists, palette):
             assert_colors_equal(artist.get_color(), color)
@@ -969,12 +957,7 @@ class TestKDEPlotBivariate:
             f, ax = plt.subplots()
             kdeplot(data=long_df, x="x", y="y", hue="c", fill=fill)
             for c in ax.collections:
-                if not _version_predates(mpl, "3.8.0rc1"):
-                    assert isinstance(c, mpl.contour.QuadContourSet)
-                elif fill or not _version_predates(mpl, "3.5.0b0"):
-                    assert isinstance(c, mpl.collections.PathCollection)
-                else:
-                    assert isinstance(c, mpl.collections.LineCollection)
+                assert isinstance(c, mpl.contour.QuadContourSet)
 
     def test_common_norm(self, rng):
 
@@ -2446,10 +2429,7 @@ class TestDisPlot:
         z = [0] * 80 + [1] * 20
 
         def count_contours(ax):
-            if _version_predates(mpl, "3.8.0rc1"):
-                return sum(bool(get_contour_coords(c)) for c in ax.collections)
-            else:
-                return sum(bool(p.vertices.size) for p in ax.collections[0].get_paths())
+            return sum(bool(p.vertices.size) for p in ax.collections[0].get_paths())
 
         g = displot(x=x, y=y, col=z, kind="kde", levels=10)
         l1 = count_contours(g.axes.flat[0])

--- a/tests/test_relational.py
+++ b/tests/test_relational.py
@@ -21,7 +21,7 @@ from seaborn.relational import (
     scatterplot
 )
 
-from seaborn.utils import _draw_figure, _version_predates
+from seaborn.utils import _draw_figure
 from seaborn._compat import get_colormap, get_legend_handles
 from seaborn._testing import assert_plots_equal
 
@@ -715,8 +715,7 @@ class TestRelationalPlotter(Helpers):
             assert same_color(pt.get_color(), palette[i])
             assert pt.get_markersize() == np.sqrt(kws["s"])
             assert pt.get_markeredgewidth() == kws["linewidth"]
-            if not _version_predates(mpl, "3.7.0"):
-                assert pt.get_marker() == kws["marker"]
+            assert pt.get_marker() == kws["marker"]
 
     def test_legend_attributes_style(self, long_df):
 
@@ -1199,8 +1198,7 @@ class TestLinePlotter(SharedAxesLevelTests, Helpers):
         for i, line in enumerate(get_legend_handles(ax.get_legend())):
             assert same_color(line.get_color(), palette[i])
             assert line.get_linewidth() == kws["linewidth"]
-            if not _version_predates(mpl, "3.7.0"):
-                assert line.get_marker() == kws["marker"]
+            assert line.get_marker() == kws["marker"]
 
     def test_legend_attributes_with_style(self, long_df):
 
@@ -1208,8 +1206,7 @@ class TestLinePlotter(SharedAxesLevelTests, Helpers):
         ax = lineplot(long_df, x="x", y="y", style="a", **kws)
         for line in get_legend_handles(ax.get_legend()):
             assert same_color(line.get_color(), kws["color"])
-            if not _version_predates(mpl, "3.7.0"):
-                assert line.get_marker() == kws["marker"]
+            assert line.get_marker() == kws["marker"]
             assert line.get_linewidth() == kws["linewidth"]
 
     def test_legend_attributes_with_hue_and_style(self, long_df):
@@ -1218,8 +1215,7 @@ class TestLinePlotter(SharedAxesLevelTests, Helpers):
         ax = lineplot(long_df, x="x", y="y", hue="a", style="b", **kws)
         for line in get_legend_handles(ax.get_legend()):
             if line.get_label() not in ["a", "b"]:
-                if not _version_predates(mpl, "3.7.0"):
-                    assert line.get_marker() == kws["marker"]
+                assert line.get_marker() == kws["marker"]
                 assert line.get_linewidth() == kws["linewidth"]
 
     def test_lineplot_vs_relplot(self, long_df, long_semantics):
@@ -1498,10 +1494,7 @@ class TestScatterPlotter(SharedAxesLevelTests, Helpers):
             assert same_color(pt.get_color(), palette[i])
             assert pt.get_markersize() == np.sqrt(kws["s"])
             assert pt.get_markeredgewidth() == kws["linewidth"]
-            if not _version_predates(mpl, "3.7.0"):
-                # This attribute is empty on older matplotlibs
-                # but the legend looks correct so I assume it is a bug
-                assert pt.get_marker() == kws["marker"]
+            assert pt.get_marker() == kws["marker"]
 
     def test_legend_attributes_style(self, long_df):
 


### PR DESCRIPTION
- **Bump minimally supported dependency versions**
- **Mark known load-bearing devtools pins**
- **Remove vestigial compatability code**
