### PR TITLE
ENH: Add weights parameter to regplot and lmplot

### DIFF
--- a/seaborn/regression.py
+++ b/seaborn/regression.py
@@ -78,7 +78,7 @@ class _RegressionPlotter(_LinearPlotter):
                  units=None, seed=None, order=1, logistic=False, lowess=False,
                  robust=False, logx=False, x_partial=None, y_partial=None,
                  truncate=False, dropna=True, x_jitter=None, y_jitter=None,
-                 color=None, label=None):
+                 color=None, label=None, weights=None):
 
         # Set member attributes
         self.x_estimator = x_estimator
@@ -98,6 +98,7 @@ class _RegressionPlotter(_LinearPlotter):
         self.y_jitter = y_jitter
         self.color = color
         self.label = label
+        self.weights = None  # set below after establish_variables
 
         # Validate the regression options:
         if sum((order > 1, logistic, robust, lowess, logx)) > 1:
@@ -107,9 +108,20 @@ class _RegressionPlotter(_LinearPlotter):
         self.establish_variables(data, x=x, y=y, units=units,
                                  x_partial=x_partial, y_partial=y_partial)
 
+        # Handle observation weights
+        if weights is not None:
+            if isinstance(weights, str):
+                if data is None:
+                    raise ValueError("Must pass `data` if `weights` is a string.")
+                self.weights = np.asarray(data[weights], dtype=float)
+            else:
+                self.weights = np.asarray(weights, dtype=float)
+            if np.any(self.weights < 0):
+                raise ValueError("Weights must be non-negative.")
+
         # Drop null observations
         if dropna:
-            self.dropna("x", "y", "units", "x_partial", "y_partial")
+            self.dropna("x", "y", "units", "x_partial", "y_partial", "weights")
 
         # Regress nuisance variables out of the data
         if self.x_partial is not None:
@@ -238,11 +250,20 @@ class _RegressionPlotter(_LinearPlotter):
 
     def fit_fast(self, grid):
         """Low-level regression and prediction using linear algebra."""
-        def reg_func(_x, _y):
-            return np.linalg.pinv(_x).dot(_y)
-
         X, y = np.c_[np.ones(len(self.x)), self.x], self.y
         grid = np.c_[np.ones(len(grid)), grid]
+        w = self.weights
+
+        if w is not None:
+            # Weighted least squares: transform X and y by sqrt(w)
+            sqrt_w = np.sqrt(w)[:, None]
+
+            def reg_func(_x, _y):
+                return np.linalg.pinv(_x * sqrt_w).dot(_y * sqrt_w.ravel())
+        else:
+            def reg_func(_x, _y):
+                return np.linalg.pinv(_x).dot(_y)
+
         yhat = grid.dot(reg_func(X, y))
         if self.ci is None:
             return yhat, None
@@ -257,8 +278,14 @@ class _RegressionPlotter(_LinearPlotter):
 
     def fit_poly(self, grid, order):
         """Regression using numpy polyfit for higher-order trends."""
-        def reg_func(_x, _y):
-            return np.polyval(np.polyfit(_x, _y, order), grid)
+        w = self.weights
+
+        if w is not None:
+            def reg_func(_x, _y):
+                return np.polyval(np.polyfit(_x, _y, order, w=w), grid)
+        else:
+            def reg_func(_x, _y):
+                return np.polyval(np.polyfit(_x, _y, order), grid)
 
         x, y = self.x, self.y
         yhat = reg_func(x, y)
@@ -277,6 +304,11 @@ class _RegressionPlotter(_LinearPlotter):
         import statsmodels.tools.sm_exceptions as sme
         X, y = np.c_[np.ones(len(self.x)), self.x], self.y
         grid = np.c_[np.ones(len(grid)), grid]
+        w = self.weights
+
+        # Pass weights to statsmodels if provided
+        if w is not None:
+            kwargs.setdefault("freq_weights", w)
 
         def reg_func(_x, _y):
             err_classes = (sme.PerfectSeparationError,)
@@ -313,10 +345,18 @@ class _RegressionPlotter(_LinearPlotter):
         """Fit the model in log-space."""
         X, y = np.c_[np.ones(len(self.x)), self.x], self.y
         grid = np.c_[np.ones(len(grid)), np.log(grid)]
+        w = self.weights
 
-        def reg_func(_x, _y):
-            _x = np.c_[_x[:, 0], np.log(_x[:, 1])]
-            return np.linalg.pinv(_x).dot(_y)
+        if w is not None:
+            sqrt_w = np.sqrt(w)[:, None]
+
+            def reg_func(_x, _y):
+                _x = np.c_[_x[:, 0], np.log(_x[:, 1])]
+                return np.linalg.pinv(_x * sqrt_w).dot(_y * sqrt_w.ravel())
+        else:
+            def reg_func(_x, _y):
+                _x = np.c_[_x[:, 0], np.log(_x[:, 1])]
+                return np.linalg.pinv(_x).dot(_y)
 
         yhat = grid.dot(reg_func(X, y))
         if self.ci is None:
