### PR TITLE
Fix histogram binwidth edge case

### DIFF
--- a/seaborn/_stats/counting.py
+++ b/seaborn/_stats/counting.py
@@ -134,6 +134,10 @@ class Hist(Stat):
         else:
             if binwidth is not None:
                 bins = int(round((stop - start) / binwidth))
+                if bins == 0 and binwidth > 0 and np.isfinite(binwidth):
+                    bins = 1
+                    if start == stop:
+                        binrange = (start, stop + binwidth)
             bin_edges = np.histogram_bin_edges(vals, bins, binrange, weight)
 
         # TODO warning or cap on too many bins?

--- a/tests/_stats/test_counting.py
+++ b/tests/_stats/test_counting.py
@@ -100,6 +100,31 @@ class TestHist:
         left, right = bin_kws["range"]
         assert (right - left) / n_bins == pytest.approx(binwidth)
 
+    def test_binwidth_exceeds_data_range(self):
+
+        h = Hist(binwidth=10)
+        bin_kws = h._define_bin_params(
+            pd.DataFrame({"x": [0, 1]}), "x", "continuous",
+        )
+        assert bin_kws == {"bins": 1, "range": (0, 1)}
+
+    def test_binwidth_single_observation(self):
+
+        binwidth = .03
+        h = Hist(binwidth=binwidth)
+        bin_kws = h._define_bin_params(
+            pd.DataFrame({"x": [.49928]}), "x", "continuous",
+        )
+        assert bin_kws["bins"] == 1
+        left, right = bin_kws["range"]
+        assert right - left == pytest.approx(binwidth)
+
+    def test_negative_binwidth_exceeds_data_range(self):
+
+        h = Hist(binwidth=-10)
+        with pytest.raises(ValueError, match="bins.*positive"):
+            h._define_bin_params(pd.DataFrame({"x": [0, 1]}), "x", "continuous")
+
     def test_binrange(self, long_df):
 
         binrange = (-4, 4)


### PR DESCRIPTION
Fixes #3646.

`Hist._define_bin_edges` currently rounds a valid positive `binwidth` to zero bins whenever the data range is less than half the requested width. Both `histplot` and `objects.Hist` then pass zero to NumPy and raise a `ValueError`.

Keep the existing approximate-width behavior, but use one bin when a finite positive width would round to zero. For constant data, provide a one-width range so singleton histograms preserve the requested width, matching the earlier #2813 behavior. Invalid negative widths remain rejected.

Tests:

- `uv run pytest -q tests/_stats/test_counting.py tests/test_distributions.py tests/test_objects.py` (292 passed, 1 skipped)
- `uv run ruff check seaborn/_stats/counting.py tests/_stats/test_counting.py`
- `uv run ty check`
