### PR TITLE
fix: support pandas Interval levels in Nominal color scales

### DIFF
--- a/seaborn/_core/scales.py
+++ b/seaborn/_core/scales.py
@@ -121,9 +121,16 @@ class Scale:
 
         # TODO sometimes we need to handle scalars (e.g. for Line)
         # but what is the best way to do that?
-        scalar_data = np.isscalar(data)
+        # pandas.Interval (from pd.cut) is not np.isscalar but also not iterable,
+        # so treat non-iterable non-string objects as scalars (#3948).
+        scalar_data = np.isscalar(data) or isinstance(data, (str, bytes))
+        if not scalar_data:
+            try:
+                iter(data)
+            except TypeError:
+                scalar_data = True
         if scalar_data:
-            trans_data = np.array([data])
+            trans_data = np.array([data], dtype=object)
         else:
             trans_data = data
 
@@ -312,9 +319,19 @@ class Nominal(Scale):
             # TODO isin fails when units_seed mixes numbers and strings (numpy error?)
             # but np.isin also does not seem any faster? (Maybe not broadcasting in C)
             # keep = x.isin(units_seed)
-            keep = np.array([x_ in units_seed for x_ in x], bool)
-            out = np.full(len(x), np.nan)
-            out[keep] = axis.convert_units(stringify(x[keep]))
+            # Normalize to a flat sequence: pandas.Interval is not iterable (#3948).
+            if np.isscalar(x) or isinstance(x, (str, bytes)):
+                values = [x]
+            else:
+                try:
+                    values = list(x)
+                except TypeError:
+                    values = [x]
+            keep = np.array([v in units_seed for v in values], bool)
+            out = np.full(len(values), np.nan)
+            if keep.any():
+                kept = np.asarray(values, dtype=object)[keep]
+                out[keep] = axis.convert_units(stringify(kept))
             return out
 
         new._pipeline = [convert_units, prop.get_mapping(new, data)]

--- a/tests/_core/test_scales.py
+++ b/tests/_core/test_scales.py
@@ -579,6 +579,19 @@ class TestNominal:
             assert ax.yaxis.major.formatter(i) == expected
 
 
+
+    def test_pandas_interval_levels(self):
+        """pd.Interval categories must map without TypeError (#3948)."""
+        x = pd.Series(
+            pd.cut(pd.Series([1.0, 2.0, 3.0, 4.0, 5.0, 6.0]), bins=3)
+        )
+        s = Nominal()._setup(x, Color())
+        mapped = s(x)
+        assert len(mapped) == len(x)
+        # Single Interval value (used by marks that resolve one level at a time)
+        scalar = s(x.iloc[0])
+        assert scalar is not None
+
 class TestTemporal:
 
     @pytest.fixture


### PR DESCRIPTION
## Description

Using `pd.cut` / `pandas.Interval` categories for `color` in `seaborn.objects.Plot` crashed:

```text
TypeError: 'pandas._libs.interval.Interval' object is not iterable
```

Root cause: `Interval` is neither an `np.isscalar` nor iterable. `Scale.__call__` only wrapped true numpy scalars, and `Nominal.convert_units` did `for x_ in x` over the value.

## Fix

1. In `Scale.__call__`, treat non-iterable non-string objects as scalars.
2. In `Nominal.convert_units`, normalize input to a sequence before membership checks.

## Tests

```text
pytest tests/_core/test_scales.py::TestNominal::test_pandas_interval_levels -q
# 1 passed
```

Also verified:

```python
df["flipper_group"] = pd.cut(df["flipper_length_mm"], bins=7)
so.Plot(df, x=..., y=..., color="flipper_group").add(so.Line()).plot()
```

## Linked Issue

Closes #3948