@@ -766,14 +806,16 @@ def regplot(
     logx=False, x_partial=None, y_partial=None,
     truncate=True, dropna=True, x_jitter=None, y_jitter=None,
     label=None, color=None, marker="o",
-    scatter_kws=None, line_kws=None, ax=None
+    scatter_kws=None, line_kws=None, ax=None,
+    weights=None,
 ):
 
     plotter = _RegressionPlotter(x, y, data, x_estimator, x_bins, x_ci,
                                  scatter, fit_reg, ci, n_boot, units, seed,
                                  order, logistic, lowess, robust, logx,
                                  x_partial, y_partial, truncate, dropna,
-                                 x_jitter, y_jitter, color, label)
+                                 x_jitter, y_jitter, color, label,
+                                 weights=weights)
 
     if ax is None:
         ax = plt.gca()

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -688,3 +688,66 @@ class TestRegressionPlots:
         lm.regplot(x=x, y=y2, truncate=False)
         line1, line2 = ax.lines
         assert np.array_equal(line1.get_xdata(), line2.get_xdata())
+
+    def test_regplot_weights_basic(self):
+        """Weights parameter should produce a regression line."""
+        f, ax = plt.subplots()
+        weights = np.ones(len(self.df))
+        weights[:45] = 10.0
+        lm.regplot(x="x", y="y", data=self.df, weights=weights, ci=None)
+        assert len(ax.lines) == 1
+
+    def test_regplot_weights_none(self):
+        """weights=None should give same result as no weights."""
+        f, ax1 = plt.subplots()
+        lm.regplot(x="x", y="y", data=self.df, ci=None)
+        line1 = ax1.lines[0].get_ydata()
+
+        f, ax2 = plt.subplots()
+        lm.regplot(x="x", y="y", data=self.df, weights=None, ci=None)
+        line2 = ax2.lines[0].get_ydata()
+
+        npt.assert_array_almost_equal(line1, line2)
+
+    def test_regplot_weights_uniform(self):
+        """Uniform weights should give same result as no weights."""
+        f, ax1 = plt.subplots()
+        lm.regplot(x="x", y="y", data=self.df, ci=None)
+        line1 = ax1.lines[0].get_ydata()
+
+        f, ax2 = plt.subplots()
+        weights = np.ones(len(self.df))
+        lm.regplot(x="x", y="y", data=self.df, weights=weights, ci=None)
+        line2 = ax2.lines[0].get_ydata()
+
+        npt.assert_array_almost_equal(line1, line2)
+
+    def test_regplot_weights_shifts_line(self):
+        """Non-uniform weights should shift the regression line."""
+        rs = np.random.RandomState(77)
+        n = 100
+        x = rs.randn(n)
+        y = x + rs.randn(n)
+        # Add an outlier with zero weight
+        x_out = np.append(x, 5.0)
+        y_out = np.append(y, -10.0)
+        weights_ignore = np.ones(n + 1)
+        weights_ignore[-1] = 0.0
+
+        f, ax1 = plt.subplots()
+        lm.regplot(x=x_out, y=y_out, ci=None)
+        line_with_outlier = ax1.lines[0].get_ydata()
+
+        f, ax2 = plt.subplots()
+        lm.regplot(x=x_out, y=y_out, weights=weights_ignore, ci=None)
+        line_without_outlier = ax2.lines[0].get_ydata()
+
+        # Lines should differ because the outlier is excluded by weight
+        assert not np.allclose(line_with_outlier, line_without_outlier)
+
+    def test_regplot_weights_negative_raises(self):
+        """Negative weights should raise ValueError."""
+        weights = np.ones(len(self.df))
+        weights[0] = -1.0
+        with pytest.raises(ValueError, match="non-negative"):
+            lm.regplot(x="x", y="y", data=self.df, weights=weights)


### PR DESCRIPTION
Closes #2163.
This adds a weights parameter to regplot( ) and lmplot() that enables weighted least squares regression. When provided, the regression line is fit using WLS instead of OLS, pulling the line toward observations with higher weight.

**What changed:**
The _RegressionPlotter class now accepts and stores a weights array. The four regression fitting methods were updated:
fit_fast: multiplies X and y by sqrt(w) before solving via pinv
fit_poly: passes weights to np.polyfit(..., w=weights)
fit_logx: same sqrt(w) transform as fit_fast, in log-space
fit_statsmodels: passes weights as freq_weights to the statsmodels model

**Behavior:**
weights=None or uniform weights give identical results to the current code (no regression)
Negative weights raise ValueError
NaN handling: if a weight is NaN, the corresponding observation is dropped (same as x/y NaN behavior)
**Tests added**: 5 new tests in tests/test_regression.py covering basic usage, None/uniform equivalence, line shift with non-uniform weights, and negative weight validation.