### PR TITLE
Fix negative margin expansion in rugplot causing clipped histogram bars

### DIFF
--- a/seaborn/distributions.py
+++ b/seaborn/distributions.py
@@ -1290,9 +1290,9 @@ class _DistributionPlotter(VectorPlotter):
             if expand_margins:
                 xmarg, ymarg = ax.margins()
                 if "x" in self.variables:
-                    ymarg += height * 2
+                    ymarg += abs(height) * 2
                 if "y" in self.variables:
-                    xmarg += height * 2
+                    xmarg += abs(height) * 2
                 ax.margins(x=xmarg, y=ymarg)
 
             if "hue" in self.variables:


### PR DESCRIPTION
Fixes #3890

`plot_rug`'s margin expansion used `height` directly rather than its absolute value. When a negative `height` is passed (common when drawing rugs below the axis with `clip_on=False`), this shrank the axis margins instead of expanding them — clipping marginal histogram bars in `jointplot`.

Confirmed with the issue's reproduction case: before the fix, `ax_marg_x` ylim shrank from `(0, 50.4)` to `(12, 36)` after adding the rug; after the fix, it correctly expands to `(0, 64.8)`.

Ran the full test suite for this file — all relevant tests pass. Two unrelated pre-existing failures occur due to a local Tk/Tcl backend issue, unrelated to this change.