### PR TITLE
Fix invisible unfilled markers (e.g. 'x') in relplot legend

### DIFF
--- a/seaborn/utils.py
+++ b/seaborn/utils.py
@@ -862,12 +862,23 @@ def _scatter_legend_artist(**kws):
 
     edgecolor = kws.pop("edgecolor", None)
     rc = mpl.rcParams
+    marker = kws.pop("marker", "o")
+
+    markeredgewidth = kws.pop("linewidth", None)
+    if markeredgewidth is None:
+        # Unfilled markers (e.g. "x", "+") are drawn using only their edge,
+        # so a zero edge width would make them invisible in the legend.
+        if mpl.markers.MarkerStyle(marker).is_filled():
+            markeredgewidth = 0
+        else:
+            markeredgewidth = rc["lines.markeredgewidth"]
+
     line_kws = {
         "linestyle": "",
-        "marker": kws.pop("marker", "o"),
+        "marker": marker,
         "markersize": np.sqrt(kws.pop("s", rc["lines.markersize"] ** 2)),
         "markerfacecolor": kws.pop("facecolor", kws.get("color")),
-        "markeredgewidth": kws.pop("linewidth", 0),
+        "markeredgewidth": markeredgewidth,
         **kws,
     }
 

--- a/tests/test_relational.py
+++ b/tests/test_relational.py
@@ -735,6 +735,13 @@ class TestRelationalPlotter(Helpers):
                 assert pt.get_markersize() == np.sqrt(kws["s"])
                 assert pt.get_markeredgewidth() == kws["linewidth"]
 
+    def test_legend_unfilled_marker_visible(self, long_df):
+        g = relplot(long_df, x="x", y="y", hue="a", marker="x", s=100)
+        palette = color_palette()
+        for i, pt in enumerate(get_legend_handles(g.legend)):
+            assert pt.get_markeredgewidth() > 0
+            assert same_color(pt.get_markeredgecolor(), palette[i])
+
 
 class TestLinePlotter(SharedAxesLevelTests, Helpers):
 


### PR DESCRIPTION
Pulling #3950 onto current master which has some fixes to make CI green

Closes #3950
Closes #3947