### PR TITLE
Fix categorical hue data swapped in split violinplot

### DIFF
--- a/seaborn/_base.py
+++ b/seaborn/_base.py
@@ -926,7 +926,7 @@ class VectorPlotter:
         if grouping_vars:
 
             grouped_data = data.groupby(
-                grouping_vars, sort=False, as_index=False, observed=False,
+                grouping_vars, sort=False, as_index=False, observed=True,
             )
 
             grouping_keys = []

--- a/tests/test_categorical.py
+++ b/tests/test_categorical.py
@@ -1728,6 +1728,34 @@ class TestViolinPlot(SharedAxesLevelTests, SharedPatchArtistTests):
                 verts = poly.get_paths()[0].vertices
                 assert np.isclose(verts[:, 0], i).sum() >= 100
 
+    def test_split_categorical_hue_order(self):
+        # Regression test for GH#3893
+        # With CategoricalDtype hue column, data was swapped between hue groups
+        # because groupby(..., observed=False).get_group() matched by category
+        # code rather than by label value.
+        df = pd.DataFrame({
+            "x": ["A"] * 100,
+            "hue": pd.Categorical(
+                ["rest"] * 70 + ["0"] * 30, categories=["0", "rest"]
+            ),
+            "y": np.concatenate([
+                np.random.default_rng(0).normal(5, 1, 70),
+                np.random.default_rng(0).normal(1, 0.3, 30),
+            ]),
+        })
+        ax = violinplot(df, x="x", y="y", hue="hue",
+                        hue_order=["0", "rest"], split=True, cut=0)
+        polys = list(ax.collections)
+        # First poly is hue="0" (30 rows, mean ~1)
+        verts_0 = polys[0].get_paths()[0].vertices
+        # Second poly is hue="rest" (70 rows, mean ~5)
+        verts_rest = polys[1].get_paths()[0].vertices
+        # The "0" violin should span the low-value range (~1)
+        # The "rest" violin should span the high-value range (~5)
+        assert verts_0[:, 1].max() < 3
+        assert verts_rest[:, 1].min() > -1
+        assert verts_rest[:, 1].max() > 3
+
     def test_density_norm_area(self, long_df):
 
         y = long_df["y"].to_numpy()


### PR DESCRIPTION
Fixes #3893.

With pandas 3.0 and a CategoricalDtype hue column, `groupby(..., sort=False, observed=False).get_group(key)` matches groups by category code rather than by label value. This causes `iter_data` to yield data belonging to the wrong hue group when the first-appearance order in the data differs from the category order - resulting in swapped violins in split violin plots.

The fix changes `observed=False` to `observed=True` in the `iter_data` groupby call. This is safe because:

1. The `observed=False` was only added in 9049ddd to silence a pandas FutureWarning - the original code used the default (which was `True` in older pandas).
2. Seaborn's minimum pandas is now 2.2, where the default is `True`.
3. `iter_data` already handles missing groups via the existing `KeyError` catch, so unobserved category combinations still produce empty DataFrames as expected.

Includes a regression test that verifies the correct hue group data is assigned to each violin half.