### PR TITLE
FIX: handle NaN positions from tight_layout with large axis values

### DIFF
--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -120,7 +120,11 @@ class Grid(_BaseGrid):
         kwargs.setdefault("rect", self._tight_layout_rect)
         if self._tight_layout_pad is not None:
             kwargs.setdefault("pad", self._tight_layout_pad)
+        saved = [ax.get_position().frozen() for ax in self._figure.axes]
         self._figure.tight_layout(*args, **kwargs)
+        if any(np.isnan(ax.get_position().x0) for ax in self._figure.axes):
+            for ax, pos in zip(self._figure.axes, saved):
+                ax.set_position(pos)
         return self
 
     def add_legend(self, legend_data=None, title=None, label_order=None,

--- a/tests/test_axisgrid.py
+++ b/tests/test_axisgrid.py
@@ -1,3 +1,4 @@
+import io
 import numpy as np
 import pandas as pd
 import matplotlib as mpl
@@ -719,6 +720,28 @@ class TestFacetGrid:
         assert g.axes.shape == (long_df["b"].nunique(), long_df["a"].nunique())
         for ax in g.axes.flat:
             assert len(ax.collections) == 1
+
+
+    def test_tight_layout_large_values(self):
+        # Regression test for GH#3963
+        df = pd.DataFrame({
+            'x': 377000 + rs.randn(18) * 1000,
+            'y': 5700000 + rs.randn(18) * 1000,
+            'id': np.repeat(range(1, 7), 3),
+            'variable': np.tile(['a', 'b', 'c'], 6),
+        })
+
+        g = ag.FacetGrid(df, col='id', row='variable')
+        g.map_dataframe(plt.scatter, x='x', y='y')
+
+        # Should not raise on render
+        g.figure.savefig(io.BytesIO(), format='png')
+
+        # Axes positions should not be NaN
+        for ax in g.axes.flat:
+            pos = ax.get_position()
+            assert not np.isnan(pos.x0)
+            assert not np.isnan(pos.y0)
 
 
 class TestPairGrid:


### PR DESCRIPTION
Closes #3963

## Summary

When axes have large numeric values (e.g. geographic coordinates) with shared axes and titles, `tight_layout` can produce NaN subplot positions. This causes a `ValueError: cannot convert float NaN to integer` on render.

## Root Cause

In matplotlib 3.11.0, `_update_title_position` uses the yaxis offset text bbox even when it's invisible. For non-left axes in a shared-y grid, the invisible offset text produces an empty/invalid bbox `(inf, inf, -inf, -inf)`. `Bbox.intersection` with this invalid bbox incorrectly returns a truthy result, causing the title position to be set to `(0.5, inf)`, which propagates NaN through the layout computation.

This is ultimately a matplotlib bug, but seaborn can work around it defensively.

## Fix

Save subplot positions before calling `tight_layout`, and restore them if the result contains NaN. This ensures that the grid layout remains valid even when matplotlib's tight_layout produces degenerate results.

## Reproducer from the issue

```python
import numpy as np
import pandas as pd
import seaborn as sns
import matplotlib.pyplot as plt

np.random.seed(42)
df = pd.DataFrame({
    'x': 377000 + np.random.randn(6 * 3) * 1000,
    'y': 5700000 + np.random.randn(6 * 3) * 1000,
    'id': np.repeat(range(1, 7), 3),
    'variable': np.tile(np.repeat(['a', 'b', 'c'], 1), 6),
})

g = sns.FacetGrid(df, col='id', row='variable')
g.map_dataframe(lambda data, **kw: plt.scatter(x=data['x'], y=data['y'], **kw))
plt.savefig('t.png')  # ValueError: cannot convert float NaN to integer
